### PR TITLE
Adding `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to PaperQA
+
+Thank you for your interest in contributing to PaperQA!
+Here are some guidelines to help you get started.
+
+## Setting up the development environment
+
+We use [`uv`](https://github.com/astral-sh/uv) for our local development.
+
+1. Install `uv` by following the instructions on the [uv website](https://astral.sh/uv/).
+2. Run the following command to install all dependencies and set up the development environment:
+
+   ```bash
+   uv sync
+   ```
+
+## Installing the package for development
+
+If you prefer to use `pip` for installing the package in development mode, you can do so by running:
+
+```bash
+pip install -e .
+```
+
+## Running tests and other tooling
+
+Use the following commands:
+
+- Run tests:
+
+  ```bash
+  pytest
+  # or for multiprocessing based parallelism
+  pytest -n auto
+  ```
+
+- Run `pre-commit` for formatting and type checking
+
+  ```bash
+  pre-commit run --all-files
+  ```
+
+- Run `mypy`, `refurb`, or `pylint` directly:
+
+  ```bash
+  mypy paperqa
+  # or
+  refurb paperqa
+  # or
+  pylint paperqa
+  ```
+
+See our GitHub Actions [`tests.yml`](.github/workflows/tests.yml) for further reference.
+
+## Additional resources
+
+For more information on contributing, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in the repository.
+
+Happy coding!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ pip install -e .
 
 Use the following commands:
 
-- Run tests:
+- Run tests (requires an OpenAI key in your environment)
 
   ```bash
   pytest

--- a/README.md
+++ b/README.md
@@ -54,13 +54,17 @@ PaperQA2 depends on some awesome libraries/APIs that make our repo possible. Her
 7. [pybtex](https://pybtex.org/)
 8. [PyMuPDF](https://pymupdf.readthedocs.io/en/latest/)
 
-## Install
+## Installation
 
-You can install PaperQA2 via pip:
+For a non-development setup,
+install PaperQA2 from [PyPI](https://pypi.org/project/paper-qa/):
 
 ```bash
 pip install paper-qa
 ```
+
+For development setup,
+please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 PaperQA2 uses an LLM to operate,
 so you'll need to either set an appropriate [API key environment variable][LiteLLM providers] (i.e. `export OPENAI_API_KEY=sk-...`)


### PR DESCRIPTION
Fixes #396

Add development setup instructions and link to CONTRIBUTING.md

* **CONTRIBUTING.md**:
  - Add a section for installing `uv` for development.
  - Add a section for installing the package for development using `pip install -e .`.
  - Add a section for running tests and other tooling.
  - Remove mentions of `uv lint`, use `pre-commit` instead.
  - Add a comment to look at our GitHub Actions `tests.yml` for reference.
  - Make a relative link for the GitHub Actions `tests.yml`.

* **README.md**:
  - Add a link to the `CONTRIBUTING.md` file in the "Installation" section.
  - Add a note redirecting developers to the `CONTRIBUTING.md` file for development setup instructions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Future-House/paper-qa/issues/396?shareId=3859bcc2-2fe0-4a1c-858a-9168fe24cb54).