### PR TITLE
Down-pinning `openai` 1.47 since it breaks CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "httpx",
     "litellm>=1.44",  # to prevent sys.stdout on router creation
     "numpy",
+    "openai<1.47",  # TODO: remove after https://github.com/BerriAI/litellm/issues/5854 resolution
     "pybtex",
     "pydantic-settings",
     "pydantic~=2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "ldp"
-version = "0.7.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -828,9 +828,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "usearch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/63/8c98d12aea67ee3ad9dccfa991e01e8b8f579038b4a74edb2dcbf4cafbca/ldp-0.7.0.tar.gz", hash = "sha256:981b7acdaec8dd113392aa2f7707b4ff278520c25865c69a89352207a946aceb", size = 248395 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/b0/95b85a9117af6dddb102d706ee853779dadd9d72ea9ffac317b2a353998c/ldp-0.7.2.tar.gz", hash = "sha256:f6aaf7866ae7424d0452d8ab3784b77f50a4b8d2b4b40634bbd27f2d32525793", size = 270009 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/b2/f61b4cba627253e38a1351a6026f6f8a3e8f85a45df03a97e823663ee0d7/ldp-0.7.0-py3-none-any.whl", hash = "sha256:e314da2b0f51827784ba37fa2da231719c6af4f38f068332031ba63da4b0a6c8", size = 87037 },
+    { url = "https://files.pythonhosted.org/packages/67/5d/4ebc53282757815e7e7880f227f64e6ccab6fbc0f1cc4b554dfa32c6b5e4/ldp-0.7.2-py3-none-any.whl", hash = "sha256:da8916dc79f86eaf3ae0eb998ab91a013e963d2087601a12a096759fe0f1a3cb", size = 87163 },
 ]
 
 [[package]]
@@ -1222,7 +1222,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.0.8.dev2+g3d2ffac.d20240923"
+version = "5.0.8.dev3+gcdfa436.d20240923"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1140,7 +1140,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.47.1"
+version = "1.46.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1152,9 +1152,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/2c/b26f179a15ddc1b9c6b986db9a71b121e77a11b82c5e9d3bb740edf95223/openai-1.47.1.tar.gz", hash = "sha256:62c8f5f478f82ffafc93b33040f8bb16a45948306198bd0cba2da2ecd9cf7323", size = 297985 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6b/470673304605c4aa4ee899dbab6ea12f6a0844e3ee7970ce7ecae0c89aea/openai-1.46.1.tar.gz", hash = "sha256:e5cf7f268bf516de23686d496c9dae7f0dcdcd0e87af4d288deeab8329fcbbaf", size = 297547 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/a1/601773020ad98d6d55f45c4482ea0c30af1351827eaab98cbc7d27b4716d/openai-1.47.1-py3-none-any.whl", hash = "sha256:34277583bf268bb2494bc03f48ac123788c5e2a914db1d5a23d5edc29d35c825", size = 375614 },
+    { url = "https://files.pythonhosted.org/packages/da/14/aabc614d8c446cb32043ed397dd8536a8f4c43a92c6609c05a958be9b960/openai-1.46.1-py3-none-any.whl", hash = "sha256:7517f07117cf66012bbc55c49fd6b983eaac0f3d2a09c90cba1140d4455e4290", size = 375150 },
 ]
 
 [[package]]
@@ -1222,7 +1222,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.0.8.dev2+g95b845f.d20240923"
+version = "5.0.8.dev2+g3d2ffac.d20240923"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1232,6 +1232,7 @@ dependencies = [
     { name = "httpx" },
     { name = "litellm" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "pybtex" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1295,6 +1296,7 @@ requires-dist = [
     { name = "ldp", marker = "extra == 'ldp'", specifier = ">=0.6" },
     { name = "litellm", specifier = ">=1.44" },
     { name = "numpy" },
+    { name = "openai", specifier = "<1.47" },
     { name = "pandas-stubs", marker = "extra == 'typing'" },
     { name = "pybtex" },
     { name = "pydantic", specifier = "~=2.0" },


### PR DESCRIPTION
Something about [`openai` version 1.47](https://github.com/openai/openai-python/releases/tag/v1.47.0) breaks either itself or LiteLLM. This brought down our CI: https://github.com/Future-House/paper-qa/actions/runs/10999639465

This PR just temporarily downpins it until we resolve whatever has happened