### PR TITLE
Cleaning up and testing `get_directory_index`

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -343,7 +343,7 @@ async def maybe_get_manifest(
             async with await anyio.open_file(filename, mode="r") as file:
                 content = await file.read()
             records = [DocDetails(**row) for row in csv.DictReader(StringIO(content))]
-            logger.info(
+            logger.debug(
                 f"Found manifest file at {filename} and read {len(records)} records"
                 " from it."
             )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -41,7 +41,9 @@ from paperqa.utils import extract_thought, get_year, md5sum
 
 @pytest.mark.asyncio
 async def test_get_directory_index(agent_test_settings: Settings) -> None:
-    # Use a tempdir here so we can delete files without affecting concurrent tests
+    # Since agent_test_settings is used by other tests, and thus uses the same
+    # paper_directory as other tests, we use a tempdir so we can delete files
+    # without affecting concurrent tests
     with tempfile.TemporaryDirectory() as tempdir:
         shutil.copytree(
             agent_test_settings.paper_directory, tempdir, dirs_exist_ok=True

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import itertools
 import json
 import re
+import shutil
+import tempfile
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -39,26 +41,54 @@ from paperqa.utils import extract_thought, get_year, md5sum
 
 @pytest.mark.asyncio
 async def test_get_directory_index(agent_test_settings: Settings) -> None:
-    index_name = f"stub{uuid4()}"  # Unique across tests
-    index = await get_directory_index(
-        index_name=index_name, settings=agent_test_settings
-    )
-    assert index.index_name == index_name, "Index name should match its specification"
-    assert index.fields == [
-        "file_location",
-        "body",
-        "title",
-        "year",
-    ], "Incorrect fields in index"
-    # paper.pdf + empty.txt + flag_day.html + bates.txt + obama.txt,
-    # but empty.txt fails to be added
-    path_to_id = await index.index_files
-    assert (
-        sum(id_ != FAILED_DOCUMENT_ADD_ID for id_ in path_to_id.values()) == 4
-    ), "Incorrect number of parsed index files"
-    results = await index.query(query="who is Frederick Bates?")
-    paper_dir = cast(Path, agent_test_settings.paper_directory)
-    assert results[0].docs.keys() == {md5sum((paper_dir / "bates.txt").absolute())}
+    # Use a tempdir here so we can delete files without affecting concurrent tests
+    with tempfile.TemporaryDirectory() as tempdir:
+        shutil.copytree(
+            agent_test_settings.paper_directory, tempdir, dirs_exist_ok=True
+        )
+        paper_dir = agent_test_settings.paper_directory = Path(tempdir)
+
+        index_name = f"stub{uuid4()}"  # Unique across test invocations
+        index = await get_directory_index(
+            index_name=index_name, settings=agent_test_settings
+        )
+        assert (
+            index.index_name == index_name
+        ), "Index name should match its specification"
+        assert index.fields == [
+            "file_location",
+            "body",
+            "title",
+            "year",
+        ], "Incorrect fields in index"
+        # paper.pdf + empty.txt + flag_day.html + bates.txt + obama.txt,
+        # but empty.txt fails to be added
+        path_to_id = await index.index_files
+        assert (
+            sum(id_ != FAILED_DOCUMENT_ADD_ID for id_ in path_to_id.values()) == 4
+        ), "Incorrect number of parsed index files"
+        results = await index.query(query="who is Frederick Bates?")
+        assert results[0].docs.keys() == {md5sum((paper_dir / "bates.txt").absolute())}
+
+        # Check getting the same index name will not reprocess files
+        with patch.object(Docs, "aadd") as mock_aadd:
+            index = await get_directory_index(
+                index_name=index_name, settings=agent_test_settings
+            )
+        assert len(await index.index_files) == len(path_to_id)
+        mock_aadd.assert_not_awaited(), "Expected we didn't re-add files"
+
+        # Now we actually remove (but not add!) a file from the paper directory,
+        # and we still don't reprocess files
+        (paper_dir / "obama.txt").unlink()
+        with patch.object(
+            Docs, "aadd", autospec=True, side_effect=Docs.aadd
+        ) as mock_aadd:
+            index = await get_directory_index(
+                index_name=index_name, settings=agent_test_settings
+            )
+        assert len(await index.index_files) == len(path_to_id) - 1
+        mock_aadd.assert_not_awaited(), "Expected we didn't re-add files"
 
 
 @pytest.mark.asyncio

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
+from uuid import uuid4
 
 import ldp.agent
 import pytest
@@ -38,7 +39,11 @@ from paperqa.utils import extract_thought, get_year, md5sum
 
 @pytest.mark.asyncio
 async def test_get_directory_index(agent_test_settings: Settings) -> None:
-    index = await get_directory_index(settings=agent_test_settings)
+    index_name = f"stub{uuid4()}"  # Unique across tests
+    index = await get_directory_index(
+        index_name=index_name, settings=agent_test_settings
+    )
+    assert index.index_name == index_name, "Index name should match its specification"
     assert index.fields == [
         "file_location",
         "body",


### PR DESCRIPTION
I found this code somewhat confusing, so I:
1. Added more tests
2. Improved variable names, removed locals, and added type hints