### PR TITLE
chore: add .gitattributes for cassettes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/cassettes/* linguist-generated=true


### PR DESCRIPTION
## Description

Context in [Dosu Community Slack](https://dosucommunity.slack.com/archives/C06T4PUD4J2/p1727123642864889)

Adds `.gitattributes` file to mark VRC test cassettes as [generated files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github), so Dosu ignores them when apply size labels.
