### PR TITLE
Avoiding div0 crash in `LitQATaskDataset.compute_trajectory_metrics`

### DIFF
--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -183,6 +183,8 @@ class LitQATaskDataset(
             ):
                 metric_list.append(  # Use mean to allow for multiple answers
                     sum(int(sa[i]) for sa in split_answers) / len(split_answers)
+                    if split_answers  # Avoid div0 (when no answer was made)
+                    else 0
                 )
         return super().compute_trajectory_metrics(trajectories) | {
             "total_paper_count": total_paper_count,


### PR DESCRIPTION
When a tool fails, this leads to no answer being present, which leads to a division by 0 error in `LitQATaskDataset.compute_trajectory_metrics`. This PR fixes that error, and also tests for it