### PR TITLE
Fixing flaky test `test_pdf_reader_match_doc_details`

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -421,11 +421,15 @@ async def get_directory_index(
     settings: MaybeSettings = None,
 ) -> SearchIndex:
     """
-    Create a Tantivy index from a directory of text files.
+    Create a Tantivy index by reading from a directory of text files.
+
+    This function only reads from the source directory, not edits or writes to it.
 
     Args:
-        sync_index_w_directory: Sync the index with the directory. (i.e. delete files not in directory)
-        index_name: Name of the index. If not given, the name will be taken from the settings
+        index_name: Override on the name of the index. If unspecified, the default
+            behavior is to generate the name from the input settings.
+        sync_index_w_directory: Sync the index with the directory (i.e. delete index
+            files if the file isn't in the source directory).
         settings: Application settings.
     """
     _settings = get_settings(settings)

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -10,7 +10,15 @@ import httpx
 import numpy as np
 import pytest
 
-from paperqa import Answer, Doc, Docs, NumpyVectorStore, Settings, print_callback
+from paperqa import (
+    Answer,
+    Doc,
+    DocDetails,
+    Docs,
+    NumpyVectorStore,
+    Settings,
+    print_callback,
+)
 from paperqa.clients import CrossrefProvider
 from paperqa.core import llm_parse_json
 from paperqa.llms import (
@@ -823,16 +831,18 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
         "41f786fcc56d27ff0c1507153fae3774",  # From file contents
         "5300ef1d5fb960d7",  # Or from crossref data
     }
+    assert isinstance(doc_details, DocDetails)
     # note year is unknown because citation string is only parsed for authors/title/doi
     # AND we do not request it back from the metadata sources
     assert doc_details.docname == "wellawatteUnknownyearaperspectiveon"
-    assert set(doc_details.authors) == {  # type: ignore[attr-defined]
+    assert doc_details.authors
+    assert set(doc_details.authors) == {
         "Geemi P. Wellawatte",
         "Heta A. Gandhi",
         "Aditi Seshadri",
         "Andrew D. White",
     }
-    assert doc_details.doi == "10.26434/chemrxiv-2022-qfv02"  # type: ignore[attr-defined]
+    assert doc_details.doi == "10.26434/chemrxiv-2022-qfv02"
     answer = docs.query("Are counterfactuals actionable? [yes/no]")
     assert "yes" in answer.answer or "Yes" in answer.answer
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -815,15 +815,13 @@ def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path) -> None:
 
 
 def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
-    doc_path = stub_data_dir / "paper.pdf"
     docs = Docs()
-    # we limit to only crossref since s2 is too flaky
     docs.add(
-        doc_path,
+        stub_data_dir / "paper.pdf",
         "Wellawatte et al, A Perspective on Explanations of Molecular Prediction"
         " Models, XAI Review, 2023",
         use_doc_details=True,
-        clients={CrossrefProvider},
+        clients={CrossrefProvider},  # Limit to only crossref since s2 is too flaky
         fields=["author", "journal"],
     )
     doc_details = next(iter(docs.docs.values()))
@@ -844,7 +842,9 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
     }
     assert doc_details.doi == "10.26434/chemrxiv-2022-qfv02"
     answer = docs.query("Are counterfactuals actionable? [yes/no]")
-    assert "yes" in answer.answer or "Yes" in answer.answer
+    assert any(
+        w in answer.answer for w in ("yes", "Yes")
+    ), f"Incorrect answer: {answer.answer}"
 
 
 @pytest.mark.flaky(reruns=5, only_rerun=["AssertionError"])

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -841,21 +841,24 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
         "Andrew D. White",
     }
     assert doc_details.doi == "10.26434/chemrxiv-2022-qfv02"
-    answer = docs.query("Are counterfactuals actionable? [yes/no]")
-    assert any(
-        w in answer.answer for w in ("yes", "Yes")
-    ), f"Incorrect answer: {answer.answer}"
+    num_retries = 3
+    for _ in range(num_retries):
+        answer = docs.query("Are counterfactuals actionable? [yes/no]")
+        if any(w in answer.answer for w in ("yes", "Yes")):
+            return
+    raise AssertionError(f"Query was incorrect across {num_retries} retries.")
 
 
-@pytest.mark.flaky(reruns=5, only_rerun=["AssertionError"])
 def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
     with (stub_data_dir / "paper.pdf").open("rb") as f:
         docs = Docs()
         docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
+    num_retries = 3
+    for _ in range(num_retries):
         answer = docs.query("Are counterfactuals actionable? [yes/no]")
-        assert any(
-            w in answer.answer for w in ("yes", "Yes")
-        ), f"Incorrect answer: {answer.answer}"
+        if any(w in answer.answer for w in ("yes", "Yes")):
+            return
+    raise AssertionError(f"Query was incorrect across {num_retries} retries.")
 
 
 def test_fileio_reader_txt(stub_data_dir: Path) -> None:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -842,7 +842,7 @@ def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
     with (stub_data_dir / "paper.pdf").open("rb") as f:
         docs = Docs()
         docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
-        answer = docs.query("Are counterfactuals actionable?[yes/no]")
+        answer = docs.query("Are counterfactuals actionable? [yes/no]")
         assert any(
             w in answer.answer for w in ("yes", "Yes")
         ), f"Incorrect answer: {answer.answer}"


### PR DESCRIPTION
Shown in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/10964558602/job/30448424249), we see the answer did not include "yes". This PR fixes the flaky test by retrying the query up to 3X.

It also better documents `get_directory_index`