### PR TITLE
Better BibTeX citekeys

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "PyCryptodome",
         "html2text",
         "tiktoken",
+        "requests",
     ],
     test_suite="tests",
     long_description=long_description,


### PR DESCRIPTION
Adds support for Better BibTeX citekeys as discussed in #67.

### Changes:
- add hostname, port, better_bibtex args to ZoteroDB init
- Make _get_citation_key a method of ZoteroDB
- If ZoteroDB is initialized with better_bibtex=True, call the Better BibTeX RPC endpoint via the Zotero Connector Integration
- Add requests to setup.py requirements
- If this errors, fall back to the default citation keys with a warning
- If better_bibtex=False, use the default citekey format