### PR TITLE
Recurse into directories; catch empty documents

### DIFF
--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -50,12 +50,6 @@ class AgentStatus(StrEnum):
     UNSURE = "unsure"
 
 
-class ImpossibleParsingError(Exception):
-    """Error to throw when a parsing is impossible."""
-
-    LOG_METHOD_NAME: ClassVar[str] = "warning"
-
-
 class MismatchedModelsError(Exception):
     """Error to throw when model clients clash ."""
 

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -27,7 +27,7 @@ from tenacity import (
 from paperqa.docs import Docs
 from paperqa.settings import MaybeSettings, Settings, get_settings
 from paperqa.types import DocDetails
-from paperqa.utils import hexdigest, pqa_directory
+from paperqa.utils import ImpossibleParsingError, hexdigest, pqa_directory
 
 from .models import SupportsPickle
 
@@ -372,7 +372,7 @@ async def process_file(
                     fields=["title", "author", "journal", "year"],
                     settings=settings,
                 )
-            except ValueError:
+            except (ValueError, ImpossibleParsingError):
                 logger.exception(
                     f"Error parsing {file_name}, skipping index for this file."
                 )

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -53,7 +53,7 @@ def chunk_pdf(
 
     if not parsed_text.content:
         raise ImpossibleParsingError(
-            "No text was parsed from the document: " "either empty or corrupted."
+            "No text was parsed from the document: either empty or corrupted."
         )
 
     for page_num, page_text in parsed_text.content.items():

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -15,6 +15,7 @@ except ImportError:
     html2text = None  # type: ignore[assignment]
 
 from paperqa.types import ChunkMetadata, Doc, ParsedMetadata, ParsedText, Text
+from paperqa.utils import ImpossibleParsingError
 from paperqa.version import __version__ as pqa_version
 
 
@@ -48,6 +49,11 @@ def chunk_pdf(
     if not isinstance(parsed_text.content, dict):
         raise NotImplementedError(
             f"ParsedText.content must be a `dict`, not {type(parsed_text.content)}."
+        )
+
+    if not parsed_text.content:
+        raise ImpossibleParsingError(
+            "No text was parsed from the document: " "either empty or corrupted."
         )
 
     for page_num, page_text in parsed_text.content.items():

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -368,6 +368,10 @@ class Settings(BaseSettings):
             " answer indexes."
         ),
     )
+    index_recursively: bool = Field(
+        default=True,
+        description="Whether to recurse into subdirectories when indexing sources.",
+    )
     verbosity: int = Field(
         default=0,
         description=(

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from functools import reduce
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, ClassVar
 from uuid import UUID
 
 import aiohttp
@@ -37,6 +37,12 @@ logger = logging.getLogger(__name__)
 
 
 StrPath = str | Path
+
+
+class ImpossibleParsingError(Exception):
+    """Error to throw when a parsing is impossible."""
+
+    LOG_METHOD_NAME: ClassVar[str] = "warning"
 
 
 def name_in_text(name: str, text: str) -> bool:


### PR DESCRIPTION
Replacement PR for #312 . It adds two features:
- `Settings.index_recursively` (defaults to True) enables recursive indexing
- If a PDF is corrupted and is parsed as an empty text, raise an exception in `chunk_pdf` (later caught by `SearchIndex`)