### PR TITLE
Add new unpaywall provider

### DIFF
--- a/paperqa/clients/__init__.py
+++ b/paperqa/clients/__init__.py
@@ -13,16 +13,24 @@ from .client_models import MetadataPostProcessor, MetadataProvider
 from .crossref import CrossrefProvider
 from .journal_quality import JournalQualityPostProcessor
 from .semantic_scholar import SemanticScholarProvider
+from .unpaywall import UnpaywallProvider
 
 logger = logging.getLogger(__name__)
 
-ALL_CLIENTS: (
+DEFAULT_CLIENTS: (
     Collection[type[MetadataPostProcessor | MetadataProvider]]
     | Sequence[Collection[type[MetadataPostProcessor | MetadataProvider]]]
 ) = {
     CrossrefProvider,
     SemanticScholarProvider,
     JournalQualityPostProcessor,
+}
+
+ALL_CLIENTS: (
+    Collection[type[MetadataPostProcessor | MetadataProvider]]
+    | Sequence[Collection[type[MetadataPostProcessor | MetadataProvider]]]
+) = DEFAULT_CLIENTS | {  # type: ignore[operator]
+    UnpaywallProvider,
 }
 
 
@@ -59,7 +67,7 @@ class DocMetadataClient:
         clients: (
             Collection[type[MetadataPostProcessor | MetadataProvider]]
             | Sequence[Collection[type[MetadataPostProcessor | MetadataProvider]]]
-        ) = ALL_CLIENTS,
+        ) = DEFAULT_CLIENTS,
     ) -> None:
         """Metadata client for querying multiple metadata providers and processors.
 

--- a/paperqa/clients/unpaywall.py
+++ b/paperqa/clients/unpaywall.py
@@ -107,11 +107,6 @@ class UnpaywallProvider(DOIOrTitleBasedProvider):
 
         return self._create_doc_details(results)
 
-    @staticmethod
-    def clean_query(query: str) -> str:
-        """Toss out any word in the query that has a forbidden character."""
-        return query
-
     async def search_by_title(
         self,
         query: str,
@@ -123,8 +118,8 @@ class UnpaywallProvider(DOIOrTitleBasedProvider):
                 **(
                     await _get_with_retrying(
                         url=(
-                            f"{UNPAYWALL_BASE_URL}search?query={quote(self.clean_query(query))}"
-                            '&email={os.environ.get("UNPAYWALL_EMAIL", "test@example.com")}'
+                            f"{UNPAYWALL_BASE_URL}search?query={quote(query)}"
+                            f'&email={os.environ.get("UNPAYWALL_EMAIL", "test@example.com")}'
                         ),
                         params={},
                         session=session,

--- a/paperqa/clients/unpaywall.py
+++ b/paperqa/clients/unpaywall.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from http import HTTPStatus
+from urllib.parse import quote
+
+import aiohttp
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ..types import DocDetails
+from ..utils import (
+    _get_with_retrying,
+    strings_similarity,
+)
+from .client_models import DOIOrTitleBasedProvider, DOIQuery, TitleAuthorQuery
+from .exceptions import DOINotFoundError
+
+UNPAYWALL_BASE_URL = "https://api.unpaywall.org/v2/"
+UNPAYWALL_TIMEOUT = float(os.environ.get("UNPAYWALL_TIMEOUT", "10.0"))  # seconds
+
+
+class Author(BaseModel):
+    family: str | None = None
+    given: str | None = None
+    sequence: str | None = None
+    affiliation: list[dict[str, str]] | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class BestOaLocation(BaseModel):
+    updated: datetime | None = None
+    url: str | None = None
+    url_for_pdf: str | None = None
+    url_for_landing_page: str | None = None
+    evidence: str | None = None
+    license: str | None = None
+    version: str | None = None
+    host_type: str | None = None
+    is_best: bool | None = None
+    pmh_id: str | None = None
+    endpoint_id: str | None = None
+    repository_institution: str | None = None
+    oa_date: str | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class UnpaywallResponse(BaseModel):
+    doi: str
+    doi_url: str | None = None
+    title: str | None = None
+    genre: str | None = None
+    is_paratext: bool | None = None
+    published_date: str | None = None
+    year: int | None = None
+    journal_name: str | None = None
+    journal_issns: str | None = None
+    journal_issn_l: str | None = None
+    journal_is_oa: bool | None = None
+    journal_is_in_doaj: bool | None = None
+    publisher: str | None = None
+    is_oa: bool
+    oa_status: str | None = None
+    has_repository_copy: bool | None = None
+    best_oa_location: BestOaLocation | None = None
+    updated: datetime | None = None
+    z_authors: list[Author] | None = None
+
+
+class SearchResponse(BaseModel):
+    response: UnpaywallResponse
+    score: float
+    snippet: str
+
+
+class SearchResults(BaseModel):
+    results: list[SearchResponse]
+    elapsed_seconds: float
+
+
+class UnpaywallProvider(DOIOrTitleBasedProvider):
+
+    async def get_doc_details(
+        self, doi: str, session: aiohttp.ClientSession
+    ) -> DocDetails:
+
+        try:
+            results = UnpaywallResponse(
+                **(
+                    await _get_with_retrying(
+                        url=f"{UNPAYWALL_BASE_URL}{doi}?email={os.environ.get("UNPAYWALL_EMAIL", "test@example.com")}",
+                        params={},
+                        session=session,
+                        timeout=UNPAYWALL_TIMEOUT,
+                        http_exception_mappings={
+                            HTTPStatus.NOT_FOUND: DOINotFoundError(
+                                f"Unpaywall not find DOI for {doi}."
+                            )
+                        },
+                    )
+                )
+            )
+        except ValidationError as e:
+            raise DOINotFoundError(
+                f"Unpaywall results returned with a bad schema for DOI {doi!r}."
+            ) from e
+
+        return self._create_doc_details(results)
+
+    @staticmethod
+    def clean_query(query: str) -> str:
+        """Toss out any word in the query that has a forbidden character."""
+        return query
+
+    async def search_by_title(
+        self,
+        query: str,
+        session: aiohttp.ClientSession,
+        title_similarity_threshold: float = 0.75,
+    ) -> DocDetails:
+        try:
+            results = SearchResults(
+                **(
+                    await _get_with_retrying(
+                        url=(
+                            f"{UNPAYWALL_BASE_URL}search?query={quote(self.clean_query(query))}"
+                            '&email={os.environ.get("UNPAYWALL_EMAIL", "test@example.com")}'
+                        ),
+                        params={},
+                        session=session,
+                        timeout=UNPAYWALL_TIMEOUT,
+                        http_exception_mappings={
+                            HTTPStatus.NOT_FOUND: DOINotFoundError(
+                                f"Could not find DOI for {query}."
+                            )
+                        },
+                    )
+                )
+            ).results
+        except ValidationError as e:
+            raise DOINotFoundError(
+                f"Unpaywall results returned with a bad schema for title {query!r}."
+            ) from e
+
+        if not results:
+            raise DOINotFoundError(
+                f"Unpaywall results did not match for title {query!r}."
+            )
+
+        details = self._create_doc_details(results[0].response)
+
+        if (
+            strings_similarity(
+                details.title or "",
+                query,
+            )
+            < title_similarity_threshold
+        ):
+            raise DOINotFoundError(
+                f"Unpaywall results did not match for title {query!r}."
+            )
+        return details
+
+    def _create_doc_details(self, data: UnpaywallResponse) -> DocDetails:
+        return DocDetails(  # type: ignore[call-arg]
+            authors=[
+                f"{author.given} {author.family}" for author in (data.z_authors or [])
+            ],
+            publication_date=(
+                None
+                if not data.published_date
+                else datetime.strptime(data.published_date, "%Y-%m-%d")
+            ),
+            year=data.year,
+            journal=data.journal_name,
+            publisher=data.publisher,
+            url=None if not data.best_oa_location else data.best_oa_location.url,
+            title=data.title,
+            doi=data.doi,
+            doi_url=data.doi_url,
+            other={
+                "genre": data.genre,
+                "is_paratext": data.is_paratext,
+                "journal_issns": data.journal_issns,
+                "journal_issn_l": data.journal_issn_l,
+                "journal_is_oa": data.journal_is_oa,
+                "journal_is_in_doaj": data.journal_is_in_doaj,
+                "is_oa": data.is_oa,
+                "oa_status": data.oa_status,
+                "has_repository_copy": data.has_repository_copy,
+                "best_oa_location": (
+                    None
+                    if not data.best_oa_location
+                    else data.best_oa_location.model_dump()
+                ),
+            },
+        )
+
+    async def _query(self, query: TitleAuthorQuery | DOIQuery) -> DocDetails | None:
+        if isinstance(query, DOIQuery):
+            return await self.get_doc_details(doi=query.doi, session=query.session)
+        return await self.search_by_title(
+            query=query.title,
+            session=query.session,
+            title_similarity_threshold=query.title_similarity_threshold,
+        )

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     USE_VOYAGE = False
 
-from .clients import ALL_CLIENTS, DocMetadataClient
+from .clients import DEFAULT_CLIENTS, DocMetadataClient
 from .llms import (
     HybridEmbeddingModel,
     LLMModel,
@@ -473,7 +473,7 @@ class Docs(BaseModel):
             else:
                 metadata_client = DocMetadataClient(
                     session=kwargs.pop("session", None),
-                    clients=kwargs.pop("clients", ALL_CLIENTS),
+                    clients=kwargs.pop("clients", DEFAULT_CLIENTS),
                 )
 
             query_kwargs: dict[str, Any] = {}

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -565,10 +565,12 @@ class DocDetails(Doc):
                 logger.warning(
                     f"Failed to generate bibtex for {data.get('docname') or data.get('citation')}"
                 )
-        if not data.get("citation"):
+        if not data.get("citation") and data.get("bibtex") is not None:
             data["citation"] = format_bibtex(
                 data["bibtex"], clean=True, missing_replacements=CITATION_FALLBACK_DATA  # type: ignore[arg-type]
             )
+        elif not data.get("citation"):
+            data["citation"] = data.get("title") or CITATION_FALLBACK_DATA["title"]
         return data
 
     @model_validator(mode="before")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ urls = {repository = "https://github.com/whitead/paper-qa"}
 
 [project.optional-dependencies]
 agents = [
+    "anthropic",
     "anyio",
     "langchain-community",
     "langchain-openai",

--- a/tests/cassettes/test_doi_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes0].yaml
@@ -95,7 +95,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/10.1101/2024.04.01.587366?email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/10.1101/2024.04.01.587366?email=test@example.com
     response:
       body:
         string:

--- a/tests/cassettes/test_doi_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes0].yaml
@@ -71,7 +71,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:51:22 GMT
+          - Thu, 29 Aug 2024 23:53:20 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -88,6 +88,79 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.unpaywall.org/v2/10.1101/2024.04.01.587366?email=api@futurehouse.org
+    response:
+      body:
+        string:
+          '{"doi": "10.1101/2024.04.01.587366", "doi_url": "https://doi.org/10.1101/2024.04.01.587366",
+          "title": "High-throughput screening of human genetic variants by pooled prime
+          editing", "genre": "posted-content", "is_paratext": false, "published_date":
+          "2024-04-01", "year": 2024, "journal_name": null, "journal_issns": null, "journal_issn_l":
+          null, "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Cold
+          Spring Harbor Laboratory", "is_oa": true, "oa_status": "green", "has_repository_copy":
+          true, "best_oa_location": {"updated": "2024-04-03T02:38:26.107690", "url":
+          "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_pdf": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_landing_page": "https://doi.org/10.1101/2024.04.01.587366", "evidence":
+          "oa repository (via page says license)", "license": "cc-by", "version": "submittedVersion",
+          "host_type": "repository", "is_best": true, "pmh_id": null, "endpoint_id":
+          null, "repository_institution": null, "oa_date": "2024-04-01"}, "first_oa_location":
+          {"updated": "2024-04-03T02:38:26.107690", "url": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_pdf": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_landing_page": "https://doi.org/10.1101/2024.04.01.587366", "evidence":
+          "oa repository (via page says license)", "license": "cc-by", "version": "submittedVersion",
+          "host_type": "repository", "is_best": true, "pmh_id": null, "endpoint_id":
+          null, "repository_institution": null, "oa_date": "2024-04-01"}, "oa_locations":
+          [{"updated": "2024-04-03T02:38:26.107690", "url": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_pdf": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "url_for_landing_page": "https://doi.org/10.1101/2024.04.01.587366", "evidence":
+          "oa repository (via page says license)", "license": "cc-by", "version": "submittedVersion",
+          "host_type": "repository", "is_best": true, "pmh_id": null, "endpoint_id":
+          null, "repository_institution": null, "oa_date": "2024-04-01"}], "oa_locations_embargoed":
+          [], "updated": "2024-04-03T02:38:52.695109", "data_standard": 2, "z_authors":
+          [{"given": "Michael", "family": "Herger", "sequence": "first"}, {"given":
+          "Christina M.", "family": "Kajba", "sequence": "additional"}, {"given": "Megan",
+          "family": "Buckley", "sequence": "additional"}, {"given": "Ana", "family":
+          "Cunha", "sequence": "additional"}, {"given": "Molly", "family": "Strom",
+          "sequence": "additional"}, {"ORCID": "http://orcid.org/0000-0002-7767-8608",
+          "given": "Gregory M.", "family": "Findlay", "sequence": "additional", "authenticated-orcid":
+          false}]}'
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "736"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:53:20 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724975600&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=laj3cS8sKKbpeuiCyR8Z43p8pXOEJ%2FH0eYIUZai%2F3E8%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724975600&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=laj3cS8sKKbpeuiCyR8Z43p8pXOEJ%2FH0eYIUZai%2F3E8%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
       status:
         code: 200
         message: OK
@@ -126,27 +199,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:51:22 GMT
+          - Thu, 29 Aug 2024 23:53:20 GMT
         Via:
-          - 1.1 d1dad7d3c339d87d553c26a84c9ca5d2.cloudfront.net (CloudFront)
+          - 1.1 4eed67f4be7da2537d3407735b8962a8.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - YdElWpMCzPZBBVcmqso_pKXH0JZf-c3i0htHXzE-jvK940UiDB0TfQ==
+          - nig_lPlTPDSDKegJrzZ6-Sxayalq9V9nQ6fBN9I7seV2KYmQ04KeWg==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdeutGf0PHcEffA=
+          - dS59qEVsPHcETfQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1325"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:51:22 GMT
+          - Thu, 29 Aug 2024 23:53:20 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 62d15057-610f-4f42-be58-3d85daa4834e
+          - ebe78919-23a8-4c6e-802a-e1bf4b585e05
       status:
         code: 200
         message: OK
@@ -176,7 +249,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:51:23 GMT
+          - Thu, 29 Aug 2024 23:53:21 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_doi_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes1].yaml
@@ -159,7 +159,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/10.1023/a:1007154515475?email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/10.1023/a:1007154515475?email=test@example.com
     response:
       body:
         string:

--- a/tests/cassettes/test_doi_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes1].yaml
@@ -28,7 +28,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:34:01 GMT
+          - Thu, 29 Aug 2024 23:53:21 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -87,27 +87,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:53:21 GMT
         Via:
-          - 1.1 ef066a0102f66b719933dbbef3bc5968.cloudfront.net (CloudFront)
+          - 1.1 4eed67f4be7da2537d3407735b8962a8.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - UTYNrOWx6hAF2oDHtNJriKFUfyI5WuhHnu6OER07rQycY9GGvhAXhg==
+          - HhLiN8GUWQnUBfgzuFDoxWgAwpeJpGSlYo40a5MygT1sZ2ZwjldeuA==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcMHEwsvHcEB4w=
+          - dS59xGSjvHcEgbg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1446"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:53:21 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 1c51e9d8-caf7-4a06-ad5d-815a80bd1356
+          - fd8f8dfb-d4c9-428c-9892-8221b5fe69c1
       status:
         code: 200
         message: OK
@@ -135,7 +135,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:53:21 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -152,6 +152,58 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.unpaywall.org/v2/10.1023/a:1007154515475?email=api@futurehouse.org
+    response:
+      body:
+        string:
+          '{"doi": "10.1023/a:1007154515475", "doi_url": "https://doi.org/10.1023/a:1007154515475",
+          "title": null, "genre": "journal-article", "is_paratext": false, "published_date":
+          "2001-01-01", "year": 2001, "journal_name": "Molecular and Cellular Biochemistry",
+          "journal_issns": "0300-8177", "journal_issn_l": "0300-8177", "journal_is_oa":
+          false, "journal_is_in_doaj": false, "publisher": "Springer Science and Business
+          Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
+          false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
+          [], "oa_locations_embargoed": [], "updated": "2021-01-15T22:46:04.723698",
+          "data_standard": 2, "z_authors": [{"given": "Subrata", "family": "Adak", "sequence":
+          "first"}, {"given": "Debashis", "family": "Bandyopadhyay", "sequence": "additional"},
+          {"given": "Uday", "family": "Bandyopadhyay", "sequence": "additional"}, {"given":
+          "Ranajit K.", "family": "Banerjee", "sequence": "additional"}]}'
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "453"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:53:25 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724975601&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=SKOqofjb3lZ5bzUOfi%2FzYH760JagHx8mAzVkqq6WQiM%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724975601&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=SKOqofjb3lZ5bzUOfi%2FzYH760JagHx8mAzVkqq6WQiM%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_doi_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes2].yaml
@@ -3,7 +3,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/10.1007/s40278-023-41815-2?email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/10.1007/s40278-023-41815-2?email=test@example.com
     response:
       body:
         string:

--- a/tests/cassettes/test_doi_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes2].yaml
@@ -3,6 +3,55 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.unpaywall.org/v2/10.1007/s40278-023-41815-2?email=api@futurehouse.org
+    response:
+      body:
+        string:
+          '{"doi": "10.1007/s40278-023-41815-2", "doi_url": "https://doi.org/10.1007/s40278-023-41815-2",
+          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "genre": "journal-article",
+          "is_paratext": false, "published_date": "2023-06-24", "year": 2023, "journal_name":
+          "Reactions Weekly", "journal_issns": "1179-2051", "journal_issn_l": "0114-9954",
+          "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Springer
+          Science and Business Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
+          false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
+          [], "oa_locations_embargoed": [], "updated": "2023-06-24T05:46:22.445497",
+          "data_standard": 2, "z_authors": null}'
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "396"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:58:47 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724975927&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=05j3DY7YmOZ7W%2FQPmQcYH%2FJ2uhYRk9AoOgBPnOXbGes%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724975927&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=05j3DY7YmOZ7W%2FQPmQcYH%2FJ2uhYRk9AoOgBPnOXbGes%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2?mailto=test@example.com
     response:
       body:
@@ -34,7 +83,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:58:47 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -84,27 +133,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:58:47 GMT
         Via:
-          - 1.1 ddd3d8441374ce62d11d031216138152.cloudfront.net (CloudFront)
+          - 1.1 4091abb8cac392d8bc54145a27288bc6.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - pNq8XNMTPxZyPVVrRe1N7igInqU9ADvOVppmBatkSrtTJM4qVmgHxA==
+          - uLvuDYnS9NBsxAfeATF3zYEQp3Tjj48hzpuzKeWEEM4PG9K-S-UA4g==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcMQHBhvHcEd-g=
+          - dS6wpEAUPHcEJgg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "837"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:34:02 GMT
+          - Thu, 29 Aug 2024 23:58:47 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - e0ccacc5-3403-42dc-a0f4-c33a60337aa0
+          - c980f66a-63cf-4008-baea-97fbfa52358c
       status:
         code: 200
         message: OK
@@ -131,7 +180,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:34:03 GMT
+          - Thu, 29 Aug 2024 23:58:47 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_ensure_sequential_run.yaml
+++ b/tests/cassettes/test_ensure_sequential_run.yaml
@@ -3,12 +3,10 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.crossref.org/works/10.48550%2Farxiv.2312.07559?mailto=test@example.com&select=DOI,title
+      uri: https://api.crossref.org/works/10.48550%2Farxiv.2312.07559?mailto=test@example.com
     response:
       body:
-        string:
-          '{"status":"failed","message-type":"validation-failure","message":[{"type":"parameter-not-allowed","value":"select","message":"This
-          route does not support select"}]}'
+        string: Resource not found.
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -20,15 +18,13 @@ interactions:
         Connection:
           - close
         Content-Type:
-          - application/json;charset=utf-8
+          - text/plain
         Date:
-          - Wed, 14 Aug 2024 19:20:22 GMT
+          - Fri, 30 Aug 2024 00:06:45 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
           - chunked
-        Vary:
-          - Accept
         permissions-policy:
           - interest-cohort=()
         x-api-pool:
@@ -42,8 +38,8 @@ interactions:
         x-ratelimit-limit:
           - "150"
       status:
-        code: 400
-        message: Bad Request
+        code: 404
+        message: Not Found
   - request:
       body: null
       headers: {}
@@ -68,27 +64,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Wed, 14 Aug 2024 19:20:22 GMT
+          - Fri, 30 Aug 2024 00:06:45 GMT
         Via:
-          - 1.1 4ce044af637284f41cd11c7043e8eaaa.cloudfront.net (CloudFront)
+          - 1.1 7a9f6a4fba100d04559a6d3a82b7dc56.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - XAy8Bc-bjjHFQpgqiH4rdAA1BOrUsXSpjmrKxH3bk3daL7NMAGDi2A==
+          - UL-OyyVRVdR96paLU60gx9tlx_HxW8Vl_f2zh15dOygkfIyn6jnqDg==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cg16mEksPHcEoiQ=
+          - dS77cGDlPHcEJyA=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "277"
         x-amzn-Remapped-Date:
-          - Wed, 14 Aug 2024 19:20:22 GMT
+          - Fri, 30 Aug 2024 00:06:45 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 1b02bab8-e592-429d-9272-23531aa671c5
+          - 3aa775c5-588d-497f-9dda-7c70416ddc85
       status:
         code: 200
         message: OK
@@ -113,7 +109,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Wed, 14 Aug 2024 19:20:23 GMT
+          - Fri, 30 Aug 2024 00:06:46 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_odd_client_requests.yaml
+++ b/tests/cassettes/test_odd_client_requests.yaml
@@ -7,7 +7,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5526,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5558,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
@@ -28,7 +28,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:34:56 GMT
+          - Fri, 30 Aug 2024 00:06:39 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -64,7 +64,7 @@ interactions:
           "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773", "name": "Oliver
           Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"}, {"authorId":
           "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853", "name":
-          "P. Schwaller"}], "matchScore": 175.55591}]}
+          "P. Schwaller"}], "matchScore": 181.12164}]}
 
           '
       headers:
@@ -77,27 +77,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:12 GMT
+          - Fri, 30 Aug 2024 00:06:39 GMT
         Via:
-          - 1.1 d1dad7d3c339d87d553c26a84c9ca5d2.cloudfront.net (CloudFront)
+          - 1.1 0af050b863ec46156a524df4e5d86692.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - jR4en8rFQR1kLKWLt8yREaFgiVbxyV3Bfsu1UfA6EUk5U1DaosU6_A==
+          - PuhKI1MYJ4RHifAS0ycRfLllMsjmdE709IIytHT8CF5MmYeAbkAGgw==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcUlEPKvHcEVtA=
+          - dS76WEOZvHcEBGg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "684"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:35:12 GMT
+          - Fri, 30 Aug 2024 00:06:39 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 57a3817d-a6a8-4bc2-bc7b-781977962682
+          - 522c1ef9-f92d-4add-8683-21125e0d7dac
       status:
         code: 200
         message: OK
@@ -122,7 +122,97 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Tue, 13 Aug 2024 18:35:12 GMT
+          - Fri, 30 Aug 2024 00:06:40 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 404
+        message: Not Found
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "title": "Augmenting large language models with chemistry tools",
+          "matchScore": 181.12164}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "348"
+        Content-Type:
+          - application/json
+        Date:
+          - Fri, 30 Aug 2024 00:06:40 GMT
+        Via:
+          - 1.1 305fa1d7f9df4e42edba1bba6d0ebb56.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - HbTLD0HxuCJYhZpK4YLAMv0gCn6-kYFcO2JKJuWSW682ZPXA91hdqw==
+        X-Amz-Cf-Pop:
+          - IAD55-P4
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - dS76nGj7vHcEq3A=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "348"
+        x-amzn-Remapped-Date:
+          - Fri, 30 Aug 2024 00:06:40 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 752b2d7c-8b51-4c80-8750-add64be344f5
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.48550%2FarXiv.2304.05376/transform/application/x-bibtex
+    response:
+      body:
+        string: Resource not found.
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Content-Type:
+          - text/plain;charset=utf-8
+        Date:
+          - Fri, 30 Aug 2024 00:06:41 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -150,7 +240,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2283974,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2292457,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
@@ -165,7 +255,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:13 GMT
+          - Fri, 30 Aug 2024 00:06:41 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -197,7 +287,7 @@ interactions:
           {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
           "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
           "38799228"}, "title": "Augmenting large language models with chemistry tools",
-          "matchScore": 181.37788}]}
+          "matchScore": 175.31604}]}
 
           '
       headers:
@@ -210,27 +300,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:19 GMT
+          - Fri, 30 Aug 2024 00:06:42 GMT
         Via:
-          - 1.1 5a0e8b615e213d3d5cc20b095e088b16.cloudfront.net (CloudFront)
+          - 1.1 f1dd5bd4f4b31b158b9e826b6e013cda.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - xPUd91qaqbhIVuKSveghxDni1dbLiULD94fqrTUnVZNi8MKuDzRiPA==
+          - xyuHHLMt63KBqox_vmb3DuJPNrHnADlIq7rVcKkDPYDClKK9zw6MVA==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcXOFbhPHcEVtA=
+          - dS764HC9PHcERcw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "348"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:35:19 GMT
+          - Fri, 30 Aug 2024 00:06:42 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - f987b3c4-dbaf-44b3-8e1d-c5dc8c821658
+          - 8cd4fe8e-6087-4460-b58f-49e8487405ab
       status:
         code: 200
         message: OK
@@ -255,7 +345,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Tue, 13 Aug 2024 18:35:19 GMT
+          - Fri, 30 Aug 2024 00:06:43 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -283,7 +373,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2283974,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2292457,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
@@ -298,7 +388,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:20 GMT
+          - Fri, 30 Aug 2024 00:06:44 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -322,122 +412,42 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
+      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2?mailto=test@example.com
     response:
       body:
         string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "title": "Augmenting large language models with chemistry tools",
-          "matchScore": 181.37788}]}
-
-          '
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T04:17:17Z","timestamp":1687580237047},"reference-count":1,"publisher":"Springer
+          Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"},{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Reactions
+          Weekly"],"DOI":"10.1007\/s40278-023-41815-2","type":"journal-article","created":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T18:42:29Z","timestamp":1687545749000},"page":"145-145","source":"Crossref","is-referenced-by-count":0,"title":["Convalescent-anti-sars-cov-2-plasma\/immune-globulin"],"prefix":"10.1007","volume":"1962","member":"297","published-online":{"date-parts":[[2023,6,24]]},"reference":[{"key":"41815_CR1","doi-asserted-by":"crossref","unstructured":"Delgado-Fernandez
+          M, et al. Treatment of COVID-19 with convalescent plasma in patients with
+          humoral immunodeficiency - Three consecutive cases and review of the literature.
+          Enfermedades Infecciosas Y Microbiologia Clinica 40\n: 507-516, No. 9, Nov
+          2022. Available from: URL: \nhttps:\/\/seimc.org\/","DOI":"10.1016\/j.eimce.2021.01.009"}],"container-title":["Reactions
+          Weekly"],"original-title":[],"language":"en","link":[{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/article\/10.1007\/s40278-023-41815-2\/fulltext.html","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T19:23:18Z","timestamp":1687548198000},"score":1,"resource":{"primary":{"URL":"https:\/\/link.springer.com\/10.1007\/s40278-023-41815-2"}},"subtitle":["Fever
+          and mild decrease in baseline oxygen saturation following off-label use: 3
+          case reports"],"short-title":[],"issued":{"date-parts":[[2023,6,24]]},"references-count":1,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,6]]}},"alternative-id":["41815"],"URL":"http:\/\/dx.doi.org\/10.1007\/s40278-023-41815-2","relation":{},"ISSN":["1179-2051"],"issn-type":[{"value":"1179-2051","type":"electronic"}],"subject":[],"published":{"date-parts":[[2023,6,24]]}}}'
       headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
         Access-Control-Allow-Origin:
           - "*"
+        Access-Control-Expose-Headers:
+          - Link
         Connection:
-          - keep-alive
+          - close
+        Content-Encoding:
+          - gzip
         Content-Length:
-          - "348"
+          - "1163"
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
-        Via:
-          - 1.1 170caffbbbc9abe2c5fd15f4f58b75b4.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - ZTE52QH0cvC-EQoaxr6Eld61DOWduPUYH5XunbuAzqJ89FeSfkePDw==
-        X-Amz-Cf-Pop:
-          - IAD55-P4
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - cdcYTFtAvHcEffA=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "348"
-        x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 1b823d40-9ea2-4f0b-b405-3fa6984154c4
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.48550%2FarXiv.2304.05376/transform/application/x-bibtex
-    response:
-      body:
-        string: Resource not found.
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Type:
-          - text/plain;charset=utf-8
-        Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
+          - Fri, 30 Aug 2024 00:06:44 GMT
         Server:
           - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 404
-        message: Not Found
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2?mailto=test@example.com&select=DOI,title
-    response:
-      body:
-        string:
-          '{"status":"failed","message-type":"validation-failure","message":[{"type":"parameter-not-allowed","value":"select","message":"This
-          route does not support select"}]}'
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Type:
-          - application/json;charset=utf-8
-        Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
         Vary:
-          - Accept
+          - Accept-Encoding
         permissions-policy:
           - interest-cohort=()
         x-api-pool:
@@ -451,8 +461,8 @@ interactions:
         x-ratelimit-limit:
           - "150"
       status:
-        code: 400
-        message: Bad Request
+        code: 200
+        message: OK
   - request:
       body: null
       headers: {}
@@ -475,27 +485,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
+          - Fri, 30 Aug 2024 00:06:44 GMT
         Via:
-          - 1.1 b3169f8fae0104e39a0a9728b6537e08.cloudfront.net (CloudFront)
+          - 1.1 8e6324c5a68bac8fd8e6eead6a5b73f2.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - BMX9JmQMQSa_4OWVgqZz3d2oDuamu6qnA6eTt087wqu-kvspzMk4-A==
+          - c_foZPMqTJQ7onQtUUhb2fUaL5iifOtIaOrGHCEvmPDdlIyAYn33gA==
         X-Amz-Cf-Pop:
           - IAD55-P4
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcZ9F1TPHcEYkQ=
+          - dS77PGPbvHcEDuw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "197"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:35:30 GMT
+          - Fri, 30 Aug 2024 00:06:44 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 74d91639-902f-4321-9e57-cb8301b2f50b
+          - f4311aac-8a64-4ce9-9221-452525e4552f
       status:
         code: 200
         message: OK
@@ -522,7 +532,50 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:35:31 GMT
+          - Fri, 30 Aug 2024 00:06:44 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2/transform/application/x-bibtex
+    response:
+      body:
+        string:
+          " @article{2023, volume={1962}, ISSN={1179-2051}, url={http://dx.doi.org/10.1007/s40278-023-41815-2},
+          DOI={10.1007/s40278-023-41815-2}, number={1}, journal={Reactions Weekly},
+          publisher={Springer Science and Business Media LLC}, year={2023}, month=jun,
+          pages={145\u2013145} }\n"
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Date:
+          - Fri, 30 Aug 2024 00:06:44 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_title_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes0].yaml
@@ -3,13 +3,126 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.unpaywall.org/v2/search?query=Effect%20of%20native%20oxide%20layers%20on%20copper%20thin-film%20tensile%20properties:%20A%20reactive%20molecular%20dynamics%20study&email=api@futurehouse.org
+    response:
+      body:
+        string:
+          '{"elapsed_seconds":0.279,"results":[{"response":{"best_oa_location":null,"data_standard":2,"doi":"10.1063/1.4938384","doi_url":"https://doi.org/10.1063/1.4938384","first_oa_location":null,"genre":"journal-article","has_repository_copy":false,"is_oa":false,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"0021-8979","journal_issns":"0021-8979,1089-7550","journal_name":"Journal
+          of Applied Physics","oa_locations":[],"oa_locations_embargoed":[],"oa_status":"closed","published_date":"2015-12-21","publisher":"AIP
+          Publishing","title":"Effect of native oxide layers on copper thin-film tensile
+          properties: A reactive molecular dynamics study","updated":"2023-07-31T05:28:57.007821","year":2015,"z_authors":[{"affiliation":[{"name":"University
+          of Rochester 1 Materials Science Program, , Rochester, New York 14627, USA"}],"family":"Skarlinski","given":"Michael
+          D.","sequence":"first"},{"affiliation":[{"name":"University of Rochester 1
+          Materials Science Program, , Rochester, New York 14627, USA"},{"name":"University
+          of Rochester 2 Department of Mechanical Engineering, , Rochester, New York
+          14627, USA"}],"family":"Quesnel","given":"David J.","sequence":"additional"}]},"score":0.009231734,"snippet":"<b>Effect</b>
+          of <b>native</b> <b>oxide</b> <b>layers</b> on <b>copper</b> <b>thin</b>-<b>film</b>
+          <b>tensile</b> <b>properties</b>: A <b>reactive</b> <b>molecular</b> <b>dynamics</b>
+          <b>study</b>"}]}
+
+          '
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "706"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:10:28 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724973027&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=W2J4tTO5PkElBGdF%2By5jjCvzwge8TzZj8EvuhirZcgs%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724973027&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=W2J4tTO5PkElBGdF%2By5jjCvzwge8TzZj8EvuhirZcgs%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Effect+of+native+oxide+layers+on+copper+thin-film+tensile+properties:+A+reactive+molecular+dynamics+study&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "4187800ac995ae172c88b83f8c2c4da990d02934", "externalIds":
+          {"MAG": "2277923667", "DOI": "10.1063/1.4938384", "CorpusId": 124514389},
+          "url": "https://www.semanticscholar.org/paper/4187800ac995ae172c88b83f8c2c4da990d02934",
+          "title": "Effect of native oxide layers on copper thin-film tensile properties:
+          A reactive molecular dynamics study", "venue": "", "year": 2015, "citationCount":
+          8, "influentialCitationCount": 0, "isOpenAccess": false, "openAccessPdf":
+          null, "publicationTypes": null, "publicationDate": "2015-12-21", "journal":
+          {"name": "Journal of Applied Physics", "pages": "235306", "volume": "118"},
+          "citationStyles": {"bibtex": "@Article{Skarlinski2015EffectON,\n author =
+          {Michael Skarlinski and D. Quesnel},\n journal = {Journal of Applied Physics},\n
+          pages = {235306},\n title = {Effect of native oxide layers on copper thin-film
+          tensile properties: A reactive molecular dynamics study},\n volume = {118},\n
+          year = {2015}\n}\n"}, "authors": [{"authorId": "9821934", "name": "Michael
+          Skarlinski"}, {"authorId": "37723150", "name": "D. Quesnel"}], "matchScore":
+          283.57123}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1109"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:10:29 GMT
+        Via:
+          - 1.1 4f3476fc0ed69f4f9209b2ccb91b0050.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - CSmoK6QfaY44SRQ6cU6W_KA-CxiFxiWmRh_XYoRwf-sm30criY6chQ==
+        X-Amz-Cf-Pop:
+          - IAD55-P4
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - dSzrpHmyPHcEP7A=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1109"
+        x-amzn-Remapped-Date:
+          - Thu, 29 Aug 2024 23:10:29 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 3537ad99-5c86-47fd-8908-f341da2ed5e7
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=test@example.com&query.title=Effect+of+native+oxide+layers+on+copper+thin-film+tensile+properties:+A+reactive+molecular+dynamics+study&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":11734918,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":11774974,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
           Publishing","issue":"23","funder":[{"DOI":"10.13039\/100000006","name":"Office
-          of Naval Research","doi-asserted-by":"publisher","award":["N00014-12-1-0542"]}],"content-domain":{"domain":["pubs.aip.org"],"crossmark-restriction":true},"published-print":{"date-parts":[[2015,12,21]]},"abstract":"<jats:p>Metal-oxide
+          of Naval Research","doi-asserted-by":"publisher","award":["N00014-12-1-0542"],"id":[{"id":"10.13039\/100000006","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["pubs.aip.org"],"crossmark-restriction":true},"published-print":{"date-parts":[[2015,12,21]]},"abstract":"<jats:p>Metal-oxide
           layers are likely to be present on metallic nano-structures due to either
           environmental exposure during use, or high temperature processing techniques
           such as annealing. It is well known that nano-structured metals have vastly
@@ -101,7 +214,7 @@ interactions:
           Sci. Eng. A"},{"key":"2023062402360541600_c55","doi-asserted-by":"publisher","first-page":"057129","DOI":"10.1063\/1.4880241","volume":"4","year":"2014","journal-title":"AIP
           Adv."},{"key":"2023062402360541600_c56","doi-asserted-by":"publisher","first-page":"94","DOI":"10.1016\/j.susc.2014.10.017","volume":"633","year":"2015","journal-title":"Surf.
           Sci."},{"key":"2023062402360541600_c57","doi-asserted-by":"publisher","first-page":"710","DOI":"10.1016\/j.pmatsci.2010.04.001","volume":"55","year":"2010","journal-title":"Prog.
-          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":64.02262,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":64.02747,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -115,11 +228,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3927"
+          - "3945"
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:33:52 GMT
+          - Thu, 29 Aug 2024 23:10:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -166,7 +279,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:33:52 GMT
+          - Thu, 29 Aug 2024 23:10:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -183,65 +296,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Effect+of+native+oxide+layers+on+copper+thin-film+tensile+properties:+A+reactive+molecular+dynamics+study&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "4187800ac995ae172c88b83f8c2c4da990d02934", "externalIds":
-          {"MAG": "2277923667", "DOI": "10.1063/1.4938384", "CorpusId": 124514389},
-          "url": "https://www.semanticscholar.org/paper/4187800ac995ae172c88b83f8c2c4da990d02934",
-          "title": "Effect of native oxide layers on copper thin-film tensile properties:
-          A reactive molecular dynamics study", "venue": "", "year": 2015, "citationCount":
-          8, "influentialCitationCount": 0, "isOpenAccess": false, "openAccessPdf":
-          null, "publicationTypes": null, "publicationDate": "2015-12-21", "journal":
-          {"name": "Journal of Applied Physics", "pages": "235306", "volume": "118"},
-          "citationStyles": {"bibtex": "@Article{Skarlinski2015EffectON,\n author =
-          {Michael Skarlinski and D. Quesnel},\n journal = {Journal of Applied Physics},\n
-          pages = {235306},\n title = {Effect of native oxide layers on copper thin-film
-          tensile properties: A reactive molecular dynamics study},\n volume = {118},\n
-          year = {2015}\n}\n"}, "authors": [{"authorId": "9821934", "name": "Michael
-          Skarlinski"}, {"authorId": "37723150", "name": "D. Quesnel"}], "matchScore":
-          283.7328}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1108"
-        Content-Type:
-          - application/json
-        Date:
-          - Tue, 13 Aug 2024 18:33:56 GMT
-        Via:
-          - 1.1 ddd3d8441374ce62d11d031216138152.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - 9aSLHkzNg4rEGApjVN3aOWzejo54f_82pKKm0MEtEsqwyPMjcpXhkw==
-        X-Amz-Cf-Pop:
-          - IAD55-P4
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - cdcKdFPEPHcEHWw=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1108"
-        x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:33:56 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 7df5e5d0-6891-4b52-8ea3-d7ecbd595932
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_title_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes0].yaml
@@ -3,7 +3,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/search?query=Effect%20of%20native%20oxide%20layers%20on%20copper%20thin-film%20tensile%20properties:%20A%20reactive%20molecular%20dynamics%20study&email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/search?query=Effect%20of%20native%20oxide%20layers%20on%20copper%20thin-film%20tensile%20properties:%20A%20reactive%20molecular%20dynamics%20study&email=test@example.com
     response:
       body:
         string:

--- a/tests/cassettes/test_title_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes1].yaml
@@ -3,15 +3,53 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.unpaywall.org/v2/search?query=PaperQA:%20Retrieval-Augmented%20Generative%20Agent%20for%20Scientific%20Research&email=api@futurehouse.org
+    response:
+      body:
+        string: '{"elapsed_seconds":0.011,"results":[]}
+
+          '
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "39"
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 29 Aug 2024 23:22:33 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724973753&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=7Ap4m1YZ4aLbo3b2Q9yXXrUrKhUit1f%2FFJGuK7MkyDg%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724973753&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=7Ap4m1YZ4aLbo3b2Q9yXXrUrKhUit1f%2FFJGuK7MkyDg%3D
+        Server:
+          - gunicorn
+        Via:
+          - 1.1 vegur
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=test@example.com&query.title=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2004346,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2013144,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
           University Press (OUP)","issue":"1","license":[{"start":{"date-parts":[[2024,2,21]],"date-time":"2024-02-21T00:00:00Z","timestamp":1708473600000},"content-version":"vor","delay-in-days":48,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"funder":[{"DOI":"10.13039\/100000092","name":"National
-          Library of Medicine","doi-asserted-by":"publisher","award":["R01LM009886","R01LM014344"]},{"DOI":"10.13039\/100006108","name":"National
-          Center for Advancing Translational Sciences","doi-asserted-by":"publisher","award":["UL1TR001873"]},{"DOI":"10.13039\/100000002","name":"National
-          Institutes of Health","doi-asserted-by":"publisher"}],"content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2024,1,4]]},"abstract":"<jats:title>Abstract<\/jats:title>\n               <jats:sec>\n                  <jats:title>Objective<\/jats:title>\n                  <jats:p>To
+          Library of Medicine","doi-asserted-by":"publisher","award":["R01LM009886","R01LM014344"],"id":[{"id":"10.13039\/100000092","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100006108","name":"National
+          Center for Advancing Translational Sciences","doi-asserted-by":"publisher","award":["UL1TR001873"],"id":[{"id":"10.13039\/100006108","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000002","name":"National
+          Institutes of Health","doi-asserted-by":"publisher","id":[{"id":"10.13039\/100000002","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2024,1,4]]},"abstract":"<jats:title>Abstract<\/jats:title>\n               <jats:sec>\n                  <jats:title>Objective<\/jats:title>\n                  <jats:p>To
           automate scientific claim verification using PubMed abstracts.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Materials
           and Methods<\/jats:title>\n                  <jats:p>We developed CliVER,
           an end-to-end scientific Claim VERification system that leverages retrieval-augmented
@@ -94,7 +132,7 @@ interactions:
           gain-based evaluation of IR techniques","volume":"20","author":"J\u00e4rvelin","year":"2002","journal-title":"ACM
           Trans Inf Syst"},{"key":"2024030720490192400_ooae021-B46","volume-title":"Evidence-Based
           Practice in Nursing & Healthcare: A Guide to Best Practice","author":"Melnyk","year":"2022"},{"key":"2024030720490192400_ooae021-B47","first-page":"206","author":"Gupta","year":"2017"},{"key":"2024030720490192400_ooae021-B48","first-page":"1","author":"Park","year":"2012"}],"container-title":["JAMIA
-          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":28.253725,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":28.277683,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -108,11 +146,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "4472"
+          - "4502"
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:33:57 GMT
+          - Thu, 29 Aug 2024 23:22:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -144,7 +182,7 @@ interactions:
           {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
           "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
           "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
-          "venue": "arXiv.org", "year": 2023, "citationCount": 21, "influentialCitationCount":
+          "venue": "arXiv.org", "year": 2023, "citationCount": 23, "influentialCitationCount":
           1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
           "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
           "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
@@ -156,7 +194,7 @@ interactions:
           "name": "Odhran O''Donoghue"}, {"authorId": "2258961451", "name": "Aleksandar
           Shtedritski"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId":
           "2258964497", "name": "Samuel G. Rodriques"}, {"authorId": "2273941271", "name":
-          "Andrew D. White"}], "matchScore": 245.13031}]}
+          "Andrew D. White"}], "matchScore": 245.03687}]}
 
           '
       headers:
@@ -169,27 +207,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:33:58 GMT
+          - Thu, 29 Aug 2024 23:22:33 GMT
         Via:
-          - 1.1 4f3476fc0ed69f4f9209b2ccb91b0050.cloudfront.net (CloudFront)
+          - 1.1 e18d3804375a86d48383ad266efc5b0a.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - CwsOIjMLqJMdElsyLdeS2wwxKXgCRhX8CmKCRqs0eqpUoxdjaDKKdw==
+          - ACfvWEQwtTn9OWE8v_ItFnmDiKM4OAIYWKREPthcdTiaBAVnwRbfYw==
         X-Amz-Cf-Pop:
-          - IAD55-P4
+          - LAX50-P5
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - cdcLUHkfPHcEbNA=
+          - dS1c9HJNvHcEu0Q=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1386"
         x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:33:58 GMT
+          - Thu, 29 Aug 2024 23:22:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 644ea493-688c-42a3-bfbf-e4778f4a1711
+          - 3ff3fb6b-1892-444c-963f-103bcff4fd87
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_title_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes1].yaml
@@ -3,7 +3,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/search?query=PaperQA:%20Retrieval-Augmented%20Generative%20Agent%20for%20Scientific%20Research&email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/search?query=PaperQA:%20Retrieval-Augmented%20Generative%20Agent%20for%20Scientific%20Research&email=test@example.com
     response:
       body:
         string: '{"elapsed_seconds":0.011,"results":[]}

--- a/tests/cassettes/test_title_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes2].yaml
@@ -3,14 +3,1675 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.unpaywall.org/v2/search?query=Augmenting%20large%20language%20models%20with%20chemistry%20tools&email=api@futurehouse.org
+    response:
+      body:
+        string:
+          '{"elapsed_seconds":0.316,"results":[{"response":{"best_oa_location":{"endpoint_id":null,"evidence":"open
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-07-28T13:13:26.235272","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"data_standard":2,"doi":"10.1038/s42256-024-00832-8","doi_url":"https://doi.org/10.1038/s42256-024-00832-8","first_oa_location":{"endpoint_id":null,"evidence":"open
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-07-28T13:13:26.235272","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"genre":"journal-article","has_repository_copy":true,"is_oa":true,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"2522-5839","journal_issns":"2522-5839","journal_name":"Nature
+          Machine Intelligence","oa_locations":[{"endpoint_id":null,"evidence":"open
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-07-28T13:13:26.235272","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},{"endpoint_id":null,"evidence":"oa
+          repository (via pmcid lookup)","host_type":"repository","is_best":false,"license":null,"oa_date":null,"pmh_id":null,"repository_institution":null,"updated":"2024-07-28T13:13:26.235373","url":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_landing_page":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_pdf":null,"version":"publishedVersion"}],"oa_locations_embargoed":[],"oa_status":"hybrid","published_date":"2024-05-08","publisher":"Springer
+          Science and Business Media LLC","title":"Augmenting large language models
+          with chemistry tools","updated":"2024-05-09T06:24:40.646053","year":2024,"z_authors":[{"family":"M.
+          Bran","given":"Andres","sequence":"first"},{"family":"Cox","given":"Sam","sequence":"additional"},{"ORCID":"http://orcid.org/0000-0003-0310-0851","authenticated-orcid":false,"family":"Schilter","given":"Oliver","sequence":"additional"},{"family":"Baldassari","given":"Carlo","sequence":"additional"},{"ORCID":"http://orcid.org/0000-0002-6647-3965","authenticated-orcid":false,"family":"White","given":"Andrew
+          D.","sequence":"additional"},{"ORCID":"http://orcid.org/0000-0003-3046-6576","authenticated-orcid":false,"family":"Schwaller","given":"Philippe","sequence":"additional"}]},"score":0.025694918,"snippet":"<b>Augmenting</b>
+          <b>large</b> <b>language</b> <b>models</b> with <b>chemistry</b> <b>tools</b>"},{"response":{"best_oa_location":{"endpoint_id":null,"evidence":"open
+          (via page says license)","host_type":"publisher","is_best":true,"license":"cc-by-nc","oa_date":"2021-12-31","pmh_id":null,"repository_institution":null,"updated":"2023-02-22T13:05:09.634202","url":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","url_for_landing_page":"https://doi.org/10.47205/jdss.2021(2-iv)74","url_for_pdf":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","version":"publishedVersion"},"data_standard":2,"doi":"10.47205/jdss.2021(2-iv)74","doi_url":"https://doi.org/10.47205/jdss.2021(2-iv)74","first_oa_location":{"endpoint_id":null,"evidence":"open
+          (via page says license)","host_type":"publisher","is_best":true,"license":"cc-by-nc","oa_date":"2021-12-31","pmh_id":null,"repository_institution":null,"updated":"2023-02-22T13:05:09.634202","url":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","url_for_landing_page":"https://doi.org/10.47205/jdss.2021(2-iv)74","url_for_pdf":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","version":"publishedVersion"},"genre":"journal-article","has_repository_copy":false,"is_oa":true,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":true,"journal_issn_l":"2709-6254","journal_issns":"2709-6254,2709-6262","journal_name":"Journal
+          of Development and Social Sciences","oa_locations":[{"endpoint_id":null,"evidence":"open
+          (via page says license)","host_type":"publisher","is_best":true,"license":"cc-by-nc","oa_date":"2021-12-31","pmh_id":null,"repository_institution":null,"updated":"2023-02-22T13:05:09.634202","url":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","url_for_landing_page":"https://doi.org/10.47205/jdss.2021(2-iv)74","url_for_pdf":"https://jdss.org.pk/issues/v2/4/water-sharing-issues-in-pakistan-impacts-on-inter-provincial-relations.pdf","version":"publishedVersion"}],"oa_locations_embargoed":[],"oa_status":"gold","published_date":"2021-12-31","publisher":"Pakistan
+          Social Sciences Research Institute (PSSRI)","title":"(2021) Volume 2, Issue
+          4 Cultural Implications of China Pakistan Economic Corridor (CPEC Authors:
+          Dr. Unsa Jamshed Amar Jahangir Anbrin Khawaja Abstract: This study is an attempt
+          to highlight the cultural implication of CPEC on Pak-China relations, how
+          it will align two nations culturally, and what steps were taken by the governments
+          of two states to bring the people closer. After the establishment of diplomatic
+          relations between Pakistan and China, the cultural aspect of relations between
+          the two states also moved forward. The flow of cultural delegations intensified
+          after the 2010, because this year was celebrated as the \u2018Pak-China Friendship
+          Year\u2019. This dimension of relations further cemented between the two states
+          with the signing of CPEC in April 2015. CPEC will not only bring economic
+          prosperity in Pakistan but it will also bring two states culturally closer.
+          The roads and other communication link under this project will become source
+          of cultural flow between the two states. Keyswords: China, CPEC, Culture,
+          Exhibitions Pages: 01-11 Article: 1 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)01
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)01 Download Pdf: download
+          pdf view article Creative Commons License Political Persona on Twittersphere:
+          Comparing the Stardom of Prime Minister(s) of Pakistan, UK and India Authors:
+          Maryam Waqas Mudassar Hussain Shah Saima Kausar Abstract: Political setup
+          demands to use Twittersphere for preserving its reputation because of significant
+          twitter audience, which follows celebrities and political figures. In this
+          perspective, political figures frequently use twitter to highlight their political
+          as well as personal lives worldwide. However, political figures take the stardom
+          status among the twitter audience that follow, retweet and comment by their
+          fans. The purpose of this study is, to analyze what kind of language, level
+          of interest is made by political figures while communicating via twitter,
+          text, phrases and languages used by political figures, and do their tweets
+          contribute in their reputation. The qualitative content analysis is used for
+          evaluation of the interests shared by PM Imran Khan, PM Boris John Son and
+          PM Narendra Modi with the key words of tweets. A well-established coding sheet
+          is developed for the analysis of text, phrases and words in the frames of
+          negative, positive and neutral from March 2020 to May 2020. The results are
+          demonstrating on the basis of content shared by Prime Ministers of three countries
+          i.e., From Pakistan, Imran Khan, United Kingdom, Johnson Boris and India,
+          Narendra Modi on twitter. The findings also reveal that varied issues discussed
+          in tweets, significantly positive and neutral words are selected by these
+          political figures. PM Imran tweeted more negative tweets than PM Boris Johnson
+          and PM Narendra Modi. However, PM Boris Johnson and PM Narendra Modi make
+          significant positive and neutral tweets. It is observed that political figures
+          are conscious about their personal reputation while tweeting. It also revealed
+          that the issues and tweets shared by these leaders contribute to their personal
+          reputation. Keyswords: Imran Khan, Johnson Boris, Narendra Modi, Political
+          Persona, Stardom, Twittersphere Pages: 12-23 Article: 2 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)02 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)02
+          Download Pdf: download pdf view article Creative Commons License An Empirical
+          Relationship between Government Size and Economic Growth of Pakistan in the
+          Presence of Different Budget Uncertainty Measures Authors: Sunila Jabeen Dr.
+          Wasim Shahid Malik Abstract: Relationship between government size and economic
+          growth has always been a debated issue all over the world since the formative
+          work of Barro (1990). However, this relationship becomes more questionable
+          when policy uncertainty is added in it. Hence, this paper presents evidence
+          on the effect of government size on economic growth in the presence of budget
+          uncertainty measured through three different approaches. Rather than relying
+          on the traditional and complicated measures of uncertainty, a new method of
+          measuring uncertainty based on government budget revisions of total spending
+          is introduced and compared with the other competing approaches. Using time
+          series annual data from 1973-2018, the short run and long run coefficients
+          from Autoregressive Distributed Lag (ARDL) framework validate the negative
+          effect of budget uncertainty and government size on economic growth of Pakistan
+          regardless of the uncertainty measure used. Therefore, to attain the long
+          run economic growth, along with the control on the share of government spending
+          in total GDP, government should keep the revisions in the budget as close
+          to the initial announcements as it can so that uncertainty can be reduced.
+          Further, the uncertainty in fiscal spending calculated through the deviation
+          method raises a big question on the credibility of fiscal policy in Pakistan.
+          Higher will be the deviation higher will be the uncertainty and lower the
+          fiscal policy credibility hence making fiscal policy less effective in the
+          long run. Keyswords: Budget Uncertainty, Economic Growth, Government Size,
+          Policy Credibility Pages: 24-38 Article: 3 , Volume 2 , Issue 4 DOI Number:
+          10.47205/jdss.2021(2-IV)03 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)03
+          Download Pdf: download pdf view article Creative Commons License Despair in
+          The Alchemist by Ben Jonson Authors: Dr. Fatima Syeda Dr. Faiza Zaheer Numrah
+          Mehmood Abstract: This research aims to challenge the assumption that The
+          Alchemist by Ben Jonson is one of the greatest examples of the \u201cexplicit
+          mirth and laughter\u201d (Veneables 86). The paper argues that The Alchemist
+          is a cynical and despairing play created in an atmosphere not suitable for
+          a comedy. This is a qualitative study of the text and aims at an analysis
+          of the theme, situations, characters, language, and the mood of the play to
+          determine that Jonson is unable to retain the comic spirit in The Alchemist
+          and in an attempt to \u201cbetter men\u201d (Prologue. 12) he becomes more
+          satirical and less humorous or comic. This research is important for it contends
+          that the play, termed as a comedy, may be read as a bitter satire on the cynical,
+          stinky, and despairing world of the Elizabethan times. Keyswords: Comedy,
+          Despair, Reformation Pages: 39-47 Article: 4 , Volume 2 , Issue 4 DOI Number:
+          10.47205/jdss.2021(2-IV)04 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)04
+          Download Pdf: download pdf view article Creative Commons License Analysis
+          of Principles of Coordinated Border Management (CBM) in articulation of War-Control
+          Strategies: An Account of Implementation Range on Pakistan and Afghanistan
+          Authors: Dr. Sehrish Qayyum Dr. Umbreen Javaid Abstract: Currently, Border
+          Management is crucial issue not only for Pakistan but for the entire world
+          due to increased technological developments and security circumstances. Pakistan
+          and Afghanistan being immediate states have inter-connected future with socio-economic
+          and security prospects. Principles of Coordinated Border Management (CBM)
+          approach have been extracted on the basis of in-depth interviews with security
+          agencies and policymakers to understand the real time needs. The current research
+          employs mixed method approach. Process Tracing is employed in this research
+          to comprehend the causal mechanism behind the contemporary issue of border
+          management system. A detailed statistical analysis of prospect outcomes has
+          been given to validate the implication of CBM. Implication range of CBM has
+          been discussed with positive and probably negative impacts due to its wide
+          range of significance. This research gives an analysis of feasibility support
+          to exercise CBM in best interest of the state and secure future of the region.
+          Keyswords: Afghanistan, Coordinated Border Management, Fencing, Pakistan,
+          Security Pages: 48-62 Article: 5 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)05
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)05 Download Pdf: download
+          pdf view article Creative Commons License The Belt and Road Initiative (BRI)
+          vs. Quadrilateral Security Dialogue (the Quad): A Perspective of a Game Theory
+          Authors: Muhammad Atif Prof. Dr. Muqarrab Akbar Abstract: Containment is the
+          central part of the U.S.''s foreign policy during the cold war. With the application
+          of containment Policy, the U.S. achieved much success in international politics.
+          Over time China has become more powerful and sees great power in international
+          politics. China wants to expand and launched the Belt and Road Initiative
+          (BRI). The primary purpose of The Belt and Road Initiative (BRI) is to achieve
+          support from regional countries and save their interests from the U.S. In
+          2017, the American administration launched its Containment policy through
+          Quadrilateral Security Dialogue (the Quad) to keep their interest from China.
+          The Quadrilateral Security Dialogue (Quad) is comprising of Australia, the
+          United States, Japan, and India. This Study is based on Qualitative research
+          with theoretical application of Game theory. This research investigates both
+          plans of China (BRI) and the U.S. (the Quad) through a Game Theory. In this
+          study, China and the U.S. both like to act as gamers in international politics.
+          This study recommends that Game theory can predict all developments in the
+          long term. Keyswords: Containment, Expansionism, Quadrilateral Security Dialogue,
+          The Belt and Road Initiative (BRI) Pages: 63-75 Article: 6 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)06 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)06
+          Download Pdf: download pdf view article Creative Commons License Narendra
+          Modi a Machiavellian Prince: An Appraisal Authors: Dr. Imran Khan Dr. Karim
+          Haider Syed Muhammad Yousaf Abstract: The comparison of Narendra Modi and
+          Machiavellian Prince is very important as policies of Modi are creating problems
+          within India and beyond the borders. The Prince is the book of Niccolo Machiavelli
+          a great philosopher of his time. If Indian Prime Minister Narendra Modi qualifies
+          as a Prince of Machiavelli is a very important question. This is answered
+          in the light of his policies and strategies to become the undisputed political
+          leader of India. Much of the Machiavellian Prince deals with the problem of
+          how a layman can raise himself from abject and obscure origins to such a position
+          that Narendra Modi has been holding in India since 2014. The basic theme of
+          this article is revolving around the question that is following: Can Modi\u2019s
+          success be attributed to techniques of The Prince in important respects? This
+          article analyzed Narendra Modi''s policies and strategies to develop an analogy
+          between Machiavellian Prince and Modi in terms of characteristics and political
+          strategies. This research work examines, how Narendra Modi became the strongest
+          person in India. Keyswords: Comparison, India, Machiavelli, Modus Operandi,
+          Narendra Modi Pages: 76-84 Article: 7 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)07
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)07 Download Pdf: download
+          pdf view article Creative Commons License Analyzing Beckett''s Waiting for
+          Godot as a Political Comedy Authors: Muhammad Umer Azim Dr. Muhammad Saleem
+          Nargis Saleem Abstract: This study was devised to analyze Samuel Beckett\u2019s
+          play Waiting for Godot in the light of Jean-Francois Lyotard\u2019s theory
+          of postmodernism given in his book The Postmodern Condition (1984). This Lyotardian
+          paradigm extends a subversive challenge to all the grand narratives that have
+          been enjoying the status of an enviable complete code of life in the world
+          for a long time. Even a cursory scan over the play under analysis creates
+          a strong feel that Beckett very smartly, comprehensively and successfully
+          questioned the relevance of the totalizing metanarratives to the present times.
+          Being an imaginative writer, he was well aware of the fact that ridicule is
+          a much more useful weapon than satire in the context of political literature.
+          There are so many foundationalist ideologies that he ridicules in his dramatic
+          writing. Christianity as a religion is well exposed; the gravity of philosophy
+          is devalued; the traditional luxury that the humans get from the art of poetry
+          is ruptured and the great ideals of struggle are punctured. He achieves his
+          artistic and ideologically evolved authorial intentions with a ringing success.
+          It is interesting to note that he maintains a healthy balance between art
+          and message. Keyswords: Beckett, Lyotard, The Postmodern Condition, Waiting
+          for Godot Pages: 85-94 Article: 8 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)08
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)08 Download Pdf: download
+          pdf view article Creative Commons License Effect of Parenting Styles on Students\u2019
+          Academic Achievement at Elementary Level Authors: Hafsa Noreen Mushtaq Ahmad
+          Uzma Shahzadi Abstract: The study intended to find out the effect of parenting
+          styles on students\u2019 academic achievement. Current study was quantitative
+          in nature. All elementary level enrolled students at government schools in
+          the province of the Punjab made the population of the study. Multistage sampling
+          was used to select the sample from four districts of one division (Sargodha)
+          of the Punjab province i.e., Sargodha. A sample size i.e., n=960; students
+          and their parents were participated in this study. Research scales i.e. Parenting
+          Styles Dimension Questionnaire (PSDQ) was adapted to analyze and measure parents\u2019
+          parenting styles and an achievement test was developed to measure the academic
+          achievement of the elementary students. After pilot testing, reliability coefficient
+          Cronbach Alpha values for PSDQ and achievement test were 0.67 and 0.71 Data
+          was collected and analyzed using frequencies count, percentages, mean scores
+          and one way ANOVA. Major findings of the study were; Majority of the parents
+          had authoritative parental style, a handsome number of parents keep connection
+          of warmth and support with their children, show intimacy, focus on discipline,
+          do not grant autonomy to their children, do not indulge with their children
+          and as well as a handsome number of students were confident during their studies
+          and study, further, found that parental style had positive relationship with
+          academic achievement. Recommendations were made on the basis of findings and
+          conclusion such as arrangement of Parents Teachers Meetings (PTM\u2018s),
+          parents\u2019 training, provision of incentives and facilities to motivate
+          families might be an inclusive component of elementary education program.
+          Keyswords: Academic Achievement, Elementary Education, Parenting Styles Pages:
+          95-110 Article: 9 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)09
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)09 Download Pdf: download
+          pdf view article Creative Commons License Kashmir Conflict and the Question
+          of Self-Determination Authors: Izzat Raazia Saqib Ur Rehman Abstract: The
+          objective of this paper is to explore relations between Pakistan and India
+          since their inception in the perspective of Kashmir conundrum and its impact
+          on the regional security. Kashmir is the unfinished agenda of partition and
+          a stumbling block in the bilateral relations between Pakistan and India. After
+          the partition of sub-continent in 1947, Pakistan and India got their sovereign
+          status. Kashmir conflict, a disputed status state, is the byproduct of partition.
+          Pakistan and India are traditional arch-foes. Any clash between Pakistan and
+          India can bring the two nuclear states toe-to-toe and accelerate into nuclear
+          warfare. Due to the revulsion, hostility and lack of trust between the two,
+          the peaceful resolution of the Kashmir issue has been long overdue. Ever-increasing
+          border spats, arms race and threat of terrorism between the two have augmented
+          anxiety in the subcontinent along with the halt of talks between India and
+          Pakistan at several times. Additionally, it hampers the economic and trade
+          ties between the two. India, time and again, backtracked on Kashmir issue
+          despite UN efforts to resolve the issue. Recently, Indian government has responded
+          heavy-handedly to the Kashmiri agitators\u2019 demand for sovereignty and
+          revocation of \u2018Special Status\u2019 of Kashmir impacting the stability
+          of the region in future. Keyswords: India, Kashmir Conundrum, Pakistan, Regional
+          Security, Sovereignty Pages: 111-119 Article: 10 , Volume 2 , Issue 4 DOI
+          Number: 10.47205/jdss.2021(2-IV)10 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)10
+          Download Pdf: download pdf view article Creative Commons License Exploring
+          Image of China in the Diplomatic Discourse: A Critical Discourse Analysis
+          Authors: Muhammad Afzaal Muhammad Ilyas Chishti Abstract: The present study
+          hinges on the major objective of analyzing Pakistani and Indian diplomatic
+          discourses employed in portrayal of image of China. Data comprises the official
+          discourse which is used in diplomatic affairs of both the states. The extensive
+          investigation seeks insights from the fundamentals of Critical Discourse Analysis
+          propounded by van Dijk, Fairclough and Wodak with a special focus on Bhatia\u2019s
+          (2006) work. The study reveals that the image of China has always been accorded
+          priority within Indian and Pakistani diplomatic discourse even though nature
+          of bilateral relations among China, India and Pakistan is based on entirely
+          different dynamics; Indian and Pakistani diplomatic discourses are reflective
+          of sensitivities involved within the bilateral relations. Through employment
+          of linguistic techniques of \u2018positivity\u2019, \u2018evasion\u2019 and
+          \u2018influence and power\u2019, Indian diplomats have managed not to compromise
+          over the fundamentals in bilateral relations with China despite Pakistan\u2019s
+          already strengthened and deep-rooted relations with China. While Pakistani
+          diplomatic fronts have been equally successful in further deepening their
+          already strengthened relations in the midst of surging controversies on CPEC,
+          BRI and OBOR. Hence, diplomatic fronts of both the counties, through employment
+          of ideologically loaded linguistic choices, leave no stone unturned in consolidation
+          of the diplomatic relations with China. Keyswords: CDA, China Image, Corpus,
+          Language of Diplomacy, Political Discourse Analysis Pages: 120-133 Article:
+          11 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)11 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)11
+          Download Pdf: download pdf view article Creative Commons License Students\u2019
+          Perception about Academic Advising Satisfaction at Higher Education Level
+          Authors: Rukhsana Sardar Zarina Akhtar Shamsa Aziz Abstract: The purpose of
+          the study was to examine the students\u2019 perception about academic advising
+          satisfaction at higher education level. All the students from two years master
+          (M.A) degree programme and four years (BS) degree programme of eight departments
+          from International Islamic University Islamabad (IIUI), Faculty of Social
+          Sciences were taken as a population of the study. 475 students were randomly
+          selected as a sample of the study. The Academic Advising Inventory (AAI) was
+          used to assess Academic Advising Style. For measuring level of the satisfaction,
+          descriptive statistics was used. To compare the mean difference department-wise
+          and gender-wise about academic advising satisfaction t.test was applied. It
+          was concluded that from the major findings of the study those students who
+          received departmental academic advising style are more satisfied as compared
+          to those students who provided prescriptive academic advising style. Female
+          students seemed more satisfied as compared to male students regarding the
+          academic advising style provided to them. Students who satisfied from developmental
+          academic advising style and they were also highly satisfied from the advising
+          provided to them at Personalizing Education (PE) and this is the subscale
+          of developmental academic advising whereas students who received prescriptive
+          academic advising they were also satisfied from the advising provided to them
+          regarding personalizing education and academic decision making but their percentage
+          is less. It is recommended to Universities Administration to focus on Developmental
+          Academic Advising Style and establish centers at universities/department level
+          and nominate staff who may be responsible to provide developmental academic
+          advising. Keyswords: Academic Advising, Higher Level, Students\u2019 Perception
+          Pages: 134-144 Article: 12 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)12
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)12 Download Pdf: download
+          pdf view article Creative Commons License Perceptions of Sexual Harassment
+          in Higher Education Institutions: A Gender Analysis Authors: Ruhina Ghassan
+          Dr. Subha Malik Nayab Javed Abstract: Sexual harassment is a social issue
+          which is present in every society, globally, which interferes in an individual\u2019s
+          social and professional life. It happens almost everywhere i.e. at workplaces,
+          public places or institutes as well. The focus of the present study was to
+          explore the differences of male and female students\u2019 perception of sexual
+          harassment. This study was a quantitative research. Sample of the study included
+          of 400 students (200 males and 200 females) from two government and two private
+          universities. In the present study, Sexual Harassment Perception Questionnaire
+          (SHPQ) was used to find out these differences in perceptions as every person
+          has his own view for different situations. The study revealed the significant
+          differences in perception of students. Study showed that both genders perceived
+          that female students get more harassed than male students. The factors that
+          affect the perception frequently were gender and age. The findings recommended
+          that regulations for sexual harassment should be implemented in universities;
+          laws should be made for sexual harassment in higher education institutes.
+          Students should be aware of sexual harassment through seminars, self-defense
+          classes and awareness campaigns. And every institute should have a counseling
+          center for the better mental health of students. Keyswords: Gender Differences,
+          Higher Educational Institutions, Sexual Harassment Pages: 145-158 Article:
+          13 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)13 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)13
+          Download Pdf: download pdf view article Creative Commons License Role of IMF
+          Over the Governance Structure and Economic Development of Pakistan Authors:
+          Ali Qamar Sheikh Dr. Muhammad Imran Pasha Muhammad Shakeel Ahmad Siddiqui
+          Abstract: Developing countries like Pakistan seeks for financial assistance
+          in order to fulfil their deficits. IMF is one of the largest financial institution
+          who give loans to countries who need it. This research has studied the IMF
+          role and the effects of IMF conditions on the economy of Pakistan. To carry
+          out this research, both quantitative data from primary sources has been gathered
+          and qualitative analysis has been made to signify whither this borrowing creating
+          and maintaining dependency of Pakistan on West and financial and governance
+          structure constructed to curtail Countries like Pakistan. The results concluded
+          that there is negative and insignificant relationship between GDP and IMF
+          loans in the long run. The short-term dynamic shows that weak economic and
+          Political Institutions in Pakistan. The Development dilemma constitutes dependency
+          even today. The Current Budget Deficit Pakistan''s fiscal deficit climbs to
+          Rs 3.403 trillion in 2020-21 needs to be readdressed in such a manner that
+          Pakistan can counter Balance of Payments and import/export imbalance. Keyswords:
+          Dependency, Development, IMF, Loans, Debt, Pakistan, Governance structure
+          Pages: 159-172 Article: 14 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)14
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)14 Download Pdf: download
+          pdf view article Creative Commons License Climate Change and the Indus Basin:
+          Prospects of Cooperation between India and Pakistan Authors: Sarah Saeed Prof.
+          Dr. Rana Eijaz Ahmad Abstract: Climate change is transforming the global societies.
+          The shift in average temperature is putting negative impacts on human health,
+          food production and the natural resources. In the wake of the altered climate,
+          water flow in the river systems is experiencing variability and uncertainty.
+          This paper aims at studying the negative impacts of climate change on the
+          water resources of the Indus Basin and investigate the prospects of cooperation
+          between India and Pakistan; two major riparian nations sharing the basin.
+          Adopting the case study approach, a theoretical framework has been built on
+          the \u2018Theory of the International Regimes\u2019. It has been argued that
+          institutional capacity and the dispute resolution mechanism provided in any
+          water sharing agreement determine the extent of cooperation among the member
+          states. Since India and Pakistan are bound by the provisions of the Indus
+          Waters Treaty, this study tries to assess the effectiveness of this agreement
+          in managing the negative consequences of the climate change. Keyswords: Climate
+          Change, Cooperation, Dispute Resolution Mechanism, Institutional Capacity
+          Pages: 173-185 Article: 15 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)15
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)15 Download Pdf: download
+          pdf view article Creative Commons License Translation, Cultural Adaptation
+          and Validation of Behavioral-Emotional Reactivity Index for Adolescents Authors:
+          Saima Saeed Farah Malik Suzanne Bartle Haring Abstract: Measuring differentiation
+          of self in terms of behavioral/emotional reactivity towards parents is important
+          because of the complex parent-child connection. This needs a valid and reliable
+          measure to assess the differentiation of self particularly in a relationship
+          with parents. Behavior\\Emotional Reactivity Index is such a tool that fulfills
+          this purpose. The present study was carried out to culturaly adapt and translate
+          BERI into the Urdu language and establish the psychometric properties of Urdu
+          version. A sample of 303 adolescents of age (M = 16.07, SD = 1.77) was taken
+          from different schools and colleges. Scale was split into Mother and father
+          forms for the convenience of respondents. Findings supported the original
+          factor structure of the BERI-original version. Higher-order factor analysis
+          showed good fit indices with excellent alpha ranges (\u03b1= .91 to \u03b1=.80).
+          BERI scores were compared for the adolescents who were securely attached with
+          parents and insecurely attached with parents which showed a significant difference
+          between the groups. BERI-Urdu version was found to be a valid and reliable
+          measure in the Pakistani cultural context which gives researchers new directions
+          to work with adolescents. Keyswords: Adolescence, Differentiation of Self,
+          Behavioral, Emotional Reactivit, Index, Parental Attachment Pages: 186-200
+          Article: 16 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)16 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)16 Download Pdf: download pdf
+          view article Creative Commons License Notion of Repression in Modern Society:
+          A Comparative Analysis of Sigmund Freud and Herbert Marcuse Authors: Khadija
+          Naz Abstract: One of the fundamental issues for modern civilized man is how
+          to adapt a modern society without losing his individual status. Is it possible
+          for an individual to adjust in a society where he/she loses his/her individuality
+          and becomes part of collectivity? One point of view is that for society to
+          flourish, man needs to be repressed. But to what extent is repression necessary
+          for societies to rise and survive? This paper shall examine the above given
+          questions from the standpoint of two thinkers who greatly influenced twentieth-century
+          thought: Sigmund Freud and Herbert Marcuse. To undertake this task, first
+          the term Repression shall be examined and then the notions of Freud and Marcuse
+          will be discussed to determine the degree of repression required for the development
+          of modern society. Keyswords: Modern Society, Performance Principle, Repression,
+          Surplus-Repression, The Pleasure Principle, The Reality Principle Pages: 201-214
+          Article: 17 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)17 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)17 Download Pdf: download pdf
+          view article Creative Commons License Perceptions of Teacher Educators about
+          Integration of (ESD) in Elementary Teachers Education Program Authors: Dr.
+          Rukhsana Durrani Dr. Fazal ur Rahman Dr. Shaista Anjum Abstract: Education
+          and sustainable development have a close relationship as education provides
+          sustainability to society. This study explored the perceptions of teacher
+          educators for integration of Education for Sustainable Development (ESD) in
+          B.Ed. 4 years\u2019 elementary program. Four major components of ESD i.e.,
+          Education, Social &amp; Culture, Economic and Environment were included in
+          study. 127 teacher educators from departments of education were randomly selected
+          from public universities of Pakistan who were offering B.Ed. 4 years\u2019
+          elementary program. Data was collected through questionnaires from teacher
+          educators. The findings recommended the inclusion of the components of Education
+          for Sustainable Development (ESD) in curriculum of B.Ed. 4 years\u2019 elementary
+          program. Keyswords: B.Ed. 4 Years Elementary Curriculum, Sustainable Development,
+          Integration, Teacher Education Pages: 215-225 Article: 18 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)18 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)18
+          Download Pdf: download pdf view article Creative Commons License Exploring
+          TPACK skills of prospective teachers and challenges faced in digital technology
+          integration in Pakistan Authors: Tariq Saleem Ghayyur Dr. Nargis Abbas Mirza
+          Abstract: The current study was aimed to explore TPACK skills of prospective
+          teachers and challenges faced in digital technology integration in Pakistan.
+          The study was qualitative in nature and semi structured interview schedule
+          was developed to collect data from prospective teachers. Purposive sampling
+          technique was employed to collect data from 20 prospective teachers of 7 public
+          sector universities. It was concluded that majority of the prospective teachers
+          used general technological and pedagogical practices (GTPP), technological
+          knowledge practices (TKP), Technological Pedagogical Knowledge practices (TPKP),
+          Technological Content Knowledge practices (TCKP). Majority of prospective
+          teachers reported multiple challenges in integration of digital technology
+          in teacher education programs including lack of teacher training as one of
+          the largest hurdle in digital technology integration, lack of digital technology
+          resources or outdated digital technology resources, inadequate computer lab,
+          lack of learning apps (courseware), financial constraints, lack of teachers\u2019
+          motivation to use digital technology, slow computers available at computer
+          labs, and unavailability of technical support. It was recommended that digital
+          technology infrastructure should be improved across all teacher education
+          institution and it was further recommended that TPACK model of digital technology
+          integration should serve digital technology integration in teacher education
+          programs in Pakistan. Keyswords: Challenges, Digital Technology Integration,
+          Digital Technology Resources, Digital Technology, TPACK Pages: 226-241 Article:
+          19 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)19 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)19
+          Download Pdf: download pdf view article Creative Commons License Revisiting
+          the Linkage between Money Supply and Income: A Simultaneous Equation Model
+          for Pakistan Authors: Zenab Faizullah Dr. Shahid Ali Muhammad Imad Khan Abstract:
+          A reliable estimate of the money supply is an important sign of the Gross
+          Domestic Product (GDP) and many other macroeconomic indicators. It is widely
+          discussed that over a long period of time, there is a strong link between
+          GDP and money supply. This link is significantly important for formation of
+          monetary policy. The main aim of this study is to estimate the income-money
+          supply model for Pakistan. This study estimates the income-money supply model
+          for Pakistan over the period of 2009 to 2019. The study uses Two Stage Least
+          Square (2SLS) econometric technique due to the presence of endogeneity problem
+          in the model under consideration. The existence of simultaneity between money
+          supply (M2) and income (GDP) is also clear from the results of Hausman Specification
+          test for simultaneity between M2 and GDP. The results further show that there
+          exists a strong money-income relationship in case of Pakistan. Keyswords:
+          Money Supply, Income, Simultaneous Equations Pages: 242-247 Article: 20 ,
+          Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)20 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)20
+          Download Pdf: download pdf view article Creative Commons License Analyzing
+          the Mechanism of Language Learning Process by the Use of Language Learning
+          Strategies Authors: Shafiq Ahmad Farooqi Dr. Muhammad Shakir Sher Muhammad
+          Awan Abstract: This analytical research study involves the use of learning
+          strategies to know the mechanism of learning a second language. People acquire
+          their native language (L1) without any conscious effort and they have a complete
+          knowledge of L1 and are competent in their native language even without going
+          to school. It is believed that language learning is a process as well as an
+          outcome and the focus of current study is to understand the process of learning
+          a second language. The population in this study comprised of 182 boys and
+          Girls Govt. Higher Secondary Schools studying at intermediate level in the
+          11 Districts of the Southern Punjab. The sample was selected through random
+          probability sampling and consisted of 40 subject specialists teaching the
+          subject of English in Govt. higher secondary schools with 400 students studying
+          English at Intermediate level. A questionnaire comprising some common and
+          easily accessible learning strategies was designed to determine the frequency
+          of these strategies used in the classrooms by the language learners through
+          the specialists of the subject. The data was collected from the selected sample
+          through the subject specialists teaching in these schools. The data was collected
+          quantitatively and was analyzed in the statistical package for social sciences
+          (SPSS) version 20. The most common 27 language learning strategies (LLS) were
+          applied to analyze the process of language learning. In the light of the results
+          of the study, it was concluded that application of the learning strategies
+          according to the nature of the text is helpful in understanding the language
+          functions and its application. Keyswords: Language Acquisition, Learning Strategies,
+          Mechanism of Language Learning Pages: 249-258 Article: 21 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)21 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)21
+          Download Pdf: download pdf view article Creative Commons License Secondary
+          School Science Teachers\u2019 Practices for the Development of Critical Thinking
+          Skills: An Observational Study Authors: Dr. Muhammad Jamil Dr. Yaar Muhammad
+          Dr. Naima Qureshi Abstract: In the National curriculum policy documents, to
+          produce rationale and independent critical thinkers, different pedagogical
+          practices have been recommended like cooperative learning, questioning, discussion,
+          etc. This qualitative case study aimed at analyzing secondary school science
+          teachers\u2019 practices for the development of critical thinking skills in
+          secondary school students. There were twelve classrooms (four from each subject
+          of Physics, Chemistry and Biology) selected as cases. Video recording was
+          used for the observations for six lessons in each classroom. In this way,
+          a total of 72 observations were conducted lasting for approximately 35 minutes.
+          Qualitative content analysis was used for data analysis through Nvivo 12.
+          The findings of the observations revealed that all the teachers used the lecture
+          method. They used this to cover the content at a given specific time. There
+          was not much focus on the development of critical thinking. In a few of the
+          classrooms, the students were engaged and active during learning different
+          specific topics. Whiteboard was used as a visual aid by most of the teachers.
+          Furthermore, to some extent, discussion, questioning, and daily life examples
+          were used in different classrooms. It is recommended that teachers\u2019 professional
+          development should be conducted to focus on the development of critical thinking
+          skills through pedagogical practices which have been recommended by the national
+          education policy documents. Keyswords: Analysis, Critical Thinking, Curriculum
+          Policy, Pedagogy, Secondary Level Pages: 259-265 Article: 22 , Volume 2 ,
+          Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)22 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)22
+          Download Pdf: download pdf view article Creative Commons License Historical
+          Development of Clinical Psychology in Pakistan: A Critical Review-based Study
+          Authors: Muhammad Nawaz Shahzad Dr. Mushtaq Ahmad Dr. Muhammad Waseem Tufail
+          Abstract: Clinical Psychology is clinical and curing psychological practices
+          in Pakistan. The present research study endeavors to examine the contemporary
+          status of Clinical Psychology in the country and descriptively analyzes the
+          significant contribution of various psychologists in its development. The
+          study also elaborates the emergence of Clinical Psychology and its treatment
+          aspects in the country. The experimental approach of the treatment psychology
+          has also been defined. The role of different scholars to set and promote the
+          Clinical Psychology as discipline and dealing about treatment of Human mind
+          has also been discussed here. The study also presented the scenario of the
+          issues of legislative acknowledgment, qualifications mandatory for practice,
+          communal awareness of cerebral treatment, the tradition of ethnic and native
+          practices about the clinical psychological treatments has also been discussed.
+          Keyswords: Approaches, Clinical Psychology, Psychologist, Therapist Pages:
+          266-272 Article: 23 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)23
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)23 Download Pdf: download
+          pdf view article Creative Commons License Impact of Devolution of Power on
+          School Education Performance in Sindh after 18th Constitutional Amendment
+          Authors: Abdul Hafeez Dr. Saima Iqbal Muhammad Imran Abstract: Devolution
+          of the authority from central units of empowering authorities to the local
+          level to develop and exercise policies at local or organizational level is
+          under debate in various countries of the world. The legation in with the name
+          of 18th constitutional amendment in constitution of 1973 of Pakistan ensures
+          more autonomy to federal units. The difference between province and federation
+          mostly creates misunderstanding in the belief of cooperation and universalism
+          of education standards, expenditures and service delivery. Very currently
+          the ministry of education and local government encoring principles and headmasters
+          to adopt self-management skills to be updated to accept the spin of power
+          from higher authorities to lower authorities\u2019 pedagogical and local schools.
+          In this qualitative research semi structured questioner were incorporated
+          as data collection tool equally, the data was analyzed by usage of NVivo software.
+          In this regard Government of Sindh has introduced various reforms and new
+          trends like objectives and policy pillars, better government schools, improved
+          learning outcomes and increased and improved funding in the education sector
+          Sindh government has so far been unable to effectively use its resources to
+          implement effective governance system which provides quality and sustained
+          education in the province. To achieve this basic universal education, equally
+          fourth objective of Sustainable Development Goal (SDG) the educational leaders
+          must develop a comparative education setup that help to educate planers to
+          plan and design standards for school leaders, instruction, appropriate professional
+          development of teachers, ways to support school leaders to change in mission.
+          Parallel, develop new program for early childhood, school and class size and
+          ensure school enrollment. Keyswords: 18th Constitutional Amendment, Devolution
+          of Power, Sindh Education Performance Pages: 273-285 Article: 24 , Volume
+          2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)24 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)24
+          Download Pdf: download pdf view article Creative Commons License Legal Aspects
+          of Evidence Collected by Modern Devices: A Case Study Authors: Muhammad Hassan
+          Zia Alvina Ali Abstract: This paper is a qualitative research of different
+          case laws dealing with modern technological evidence. Courts were required
+          to adopt new methods, techniques and devices obtained through advancement
+          of science without affecting the original intention of law. Because of modern
+          technology, a benefit could be taken from said technology to preserve evidences
+          and to assist proceedings of the Court in the dispensation of justice in modern
+          times. Owing to the scientific and technological advancements the admissibility
+          of audio and visual proofs has grown doubtful. No doubt modern evidence assist
+          the court in reaching out to the just decision but at the same time certain
+          criteria need to be laid down which must be satisfied to consider such evidence
+          admissible. Different Case laws are discussed here to show how the cases were
+          resolved on the basis of technological evidence and when and why such evidence
+          have been rejected by the court, if it did. Moreover, legal practices developed
+          in various countries allow our Courts to record evidence through video conferencing.
+          The Honorable Supreme Court of Pakistan directed that in appropriate cases
+          statement of juvenile rape victims and other cases of sensitive nature must
+          be recorded through video conferencing to avoid inconvenience for them to
+          come to the Court. Nevertheless, it has some problems. The most important
+          among them is the identification of the witness and an assurance that he is
+          not being prompted when his statement is recorded. In this paper protocols
+          that are necessary to follow while examining witness through video link are
+          discussed Keyswords: DNA Profiling, Finger Prints, , Telephone Calls, Video
+          Tape Pages: 286-297 Article: 25 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)25
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)25 Download Pdf: download
+          pdf view article Creative Commons License The Political Economy of Terrorisms:
+          Economic Cost of War on Terror for Pakistan Authors: Muhammad Shakeel Ahmad
+          Siddiqui Dr. Muhammad Imran Pasha Saira Akram Abstract: Terrorism and its
+          effect on contemporary society is one of the core and vital subjects of International
+          Political Economy (IPE) during the last years. Despite the fact that this
+          is not a new phenomenon, special attention has been given to this issue, specifically
+          after the terrorist attacks of 9/11, 2001. The objective of this paper analyzes
+          to what dimensions terrorism affects the global economy mainly the two predominant
+          actors of the conflict i.e. Pakistan and the United States. For this purpose,
+          this article will take a look at the financial cost of War for Pakistan and
+          how Pakistan\u2019s decision to become frontline State has affected its Economy,
+          its effect on agriculture, manufacturing, tourism, FDI, increased defense
+          costs The normative and qualitative methodology shows a significant disadvantage
+          between terrorist activities and economic growth, social progress, and political
+          development. The results shows that Pakistan has bear slow economic growth
+          while facing terrorist activities more than US. In this last section, the
+          paper suggests ways and means to satisfy people around the world not to go
+          in the hands of fundamentals and terrorists. Keyswords: Cost of War, Economic
+          Growth, Frontline States, Pak Us Relations, Terrorism Pages: 297-309 Article:
+          26 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)26 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)26
+          Download Pdf: download pdf view article Creative Commons License A Comparative
+          Study of Grade 10 English Textbooks of Sindh Textbook Board and Cambridge
+          \u201cO Level\u201d in the perspective of Revised Bloom\u2019s Taxonomy Authors:
+          Mahnoor Shaikh Dr. Shumaila Memon Abstract: The present study evaluated the
+          cognitive levels of reading comprehension questions present in grade 10 English
+          Textbooks namely English Textbook for grade 10 by Sindh Textbook Board and
+          compared it to Oxford Progressive English book 10 used in Cambridge \u201cO
+          Level\u201d in the perspective of Revised Bloom\u2019s Taxonomy. Qualitative
+          content analysis was used as a methodology to carry out the study. To collect
+          the data, a checklist based on Revised Bloom\u2019s taxonomy was used as an
+          instrument. A total of 260 reading comprehension questions from both the textbooks
+          were evaluated. The findings of the study revealed that reading comprehension
+          questions in English textbook for grade 10 were solely based on remembering
+          level (100%) whereas the questions in Oxford Progressive English 10 were mainly
+          based on understanding level (75.5%) with a small percentage of remembering
+          (12.5%), analyzing (11.1%) and evaluating level (0.74%). This suggests that
+          the reading comprehension questions in both the textbooks are dominantly based
+          on lower-order thinking skills. Keyswords: Bloom\u2019s Taxonomy, Content
+          Analysis, Reading Comprehension, Textbook Evaluation Pages: 310-320 Article:
+          27 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)27 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)27
+          Download Pdf: download pdf view article Creative Commons License Assessing
+          the Preparedness of Government Hospitals: A Case of Quetta City, Balochiatan
+          Authors: Sahar Arshad Syed Ainuddin Jamal ud din Abstract: Earthquake with
+          high magnitude is often resulting in massive destruction with more causalities
+          and high mortality rate. Timely providence of critical healthcare facilities
+          to affected people during an emergency response is the core principle of disaster
+          resilient communities. The main objective of this paper is assessing the hospital
+          preparedness of government hospitals in Quetta. Primary data was collected
+          through questionnaire survey. Total of 165 sample size chosen via simple random
+          sampling. Relative important index (RII) is used to analyze the overall situation
+          of hospitals preparedness in term of earthquake disaster. Findings of the
+          study showed that the preparedness level of government hospitals in Quetta
+          is weak to moderate level. Based on the findings this study recommends the
+          necessary measures to minimize the risk of earthquake disaster including training
+          and exercise programs for the staff of hospital, proper resource management
+          to efficiently use the existing machinery and equipment in the meeting of
+          disaster to enhance employee\u2019s performance and preparedness of government
+          hospitals in Quetta to deal with earthquake disaster. Keyswords: Earthquake,
+          Preparedness, Relative Important Index Pages: 321-329 Article: 28 , Volume
+          2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)28 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)28
+          Download Pdf: download pdf view article Creative Commons License Development
+          of Reasoning Skills among Prospective Teachers through Cognitive Acceleration
+          Approach Authors: Memoona Bibi Dr. Shamsa Aziz Abstract: The main objectives
+          of this study were to; investigate the effects of the Cognitive Acceleration
+          approach on the reasoning skills of the prospective teachers at the university
+          level and compare the effects of the Cognitive Acceleration approach and traditional
+          approach concerning reasoning skills of prospective teachers\u2019 at the
+          university level. The study was experimental and followed a pre-test post-test
+          control group experimental design. The sample of the study included the experimental
+          group and control group from the BS Education program in the Department of
+          Education at International Islamic University Islamabad. A simple random sampling
+          technique was used to select the sample after pre-test and pairing of prospective
+          teachers. CTSR (classroom test for scientific reasoning) developed by A.E.
+          Lawson (2000) was used to collect the data through pre-tests and post-tests.
+          The experimental group\u2019s perception about different activities of the
+          experiment was taken through a self-made rating scale. Collected data were
+          analyzed by calculating mean scores and t-test for hypothesis testing by using
+          SPSS. The main findings of the study revealed that the Cognitive Acceleration
+          teaching approach has a significant positive effect on the reasoning skills
+          development of prospective teachers at the university level. Findings also
+          showed that participants found this teaching approach effective and learned
+          many new concepts and skills with the help of thinking activities. Based on
+          findings it has been concluded that the Cognitive Acceleration teaching approach
+          might be encouraged for training prospective teachers at the university level
+          and training sessions about the use of the Cognitive Acceleration approach
+          must be arranged by teacher education programs and institutions. Keyswords:
+          Cognitive Acceleration Approach, Prospective Teachers, Reasoning Skills, Traditional
+          Approach Pages: 330-342 Article: 29 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)29
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)29 Download Pdf: download
+          pdf view article Creative Commons License Spatial Injustice in Shamsie\u2019s
+          Kartography Authors: Syeda Hibba Zainab Zaidi Dr. Ali Usman Saleem Sadia Waheed
+          Abstract: Social space under postmodernism and wave of globalization have
+          suffered in and its idealistic representations are lost and deteriorated which
+          ultimately led to discursiveness in the lives of postmodern man, especially
+          Karachiites. The boundaries of geographies play a significant role in shaping
+          fates, biographies, social superstructures and shared collective histories
+          of its residents. Considering this, Henri Lefebvre and Edward William Soja,
+          argue that space is something which determines the living circumstances within
+          the particular social framework and instigates and controls various societal
+          happenings. City space of Karachi suffers from appalling distortions as a
+          part of postmodern, globalized and capitalist world. By employing Lefebvre\u2019s
+          idea of spatial triad and Soja\u2019s views of the trialectrics of spaciality,
+          this paper foregrounds how social space enforces spatial injustice and serves
+          for the inculcation of spatial cleansing in the lives of inhabitants of urban
+          space. Using Shamsie\u2019s Kartography as an interpretive tool for contemporary
+          urban environment, this paper inquires the engrafting of spatial cleansing
+          in the lives of Karachiites resulting in multiple standardization and segregation
+          on the basis of living standards among different social strata. This research
+          substantiates how in Kartography, Materialism nibbles the roots of social
+          values and norms while sequentially administering Spatial Injustice in the
+          lives of Karachiites. This paper proclaims the scarcity of execution of Spatial
+          Justice in the lives of common people in this postmodern globalized capitalist
+          era. This paper urges the possibility of a utopian urban space with enforced
+          spatial justice where people can be saved from dilemmas of injustice and segregation,
+          especially Karachiites. Keyswords: Capitalistic Hegemony, City Space, Globalization,
+          Spatial Cleansing, Spatial Injustice Pages: 343-352 Article: 30 , Volume 2
+          , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)30 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)30
+          Download Pdf: download pdf view article Creative Commons License A Quasi-Experimental
+          Study on the Performance and Attitudes of Pakistani Undergraduate Students
+          towards Hello English Language Learning Application Authors: Wafa Pirzada
+          Dr. Shumaila Memon Dr. Habibullah Pathan Abstract: With the advancement of
+          technology, more and more avenues of bringing creativity and innovation in
+          language learning have opened up. These exciting advances have given rise
+          to a new field of study within linguistics, termed Mobile Assisted Language
+          Learning (MALL). This paper aims to fill the gap of MALL research in the area
+          of grammar teaching in the Pakistan. Two BS Part 1 classes from University
+          of Sindh, Jamshoro, were chosen for this quasi-experimental study. In total,
+          62 out of 101 students volunteered to use the Hello English application for
+          2 months, making up the experiment group, and the remaining 39 students were
+          put in a control group. Paired Samples T-Test was run on pretest and posttest
+          results which revealed no significant difference in both groups\u2019 performances,
+          proving that Hello English application could not significantly improve students\u2019
+          grammar performance. However, in spite of the lack of a significant difference
+          between the test results, the data gathered through the attitudinal survey
+          showed that students still found mobile application very easy to use and effective
+          in language learning. Keyswords: Attitudes, Grammar Learning, Hello English,
+          Mobile Language Learning, Technology In Language Learning Pages: 353-367 Article:
+          31 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)31 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)31
+          Download Pdf: download pdf view article Creative Commons License Impact of
+          Determinants on the Profile Elevation of Secondary School Teachers in Pakistan
+          Authors: Zahida Aziz Sial Dr. Farah Latif Naz Humaira Saadia Abstract: The
+          foremost purpose of this research paper was to interrogate the effects of
+          determinants on the educational and social profile of secondary school teachers
+          in Pakistan. The key question taken was related to determinants that affect
+          teachers\u2019 profile. The Population of the study was secondary school teachers
+          of Punjab province. A questionnaire was used as research instrument. The researcher
+          personally visited the schools to administer the questionnaire. E-Views software
+          was used for data analysis. Moreover, OLS regression model and LOGIT regression
+          model were carried out. It was found that the variable years of teaching experience
+          (EXPYR) (*** 0.03) can have a vital concrete effect upon the societal figuration
+          of teachers as the experience of teachers grows, so does their social interactions
+          with officials, colleagues, students and friends increases. The said variable
+          is significant at 10 percent level. The variable, Residence (RESIDE) (** 0.53)
+          have a significant impact upon civic links. This obviously associated with
+          less community connection of country side teachers than the teachers residing
+          in urban areas. Keyswords: Determinants, Elevation, Educational Profile, Social
+          Profile, Secondary School Teacher Pages: 368-372 Article: 32 , Volume 2 ,
+          Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)32 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)32
+          Download Pdf: download pdf view article Creative Commons License Impact of
+          War on Terror on the Tourism Industry in Swat, Pakistan Authors: Sabir Ihsan
+          Prof. Dr. Anwar Alam Aman Ullah Abstract: The present study was designed to
+          ascertain the status of tourism before insurgency, during insurgency and after
+          insurgency in District Swat-KP Pakistan. The study is quantitative and descriptive
+          in nature. A diverse sample size of 370 out of 9014 was selected through convenient
+          sampling strategy. Notwithstanding, the objectives of the study was achieved
+          through structured questionnaire. Data was analysed through chi-square at
+          Bi Variate level. Findings of the study revealed that earning livelihood in
+          swat was significantly associated (P=0.016), (P=0.003) with tourism industry
+          prior 2009 and present time respective, but the same statement was observed
+          non-significant (P=0.075) at the time of insurgency. Arranging different festivals
+          in the study area and establishment of different showrooms for local handcrafts,
+          artificial jewellery and woollen shawl are some of the recommendations of
+          the study. Keyswords: Business, Insurgency, Swat, Tourism Pages: 373-385 Article:
+          33 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)33 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)33
+          Download Pdf: download pdf view article Creative Commons License Challenges
+          and Prospects of Pak-China Economic Corridor Authors: Muhammad Mudabbir Malik
+          Prof. Dr. Muqarrab Akbar Abstract: Pak-China has historic relationships from
+          the emergence of both states, and were proved long-lasting in every thick
+          and thin times. In initial times they supported each other in foreign policies
+          and regional issues. Pakistan and China have border disputes with India, which
+          forced them to come close to counter India, letter on the economic interests
+          strengthened these relations. In order to maximize the economic benefits,
+          China announced economic corridor with the name China Pakistan Economic Corridor
+          (CEPC). It was thought it will boost the economic growth of China, and as
+          a prime partner Pakistan will also get economic benefits. In order to completely
+          understand how Pakistan and China came on the same page and decided to put
+          CPEC into reality we have to understand the Geo-political Importance of Pakistan,
+          Strategic and economic importance of CPEC for China and Pakistan, Influence
+          and concerns of West and neighboring countries including India. Domestic limitations
+          and all the possible benefits and risks involved in this project for both
+          Pakistan and China, this research acknowledges all these questions. Keyswords:
+          Challenges, China, CPEC, Domestic Limitations Economic Growth, Pakistan, Western
+          and Regional Concerns Pages: 386-404 Article: 34 , Volume 2 , Issue 4 DOI
+          Number: 10.47205/jdss.2021(2-IV)34 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)34
+          Download Pdf: download pdf view article Creative Commons License An Analysis
+          of Learning Practices and Habits of Children at Early Childhood Education:
+          Students\u2019 Perspective Authors: Masood Ahmad Sabiha Iqbal Shaista Noreen
+          Abstract: The study was designed to analysis learning practices and habits
+          of children at early childhood education. The major objective of the study
+          was to find out the learning practices and habits of children. Problem was
+          related to current situation, so survey method was exercised, 220 students
+          were selected with the help of convenient sampling technique. Self-constructed
+          questionnaire were exercised. The collected data was analyzed and calculate
+          frequency, percentage, mean score, standard deviation and t-test of independent
+          variable. The major findings of the study were; students learn from the pictures,
+          cartoons and funny face; student\u2019s eyes get tired of reading. When student
+          read context continuously then they feel that their eyes get tired. There
+          was a significance difference between male and female student about learning
+          practices and habits of children. Keyswords: Early Childhood Education, Learning
+          Practices and Habits, Pre-School Students Pages: 405-416 Article: 35 , Volume
+          2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)35 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)35
+          Download Pdf: download pdf view article Creative Commons License Gender Identity
+          Construction in Akhtar\u2019s Melody of a Tear Authors: Dr. Amna Saeed Hina
+          Quddus Abstract: This study aims to discuss the notion of gender in terms
+          of performativity and social construction. It also draws upon the idea of
+          gender identity construction and how it relates to the society, performativity
+          and biology. As its theoretical framework, the study relies upon the Performative
+          Theory of Gender and Sex (1990) presented by Judith Butler and studies the
+          gender identity construction in the female protagonist of Akhtar\u2019s Melody
+          of a Tear. Zara is a girl who is raised as a boy from his father and there
+          is a kind of dilemma in Zara\u2019s personality related to being masculine
+          and feminine. The cultural norms of a particular gender are also a cause of
+          this dilemma. Throughout the novel, she is in a conflicting state whether
+          she should behave feminine or masculine. She is being depicted as an incomplete
+          person until she finds and resolves this issue of gender identity. The paper
+          discusses the gender performativity, social construction, cultural norms and
+          identity as these are all contributing to the confusion and construction of
+          the protagonist\u2019s identity. Character analysis is used as the methodology
+          of analysis. Keyswords: Cultural Norms, Femininity And Identity Confusion,
+          Gender, Performativity, Masculinity, Social Construction Pages: 417-427 Article:
+          36 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)36 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)36
+          Download Pdf: download pdf view article Creative Commons License The Level
+          of Impulsivity and Aggression among Crystal Meth and Cannabis Users Authors:
+          Dr. Umbreen Khizar Muhammad Shafique Sana Nawab Abstract: Cannabis and crystal
+          meth use is pervading in our society. Present study was conducted to explore
+          the relationship between level of impulsivity and aggression among crystal
+          meth and cannabis users. The sample of the present study was comprised of
+          100 participants. There were 50 cannabis and 50 crystal meth users who were
+          diagnosed on the basis of DSM-V without any comorbidity. The sample were taken
+          from all age range of population. The minimum education level was primary
+          and maximum education level was graduation and above. The sample was selected
+          from different drug rehabilitation centers of Rawalpindi and Islamabad, Pakistan.
+          Demographic Performa was used to collect the initial important information,
+          The \u201cBarratt Impulsiveness Scale was used to measure the impulsivity
+          and \u201cAggression Questionnaire\u201d were used to measure the level of
+          aggression. Finding of the study showed that there are significant differences
+          among crystal meth and cannabis users on level of aggression. The calculated
+          mean value for crystal meth user and for cannabis users indicates that crystal
+          meth users have higher level of aggression as compared to the cannabis user.
+          Over all analysis indicates a significant positive correlation of impulsivity
+          with the variable aggression. The alpha coefficient value for all scale is
+          acceptable. Keyswords: Aggression, Cannabis Users, Crystal Meth, Impulsivity
+          Pages: 428-439 Article: 37 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)37
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)37 Download Pdf: download
+          pdf view article Creative Commons License Impact of Social Factors on the
+          Status of Tribal Women: A Case Study of the (Erstwhile) Mohmand Agency Authors:
+          Sadia Jabeen Prof. Dr. Anwar Alam Muhammad Jawad Abstract: This study investigates
+          the impact of socio-economic and cultural factors on the status of tribal
+          women in the erstwhile Mohmand agency of the Ex-Federally Administered Tribal
+          Area (FATA), Pakistan. Cultural practices and illiteracy impede the role of
+          women in socio-economic development. The respondents were randomly selected
+          from tehsil Ekka Ghund and Pindialai with a sample size of 370, through stratified
+          random sampling. Data collected through structured interview schedule, FGD
+          and observation technique. The study reveals that tribal practices early marriages,
+          joint family system, tradition of forced marriages, compensation/Swara, exchange,
+          purchase marriages, hampers women\u2019s socioeconomic status. The illiteracy
+          rate is high among the tribal women and it further undermines their role and
+          negatively affects their socio-economic status. However, improvement in women
+          status needs peace and stability, reforms in the constitution for women empowerment
+          and active participation, improvement in the quality and quantity of education,
+          women employability, skills development and women entrepreneurship Keyswords:
+          Empowerment and Education, Marriage Types, Tribal Women Role, Tribal Women
+          Status, Violence against Women Pages: 440-455 Article: 38 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)38 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)38
+          Download Pdf: download pdf view article Creative Commons License Effects of
+          Heavy School Bags on Students\u2019 Health at Primary Level in District Haveli
+          (Kahutta) Azad Jammu and Kashmir Authors: Dr. Muhammad Mushtaq Shamsa Rathore
+          Mishbah Saba Abstract: Heavy school bags is a very serious issue for the health
+          of the primary level students throughout the world particularly in Azad Jammu
+          and Kashmir. This study intends to explore the effect of heavy school bags
+          on students\u2019 health at primary level in district Kahuta. Naturally the
+          study was descriptive and survey method was used, the population consists
+          of one hundred ninety teachers and a sample of one hundred twenty seven teachers
+          was selected using non probability sampling technique. A likert scale questionnaire
+          was developed validated and distributed among the sampled respondents. The
+          researcher personally visited the schools and collected the filled questionnaire.
+          The data was coded and fed to the SPSS to analyze and interpret. The Chi Square
+          test was applied to see the effect of heavy school bags on student\u2019s
+          health and academic achievement. The study found that heavy bags have negative
+          effect on their health as well as their academic achievement. Students were
+          found complaining their sickness, body and back pain. They were also found
+          improper in their gait and their body postures. The researcher recommended
+          the policy makers to take and develop strategies to decrease the heavy school
+          bags. The school administration needs to make alternate days\u2019 time tables
+          of the subjects. Keyswords: Health, Primary Level, School, Bags, Students
+          Heavy Pages: 456-466 Article: 39 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)39
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)39 Download Pdf: download
+          pdf view article Creative Commons License Exploring the \u2018Civil Repair\u2019
+          Function of Media: A Case Study of The Christchurch Mosques Shootings Authors:
+          Ayaz Khan Dr. Muhammad Junaid Ghauri Riffat Alam Abstract: This research endeavor
+          is an attempt to explore and analyze the discourse produced by The New Zealand
+          Herald; a newspaper from New Zealand and by The News International; a Pakistani
+          newspaper. The researchers intend to determine whether and to what extent
+          both the newspapers have the role of \u2018civil repair\u2019 played after
+          the Christchurch mosques shootings. The researchers have incorporated the
+          \u2018lexicalization\u2019 and the \u2018ideological square\u2019 techniques
+          proposed by Tuen A. van Dijk within the scope of Critical Discourse Analysis.
+          The findings of this study show that both the selected newspapers assuming
+          the social status of \u2018vital center\u2019 performed the role of \u2018civil
+          repair\u2019 in the aftermath of the shootings by producing the \u2018solidarity
+          discourse\u2019. The \u2018solidarity discourse\u2019 has been produced in
+          terms of the \u2018we-ness\u2019, harmony, understanding, and by mitigating
+          the conflicting opinions. Keyswords: Christchurch Mosque Shootings, Civil
+          Repair, Civil Sphere Theory, Lexicalization, Solidarity Discourse Pages: 467-484
+          Article: 40 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)40 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)40 Download Pdf: download pdf
+          view article Creative Commons License China Pakistan Economic Corridor: Regional
+          Dominance into Peace and Economic Development Authors: Tayba Anwar Asia Saif
+          Alvi Abstract: The purpose of this qualitative study was to investigate the
+          true motivations behind CPEC idea and the advantages it delivers to Pakistan
+          and China. It also recognizes the Corridor''s potential for mixing regional
+          economies while dissolving geographical borders. The study is deductive in
+          character, since it examines financial, political, and military elements of
+          Pakistan and China''s positions and situations. Enhancing geographical linkages
+          through improved road, train, and air transport systems with regular and free
+          exchanges of development and individual\u2019s interaction, boosting through
+          educational, social, and regional civilization and wisdom, activity of larger
+          quantity of investment and commerce flow, generating and moving energy to
+          provide more optimal businesses for the region. Keyswords: Geographical Linkages,
+          Globalized World, Landlocked, Regional Connectivity, Regionalization Pages:
+          485-497 Article: 41 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)41
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)41 Download Pdf: download
+          pdf view article Creative Commons License China\u2019s New Great Game in Central
+          Asia: Its Interest and Development Authors: Bushra Fatima Rana Eijaz Ahmad
+          Abstract: Central Asia is rich in hydrocarbon resources. It\u2019s geostrategic,
+          geopolitical, and geo-economic significance has grasped the attention of multiple
+          actors such as China, the USA, Russia, Turkey, the European Union, Pakistan,
+          Afghanistan, and India. Due to its location, the Central Asian region appeared
+          as a strategic hub. In the present scenario, China\u2019s strategy is massive
+          economic development, energy interest, peace, and stability. This article
+          highlights China\u2019s interest, political and economic development, and
+          its role as a major player in the New Great Game in Central Asia. Shanghai
+          Cooperation Organization (SCO) which presents as a platform where China is
+          playing an active role in political, economic, and security concerns for achieving
+          its objectives in Central Asia. The new step of the Belt and Road Initiative
+          (BRI) sheds light on China\u2019s progressive move in this region via land
+          and sea routes, which creates opportunities for globalization. Keyswords:
+          Belt and Road Initiative, Central Asia, China, New Great Game Pages: 498-509
+          Article: 42 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)42 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)42 Download Pdf: download pdf
+          view article Creative Commons License Personality Traits as Predictors of
+          Self-Esteem and Death Anxiety among Drug Addicts Authors: Umbreen Khizar Saira
+          Irfan Iram Ramzan Abstract: This study seeks to investigate whether personality
+          traits predict self-esteem and death anxiety among drug addicts. The sample
+          consisted of 100 drug addicts taken from the two hospitals in Multan city.
+          Only men between the ages of 20 and 65 were included in the study. Data was
+          collected through reliable and valid questionnaires. Results revealed positive
+          relationship between conscientiousness, openness to experience and self-esteem.
+          Moreover, findings showed positive relationship between extraversion and death
+          anxiety, and negative correlation between neuroticism and death anxiety. Findings
+          also showed that self-esteem and death anxiety are significantly and negatively
+          correlated. Additionally, findings revealed that conscientiousness positively
+          predicted self-esteem and neuroticism negatively predicted death anxiety.
+          Furthermore, significant differences were observed in self-esteem, and death
+          anxiety based on age. Significant differences were also found in extraversion,
+          agreeableness, openness to experience, and death anxiety based on location.
+          Understanding how personality traits affect behavior can help drug addicts
+          get the support they need to live a better life and reduce their risk of death
+          anxiety and premature death. Keyswords: Death Anxiety, Drug Users, Personality
+          Traits, Self- Esteem Pages: 510-524 Article: 43 , Volume 2 , Issue 4 DOI Number:
+          10.47205/jdss.2021(2-IV)43 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)43
+          Download Pdf: download pdf view article Creative Commons License Middle East:
+          A Regional Instability Prototype Provoking Third Party Interventions Authors:
+          Waseem Din Prof. Dr. Iram Khalid Abstract: Third party interventions always
+          prolong the interstate or civil wars with unending sufferings and devastations.
+          The entire Middle East region is fraught with tensions, conflicts, civil wars
+          and rivalries. From strategic interests to power grabbing, sectarian divisions,
+          flaws in the civil and social structure of the state and society, ethnic insurrections,
+          and many other shapes of instability syndromes can be diagnosed in this region.
+          In the post-Arab Spring, 2011, the emerging new regional hierarchical order
+          for power/dominance, in addition to the weakening/declining dominant US power
+          in the region, changed the entire shape of already conflict-ridden region.
+          New weak or collapsing states and bifurcation of the \u2018status quo\u2019
+          and \u2018counter-hegemonic\u2019 states along with their respective allies,
+          made this region a prototype of instability in the regional security complex
+          of the Middle East, as a direct result of these developments. The perpetuation
+          of these abnormalities would not recede this instability conundrum from the
+          region, provoking third party intervention, if not contained. Keyswords: Conflicts/Civil
+          Wars, Dominant Power, Instability, Intervention, Middle East, Middle Powers,
+          Regional Hierarchy, Regional Powers, Security Complex, Weak State Pages: 525-542
+          Article: 44 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)44 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)44 Download Pdf: download pdf
+          view article Creative Commons License Impact of Classroom Environment on Second
+          Language Learning Anxiety Authors: Zohaib Zahid Abstract: Second language
+          learning anxiety has attained the attention of the researchers in almost every
+          part of the world. Pakistan is a country where English is taught as a second
+          language from the very beginning of school education. Second Language learning
+          anxiety is a phenomenon which has been prominently found among the learners
+          because of their less proficiency in learning English language. This study
+          has been conducted to investigate the effect of anxiety in learning and using
+          English language in classroom, university and outside the classroom. There
+          are variables that affect language learning performance of the learners but
+          this paper has solely investigated the effect of anxiety. The paper has concluded
+          that anxiety is a variable which has a striking affect in second language
+          learning and its use inside classrooms. Keyswords: Effect of Anxiety, Proficiency,
+          Second Language Learning Anxiety, Striking Affect Pages: 485-497 Article:
+          45 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)45 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)45
+          Download Pdf: download pdf view article Creative Commons License Struggling
+          for Democracy: A Case of Democratization in Pakistan Authors: Ammara Tariq
+          Cheema Dr. Rehana Saeed Hashmi Abstract: The objective of this research paper
+          is to review the challenges for democratization in Pakistan. The problem of
+          democratization and consolidation refers to the structure of democracy following
+          the collapse of non-democratic regime. Ten factors as given by Michael J.
+          Sodaro are considered effective in helping a democratically unstable state
+          to stabilize its system in other words helps in the democratic consolidation.
+          It is argued in this research that the ten factors of democratization as given
+          by Michael J. Sodaro have been absent in the political system of Pakistan
+          and working on these factors can lead Pakistan to the road of democratization.
+          This study uses qualitative method of research and proposes a novel framework
+          for the deed of parliament, because the effectiveness of parliament can contribute
+          positively to democratization/consolidated democracy. Keyswords: Electoral
+          Politics, General Elections, Political Participation, Women Empowerment Pages:
+          554-562 Article: 46 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)46
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)46 Download Pdf: download
+          pdf view article Creative Commons License Impact of Dependency Ratio on Economic
+          Growth among Most Populated Asian Countries Authors: Dilshad Ahmad Salyha
+          Zulfiqar Ali Shah Abstract: Demographic transition through different channels
+          significantly influences economic growth. Malthusian view postulated as dependency
+          ratio adversely affects economic growth while Julian Simon''s view is quite
+          different, highlighted the long-run benefits of the population in the range
+          of 5 to15 years on economic growth. This study can be a valuable addition
+          in research to analyzing the association of dependency ratio and economic
+          growth of the five most populated Asian countries (Bangladesh, China, Indonesia,
+          India, and Pakistan). Empirical findings of the study indicated that a total
+          dependency and younger dependency ratio has a positive and significant influence
+          on economic growth in both short-run and long-run scenarios while the old
+          dependency ratio shows a negative influence on economic growth in the long
+          run while short-run results are unpredictable. There is a need for state-based
+          proper policy measures in focusing the higher financing in human capital development
+          specifically in education and health. Keyswords: Economic Growth, Gross Saving,
+          Old Dependency Ratio, Young Dependency Ratio Pages: 563-579 Article: 47 ,
+          Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)47 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)47
+          Download Pdf: download pdf view article Creative Commons License Chinese Geo-Strategic
+          Objectives and Economic Interests in Afghanistan under President Xi Jinping
+          Authors: Farooq Ahmed Prof. Dr. Iram Khalid Abstract: China has its own distinctive
+          interests, concerns and strategies with respect to the changing security dynamics
+          in Afghanistan. China has taken an active interest, though retaining a low
+          profile and avoiding direct military interaction. China has exclusively relished
+          on economic engagement actively and provided numerous financial aid and financial
+          support in the rebuilding of Afghanistan''s economy. The aim of this research
+          study is to analyze the geo-strategic objectives and economic interests of
+          China under the leadership of President Xi Jinping. This study looks at the
+          actual diplomatic, economic and protection commitments of both countries as
+          well as the basis of the geopolitical complexities \u2013 core variables that
+          form China''s current foreign policy to Afghanistan. Keyswords: Afghanistan,
+          BRI, China, NATO Withdrawal Pages: 580-592 Article: 48 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)48 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)48
+          Download Pdf: download pdf view article Creative Commons License The Argument
+          Structure of Intransitive Verbs in Pashto Authors: Abdul Hamid Nadeem Haider
+          Bukhari Ghani Rehman Abstract: This study focuses on the description and categorization
+          of intransitive verbs in terms of its argument structure. The study concludes
+          that the unaccusative verbs only project an internal argument. It does not
+          require the event argument. However, the said verb can be causativised by
+          adding external argument and at the same time the event argument gets included
+          in the valency of the derived causative of the unaccusative root. The unergative,
+          on the other hand, requires an external argument as an obligatory argument
+          while the internal argument is not the obligatory argument of the verb. The
+          event argument is also a part of the valency of the verb. The APFs require
+          one argument which is the internal argument of the verb. However, since the
+          external argument is not available, the internal argument of the verb gets
+          realized as the subject of the verb. The verb does not project event argument.
+          The ergative predicates are derived by the suppression of the external argument
+          and by the externalization of the internal argument. Keyswords: Argument Structure,
+          Ergative Case, Event Argument, External Argument, Internal Argument, Valency
+          Pages: 593-610 Article: 49 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)49
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)49 Download Pdf: download
+          pdf view article Creative Commons License Positive, Negative and Criminal
+          Orientation of Beggars in Okara: Perspective of Students Authors: Shahzad
+          Farid Saif-Ur-Rehman Saif Abbasi Hassan Raza Abstract: This study aimed to
+          measure the perspective of students about the criminal orientation of beggars.
+          The sample size of the study (i.e., 100 students) was explored using Taro
+          Yamane\u2019 equation from the university of Okara, Punjab, Pakistan. The
+          respondents were approached using simple random sampling and interviewed using
+          face to face interview schedule. The data was collected using a structured
+          questionnaire. The analysis was administered through SPSS-20.The study explored
+          that parental illiteracy is associated with the high criminal and negative
+          orientation of students towards beggars. It was also explored that females
+          and respondents from rural background have low negative orientation towards
+          beggars. However, males and respondents from urban background have medium
+          criminal orientation and low positive orientation towards beggars, respectively.
+          The study is useful for the government of Punjab, Pakistan campaign and policy
+          for anti-begging. The study introduced the geometrical model of youth\u2019s
+          orientation toward begging. The study also contributed to the literature on
+          begging by extending its domain from Law and Criminology to sociology as it
+          incorporated social variables e.g., parents\u2019 education, gender, etc.,
+          to explore their association with the youth\u2019s socialization about begging.
+          Keyswords: Begging, Crime, Education, Gender, Students Pages: 611-621 Article:
+          50 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)50 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)50
+          Download Pdf: download pdf view article Creative Commons License Relationship
+          between Entrepreneurial Export Orientation and Export Entrepreneurship through
+          Mediation of Entrepreneurial Capabilities Authors: Muhammad Saqib Nawaz Masood
+          ul Hassan Abstract: Export led growth is prominent paradigm in developing
+          world since decades. Exports play vital role in the economy by improving the
+          level of balance of payments, economic growth and employment. Due to strategic
+          importance of exports, organizational researchers focused on finding antecedents
+          of export performance of the organizations. To line with this, current study
+          aims to find the impact of entrepreneurial export orientation on export entrepreneurship
+          through mediation of entrepreneurial capabilities in the Pakistani context.
+          For this purpose, data was collected from 221 exporting firms of Pakistan
+          by using questionnaire. Collected data was analyzed with the help of Smart
+          PLS. In findings, measurement model confirmed the validity and reliability
+          of measures of variables. Additionally, structural model provides the positive
+          impact of entrepreneurial export orientation on export entrepreneurship. Similarly,
+          entrepreneurial capabilities mediate the relationship between entrepreneurial
+          export orientation on export entrepreneurship. The findings provide important
+          implications for the managers of exporting firms to improve export performance.
+          Keyswords: Entrepreneurial Capabilities, Entrepreneurial Export Orientation,
+          Export Entrepreneurship Pages: 622-636 Article: 51 , Volume 2 , Issue 4 DOI
+          Number: 10.47205/jdss.2021(2-IV)51 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)51
+          Download Pdf: download pdf view article Creative Commons License China Pakistan
+          Economic Corridor: Explaining U.S-India Strategic Concerns Authors: Nasreen
+          Akhtar Dilshad Bano Abstract: Regional and International political and economic
+          landscape is being changed owing to China Pakistan Economic Corridor (CEPEC)-the
+          new security paradigm has taken place-that has increased the strategic concerns
+          of the U.S. and India. This research paper attempts to re-examine China-Pakistan
+          relations in the new emerging geo-political compass. This paper has investigated
+          the question that how regional, and global developments have impacted the
+          China-Pakistan relationship? And why China \u2013 Pakistan have become partners
+          of CPEC? In the global context, this paper assesses the emerging International
+          Order, Indo-U. S strategic narrative vis-\u00e0-vis CPEC, and the containment
+          of China through the new alliances and their impacts on China -Pakistan vis-\u00e0-vis
+          the Belt Road Initiative (BRI). Quadrilateral (Quad) alliances is shaping
+          the new strategic political and security paradigms in the world politics.
+          Keyswords: BRI, China, CPEC, India, Pakistan, Silk Road, Strategic Concerns
+          Pages: 637-649 Article: 52 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)52
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)52 Download Pdf: download
+          pdf view article Creative Commons License The Structure of Domestic Politics
+          and 1973 Constitution of Pakistan Authors: Dr. Fida Bazai Dr. Ruqia Rehman
+          Amjad Rashid Abstract: Pakistan is located in a pivotal region. Its geo-strategic
+          location affects its national identity as a nation state. Unlike Europe in
+          South Asia security dilemma, proxy warfare and nuclear arms race are consistent
+          features of the regional politics. The identity of Pakistan as security-centric
+          state gives its army disproportional power, which created institutional imbalance
+          that directly affected constitutionalism in the country. The constitution
+          of Pakistan is based on principles of civilian supremacy and separation of
+          power but in reality Pakistan\u2019s army is the most powerful institution
+          in country. This paper argues that the structure of Pakistani politics; created
+          institutional imbalances by the disproportionate distribution of resources
+          is the key variable in creating dichotomy. The structure of domestic politics
+          is based upon the principles of hostility to India, use of Islam for national
+          unity and strategic alliances with major powers to finance defense against
+          the neighboring countries. Keyswords: Constitutionalism, Identity, Islam,
+          South Asia Pages: 650-661 Article: 53 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)53
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)53 Download Pdf: download
+          pdf view article Creative Commons License National Integration and Regionalism
+          in Pakistan: Government\u2019s Strategy and Response toward Regionalist Demands
+          1947-77 Authors: Najeeb ur Rehman Mohammad Dilshad Mohabbat Muhammad Wahid
+          Abstract: The countries of South Asian region have pluralistic societies with
+          different language, religious, and ethnic identities. Pakistan is no exception
+          who is facing the challenge of regionalism since its inception. Different
+          ethnic groups have been consistently raising their voices for separatism or
+          autonomy within the frame work of an existing territorial state. The issues
+          of provincialism, ethnicity, and regionalism is posing a serious challenge
+          to the integrity of the country. This paper aims to explore the causes of
+          the regionalism in Pakistan and intends to analyze the policies and strategies
+          of different political governments which they launched to tackle this all
+          important issue. The paper follows the historical method of research and analyzes
+          different types of qualitative data to conclude the finding of the research.
+          The paper develops the theory of \u201cRegionalists Demand and Government
+          Response\u201d which shows how different regionalist forces put their demands
+          and how the governments react on these demands. It recommends the grant of
+          greater regional autonomy to the regionalists to enhance internal security
+          and to protect the country from disintegration. Keyswords: Demands, Ethnicity,
+          Government Strategy, National Integrity, Nationalism, Regionalism Pages: 662-678
+          Article: 54 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)54 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)54 Download Pdf: download pdf
+          view article Creative Commons License Fostering Entrepreneurial Mindset through
+          Entrepreneurial Education: A Qualitative Study Authors: Saira Maqbool Dr.
+          Qaisara Parveen Dr. Muhammad Hanif Abstract: Research on entrepreneurial mindset
+          has flourished in these recent years. Its significance lies in a critical
+          suspicion and its matters for inventive behavior. Entrepreneurship joined
+          with innovative abilities, seen as one of the most wanted in this day and
+          age. This study aims to determine the perceptions about entrepreneurial mindset,
+          its importance, and the role of entrepreneurship education and Training in
+          developing the entrepreneurial mindset. This is a qualitative study based
+          on interviews conducted by professors of Pakistan and Germany. The analysis
+          was determined through content analysis. The results determine that ''Making
+          Entrepreneurial Mindset'' assists with seeing better all parts of business
+          venture, which will undoubtedly influence their view of business venture,
+          pioneering abilities, and mentalities. Keyswords: Entrepreneurship Education,
+          Entrepreneurial Mindset Pages: 679-691 Article: 55 , Volume 2 , Issue 4 DOI
+          Number: 10.47205/jdss.2021(2-IV)55 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)55
+          Download Pdf: download pdf view article Creative Commons License Benefits
+          of Implementing Single National Curriculum in Special Schools of Lahore city
+          for Children with Intellectual Disability: Teachers\u2019 Perception Authors:
+          Dr. Hina Fazil Khurram Rameez Sidra Ansar Abstract: Single national curriculum
+          (SNC) is an important issue across the Punjab Province of Pakistan. Making
+          and implementing SNC is not only focusing the education of normal pupils,
+          but also focusing students with disabilities (SWD). The field of special education
+          experienced an increased discussion of curriculum for students with intellectual
+          disabilities (SID). The present research aimed to know the benefits to implement
+          first stage of single national curriculum for students with Intellectual disability
+          and to know the differences about the benefits between public and private
+          schools regarding SNC for students with ID based on demographic characteristics.
+          Likert type researchers-made questionnaire with reliability) Cronbach alpha
+          .922) was used. 90 special educationists from public and private schools were
+          chosen through random sampling technique. The findings raised some benefits
+          such as: SNC will bridge the social and economic disparities which will increase
+          the acceptance of ID students. It was recommended that SNC should include
+          areas of adaptive skills, motor, and vocational skills to get involved in
+          work activities. Keyswords: Benefits, Children with Intellectual Disability,
+          Single National Curriculum Pages: 692-703 Article: 56 , Volume 2 , Issue 4
+          DOI Number: 10.47205/jdss.2021(2-IV)56 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)56
+          Download Pdf: download pdf view article Creative Commons License Last Rituals
+          and Problems Faced by the Hindu Community in Punjab: A Case Study of Lahore
+          Authors: Sabir Naz Abstract: Lahore is the provincial capital of Punjab, where
+          a sizeable population of the Hindus has been residing there since the inception
+          of Pakistan. There had been many crematoriums in the city but with the passage
+          of time, one after another, disappeared from the land after partition of the
+          Sub-continent. Those places were replaced by commercial or residential sites.
+          There is also a graveyard in the city which is in the use of Hindu Valmik
+          Sect. However, it was encroached by some Muslims due to very small size of
+          population and indolence of the Hindus. Later on, the encroachments were removed
+          by the District Government Lahore in compliance of order of the Supreme Court
+          of Pakistan. Presently, there is a graveyard as well as a crematorium in the
+          city. The community remained deprived of a place to dispose of a dead body
+          according to their faith for a long period which is contravention with the
+          guidelines of the Quaid-e-Azam, founder of the nation Keyswords: Crematorium,
+          Graveyard, Hindu community, Last Rituals Pages: 704-713 Article: 57 , Volume
+          2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)57 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)57
+          Download Pdf: download pdf view article Creative Commons License Estimating
+          Growth Model by Non-Nested Encompassing: A Cross Country Analysis Authors:
+          Benish Rashid Dr. Shahid Razzaque Dr. Atiq ur Rehman Abstract: Whether models
+          are nested or non-nested it is important to be able to compare them and evaluate
+          their comparative results. In this study six growth models have been used
+          for analyzing the main determinants of economic growth in case of cross countries,
+          therefore by using these six models we have tested them for non-nested and
+          nested encompassing through Cox test and F-test respectively. Data from 1980
+          to 2020 were used to analyze the cross country growth factors so therefore,
+          the current study looked at about forty four countries with modelling these
+          different comparative studies based on growth modelling. So, we can make these
+          six individual models and we can estimate the General Unrestricted Model with
+          the use of econometric technique of Non-Nested Encompassing. By evaluating
+          the data using the Non-Nested Encompassing econometric technique, different
+          sets of economic variables has been used to evaluate which sets of the economic
+          variables are important to boost up the growth level of the country. And found
+          that in case of nested model or full model it is concluded that model with
+          lag value of GDP, trade openness, population, real export, and gross fix capital
+          formation are the main and potential determinants to boost up the Economic
+          Growth in most of the countries. Keyswords: Cross Country, Economic Growth,
+          Encompassing, Nested, Non-nested Pages: 714-727 Article: 58 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)58 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)58
+          Download Pdf: download pdf view article Creative Commons License Assessment
+          of Youth Buying Behaviour for Organic Food Products in Southern Punjab: Perceptions
+          and Hindrances Authors: Ayousha Rahman Asif Yaseen Muhammad Arif Nawaz Abstract:
+          This research examined the cognitive antecedental effects on organic food
+          purchase behaviour for understanding the perceptions and hindrances associated
+          with purchasing organic food products. Theory of Planned Behaviour (TPB) was
+          adopted as a theoretical framework. A total of 250 young consumers in the
+          two cities of Southern Punjab, Pakistan was randomly sampled and data were
+          collected via a face-to-face survey method. Partial least square technique
+          was employed to test the model. The results showed that attitude towards organic
+          food purchasing motivated when moral norms were activated to consume organic
+          food products. Further, environmental knowledge moderated the relationship
+          of organic food purchase intentions and behaviour significantly. The findings
+          highlighted the importance of moral norms as a meaningful antecedent that
+          could increase the TP-based psychosocial processes if consumers have sufficient
+          environmental knowledge. Therefore, farmers, organic products marketers, government
+          administrators, and food retailers should take initiatives not only to highlight
+          the norms and values but also when promoting organic food production and consumption.
+          Keyswords: Environmental Knowledge, Organic Food Purchase Behaviour, Personal
+          Attitude, PLS-SEM, Subjective &amp; Moral Norms Pages: 728-748 Article: 59
+          , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)59 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)59
+          Download Pdf: download pdf view article Creative Commons License An Analysis
+          on Students Ideas about English and Urdu as Medium of Instructions in the
+          Subjects of Social Sciences studying in the Colleges of the Punjab, Pakistan
+          Authors: Ashiq Hussain Asma Amanat Abstract: The worth and usefulness of English
+          education as a foreign language is of great concern to language rule and planning
+          (LRP) researchers compared to teaching their native language globally in higher
+          education. The study under research examines the perspectives of two similar
+          groups of the final year students of at Higher Education Institutions of Pakistan.
+          The first group consists of art students who received the Urdu medium of instruction
+          (UMI), and the second group received the English medium of instruction (EMI).
+          An empirical methodology was carried out in the present year, students answered
+          questionnaires to find out the benefits and challenges of learning subject-based
+          knowledge, what subject-based knowledge means to them, and their understanding
+          of language as a teaching language. Interviews were conducted with the selected
+          group of students who wished to participate in research. Additional information
+          is available from the tests and results obtained in the two equivalent courses.
+          Although many similarities have been identified between the two groups, the
+          overall knowledge of disciplinary knowledge of English medium instruction
+          students was not very effective, while that of UMI students was very effective.
+          It explains the implications of the findings to continue the language rule
+          as policy experience for teaching in higher education institutions. Keyswords:
+          English as Medium of Instruction (EMI), Higher Education Institutions (HEIs),
+          Urdu as Medium of Instruction (UMI) Pages: 749-760 Article: 60 , Volume 2
+          , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)60 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)60
+          Download Pdf: download pdf view article Creative Commons License Environment
+          and Women in Kurt Vonnegut\u2019s \u2018Happy Birthday Wanda Juny\u2019: An
+          Eco- Critical and Feminist Analysis Authors: Dr. Muhammad Asif Safana Hashmat
+          Khan Muhammad Afzal Khan Janjua Abstract: This is an Eco-feminist study of
+          Vonnegut\u2019s \u2018Happy Birthday Wanda Juny\u2019 and focuses on how both
+          women and environment are exploited by patriarchy. Ecofeminism critiques masculine
+          dominance highlighting its role in creating and perpetuating gender discrimination,
+          social inequity and environmental degradation. Women suffer more because of
+          power disparity in society. Environmental crises affect women more than men
+          because of their already precarious existence and subaltern position. There
+          is affinity between women and nature are victims of climate change and other
+          environmental hazards. Cheryl Glotfelty introduced interdisciplinary approach
+          to the study of literature and environment. Literary ecology as an emerging
+          discipline explores the intriguing relationship between environment and literature.
+          Ecofeminism draws on feminist critique of gender inequality showing how gender
+          categories inscribed in power structure exploit both women and nature. Francoise
+          d\u2018Eaubonne coined the term ecofeminism to critique the prevalent exploitation
+          of both women and environment. Ecofeminism asserts that exploitation of women
+          and degradation of the environment are the direct result of male dominance
+          and capitalism. Ecofeminism argues for redressing the plight of women and
+          protection of environment. Vonnegut\u2019s play \u2018Happy Birthday Wanda
+          June\u2019 was written at a time when the movement for the right of women
+          and protection of environment were gaining momentum. The play shows how toxic
+          masculinity rooted in power and capitalism exploit both women and environment.
+          Keyswords: Eco-Feminism, Eco-Criticism, Ecology, Environment, Exploitation
+          Pages: 761-773 Article: 61 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)61
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)61 Download Pdf: download
+          pdf view article Creative Commons License Critical Analysis of Social Equity
+          and Economic Opportunities in the Light of Quranic Message Authors: Prof.
+          Dr. Muhammad Yousuf Sharjeel Mahnaz Aslam Zahida Shah Abstract: This study
+          critically evaluated the key verses of Surah Al-Baqarah -the second chapter
+          of Quran, a sacred scripture of Islam- which specifically relates to social
+          equity opportunities and a code of conduct in the context of economics. The
+          Quran claims that it is a book which explains every situation; therefore,
+          the aim of this study remained to extract those verses of Surah Al-Baqarah
+          which can guide us in Economics. The authentic and approved Islamic clerics
+          and their translations were consulted for the interpretations of the Holy
+          verses. The researchers chiefly focused and studied Surah Baqarah with regards
+          to social equity and economic opportunities. The translations were primarily
+          in the regional language Urdu so the interpretations must not be related exactly
+          equitable in English. The study engaged the document analysis research strategy.
+          This study is only an endeavour to decipher Holy Quran\u2019s message from
+          Allah for the mankind so it must not be considered as the full and complete
+          solution to the all the economic issues, challenges and opportunities. Ahadees
+          and the saying of the Holy prophet were referred to where ever required and
+          available. The researcher also considered the Tafasir (detail intellectual
+          interpretations) of the Quran done by the well-known scholars of Islam for
+          the verses studied therein and any statements and/or material - such as ideas,
+          studies, articles, documentation, data, reports, facts, statistics etc. For
+          the study, data was collected and analyzed qualitatively. On the basis of
+          the study, recommendations were also primed. Keyswords: Economic Issues and
+          Challenges, Social Equity, Surah Al-Baqarah, Al Quran Pages: 774-790 Article:
+          62 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)62 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)62
+          Download Pdf: download pdf view article Creative Commons License A Critical
+          Discourse Analysis of Dastak by Mirza Adeeb Authors: Muhammad Afzal Dr. Syed
+          Kazim Shah Umar Hayat Abstract: The present research aims to explore ideology
+          in Pakistani drama. The drama, \u201cDastak\u201d, written by Mirza Adeeb,
+          has been taken for exploration ideologically. Fairclough\u2019s (1992) three-dimensional
+          model has been used for analyzing the text of the above-mentioned drama which
+          includes textual, discursive practice and social practice analyses. The linguistic
+          and social analyses of the drama reveal the writer\u2019s ideology about socio-cultural,
+          conventional and professional aspects of life. The study has also explored
+          the past and present states of mind of Dr. Zaidi, the central and principal
+          character of the drama, Dastak. The text implies that the writer has conveyed
+          personal as well as social aspects of his times through the drama of Dastak.
+          Keyswords: Dastak, Drama, Ideology, Semiotics Pages: 791-807 Article: 63 ,
+          Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)63 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)63
+          Download Pdf: download pdf view article Creative Commons License Linking Job
+          Satisfaction to Employee Performance: The Moderating Role of Islamic Work
+          Ethics Authors: Dr. Shakira Huma Siddiqui Dr. Hira Salah ud din Khan Dr. Nabeel
+          Younus Ansari Abstract: The most pervasive concern in public sector organizations
+          is declining employee performance and workforce of these organizations are
+          less satisfied with their jobs. The aim of this study is to investigate the
+          impact of Job Satisfaction on employee\u2019s performance and how Islamic
+          work ethics moderates the above mentioned direct relationship in the public
+          sector organizations of Pakistan. The data were collected from the sample
+          of 193 permanent employees working in public sector organizations through
+          stratified sampling technique. The results revealed that employees Job satisfaction
+          is significantly related to higher performance. Further, the findings indicated
+          that Islamic work ethics moderates the relationship between job satisfaction
+          and employee performance. The present research has some theoretical and empirical
+          implications for academicians, policymakers, especially of public sector organizations,
+          for the improvement of performance of their workforce. Keyswords: Employee
+          Performance, Islamic Work Ethics, Job Satisfaction, Person-Environment Fit
+          Theory Pages: 808-821 Article: 64 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)64
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)64 Download Pdf: download
+          pdf view article Creative Commons License Semantics of Qawwali: Poetry, Perception,
+          and Cultural Consumption Authors: Rao Nadeem Alam Tayyaba Khalid Abstract:
+          Semantics is about meanings and meanings are arbitrary and shared. Understanding
+          qawwali context requires comprehension of semantics or process of meaning
+          creation and meaning sharing among the qawwal party and the audience. This
+          interactive activity might frequently be hindered when interrupted by subjective
+          meanings creation during cultural consumption. Qawwali is a cultural tradition,
+          its semantics are conditioned by axiological premises of poetry and perceptions
+          which are transforming. The previous researches revealed that qawwali is associated
+          with religion which provides the religious message by singing hamd and naat.
+          It was a means to experience Divine; therefore, semantics are multi-layered
+          and often crossroad with values and subjective experiences. It is novel due
+          to its ritual of Sama. It has the therapeutic power that helps mentally disturbed
+          people and they find refuge. This study is exploratory having a small sample
+          size of twenty purposively selected audiences. This phenomenological inquiry
+          used ethnographic method of conversational interviews at selected shrines
+          and cultural spaces in Islamabad. The results indicate that qawwali is a strong
+          refuge for people facing miseries of life and they attend Sama with a belief
+          that attending and listening will consequently resolve their issues, either
+          psychological or physiological. They participate in Sama which teaches them
+          how to be optimistic in a negative situation; this paper brings forth this
+          nodal phenomenon using the verbatim explanations by the interlocutors. Semantics
+          of Qawwali are conditioned and some of these elements are highlighted including
+          poetry and axiology based perceptions and cultural consumption of a cultural
+          realm. Keyswords: Cognition, Culture, Poetry, Qawwal, Qawwali, Semantics Pages:
+          822-834 Article: 65 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)65
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)65 Download Pdf: download
+          pdf view article Creative Commons License Political Economy of Smuggling:
+          The Living Source for the Natives (A Case Study of Jiwani-Iran Border, Baluchistan)
+          Authors: Abdul Raheem Dr. Ikram Badshah Wasia Arshed Abstract: This study
+          explores the political economy of smuggling on Jiwani-Iran border. The natives
+          are majorly involved in illegal transportation of goods and objects, therefore;
+          the study sets to explain how significant smuggling for the local people is.
+          It describes the kinship role in reciprocity of their trade and transportation.
+          The qualitative methods such as purposive sampling and interview guide were
+          employed for data collection. The research findings revealed that local people
+          were satisfied with their illegal trading which is depended largely on their
+          expertise and know-how of smuggling at borders. They disclosed that their
+          total economy was predominantly based on smuggling of stuff like drugs, diesel,
+          oil, gas, petrol, ration food from Iran, and human trafficking. They also
+          enjoyed the privilege of possessing Sajjil (Iranian identity card), thus;
+          the dual nationality helped them in their daily business and rahdari (border
+          crossing agreement), enabling them to travel to Iran for multiple purposes.
+          Keyswords: Drugs, Human, Navigation, Political Economy, Reciprocity, Smuggling,
+          Trafficking Pages: 835-848 Article: 66 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)66
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)66 Download Pdf: download
+          pdf view article Creative Commons License The Vicious Circles of System: A
+          Kafkaesque Study of Kobo Abe\u2019s The Woman in the Dunes Authors: Imran
+          Aslam Kainat Azhar Abstract: This paper analyses the Kafkaesque/Kafkan features
+          of Kobo Abe\u2019s novel The Woman in the as formulated by Kundera in \u201cKafka\u2019s
+          World.\u201d For Kundera, in a Kafkaesque work human existence is bleakly
+          represented through intermingling of tragedy and comedy in an indifferent
+          world dominated by hegemonic systems. The Kafkaesque is characterised by the
+          following: World is a huge forking labyrinthine institution where the man
+          has been thrown to suffer its complexities, confrontation with the labyrinth
+          makes his existence meaningless because freedom is a taboo in no man\u2019s
+          land, he is punished for an unknown sin for which he seeks justification from
+          the superior authorities, but his efforts are viewed as ludicrous or comic
+          despite the underlying sense of tragedy. (5) The Kafkaesque tendency to present
+          tragic situation comically is also explored in Abe\u2019s novel. The paper
+          studies the effect of higher authorities exercising their power over man and
+          the inscrutability of cosmic structures continuously undermining human freedom
+          in nightmarish conditions. The paper establishes Kobo Abe in the literary
+          world as a writer who portrays the hollowness and futility of human lives
+          with a Kafkaesque touch. Keyswords: Authority, Institutions, Kafka, Kafkaesque,
+          Kafkan, Kobo Abe, Kundera, The Trial, The Woman in the Dune Pages: 849-861
+          Article: 67 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)67 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)67 Download Pdf: download pdf
+          view article Creative Commons License Subjectivity and Ideological Interpellation:
+          An Investigation of Omar Shahid Hamid\u2019s The Spinner\u2019s Tale Authors:
+          Hina Iqbal Dr. Muhammad Asif Asia Saeed Abstract: Louis Althusser\u2019s concept
+          of interpellation is a process in which individuals internalize cultural values
+          and ideology and becomes subject. Althusser believes that ideology is a belief
+          system of a society in which ideological agencies establish hierarchies in
+          society through reinforcement and discrimination for cultural conditioning.
+          These agencies function through ideological state apparatuses. These ideological
+          agencies help to construct individual identity in society. The undesirable
+          ideologies promote repressive political agendas. The non-repressive ideologies
+          are inhaled by the individuals as a natural way of looking at the culture
+          and society. This research seeks to investigate Omar Shahid Hamid\u2019s novel
+          The Spinners Tales through the lens of Althusser\u2019s ideology and interpellation.
+          This study examines how the characters of Shahid\u2019s novel inhaled ideology
+          and became its subjects. This research also depicts the alarming effects of
+          cultural hegemony that creates cultural infidelity and hierarchies between
+          the bourgeoisie and proletariat classes. Keyswords: Cultural Hegemony, Ideological
+          State Apparatus, Ideology, Interpellation, Repressive Factors Pages: 862-872
+          Article: 68 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)68 DOI
+          Link: http://doi.org/10.47205/jdss.2021(2-IV)68 Download Pdf: download pdf
+          view article Creative Commons License Blessing in Disguise: Recommendations
+          of Indian Education Commission (1882) and Christian Missionaries\u2019 Educational
+          Policy in the Colonial Punjab Authors: Mohammad Dilshad Mohabbat Muhammad
+          Hassan Muhammad Ayaz Rafi Abstract: Woods Education Despatch is considered
+          to be the Magna Carta of Indian Education. It controlled the Indian education
+          field till the establishment of Indian Education Commission, 1882. The Despatch
+          provided space to Christian missionaries by promising government\u2019s gradual
+          withdrawal from the education in favour of missionaries. It also facilitated
+          the missionaries by offering system of \u2018grants on aid\u2019 to the private
+          bodies. Consequently, the missionaries fancied to replace the government institutions
+          in the Punjab and initiated their efforts to increase the number of their
+          educational institutions. They tried to occupy the educational field by establishing
+          more and more educational institutions. But after the Recommendations of the
+          Indian Education Commission 1882, a change in their policy of numeric increase
+          of educational institutions is quite visible. With the turn of the century,
+          they are found to be eager to establish a few institutions with good quality
+          of education. This paper intends to analyse different factors behind the change
+          of their policy of quantitative dominance to qualitative improvement. It also
+          attempts to evaluate how their change of policy worked and what steps were
+          taken to improve the quality of their educational institutions. Following
+          the historical method qualitative data comprising educational reports, missionaries\u2019
+          autobiographies, Reports of missionaries\u2019 conferences, and the other
+          relevant primary and secondary sources has been collected from different repositories.
+          The analysis of the data suggests that the attitude of the administration
+          of the education department and the recommendations of Indian Education Commission
+          were the major driving forces behind the change of missionaries\u2019 educational
+          policy in the 20th century. The missionaries, after adopting the new policy,
+          worked on the quality of education in their institutions and became successful.
+          Keyswords: Christian Missionaries, Indian Education Commission, Missionary
+          Schools, Numeric Increase, Quality of Education. The Punjab, Woods Education
+          Despatch Pages: 873-887 Article: 69 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)69
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)69 Download Pdf: download
+          pdf view article Creative Commons License Basic Life Values of Prospective
+          Special Education Teachers Authors: Dr. Maria Sohaib Qureshi Dr. Syeda Samina
+          Tahira Dr. Muhammad Irfan Arif Abstract: Future teachers'' preconceived values
+          about how to live their lives and how that affects the lives of their students
+          were the focus of this study. Descriptive research was used by the researchers.
+          The study was carried out by using Morris''s Ways to Live Scale. Researchers
+          used this scale to study prospective special education teachers'' gender,
+          social status, personal relationships, aesthetics and mental approach using
+          purposive sampling method. Descriptive and inferential stats were used to
+          analyse the data collected from those who participated in the study on basic
+          life values of prospective teachers. Results indicated that being social and
+          sympathetic are the most important values among prospective special education
+          teachers. It was also found that male and female prospective special education
+          teachers living in urban and rural areas had no significant differences in
+          their basic life values. Keyswords: Special Education, Teacher, Values Pages:
+          888-896 Article: 70 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)70
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)70 Download Pdf: download
+          pdf view article Creative Commons License Perception of Dowry: Effects on
+          Women Rights in Punjab Authors: Dr. Bushra Yasmeen Dr. Muhammad Ramzan Dr.
+          Asma Seemi Malik Abstract: Dowry is a common tradition in south Asian countries,
+          especially in Pakistan and India. Daughters became curses and liability for
+          parents causing serious consequences. For control, there are legal ban/restrictions
+          (Dowry and Wedding Gifts (Restriction) Act, 1976; Amendment in Act, 1993)
+          on its practice in Pakistan. Despite the legal cover, the custom has been
+          extended. Dowry amount seems to be increasing due to changing lifestyle and
+          trends of society. To understand males\u2019 and females\u2019 perceptions
+          about dowry; impacts of dowry; why dowry is essential; and how it is affecting
+          women\u2019s rights and eventually affecting women\u2019s autonomy. A qualitative
+          study was conducted. Data was collected by using unstructured interviews from
+          males and females including social activists, economists, and married couples
+          about wedding expenses, demands, society pressure, men\u2019s support, and
+          perception against dowry especially with regards to women\u2019s rights and
+          autonomy. The study concluded heavy dowry especially in terms of furniture,
+          electronics, kitchenware, car, furnished houses, and cash highly associated
+          with women\u2019s development and their rights. General people\u2019s perception
+          showed that dowry is no longer remained a custom or tradition in Asian countries.
+          It is just a trend and people follow it as a symbol of respect for parents
+          and women as well. Keyswords: Dowry, Effects, Impacts Of Dowry, Perceptions,
+          Women Autonomy, Women Rights Pages: 897-909 Article: 71 , Volume 2 , Issue
+          4 DOI Number: 10.47205/jdss.2021(2-IV)71 DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)71
+          Download Pdf: download pdf view article Creative Commons License NCOC-An Emblem
+          of Effective Governance: An analysis of Pakistan\u2019s Counter Strategy for
+          Covid-19 as a Non-Traditional Security Challenge Authors: Dr. Iram Khalid
+          Abstract: COVID -19 affected the world unprecedentedly. Lack of capacity and
+          poor standards of governance caused nontraditional security challenges to
+          Pakistan too. The NCOC is the central nerve center to guide the national response
+          to COVID-19 by Pakistan and can be best analyzed in the light of the decision-making
+          theory of Naturalist Decision Making (NDM). The study points out the effective
+          role performed by NCOC at policy formation through a more prosaic combination
+          of science, data, decision making and execution of decisions at the level
+          of federalism. The study highlights the changing patterns of government\u2019s
+          approach during the pandemic at various levels. Pakistan faced economic, political
+          and social crisis during this phase. This study uses a survey and key informant
+          interviews as the source of analysis for qualitative data collection. By applying
+          the decision- making theory, the paper extends that there is a need to use
+          a model to balance the existing gap within the system, to meet challenges.
+          The study suggests a coordinating approach among various units and center;
+          that might raise the level of performance to meet the nontraditional security
+          challenges with innovation, creativity and boldness. Keyswords: COVID-19,
+          Decision Making Theory, Governance, Nontraditional Threats, Strategy Pages:
+          910-930 Article: 72 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)72
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)72 Download Pdf: download
+          pdf view article Creative Commons License Comparative Implications of Wednesbury
+          Principle in England and Pakistan Authors: Safarat Ahmad Ali Shah Dr. Sara
+          Qayum Arzoo Farhad Abstract: Wednesbury principle is one of the most important
+          and useful grounds of the Judicial Review. Judicial review is a remedy provided
+          by the public law and is exercised by the superior and higher courts to supervise
+          administrative authorities'' powers and functions. The main objective of the
+          judicial review is to ensure the fair and transparent treatment of individuals
+          by public authorities. The ground of the judicial review, i.e., Unreasonableness
+          or irrationality or popularly known as Wednesbury Unreasonableness was introduced
+          by lord Greene in the Wednesbury Corporation case in 1948. Initially, the
+          scope of this ground of judicial review was very narrow and was allowed only
+          in rare cases. However, with the development of administrative law and Human
+          rights, it also developed. Its development resulted in different controversies
+          and issues about the application of this ground. The main issue is about its
+          encroachment in the jurisdiction of other branches of the government i.e.,
+          the parliament and executive. The free and loose application of this principle
+          results in confusion and conflict between different organs of the government.
+          The present paper is based on the implications of the limitations on the ground
+          of Wednesbury Unreasonableness both on the judicial and administrative bodies
+          in Pakistan to avoid the chaos and confusion that results in the criticisms
+          on this ground of judicial review. Keyswords: Administrative Authorities,
+          Critical Analysis, Illegality, Judicial Review, Pakistan, Wednesbury Unreasonableness
+          Pages: 931-946 Article: 73 , Volume 2 , Issue 4 DOI Number: 10.47205/jdss.2021(2-IV)73
+          DOI Link: http://doi.org/10.47205/jdss.2021(2-IV)73 Download Pdf: download
+          pdf view article Creative Commons License Water Sharing Issues in Pakistan:
+          Impacts on Inter-Provincial Relations","updated":"2022-09-19T20:05:00.111001","year":2021,"z_authors":null},"score":8.0090365e-07,"snippet":"(2021)
+          Volume 2, Issue 4 Cultural Implications of China Pakistan Economic Corridor
+          (CPEC Authors: Dr"}]}
+
+          '
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "39584"
+        Content-Type:
+          - application/json
+        Date:
+          - Fri, 30 Aug 2024 00:01:48 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1724976108&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=EGvJRtowVSV%2BSm%2FAoUU1eolnXBunP28fswisqrkwMKs%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1724976108&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=EGvJRtowVSV%2BSm%2FAoUU1eolnXBunP28fswisqrkwMKs%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
+          "title": "Augmenting large language models with chemistry tools", "venue":
+          "Nat. Mac. Intell.", "year": 2023, "citationCount": 190, "influentialCitationCount":
+          12, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
+          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
+          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
+          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
+          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
+          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
+          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
+          {Augmenting large language models with chemistry tools},\n volume = {6},\n
+          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
+          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
+          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
+          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
+          "name": "P. Schwaller"}], "matchScore": 181.12164}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1551"
+        Content-Type:
+          - application/json
+        Date:
+          - Fri, 30 Aug 2024 00:01:49 GMT
+        Via:
+          - 1.1 2db4851b6d360f79d8bbeb4eae3c9eb6.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - TEeMAmwZVE61i3BXI2i823TUXoIc4GywhxKImmMo8XWVFRYbq7u0QA==
+        X-Amz-Cf-Pop:
+          - IAD55-P4
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - dS7NCHeTvHcEp7g=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1551"
+        x-amzn-Remapped-Date:
+          - Fri, 30 Aug 2024 00:01:49 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 83e8cea6-8edb-40d9-bbc9-19baedad52db
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=test@example.com&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2283974,"items":[{"indexed":{"date-parts":[[2024,8,9]],"date-time":"2024-08-09T17:10:06Z","timestamp":1723223406992},"reference-count":103,"publisher":"Springer
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2292457,"items":[{"indexed":{"date-parts":[[2024,8,28]],"date-time":"2024-08-28T07:45:58Z","timestamp":1724831158151},"reference-count":103,"publisher":"Springer
           Science and Business Media LLC","issue":"5","license":[{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"},{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"}],"funder":[{"DOI":"10.13039\/501100001711","name":"Schweizerischer
-          Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","doi-asserted-by":"publisher","award":["180544","180544","180544"]},{"DOI":"10.13039\/100000001","name":"National
-          Science Foundation","doi-asserted-by":"publisher","award":["1751471","1751471"]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"short-container-title":["Nat
+          Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","doi-asserted-by":"publisher","award":["180544","180544","180544"],"id":[{"id":"10.13039\/501100001711","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000001","name":"National
+          Science Foundation","doi-asserted-by":"publisher","award":["1751471","1751471"],"id":[{"id":"10.13039\/100000001","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"short-container-title":["Nat
           Mach Intell"],"abstract":"<jats:title>Abstract<\/jats:title><jats:p>Large
           language models (LLMs) have shown strong performance in tasks across domains
           but struggle with chemistry-related problems. These models also lack access
@@ -24,7 +1685,7 @@ interactions:
           both LLM and expert assessments, demonstrates ChemCrow\u2019s effectiveness
           in automating a diverse set of chemical tasks. Our work not only aids expert
           chemists and lowers barriers for non-experts but also fosters scientific advancement
-          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":12,"title":["Augmenting
+          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":14,"title":["Augmenting
           large language models with chemistry tools"],"prefix":"10.1038","volume":"6","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"member":"297","published-online":{"date-parts":[[2024,5,8]]},"reference":[{"key":"832_CR1","unstructured":"Devlin,
@@ -313,7 +1974,7 @@ interactions:
           (2024).","DOI":"10.5281\/zenodo.10884645"},{"key":"832_CR103","doi-asserted-by":"publisher","unstructured":"Bran,
           A., Cox, S., White, A. & Schwaller, P. ur-whitelab\/chemcrow-public: v0.3.24.
           Zenodo https:\/\/doi.org\/10.5281\/zenodo.10884639 (2024).","DOI":"10.5281\/zenodo.10884639"}],"container-title":["Nature
-          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.864754,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
+          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.873142,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
           September 2023","order":1,"name":"received","label":"Received","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"27 March 2024","order":2,"name":"accepted","label":"Accepted","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"8 May 2024","order":3,"name":"first_online","label":"First
@@ -334,11 +1995,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "10544"
+          - "10572"
         Content-Type:
           - application/json
         Date:
-          - Tue, 13 Aug 2024 18:33:59 GMT
+          - Fri, 30 Aug 2024 00:01:49 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -384,7 +2045,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Tue, 13 Aug 2024 18:33:59 GMT
+          - Fri, 30 Aug 2024 00:01:49 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -401,69 +2062,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
-          "title": "Augmenting large language models with chemistry tools", "venue":
-          "Nat. Mac. Intell.", "year": 2023, "citationCount": 187, "influentialCitationCount":
-          12, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
-          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
-          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
-          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
-          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
-          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
-          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
-          {Augmenting large language models with chemistry tools},\n volume = {6},\n
-          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
-          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
-          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
-          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
-          "name": "P. Schwaller"}], "matchScore": 181.37788}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1551"
-        Content-Type:
-          - application/json
-        Date:
-          - Tue, 13 Aug 2024 18:34:01 GMT
-        Via:
-          - 1.1 2896f6be77233cf3f24b7a1aaae1c6f2.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - jArWyr3rFLmJjudRoMU1SmrmySKA3uObh6sqBSPt_3sUKPl5Rxam4A==
-        X-Amz-Cf-Pop:
-          - IAD55-P4
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - cdcLsGaQvHcEOxA=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1551"
-        x-amzn-Remapped-Date:
-          - Tue, 13 Aug 2024 18:34:01 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 2347c943-5dab-4e0f-b1e3-d3d152e38b92
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_title_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes2].yaml
@@ -3,7 +3,7 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/search?query=Augmenting%20large%20language%20models%20with%20chemistry%20tools&email=api@futurehouse.org
+      uri: https://api.unpaywall.org/v2/search?query=Augmenting%20large%20language%20models%20with%20chemistry%20tools&email=test@example.com
     response:
       body:
         string:


### PR DESCRIPTION
Adds a new metadata provider, unpaywall. (https://unpaywall.org/) Also associated tests to get open access status of papers. 

Additional minor bookeeping updates: 
- Refreshes all the cassettes for having extra data from unpaywall, also fixes a bug caused by the prior PR which removed facet filtering from crossref on doi queries (it's not supported anyway) 
- Renamed ALL_CLIENTS -> DEFAULT_CLIENTS since that's really what it is
- Adds `anthropic` into the agents module since it was needed in the import path 