### PR TITLE
Run nest_asyncio.apply() automatically inside Jupyter

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -66,6 +66,25 @@ class Docs:
             embeddings = OpenAIEmbeddings()
         self.embeddings = embeddings
 
+        if self._in_notebook():
+            import nest_asyncio
+            nest_asyncio.apply()
+    
+    def _in_notebook(self) -> bool:
+        # From https://stackoverflow.com/questions/15411967/how-can-i-check-if-code-is-executed-in-the-ipython-notebook
+        try:
+            from IPython import get_ipython
+            shell = get_ipython().__class__.__name__
+            if shell == 'ZMQInteractiveShell':
+                return True   # Jupyter notebook or qtconsole
+            elif shell == 'TerminalInteractiveShell':
+                return False  # Terminal running IPython
+            else:
+                return False  # Other type (?)
+        except NameError:
+            return False      # Probably standard Python interpreter
+
+
     def update_llm(
         self,
         llm: Optional[Union[LLM, str]] = None,


### PR DESCRIPTION
## What does this do?
On Docs.__init__(), try to check if we're inside a Jupyter notebook. If so, run `nest_asyncio.apply()`

## Test Status
- [x] Running the code example from the README fails in Jupyter if this is not included*
- [x] Running the code example from the README succeeds in Jupyter with this fix*
- [x] Running the code example from the README succeeds in the terminal*

*only tested up to Docs.add()