### PR TITLE
No google auth, better CI names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: publish
+name: Publish
 
 on:
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,10 @@
-name: test
+name: Lint and Test
 
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,9 +46,6 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           uv python pin ${{ matrix.python-version }}
       - run: uv sync --python-preference=only-managed
-      - uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
       - run: uv run pytest -n auto
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
- Removed `google-github-actions/auth` since [this GitHub Action run](https://github.com/Future-House/paper-qa/actions/runs/10825145826/job/30033656715?pr=379) made it clear it doesn't play nice with external members
    - I don't know why we have it here anyways
- Updated CI names to be more readable
- Allowing lint/test CI to be manually kicked off using `gh workflow run` from CLI