### PR TITLE
`pytest-recording` docs in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,27 @@ Use the following commands:
 
 See our GitHub Actions [`tests.yml`](.github/workflows/tests.yml) for further reference.
 
+## Using `pytest-recording` and VCR cassettes
+
+We use the [`pytest-recording`](https://github.com/kiwicom/pytest-recording) plugin
+to create VCR cassettes to cache HTTP requests,
+making our unit tests more deterministic.
+
+To record a new VCR cassette:
+
+```bash
+uv run pytest tests/desired_test_module.py
+```
+
+And the new cassette(s) should appear in [`tests/cassettes`](tests/cassettes).
+
+Our configuration for `pytest-recording` can be found in [`tests/conftest.py`](tests/conftest.py).
+This includes header removals (e.g. OpenAI `authorization` key)
+from responses to ensure sensitive information is excluded from the cassettes.
+
+Please ensure cassettes are less than 1 MB
+to keep tests loading quickly.
+
 ## Additional resources
 
 For more information on contributing, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file in the repository.


### PR DESCRIPTION
Fixes #409

Add documentation for `pytest-recording` and VCR cassettes in `CONTRIBUTING.md`.

* Add a section for `pytest-recording` plugin.
* Link to `pytest-recording` documentation.
* Provide a brief summary on how to record a new VCR using `uv run pytest tests/desired_test_module.py`.
* Link to the config in `tests/conftest.py`.
* Document header removals from responses.
* Add relative links for `tests/cassettes` and `tests/conftest.py`.
* Add a comment about keeping the cassettes less than 1 MB in size.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Future-House/paper-qa/issues/409?shareId=57e021b4-67c7-4886-ac81-51fa8e012770).