### PR TITLE
Pinning min `pymupdf` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "PyCryptodome",
+    "PyMuPDF>=1.24.3",  # python -c "import pymupdf" won't run before version 1.24.3
     "aiohttp",  # TODO: remove in favor of httpx
     "anyio",
     "fhaviary[llm]>=0.6",  # For info on Message
@@ -28,7 +29,6 @@ dependencies = [
     "pybtex",
     "pydantic-settings",
     "pydantic~=2.0",
-    "pymupdf",
     "rich",
     "setuptools",  # TODO: remove after release of https://bitbucket.org/pybtex-devs/pybtex/pull-requests/46/replace-pkg_resources-with-importlib
     "tantivy",

--- a/uv.lock
+++ b/uv.lock
@@ -1217,7 +1217,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.0.3.dev3+g5363d94"
+version = "5.0.4.dev8+gca25963.d20240917"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1298,7 +1298,7 @@ requires-dist = [
     { name = "pycryptodome" },
     { name = "pydantic", specifier = "~=2.0" },
     { name = "pydantic-settings" },
-    { name = "pymupdf" },
+    { name = "pymupdf", specifier = ">=1.24.3" },
     { name = "pyzotero", marker = "extra == 'zotero'" },
     { name = "rich" },
     { name = "setuptools" },


### PR DESCRIPTION
Apparently `import pymupdf` won't work with version 1.23. Would appreciate a second set of eyes here