### PR TITLE
Centralizing Rate Limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,18 @@ with open("my_docs.pkl", "rb") as f:
     docs = pickle.load(f)
 ```
 
+### Rate limits/PQA Speed
+
+For ease of use, we've tried to tune the library for a typical Tier 1 OpenAI account (typical spend of $5 / month). That means we've reduced the speed of a few things. If you have a high tier account and S2/Crossref keys, you can increase the `index_concurrency` setting to 30-50 and increase the TPM/RPM via a complete specification
+
+```python
+llm_config = dict(
+    model_list=dict(model_name="o1-preview", router_kwargs=dict(tpm=30_000_000, rpm=5))
+)
+
+settings = Settings(llm_config=llm_config)
+```
+
 ## Citation
 
 Please read and cite the following papers if you use this software:

--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -35,9 +35,9 @@ def configure_cli_logging(verbosity: int = 0) -> None:
             "httpx": logging.WARNING,
             "paperqa.agents.models": logging.WARNING,
             "paperqa.agents.search": logging.INFO,
-            "litellm": logging.WARNING,
-            "LiteLLM Router": logging.WARNING,
-            "LiteLLM Proxy": logging.WARNING,
+            "LiteLLM": logging.CRITICAL,
+            "LiteLLM Router": logging.CRITICAL,
+            "LiteLLM Proxy": logging.CRITICAL,
         }
     }
 
@@ -52,13 +52,15 @@ def configure_cli_logging(verbosity: int = 0) -> None:
         "paperqa.agents.main.agent_callers": logging.DEBUG,
         "paperqa.models": logging.DEBUG,
         "paperqa.agents.search": logging.DEBUG,
-        "litellm": logging.INFO,
+        "LiteLLM": logging.INFO,
         "LiteLLM Router": logging.INFO,
         "LiteLLM Proxy": logging.INFO,
     }
 
     verbosity_map[3] = verbosity_map[2] | {
-        "litellm": logging.DEBUG,  # <-- every single LLM call
+        "LiteLLM": logging.DEBUG,  # <-- every single LLM call
+        "LiteLLM Router": logging.DEBUG,
+        "LiteLLM Proxy": logging.DEBUG,
     }
 
     rich_handler = RichHandler(
@@ -78,7 +80,7 @@ def configure_cli_logging(verbosity: int = 0) -> None:
 
     for logger_name, logger_ in logging.Logger.manager.loggerDict.items():
         if isinstance(logger_, logging.Logger) and (
-            log_level := verbosity_map.get(min(verbosity, 2), {}).get(logger_name)
+            log_level := verbosity_map.get(min(verbosity, 3), {}).get(logger_name)
         ):
             logger_.setLevel(log_level)
 

--- a/paperqa/configs/contracrow.json
+++ b/paperqa/configs/contracrow.json
@@ -52,6 +52,6 @@
     "timeout": 500.0,
     "should_pre_search": false,
     "tool_names": null,
-    "index_concurrency": 30
+    "index_concurrency": 10
   }
 }

--- a/paperqa/configs/debug.json
+++ b/paperqa/configs/debug.json
@@ -7,7 +7,7 @@
     "evidence_summary_length": "25 to 50 words",
     "answer_max_sources": 2,
     "answer_length": "50 to 100 words",
-    "max_concurrent_requests": 5
+    "max_concurrent_requests": 4
   },
   "parsing": {
     "use_doc_details": false

--- a/paperqa/configs/fast.json
+++ b/paperqa/configs/fast.json
@@ -5,7 +5,7 @@
     "evidence_summary_length": "25 to 50 words",
     "answer_max_sources": 3,
     "answer_length": "50 to 100 words",
-    "max_concurrent_requests": 5
+    "max_concurrent_requests": 4
   },
   "parsing": {
     "use_doc_details": false

--- a/paperqa/configs/high_quality.json
+++ b/paperqa/configs/high_quality.json
@@ -2,7 +2,7 @@
   "answer": {
     "evidence_k": 20,
     "answer_max_sources": 5,
-    "max_concurrent_requests": 10
+    "max_concurrent_requests": 4
   },
   "parsing": {
     "use_doc_details": true,

--- a/paperqa/configs/wikicrow.json
+++ b/paperqa/configs/wikicrow.json
@@ -52,6 +52,6 @@
     "timeout": 500.0,
     "should_pre_search": false,
     "tool_names": null,
-    "index_concurrency": 30
+    "index_concurrency": 10
   }
 }

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -469,6 +469,7 @@ def setup_default_logs() -> None:
                 "httpcore": {"level": "WARNING"},
                 "httpx": {"level": "WARNING"},
                 # SEE: https://github.com/BerriAI/litellm/issues/2256
+                "LiteLLM.Info": {"level": "WARNING"},
                 "LiteLLM": {"level": "WARNING"},
                 "LiteLLM Router": {"level": "WARNING"},
                 "LiteLLM Proxy": {"level": "WARNING"},

--- a/router_test.py
+++ b/router_test.py
@@ -24,7 +24,7 @@ async def test(router):
         [
             {
                 "role": "user",
-                "content": f"{pre_fill}\n\nRecite the Declaration of independence at a speed of {random.random() * 100} words per minute.",
+                "content": f"{pre_fill * 3}\n\nRecite the Declaration of independence at a speed of {random.random() * 100} words per minute.",
             }
         ],
         stream=True,

--- a/router_test.py
+++ b/router_test.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from litellm import Router
+
+
+async def test(router):
+    completion = await router.acompletion(
+        "gpt-4o-2024-08-06",
+        [{"role": "user", "content": "Recite the Declaration of independence."}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    async for chunk in completion:
+        pass
+
+
+async def main():
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-2024-08-06",
+                "litellm_params": {"model": "gpt-4o-2024-08-06", "temperature": 0.0},
+                "rpm": 125,
+                "tpm": 7500,
+            }
+        ],
+        num_retries=3,
+        retry_after=10,
+        cooldown_time=100,
+        allowed_fails=2,
+    )
+    await asyncio.gather(*[test(router) for _ in range(10)])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/router_test.py
+++ b/router_test.py
@@ -1,18 +1,40 @@
 import asyncio
+import random
 
 from litellm import Router
+
+pre_fill = """
+
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ut finibus massa. Quisque a magna magna. Quisque neque diam, varius sit amet tellus eu, elementum fermentum sapien. Integer ut erat eget arcu rutrum blandit. Morbi a metus purus. Nulla porta, urna at finibus malesuada, velit ante suscipit orci, vitae laoreet dui ligula ut augue. Cras elementum pretium dui, nec luctus nulla aliquet ut. Nam faucibus, diam nec semper interdum, nisl nisi viverra nulla, vitae sodales elit ex a purus. Donec tristique malesuada lobortis. Donec posuere iaculis nisl, vitae accumsan libero dignissim dignissim. Suspendisse finibus leo et ex mattis tempor. Praesent at nisl vitae quam egestas lacinia. Donec in justo non erat aliquam accumsan sed vitae ex. Vivamus gravida diam vel ipsum tincidunt dignissim.
+
+Cras vitae efficitur tortor. Curabitur vel erat mollis, euismod diam quis, consequat nibh. Ut vel est eu nulla euismod finibus. Aliquam euismod at risus quis dignissim. Integer non auctor massa. Nullam vitae aliquet mauris. Etiam risus enim, dignissim ut volutpat eget, pulvinar ac augue. Mauris elit est, ultricies vel convallis at, rhoncus nec elit. Aenean ornare maximus orci, ut maximus felis cursus venenatis. Nulla facilisi.
+
+Maecenas aliquet ante massa, at ullamcorper nibh dictum quis. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque id egestas justo. Suspendisse fringilla in massa in consectetur. Quisque scelerisque egestas lacus at posuere. Vestibulum dui sem, bibendum vehicula ultricies vel, blandit id nisi. Curabitur ullamcorper semper metus, vitae commodo magna. Nulla mi metus, suscipit in neque vitae, porttitor pharetra erat. Vestibulum libero velit, congue in diam non, efficitur suscipit diam. Integer arcu velit, fermentum vel tortor sit amet, venenatis rutrum felis. Donec ultricies enim sit amet iaculis mattis.
+
+Integer at purus posuere, malesuada tortor vitae, mattis nibh. Mauris ex quam, tincidunt et fermentum vitae, iaculis non elit. Nullam dapibus non nisl ac sagittis. Duis lacinia eros iaculis lectus consectetur vehicula. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut cursus semper est, vel interdum turpis ultrices dictum. Suspendisse posuere lorem et accumsan ultrices. Duis sagittis bibendum consequat. Ut convallis vestibulum enim, non dapibus est porttitor et. Quisque suscipit pulvinar turpis, varius tempor turpis. Vestibulum semper dui nunc, vel vulputate elit convallis quis. Fusce aliquam enim nulla, eu congue nunc tempus eu.
+
+Nam vitae finibus eros, eu eleifend erat. Maecenas hendrerit magna quis molestie dictum. Ut consequat quam eu massa auctor pulvinar. Pellentesque vitae eros ornare urna accumsan tempor. Maecenas porta id quam at sodales. Donec quis accumsan leo, vel viverra nibh. Vestibulum congue blandit nulla, sed rhoncus libero eleifend ac. In risus lorem, rutrum et tincidunt a, interdum a lectus. Pellentesque aliquet pulvinar mauris, ut ultrices nibh ultricies nec. Mauris mi mauris, facilisis nec metus non, egestas luctus ligula. Quisque ac ligula at felis mollis blandit id nec risus. Nam sollicitudin lacus sed sapien fringilla ullamcorper. Etiam dui quam, posuere sit amet velit id, aliquet molestie ante. Integer cursus eget sapien fringilla elementum. Integer molestie, mi ac scelerisque ultrices, nunc purus condimentum est, in posuere quam nibh vitae velit.
+"""
 
 
 async def test(router):
     completion = await router.acompletion(
         "gpt-4o-2024-08-06",
-        [{"role": "user", "content": "Recite the Declaration of independence."}],
+        [
+            {
+                "role": "user",
+                "content": f"{pre_fill}\n\nRecite the Declaration of independence at a speed of {random.random() * 100} words per minute.",
+            }
+        ],
         stream=True,
+        temperature=0.0,
         stream_options={"include_usage": True},
     )
 
     async for chunk in completion:
         pass
+    print("done", chunk)
 
 
 async def main():
@@ -21,16 +43,12 @@ async def main():
             {
                 "model_name": "gpt-4o-2024-08-06",
                 "litellm_params": {"model": "gpt-4o-2024-08-06", "temperature": 0.0},
-                "rpm": 125,
-                "tpm": 7500,
+                "rpm": 500,
+                "tpm": 30000,
             }
         ],
-        num_retries=3,
-        retry_after=10,
-        cooldown_time=100,
-        allowed_fails=2,
     )
-    await asyncio.gather(*[test(router) for _ in range(10)])
+    await asyncio.gather(*[test(router) for _ in range(16)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I created an OpenAI project set at the tier 1 usage and tried to get `liteLLM` to work with lower rate limits. I centralized the Router to originate from the settings, but still am running into a lot of issues. 

I've built a Router with

```py
{
    "model_list": [
        {
            "model_name": "gpt-4o-2024-08-06",
            "litellm_params": {"model": "gpt-4o-2024-08-06", "temperature": 0.0},
            "rpm": 500,
            "tpm": 30000,
        }
    ],
    "num_retries": 3,
    "retry_after": 10,
    "enable_pre_call_checks": True,
}


```

The issues are that - with async concurrency:

1. The rate limits are not respected and we're getting 429s from OpenAI. LiteLLM also does not actually respect the message in 429 to wait the requested time (e.g., retry in 3.5 seconds)
2. The logs are full of "Give Feedback / Get Help: https://github.com/BerriAI/litellm/issues/new" regardless of my log settings
3. Even if it did work, we have a fundamental mismatch in usage. Because of how gpt-4o rate limits work, we need to share rate limits across multiple models - but litellm will only share across deployments (which are keyed to one model or group of models). This is the opposite of what we need.


I reproduced these errors in the min file `router_test.py` which triggers 429, even though the rate limits are set to match my OpenAI rate limits.

Opening this PR to start discussion on how to proceed