### PR TITLE
All Ruff `ANN` autofixes

### DIFF
--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -163,7 +163,7 @@ def save_settings(
         logger.info(f"Settings saved to: {full_settings_path}")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="PaperQA CLI")
 
     parser.add_argument(

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -166,7 +166,7 @@ class SimpleProfiler(BaseModel):
         except RuntimeError:  # No running event loop (not in async)
             self.running_timers[name] = TimerData(start_time=time.time())
 
-    def stop(self, name: str):
+    def stop(self, name: str) -> None:
         timer_data = self.running_timers.pop(name, None)
         if timer_data:
             try:

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -193,7 +193,7 @@ class SearchIndex:
 
     async def add_document(
         self, index_doc: dict, document: Any | None = None, max_retries: int = 1000
-    ):
+    ) -> None:
         @retry(
             stop=stop_after_attempt(max_retries),
             wait=wait_random_exponential(multiplier=0.25, max=60),

--- a/paperqa/clients/exceptions.py
+++ b/paperqa/clients/exceptions.py
@@ -1,4 +1,4 @@
 class DOINotFoundError(Exception):
-    def __init__(self, message="DOI not found"):
+    def __init__(self, message="DOI not found") -> None:
         self.message = message
         super().__init__(self.message)

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -54,11 +54,11 @@ from paperqa.utils import (
 
 
 # this is just to reduce None checks/type checks
-async def empty_callback(result: LLMResult):
+async def empty_callback(result: LLMResult) -> None:
     pass
 
 
-async def print_callback(result: LLMResult):
+async def print_callback(result: LLMResult) -> None:
     pass
 
 
@@ -85,7 +85,7 @@ class Docs(BaseModel):
             return PAPERQA_DIR / info.data["name"]
         return value
 
-    def clear_docs(self):
+    def clear_docs(self) -> None:
         self.texts = []
         self.docs = {}
         self.docnames = set()
@@ -451,7 +451,7 @@ class Docs(BaseModel):
         self.deleted_dockeys.add(dockey)
         self.texts = list(filter(lambda x: x.doc.dockey != dockey, self.texts))
 
-    def _build_texts_index(self):
+    def _build_texts_index(self) -> None:
         texts = [t for t in self.texts if t not in self.texts_index]
         self.texts_index.add_texts_and_embeddings(texts)
 

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -488,10 +488,10 @@ class VectorStore(BaseModel, ABC):
     model_config = ConfigDict(extra="forbid")
     texts_hashes: set[int] = Field(default_factory=set)
 
-    def __contains__(self, item):
+    def __contains__(self, item) -> bool:
         return hash(item) in self.texts_hashes
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.texts_hashes)
 
     @abstractmethod
@@ -614,7 +614,7 @@ class LangchainVectorStore(VectorStore):
     class_type: type[Embeddable] = Field(default=Embeddable)
     model_config = ConfigDict(extra="forbid")
 
-    def __init__(self, **data):
+    def __init__(self, **data) -> None:
         raise NotImplementedError(
             "Langchain has updated vectorstore internals and this is not yet supported"
         )

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -89,7 +89,7 @@ class LLMResult(BaseModel):
         default=0.0, description="Delta time (sec) to last response token's arrival."
     )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.text
 
     @computed_field  # type: ignore[prop-decorator]
@@ -198,7 +198,7 @@ class Answer(BaseModel):
             raise ValueError(f"Could not find docname {name} in contexts.") from exc
         return doc.citation
 
-    def add_tokens(self, result: LLMResult):
+    def add_tokens(self, result: LLMResult) -> None:
         """Update the token counts for the given result."""
         if result.model not in self.token_counts:
             self.token_counts[result.model] = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,12 @@ PAPER_DIRECTORY = Path(__file__).parent
 
 
 @pytest.fixture(autouse=True, scope="session")
-def _load_env():
+def _load_env() -> None:
     load_dotenv()
 
 
 @pytest.fixture(autouse=True)
-def _setup_default_logs():
+def _setup_default_logs() -> None:
     setup_default_logs()
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -48,7 +48,7 @@ async def test_get_directory_index(agent_test_settings) -> None:
 @pytest.mark.asyncio
 async def test_get_directory_index_w_manifest(
     agent_test_settings, reset_log_levels, caplog  # noqa: ARG001
-):
+) -> None:
     agent_test_settings.manifest_file = "stub_manifest.csv"
     index = await get_directory_index(settings=agent_test_settings)
     assert index.fields == [
@@ -71,7 +71,7 @@ async def test_get_directory_index_w_manifest(
 @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError", "httpx.RemoteProtocolError"])
 @pytest.mark.parametrize("agent_type", ["fake", "OpenAIFunctionsAgent"])
 @pytest.mark.asyncio
-async def test_agent_types(agent_test_settings, agent_type):
+async def test_agent_types(agent_test_settings, agent_type) -> None:
 
     question = "How can you use XAI for chemical property prediction?"
 
@@ -87,7 +87,7 @@ async def test_agent_types(agent_test_settings, agent_type):
 
 
 @pytest.mark.asyncio
-async def test_timeout(agent_test_settings):
+async def test_timeout(agent_test_settings) -> None:
     agent_test_settings.prompts.pre = None
     agent_test_settings.agent.timeout = 0.001
     agent_test_settings.llm = "gpt-4o-mini"
@@ -287,7 +287,7 @@ def test_functions() -> None:
     ]
 
 
-def test_query_request_docs_name_serialized():
+def test_query_request_docs_name_serialized() -> None:
     """Test that the query request has a docs_name property."""
     request = QueryRequest(query="Are COVID-19 vaccines effective?")
     request_data = json.loads(request.model_dump_json())
@@ -298,7 +298,7 @@ def test_query_request_docs_name_serialized():
     assert request_data["docs_name"] == "my_doc"
 
 
-def test_answers_are_striped():
+def test_answers_are_striped() -> None:
     """Test that answers are striped."""
     answer = Answer(
         question="What is the meaning of life?",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ except ImportError:
     pytest.skip("agents module is not installed", allow_module_level=True)
 
 
-def test_can_modify_settings():
+def test_can_modify_settings() -> None:
     old_argv = sys.argv
     old_stdout = sys.stdout
     captured_output = io.StringIO()
@@ -37,7 +37,7 @@ def test_can_modify_settings():
         os.unlink(pqa_directory("settings") / "unit_test.json")
 
 
-def test_cli_ask(agent_index_dir: Path, stub_data_dir: Path):
+def test_cli_ask(agent_index_dir: Path, stub_data_dir: Path) -> None:
     settings = Settings.from_name("debug")
     settings.index_directory = agent_index_dir
     settings.paper_directory = stub_data_dir
@@ -56,7 +56,9 @@ def test_cli_ask(agent_index_dir: Path, stub_data_dir: Path):
     assert found_answer.model_dump_json() == response.model_dump_json()
 
 
-def test_cli_can_build_and_search_index(agent_index_dir: Path, stub_data_dir: Path):
+def test_cli_can_build_and_search_index(
+    agent_index_dir: Path, stub_data_dir: Path
+) -> None:
     settings = Settings.from_name("debug")
     settings.index_directory = agent_index_dir
     index_name = "test"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -96,7 +96,7 @@ from paperqa.clients.journal_quality import JournalQualityPostProcessor
     ],
 )
 @pytest.mark.asyncio
-async def test_title_search(paper_attributes: dict[str, str]):
+async def test_title_search(paper_attributes: dict[str, str]) -> None:
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session, clients=ALL_CLIENTS)
         details = await client.query(title=paper_attributes["title"])
@@ -192,7 +192,7 @@ async def test_title_search(paper_attributes: dict[str, str]):
     ],
 )
 @pytest.mark.asyncio
-async def test_doi_search(paper_attributes: dict[str, str]):
+async def test_doi_search(paper_attributes: dict[str, str]) -> None:
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session, clients=ALL_CLIENTS)
         details = await client.query(doi=paper_attributes["doi"])
@@ -210,7 +210,7 @@ async def test_doi_search(paper_attributes: dict[str, str]):
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_bulk_doi_search():
+async def test_bulk_doi_search() -> None:
     dois = [
         "10.1063/1.4938384",
         "10.48550/arxiv.2312.07559",
@@ -228,7 +228,7 @@ async def test_bulk_doi_search():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_bulk_title_search():
+async def test_bulk_title_search() -> None:
     titles = [
         (
             "Effect of native oxide layers on copper thin-film tensile properties: A"
@@ -253,7 +253,7 @@ async def test_bulk_title_search():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_bad_titles():
+async def test_bad_titles() -> None:
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session)
         details = await client.query(title="askldjrq3rjaw938h")
@@ -269,7 +269,7 @@ async def test_bad_titles():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_bad_dois():
+async def test_bad_dois() -> None:
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session)
         details = await client.query(title="abs12032jsdafn")
@@ -278,7 +278,7 @@ async def test_bad_dois():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_minimal_fields_filtering():
+async def test_minimal_fields_filtering() -> None:
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session)
         details = await client.query(
@@ -303,7 +303,7 @@ async def test_minimal_fields_filtering():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_s2_only_fields_filtering():
+async def test_s2_only_fields_filtering() -> None:
     async with aiohttp.ClientSession() as session:
         # now get with authors just from one source
         s2_client = DocMetadataClient(session, clients=[SemanticScholarProvider])
@@ -373,7 +373,7 @@ async def test_crossref_journalquality_fields_filtering() -> None:
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_author_matching():
+async def test_author_matching() -> None:
     async with aiohttp.ClientSession() as session:
         crossref_client = DocMetadataClient(session, clients=[CrossrefProvider])
         s2_client = DocMetadataClient(session, clients=[SemanticScholarProvider])
@@ -402,7 +402,7 @@ async def test_author_matching():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_odd_client_requests():
+async def test_odd_client_requests() -> None:
     # try querying using an authors match, but not requesting authors back
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session)
@@ -449,7 +449,7 @@ async def test_odd_client_requests():
 
 
 @pytest.mark.asyncio
-async def test_ensure_robust_to_timeouts(monkeypatch):
+async def test_ensure_robust_to_timeouts(monkeypatch) -> None:
     # 0.15 should be short enough to not get a response in time.
     monkeypatch.setattr(paperqa.clients.crossref, "CROSSREF_API_REQUEST_TIMEOUT", 0.05)
     monkeypatch.setattr(
@@ -466,7 +466,7 @@ async def test_ensure_robust_to_timeouts(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_bad_init():
+async def test_bad_init() -> None:
     with pytest.raises(
         ValueError, match="At least one MetadataProvider must be provided."
     ):
@@ -475,7 +475,7 @@ async def test_bad_init():
 
 @pytest.mark.vcr
 @pytest.mark.asyncio
-async def test_ensure_sequential_run(caplog, reset_log_levels):  # noqa: ARG001
+async def test_ensure_sequential_run(caplog, reset_log_levels) -> None:  # noqa: ARG001
     caplog.set_level(logging.DEBUG)
     # were using a DOI that is NOT in crossref, but running the crossref client first
     # we will ensure that both are run sequentially
@@ -512,7 +512,7 @@ async def test_ensure_sequential_run(caplog, reset_log_levels):  # noqa: ARG001
 @pytest.mark.asyncio
 async def test_ensure_sequential_run_early_stop(
     caplog, reset_log_levels  # noqa: ARG001
-):
+) -> None:
     caplog.set_level(logging.DEBUG)
     # now we should stop after hitting s2
     async with aiohttp.ClientSession() as session:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -11,7 +11,7 @@ from paperqa.settings import (
 )
 
 
-def test_prompt_settings_validation():
+def test_prompt_settings_validation() -> None:
     with pytest.raises(ValidationError):
         PromptSettings(summary="Invalid {variable}")
 
@@ -27,13 +27,13 @@ def test_prompt_settings_validation():
     assert valid_pre_settings.pre == "{question}"
 
 
-def test_get_formatted_variables():
+def test_get_formatted_variables() -> None:
     template = "This is a test {variable} with {another_variable}"
     variables = get_formatted_variables(template)
     assert variables == {"variable", "another_variable"}
 
 
-def test_get_settings_with_valid_config():
+def test_get_settings_with_valid_config() -> None:
     settings = get_settings("fast")
     assert not settings.parsing.use_doc_details
 
@@ -46,7 +46,7 @@ def test_get_settings_missing_file() -> None:
         get_settings("missing_config")
 
 
-def test_settings_default_instantiation():
+def test_settings_default_instantiation() -> None:
     settings = Settings()
     assert "gpt-" in settings.llm
     assert settings.answer.evidence_k == 10

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -52,7 +52,7 @@ def docs_fixture(stub_data_dir: Path) -> Docs:
     return docs
 
 
-def test_get_citations():
+def test_get_citations() -> None:
     text = (
         "Yes, COVID-19 vaccines are effective. Various studies have documented the"
         " effectiveness of COVID-19 vaccines in preventing severe disease,"
@@ -88,17 +88,17 @@ def test_get_citations():
     assert get_citenames(text) == ref
 
 
-def test_single_author():
+def test_single_author() -> None:
     text = "This was first proposed by (Smith 1999)."
     assert strip_citations(text) == "This was first proposed by ."
 
 
-def test_multiple_authors():
+def test_multiple_authors() -> None:
     text = "Recent studies (Smith et al. 1999) show that this is true."
     assert strip_citations(text) == "Recent studies  show that this is true."
 
 
-def test_multiple_citations():
+def test_multiple_citations() -> None:
     text = (
         "As discussed by several authors (Smith et al. 1999; Johnson 2001; Lee et al."
         " 2003)."
@@ -106,47 +106,47 @@ def test_multiple_citations():
     assert strip_citations(text) == "As discussed by several authors ."
 
 
-def test_citations_with_pages():
+def test_citations_with_pages() -> None:
     text = "This is shown in (Smith et al. 1999, p. 150)."
     assert strip_citations(text) == "This is shown in ."
 
 
-def test_citations_without_space():
+def test_citations_without_space() -> None:
     text = "Findings by(Smith et al. 1999)were significant."
     assert strip_citations(text) == "Findings bywere significant."
 
 
-def test_citations_with_commas():
+def test_citations_with_commas() -> None:
     text = "The method was adopted by (Smith, 1999, 2001; Johnson, 2002)."
     assert strip_citations(text) == "The method was adopted by ."
 
 
-def test_citations_with_text():
+def test_citations_with_text() -> None:
     text = "This was noted (see Smith, 1999, for a review)."
     assert strip_citations(text) == "This was noted ."
 
 
-def test_no_citations():
+def test_no_citations() -> None:
     text = "There are no references in this text."
     assert strip_citations(text) == "There are no references in this text."
 
 
-def test_malformed_citations():
+def test_malformed_citations() -> None:
     text = "This is a malformed citation (Smith 199)."
     assert strip_citations(text) == "This is a malformed citation (Smith 199)."
 
 
-def test_edge_case_citations():
+def test_edge_case_citations() -> None:
     text = "Edge cases like (Smith et al.1999) should be handled."
     assert strip_citations(text) == "Edge cases like  should be handled."
 
 
-def test_citations_with_special_characters():
+def test_citations_with_special_characters() -> None:
     text = "Some names have dashes (O'Neil et al. 2000; Smith-Jones 1998)."
     assert strip_citations(text) == "Some names have dashes ."
 
 
-def test_citations_with_nonstandard_chars():
+def test_citations_with_nonstandard_chars() -> None:
     text = (
         "In non-English languages, citations might look different (Müller et al. 1999)."
     )
@@ -156,7 +156,7 @@ def test_citations_with_nonstandard_chars():
     )
 
 
-def test_maybe_is_text():
+def test_maybe_is_text() -> None:
     assert maybe_is_text("This is a test. The sample conc. was 1.0 mM (at 245 ^F)")
     assert not maybe_is_text("\\C0\\C0\\B1\x00")
     # get front page of wikipedia
@@ -172,7 +172,7 @@ def test_maybe_is_text():
     assert not maybe_is_text(bad_text)
 
 
-def test_name_in_text():
+def test_name_in_text() -> None:
     name1 = "FooBar2022"
     name2 = "FooBar2022a"
     name3 = "FooBar20"
@@ -213,7 +213,7 @@ def test_name_in_text():
     assert not name_in_text(name3, text7)
 
 
-def test_extract_score():
+def test_extract_score() -> None:
     sample = """
     The text describes an experiment where different cell subtypes,
     including colorectal cancer-associated fibroblasts, were treated with
@@ -387,11 +387,11 @@ I have written the json you asked for.""",
 """,
     ],
 )
-def test_llm_parse_json(example: str):
+def test_llm_parse_json(example: str) -> None:
     assert llm_parse_json(example) == {"example": "json"}
 
 
-def test_llm_parse_json_newlines():
+def test_llm_parse_json_newlines() -> None:
     """Make sure that newlines in json are preserved and escaped."""
     example = textwrap.dedent(
         """
@@ -409,7 +409,7 @@ def test_llm_parse_json_newlines():
 
 
 @pytest.mark.asyncio
-async def test_chain_completion():
+async def test_chain_completion() -> None:
     s = Settings(llm="babbage-002", temperature=0.2)
     outputs = []
 
@@ -438,7 +438,7 @@ async def test_chain_completion():
 
 
 @pytest.mark.asyncio
-async def test_chain_chat():
+async def test_chain_chat() -> None:
     model_config = {
         "model_list": [
             {
@@ -535,7 +535,7 @@ async def test_anthropic_chain(stub_data_dir: Path) -> None:
     assert result.cost > 0
 
 
-def test_make_docs(stub_data_dir: Path):
+def test_make_docs(stub_data_dir: Path) -> None:
     docs = Docs()
     docs.add(
         stub_data_dir / "flag_day.html",
@@ -545,7 +545,7 @@ def test_make_docs(stub_data_dir: Path):
     assert docs.docs["test"].docname == "Wiki2023"
 
 
-def test_evidence(docs_fixture):
+def test_evidence(docs_fixture) -> None:
     fast_settings = Settings.from_name("debug")
     evidence = docs_fixture.get_evidence(
         Answer(question="What does XAI stand for?"),
@@ -554,7 +554,7 @@ def test_evidence(docs_fixture):
     assert len(evidence) >= fast_settings.answer.evidence_k
 
 
-def test_json_evidence(docs_fixture):
+def test_json_evidence(docs_fixture) -> None:
     settings = Settings.from_name("fast")
     settings.prompts.use_json = True
     settings.prompts.summary_json_system = (
@@ -574,7 +574,7 @@ def test_json_evidence(docs_fixture):
     assert evidence[0].author_name
 
 
-def test_ablations(docs_fixture):
+def test_ablations(docs_fixture) -> None:
     settings = Settings()
     settings.answer.evidence_skip_summary = True
     settings.answer.evidence_retrieval = False
@@ -589,7 +589,7 @@ def test_ablations(docs_fixture):
     assert len(contexts) == len(docs_fixture.texts), "evidence retrieval not ablated"
 
 
-def test_location_awareness(docs_fixture):
+def test_location_awareness(docs_fixture) -> None:
     settings = Settings()
     settings.answer.evidence_k = 3
     settings.prompts.use_json = False
@@ -608,14 +608,14 @@ def test_location_awareness(docs_fixture):
     ), "location not found in evidence"
 
 
-def test_query(docs_fixture):
+def test_query(docs_fixture) -> None:
     docs_fixture.query("Is XAI usable in chemistry?")
 
 
-def test_llmresult_callback(docs_fixture):
+def test_llmresult_callback(docs_fixture) -> None:
     my_results = []
 
-    async def my_callback(result):
+    async def my_callback(result) -> None:
         my_results.append(result)
 
     settings = Settings.from_name("fast")
@@ -655,7 +655,7 @@ def test_duplicate(stub_data_dir: Path) -> None:
     ), "Unique documents should be hashed as unique"
 
 
-def test_custom_embedding(stub_data_dir: Path):
+def test_custom_embedding(stub_data_dir: Path) -> None:
     class MyEmbeds(EmbeddingModel):
         name: str = "my_embed"
 
@@ -758,7 +758,7 @@ def test_custom_llm(stub_data_dir: Path) -> None:
     "Langchain updated vector stores and I haven't yet updated the implementation"
 )
 @pytest.mark.asyncio
-async def test_langchain_vector_store(stub_data_dir: Path):
+async def test_langchain_vector_store(stub_data_dir: Path) -> None:
     from langchain_community.vectorstores.faiss import FAISS
     from langchain_openai import OpenAIEmbeddings
 
@@ -839,7 +839,7 @@ def test_docs_pickle(stub_data_dir) -> None:
     assert len(unpickled_docs.docs) == 1
 
 
-def test_bad_context(stub_data_dir):
+def test_bad_context(stub_data_dir) -> None:
     docs = Docs()
     docs.add(stub_data_dir / "bates.txt", "WikiMedia Foundation, 2023, Accessed now")
     answer = docs.query(
@@ -848,7 +848,7 @@ def test_bad_context(stub_data_dir):
     assert "cannot answer" in answer.answer
 
 
-def test_repeat_keys(stub_data_dir):
+def test_repeat_keys(stub_data_dir) -> None:
     docs = Docs()
     result = docs.add(
         stub_data_dir / "bates.txt", "WikiMedia Foundation, 2023, Accessed now"
@@ -871,12 +871,12 @@ def test_repeat_keys(stub_data_dir):
     assert ds[1].docname == "Wiki2023a"
 
 
-def test_can_read_normal_pdf_reader(docs_fixture):
+def test_can_read_normal_pdf_reader(docs_fixture) -> None:
     answer = docs_fixture.query("Are counterfactuals actionable? [yes/no]")
     assert "yes" in answer.answer or "Yes" in answer.answer
 
 
-def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path):
+def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path) -> None:
     docs = Docs()
     docs.add(stub_data_dir / "paper.pdf", "Wellawatte et al, XAI Review, 2023")
     # doc will be a DocDetails object, but nothing can be found
@@ -886,7 +886,7 @@ def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path):
     )
 
 
-def test_pdf_reader_match_doc_details(stub_data_dir: Path):
+def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
     doc_path = stub_data_dir / "paper.pdf"
     docs = Docs()
     # we limit to only crossref since s2 is too flaky
@@ -926,7 +926,7 @@ def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
         assert "yes" in answer.answer or "Yes" in answer.answer
 
 
-def test_fileio_reader_txt(stub_data_dir: Path):
+def test_fileio_reader_txt(stub_data_dir: Path) -> None:
     # can't use curie, because it has trouble with parsed HTML
     docs = Docs()
     with (stub_data_dir / "bates.txt").open("rb") as file:
@@ -940,7 +940,7 @@ def test_fileio_reader_txt(stub_data_dir: Path):
     assert "United States" in answer.answer
 
 
-def test_pdf_pypdf_reader(stub_data_dir: Path):
+def test_pdf_pypdf_reader(stub_data_dir: Path) -> None:
     doc_path = stub_data_dir / "paper.pdf"
     splits1 = read_doc(
         Path(doc_path),
@@ -957,7 +957,7 @@ def test_pdf_pypdf_reader(stub_data_dir: Path):
     )
 
 
-def test_parser_only_reader(stub_data_dir: Path):
+def test_parser_only_reader(stub_data_dir: Path) -> None:
     doc_path = stub_data_dir / "paper.pdf"
     parsed_text = read_doc(
         Path(doc_path),
@@ -973,7 +973,7 @@ def test_parser_only_reader(stub_data_dir: Path):
     )
 
 
-def test_chunk_metadata_reader(stub_data_dir: Path):
+def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
     doc_path = stub_data_dir / "paper.pdf"
     chunk_text, metadata = read_doc(
         Path(doc_path),
@@ -1025,7 +1025,7 @@ def test_chunk_metadata_reader(stub_data_dir: Path):
     assert metadata.total_parsed_text_length // 3000 <= len(chunk_text)
 
 
-def test_code():
+def test_code() -> None:
     # load this script
     doc_path = Path(os.path.abspath(__file__))
     settings = Settings.from_name("fast")
@@ -1046,7 +1046,7 @@ def test_zotero() -> None:
         ZoteroDB()  # "group" if group library
 
 
-def test_too_much_evidence(stub_data_dir: Path, stub_data_dir_w_near_dupes):
+def test_too_much_evidence(stub_data_dir: Path, stub_data_dir_w_near_dupes) -> None:
     doc_path = stub_data_dir / "obama.txt"
     mini_settings = Settings(llm="gpt-4o-mini", summary_llm="gpt-4o-mini")
     docs = Docs()
@@ -1065,7 +1065,7 @@ def test_too_much_evidence(stub_data_dir: Path, stub_data_dir_w_near_dupes):
     docs.query("What is Barrack's greatest accomplishment?", settings=settings)
 
 
-def test_custom_prompts(stub_data_dir: Path):
+def test_custom_prompts(stub_data_dir: Path) -> None:
     my_qaprompt = (
         "Answer the question '{question}' using the country name alone. For example: A:"
         " United States\nA: Canada\nA: Mexico\n\n Using the"
@@ -1079,7 +1079,7 @@ def test_custom_prompts(stub_data_dir: Path):
     assert "United States" in answer.answer
 
 
-def test_pre_prompt(stub_data_dir: Path):
+def test_pre_prompt(stub_data_dir: Path) -> None:
     pre = (
         "What is water's boiling point in Fahrenheit? Please respond with a complete"
         " sentence."
@@ -1096,7 +1096,7 @@ def test_pre_prompt(stub_data_dir: Path):
     )
 
 
-def test_post_prompt(stub_data_dir: Path):
+def test_post_prompt(stub_data_dir: Path) -> None:
     post = "The opposite of down is"
     settings = Settings.from_name("fast")
     settings.prompts.post = post
@@ -1106,7 +1106,7 @@ def test_post_prompt(stub_data_dir: Path):
     assert "up" in response.answer.lower()
 
 
-def test_external_doc_index(stub_data_dir: Path):
+def test_external_doc_index(stub_data_dir: Path) -> None:
     docs = Docs()
     docs.add(
         stub_data_dir / "flag_day.html", "WikiMedia Foundation, 2023, Accessed now"


### PR DESCRIPTION
This enables `mypy` to look at all of these tests, even without `check_untyped_defs` enabled in the config