### PR TITLE
Rollback search fields to `list` and dynamically compute md5 hash in tests

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -47,7 +47,6 @@ async def agent_query(
     verbosity: int = 0,
     index_directory: str | os.PathLike | None = None,
 ) -> AnswerResponse:
-
     if isinstance(query, str):
         query = QueryRequest(query=query)
 
@@ -64,7 +63,7 @@ async def agent_query(
     )
 
     search_index = SearchIndex(
-        fields=SearchIndex.REQUIRED_FIELDS | {"question"},
+        fields=[*SearchIndex.REQUIRED_FIELDS, "question"],
         index_name="answers",
         index_directory=index_directory,
         storage=SearchDocumentStorage.JSON_MODEL_DUMP,
@@ -115,8 +114,7 @@ async def run_agent(
     profiler.start(outer_profile_name)
 
     logger.info(
-        f"Beginning agent {agent_type!r} run with question {query.query!r} and full"
-        f" query {query.model_dump()}."
+        f"Beginning agent {agent_type!r} run with question {query.query!r} and full query {query.model_dump()}."
     )
 
     if agent_type == "fake":
@@ -130,8 +128,7 @@ async def run_agent(
         agent_status = AgentStatus.UNSURE
     # stop after, so overall isn't reported as long-running step.
     logger.info(
-        f"Finished agent {agent_type!r} run with question {query.query!r} and status"
-        f" {agent_status}."
+        f"Finished agent {agent_type!r} run with question {query.query!r} and status {agent_status}."
     )
     return AnswerResponse(
         answer=answer,
@@ -313,7 +310,6 @@ async def search(
     index_name: str = "answers",
     index_directory: str | os.PathLike | None = None,
 ) -> list[tuple[AnswerResponse, str] | tuple[Any, str]]:
-
     search_index = SearchIndex(
         ["file_location", "body", "question"],
         index_name=index_name,

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -9,7 +9,7 @@ import pickle
 import zlib
 from enum import Enum, auto
 from io import StringIO
-from typing import Any, ClassVar, Collection
+from typing import Any, ClassVar, Sequence
 from uuid import UUID
 
 import anyio
@@ -81,12 +81,11 @@ class SearchDocumentStorage(str, Enum):
 
 
 class SearchIndex:
-
-    REQUIRED_FIELDS: ClassVar[set[str]] = {"file_location", "body"}
+    REQUIRED_FIELDS: ClassVar[list[str]] = ["file_location", "body"]
 
     def __init__(
         self,
-        fields: Collection[str] | None = None,
+        fields: Sequence[str] | None = None,
         index_name: str = "pqa_index",
         index_directory: str | os.PathLike | None = None,
         storage: SearchDocumentStorage = SearchDocumentStorage.PICKLE_COMPRESSED,
@@ -287,7 +286,7 @@ class SearchIndex:
         return None
 
     def clean_query(self, query: str) -> str:
-        for replace in {"*", "[", "]"}:
+        for replace in ("*", "[", "]"):
             query = query.replace(replace, "")
         return query
 
@@ -350,9 +349,7 @@ async def process_file(
     semaphore: anyio.Semaphore,
     docs_kwargs: dict[str, Any],
 ) -> None:
-
     async with semaphore:
-
         file_name = file_path.name
         if not await search_index.filecheck(str(file_path)):
             logger.info(f"New file to index: {file_name}...")
@@ -437,7 +434,7 @@ async def get_directory_index(
         directory = await directory.absolute()
 
     search_index = SearchIndex(
-        fields=SearchIndex.REQUIRED_FIELDS | {"title", "year"},
+        fields=[*SearchIndex.REQUIRED_FIELDS, "title", "year"],
         index_name=index_name,
         index_directory=index_directory or pqa_directory("indexes"),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def agent_index_dir(agent_home_dir: Path) -> Path:
     return agent_home_dir / ".pqa" / "indexes"
 
 
-@pytest.fixture(name="agent_test_kit")
+@pytest.fixture(name="agent_stub_answer")
 def fixture_stub_answer() -> Answer:
     return Answer(question="What is is a self-explanatory model?")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -16,7 +16,7 @@ from pytest_subtests import SubTests
 from paperqa.docs import Docs
 from paperqa.llms import LangchainLLMModel
 from paperqa.types import Answer, Context, Doc, PromptCollection, Text
-from paperqa.utils import get_year
+from paperqa.utils import get_year, md5sum
 
 try:
     from langchain.agents.openai_functions_agent.base import OpenAIFunctionsAgent
@@ -66,7 +66,9 @@ async def test_get_directory_index(agent_index_dir):
     assert len(await index.index_files) == 4, "Incorrect number of index files"
     results = await index.query(query="who is Frederick Bates?")
     # added docs.keys come from md5 hash of the file location
-    assert results[0].docs.keys() == {"dab5b86dea3bd4c7ffe05a9f33ae95f7"}
+    assert results[0].docs.keys() == {
+        md5sum((PAPER_DIRECTORY / "example.txt").absolute())
+    }
 
 
 @pytest.mark.asyncio
@@ -87,7 +89,7 @@ async def test_get_directory_index_w_manifest(agent_index_dir):
     assert len(await index.index_files) == 4, "Incorrect number of index files"
     results = await index.query(query="who is Barack Obama?")
     top_result = next(iter(results[0].docs.values()))
-    assert top_result.dockey == "af2c9acf6018e62398fc6efc4f0a04b4"
+    assert top_result.dockey == md5sum((PAPER_DIRECTORY / "example2.txt").absolute())
     # note: this title comes from the manifest, so we know it worked
     assert top_result.title == "Barack Obama (Wikipedia article)"
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -58,9 +58,9 @@ async def test_get_directory_index(agent_index_dir):
         index_directory=agent_index_dir,
     )
     assert index.fields == [
-        "title",
         "file_location",
         "body",
+        "title",
         "year",
     ], "Incorrect fields in index"
     assert len(await index.index_files) == 4, "Incorrect number of index files"
@@ -78,9 +78,9 @@ async def test_get_directory_index_w_manifest(agent_index_dir):
         manifest_file=anyio.Path(PAPER_DIRECTORY) / "stub_manifest.csv",
     )
     assert index.fields == [
-        "title",
         "file_location",
         "body",
+        "title",
         "year",
     ], "Incorrect fields in index"
     # 4 = example.txt + example2.txt + paper.pdf + example.html
@@ -96,7 +96,6 @@ async def test_get_directory_index_w_manifest(agent_index_dir):
 @pytest.mark.parametrize("agent_type", ["OpenAIFunctionsAgent", "fake"])
 @pytest.mark.asyncio
 async def test_agent_types(agent_index_dir, agent_type):
-
     question = "How can you use XAI for chemical property prediction?"
 
     request = QueryRequest(


### PR DESCRIPTION
@sidnarayanan found a couple of issues while testing:
- seems that the md5 filehash isn't resolving correctly in local tests -- I replaced the hard coded md5 hash with one that is dynamically calculated to remove ambiguity in the tests. 
- he rolled back the type of a SearchIndex.fields attribute from a set back to a list to align with tanvity's expected type.