### PR TITLE
Removed `html2text` requirement

### DIFF
--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -12,7 +12,7 @@ try:
 except ImportError as e:
     raise ImportError(
         "zotero requires the 'zotero' extra for 'pyzotero'. Please:"
-        " `pip install aviary[zotero]`."
+        " `pip install paper-qa[zotero]`."
     ) from e
 from paperqa.paths import PAPERQA_DIR
 from paperqa.utils import StrPath, count_pdf_pages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 dependencies = [
     "PyCryptodome",
     "aiohttp",  # TODO: remove in favor of httpx
-    "html2text",
     "httpx",
     "litellm",
     "numpy",
@@ -57,6 +56,9 @@ agents = [
     "tantivy",
     "typer",
     "typing_extensions",
+]
+html = [
+    "html2text",
 ]
 typing = [
     "types-PyYAML",
@@ -387,7 +389,7 @@ dev-dependencies = [
     "build",  # TODO: remove after https://github.com/astral-sh/uv/issues/6278
     "ipython>=8",  # Pin to keep recent
     "mypy>=1.8",  # Pin for mutable-override
-    "paper-qa[agents,llms,typing]",
+    "paper-qa[agents,html,typing]",
     "pre-commit~=3.4",  # Pin to keep recent
     "pytest-asyncio",
     "pytest-recording",

--- a/uv.lock
+++ b/uv.lock
@@ -1125,11 +1125,10 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.0.0a2.dev32+g01bb765.d20240909"
+version = "5.0.0a2.dev35+g8863c3d.d20240910"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "html2text" },
     { name = "httpx" },
     { name = "litellm" },
     { name = "numpy" },
@@ -1156,6 +1155,9 @@ agents = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
+html = [
+    { name = "html2text" },
+]
 typing = [
     { name = "types-pyyaml" },
     { name = "types-setuptools" },
@@ -1168,6 +1170,7 @@ zotero = [
 dev = [
     { name = "anyio" },
     { name = "build" },
+    { name = "html2text" },
     { name = "ipython" },
     { name = "langchain" },
     { name = "langchain-community" },
@@ -1199,7 +1202,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp" },
     { name = "anyio", marker = "extra == 'agents'" },
-    { name = "html2text" },
+    { name = "html2text", marker = "extra == 'html'" },
     { name = "httpx" },
     { name = "langchain", marker = "extra == 'agents'" },
     { name = "langchain-community", marker = "extra == 'agents'" },
@@ -1230,7 +1233,7 @@ dev = [
     { name = "build" },
     { name = "ipython", specifier = ">=8" },
     { name = "mypy", specifier = ">=1.8" },
-    { name = "paper-qa", extras = ["agents", "llms", "typing"] },
+    { name = "paper-qa", extras = ["agents", "html", "typing"] },
     { name = "pre-commit", specifier = "~=3.4" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio" },


### PR DESCRIPTION
- Made `html2text` an opt-in extra `html`
- Also, https://github.com/Future-House/paper-qa/pull/343 forgot to remove `llms` from `dev` dependencies
- Also, https://github.com/Future-House/paper-qa/pull/331 used the wrong name for a lazy `ImportError`