### PR TITLE
Handling `AttributeError` on structured citation prompt failure

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -308,6 +308,7 @@ class Docs(BaseModel):
 
         # try to extract DOI / title from the citation
         if (doi is title is None) and parse_config.use_doc_details:
+            # TODO: specify a JSON schema here when many LLM providers support this
             result = await llm_model.run_prompt(
                 prompt=parse_config.structured_citation_prompt,
                 data={"citation": citation},


### PR DESCRIPTION
Our `ParsingSettings.structured_citation_prompt` extracts a JSON that is supposed to contain the paper's title, DOI, and authors. However, last night I hit a new crash possibility:
1. The paper `Casein Kinase 1&delta; Triggers Giant Ankyrin Expression` had its references on the first page.
2. This led to `ParsingSettings.structured_citation_prompt` extracting a list of authors dicts (one dict per reference).
3. `list[dict]` was not accounted for in `Docs.aadd`, it leads to an `AttributeError` and crashes the indexing process.

This PR handles the `AttributeError` possibility, and logs a warning if it happens