### PR TITLE
Truncating failing `test_evaluation` via `max_rollout_steps`

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -313,14 +313,14 @@ class SearchIndex:
         query_fields = list(field_subset or self.fields)
         searcher = await self.searcher
         index = await self.index
-        results = [
+        addresses = [
             s[1]
             for s in searcher.search(
                 index.parse_query(self.clean_query(query), query_fields), top_n
             ).hits
             if s[0] > min_score
         ][offset : offset + top_n]
-        search_index_docs = [searcher.doc(result) for result in results]
+        search_index_docs = [searcher.doc(address) for address in addresses]
         return [
             result
             for result in [

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -132,7 +132,8 @@ class PaperSearch(NamedTool):
             field_subset=[f for f in index.fields if f != "year"],
         )
         logger.info(
-            f"{self.TOOL_FN_NAME} for query {query!r} returned {len(results)} papers."
+            f"{self.TOOL_FN_NAME} for query {query!r} and offset {offset} returned"
+            f" {len(results)} papers."
         )
 
         # combine all the resulting doc objects into one and update the state

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -4,14 +4,14 @@ import inspect
 import logging
 import re
 import sys
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from paperqa.docs import Docs
 from paperqa.llms import EmbeddingModel, LiteLLMModel
 from paperqa.settings import Settings
-from paperqa.types import Answer
+from paperqa.types import Answer, DocDetails
 
 from .search import get_directory_index
 
@@ -125,7 +125,7 @@ class PaperSearch(NamedTool):
 
         logger.info(f"Starting paper search for {query!r}.")
         index = await get_directory_index(settings=self.settings)
-        results = await index.query(
+        results: list[Docs] = await index.query(
             query,
             top_n=self.settings.agent.search_count,
             offset=offset,
@@ -137,14 +137,14 @@ class PaperSearch(NamedTool):
         )
 
         # combine all the resulting doc objects into one and update the state
-        # there's only one doc per result, so we can just take the first one
-        all_docs = []
+        all_doc_details: list[DocDetails] = []
         for r in results:
-            this_doc = next(iter(r.docs.values()))
-            all_docs.append(this_doc)
+            # there's only one doc per result, so just take the first one
+            this_doc_details = cast(DocDetails, next(iter(r.docs.values())))
+            all_doc_details.append(this_doc_details)
             await state.docs.aadd_texts(
                 texts=r.texts,
-                doc=this_doc,
+                doc=this_doc_details,
                 settings=self.settings,
                 embedding_model=self.embedding_model,
             )
@@ -154,7 +154,9 @@ class PaperSearch(NamedTool):
         # mark how far we've searched so that continuation will start at the right place
         self.previous_searches[search_key] += self.settings.agent.search_count
         if self.settings.agent.return_paper_metadata:
-            retrieved_papers = "\n".join([f"{x.title} ({x.year})" for x in all_docs])
+            retrieved_papers = "\n".join(
+                [f"{x.title} ({x.year})" for x in all_doc_details]
+            )
             return f"Retrieved Papers:\n{retrieved_papers}\n\n{status}"
         return status
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,11 +77,9 @@ def fixture_stub_data_dir() -> Path:
 
 @pytest.fixture
 def agent_test_settings(agent_index_dir: Path, stub_data_dir: Path) -> Settings:
-    settings = Settings(
-        paper_directory=stub_data_dir,
-        index_directory=agent_index_dir,
-        embedding="sparse",
-    )
+    # NOTE: originally here we had usage of embedding="sparse", but this was
+    # shown to be too crappy of an embedding to get past the Obama article
+    settings = Settings(paper_directory=stub_data_dir, index_directory=agent_index_dir)
     settings.agent.search_count = 2
     settings.answer.answer_max_sources = 2
     settings.answer.evidence_k = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-from collections.abc import Generator, Iterator
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -59,9 +59,7 @@ def tmp_path_cleanup(tmp_path: Path) -> Iterator[Path]:
 
 
 @pytest.fixture
-def agent_home_dir(
-    tmp_path_cleanup: str | os.PathLike,
-) -> Generator[str | os.PathLike, None, None]:
+def agent_home_dir(tmp_path_cleanup: str | os.PathLike) -> Iterator[str | os.PathLike]:
     """Set up a unique temporary folder for the agent module."""
     with patch.dict("os.environ", {"PQA_HOME": str(tmp_path_cleanup)}):
         yield tmp_path_cleanup

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -95,8 +95,12 @@ class TestTaskDataset:
             not base_query_request.query
         ), "Should not have mutated query in base request"
         assert not docs.docs, "Should not have mutated docs in base docs"
-        assert isinstance(metrics_callback.eval_means["reward"], float)
-        assert isinstance(metrics_callback.eval_means["total_paper_count"], float)
+        assert (
+            isinstance(metrics_callback.eval_means["total_paper_count"], float) > 0
+        ), "Expected some papers to help us answer questions"
+        assert (
+            isinstance(metrics_callback.eval_means["reward"], float) > 0
+        ), "Expected some wins"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -84,7 +84,7 @@ class TestTaskDataset:
         metrics_callback = MeanMetricsCallback(eval_dataset=dataset)
 
         evaluator = Evaluator(
-            config=EvaluatorConfig(batch_size=3),
+            config=EvaluatorConfig(batch_size=3, max_rollout_steps=10),
             agent=SimpleAgent(),
             dataset=dataset,
             callbacks=[metrics_callback],


### PR DESCRIPTION
From [this CI run](https://github.com/Future-House/paper-qa/actions/runs/11004228948/job/30554749240), we see:

```none
[success] 55.58% tests/test_task.py::TestTaskDataset::test_evaluation: 5790.4625s
```

Nearly 2 hours! I observed locally it's possible for our indexing process to not find a piece of data in the `stub_data` folder, leading to infinite "failed to answer" loops.

Normal behavior should concluded a rollout in 3 actions (one search, one gather, one answer), so this PR just truncates long rollouts by specifying a `max_rollout_steps` of 10. 