### PR TITLE
Fixing Pydantic validation in Python<3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.event_name == 'pull_request' # pre-commit-ci/lite-action only runs here
     strategy:
       matrix:
-        python-version: [3.12] # Our min and max supported Python versions
+        python-version: [3.11, 3.12] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12] # Our min and max supported Python versions
+        python-version: [3.11, 3.12] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, Awaitable, Callable, Iterable, Sequence
 from enum import StrEnum
 from inspect import signature
+from sys import version_info
 from typing import Any
 
 import numpy as np
@@ -350,9 +351,12 @@ DEFAULT_VERTEX_SAFETY_SETTINGS: list[dict[str, str]] = [
     },
 ]
 
-_DeploymentTypedDictValidator = TypeAdapter(
-    list[DeploymentTypedDict], config=ConfigDict(arbitrary_types_allowed=True)
-)
+
+IS_PYTHON_BELOW_312 = version_info < (3, 12)
+if not IS_PYTHON_BELOW_312:
+    _DeploymentTypedDictValidator = TypeAdapter(
+        list[DeploymentTypedDict], config=ConfigDict(arbitrary_types_allowed=True)
+    )
 
 
 class LiteLLMModel(LLMModel):
@@ -390,11 +394,15 @@ class LiteLLMModel(LLMModel):
                 "router_kwargs": {"num_retries": 3, "retry_after": 5},
             }
         # we only support one "model name" for now, here we validate
-        _DeploymentTypedDictValidator.validate_python(data["config"]["model_list"])
-        if (
-            "config" in data
-            and len({m["model_name"] for m in data["config"]["model_list"]}) > 1
-        ):
+        model_list = data["config"]["model_list"]
+        if IS_PYTHON_BELOW_312:
+            if not isinstance(model_list, list):
+                # Work around https://github.com/BerriAI/litellm/issues/5664
+                raise TypeError(f"model_list must be a list, not a {type(model_list)}.")
+        else:
+            # pylint: disable-next=possibly-used-before-assignment
+            _DeploymentTypedDictValidator.validate_python(model_list)
+        if "config" in data and len({m["model_name"] for m in model_list}) > 1:
             raise ValueError("Only one model name per router is supported for now.")
         return data
 


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/322 dropped our min Python version from CI during debugging. This enabled a slight Pydantic incompatibility with Python<3.12 to slide under the radar in https://github.com/Future-House/paper-qa/pull/383.

This PR:
- Reintroduces min version testing to CI
- Fixes the incompatibility