### PR TITLE
Fixing two more tests

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -899,7 +899,10 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path):
         fields=["author", "journal"],
     )
     doc_details = next(iter(docs.docs.values()))
-    assert doc_details.dockey == "5300ef1d5fb960d7"
+    assert doc_details.dockey in {
+        "41f786fcc56d27ff0c1507153fae3774",  # From file contents
+        "5300ef1d5fb960d7",  # Or from crossref data
+    }
     # note year is unknown because citation string is only parsed for authors/title/doi
     # AND we do not request it back from the metadata sources
     assert doc_details.docname == "wellawatteUnknownyearaperspectiveon"

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -917,7 +917,8 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path):
     assert "yes" in answer.answer or "Yes" in answer.answer
 
 
-def test_fileio_reader_pdf(stub_data_dir: Path):
+@pytest.mark.flaky(reruns=3, only_rerun=["AssertionError"])
+def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
     with (stub_data_dir / "paper.pdf").open("rb") as f:
         docs = Docs()
         docs.add_file(f, "Wellawatte et al, XAI Review, 2023")


### PR DESCRIPTION
Marked a flaky test, and allowing for a second possible ID in `test_pdf_reader_match_doc_details`