### PR TITLE
Removing `new_episodes` on `test_crossref_journalquality_fields_filtering`

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -345,7 +345,7 @@ async def test_s2_only_fields_filtering() -> None:
         assert not s2_details.source_quality, "No source quality data should exist"  # type: ignore[union-attr]
 
 
-@pytest.mark.vcr(record_mode="new_episodes")
+@pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_crossref_journalquality_fields_filtering() -> None:
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
This flag was leading local `pytest -n auto` to remake the fixture a bunch, when we don't want that