### PR TITLE
Fixing `pymupdf.mupdf.FzErrorFormat` crash by recasting as an `ImpossibleParsingError`

### DIFF
--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -21,7 +21,14 @@ def parse_pdf_to_pages(path: Path) -> ParsedText:
         total_length = 0
 
         for i in range(file.page_count):
-            page = file.load_page(i)
+            try:
+                page = file.load_page(i)
+            except pymupdf.mupdf.FzErrorFormat as exc:
+                raise ImpossibleParsingError(
+                    f"Page loading via {pymupdf.__name__} failed on page {i} of"
+                    f" {file.page_count} for the PDF at path {path}, likely this PDF"
+                    " file is corrupt"
+                ) from exc
             pages[str(i + 1)] = page.get_text("text", sort=True)
             total_length += len(pages[str(i + 1)])
 


### PR DESCRIPTION
Seen today when parsing DOI `10.1038/nchembio.1979` with title `'Deadman' and 'Passcode' microbial kill switches for bacterial containment` into an index:

```none
    | Traceback (most recent call last):
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 382, in process_file
    |     await tmp_docs.aadd(
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/docs.py", line 267, in aadd
    |     texts = read_doc(
    |             ^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/readers.py", line 276, in read_doc
    |     parsed_text = parse_pdf_to_pages(path)
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/readers.py", line 24, in parse_pdf_to_pages
    |     page = file.load_page(i)
    |            ^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/pymupdf/__init__.py", line 4838, in load_page
    |     page = mupdf.fz_load_page(self.this, page_id)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/pymupdf/mupdf.py", line 42227, in fz_load_page
    |     return _mupdf.fz_load_page(doc, number)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | pymupdf.mupdf.FzErrorFormat: code=7: cannot find page tree
    +------------------------------------
```

This PR just handles this crash by recasting it to a handled exception type