### PR TITLE
Discovered Renovate `:automergeMinor` and preventing `openai` version bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,4 +15,11 @@
   "pre-commit": {
     enabled: true,
   },
+  packageRules: [
+    {
+      // Allow 'widen' range strategy while matching aviary_internal pyproject.toml
+      matchPackageNames: ["openai"],
+      allowedVersions: "<1.47",
+    },
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
+  extends: [
+    "config:recommended",
+    "group:allNonMajor", // Rely on config:recommended for major version updates
+    ":automergeMinor",
+  ],
   schedule: ["* 2 * * 1"],
   prHourlyLimit: 4,
   timezone: "America/Los_Angeles",
@@ -11,18 +15,4 @@
   "pre-commit": {
     enabled: true,
   },
-  packageRules: [
-    {
-      matchUpdateTypes: ["lockFileMaintenance"],
-      automerge: true,
-    },
-    {
-      // group:allNonMajor, with automerge
-      groupName: "all non-major dependencies",
-      groupSlug: "all-minor-patch",
-      matchPackageNames: ["*"],
-      matchUpdateTypes: ["minor", "patch"],
-      automerge: true,
-    },
-  ],
 }


### PR DESCRIPTION
- I discovered the preset [`:automergeMinor`](https://docs.renovatebot.com/presets-default/#automergeminor) that enables much config simplification
- Not bumping `openai` to remain compliant with the fix in https://github.com/Future-House/paper-qa/pull/466