### PR TITLE
Fixing `LitQATaskDatasetcompute_trajectory_metrics` crash with bad status extraction

### DIFF
--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -175,15 +175,20 @@ class LitQATaskDataset(
         evidence_count: list[float] = []
         for t in trajectories:
             split_answers = [
-                re.split(
-                    pattern=GenerateAnswer.ANSWER_SPLIT_REGEX_PATTERN,
-                    string=obs.content,
+                split_answers
+                for split_answers in (
+                    re.split(
+                        pattern=GenerateAnswer.ANSWER_SPLIT_REGEX_PATTERN,
+                        string=obs.content,
+                    )
+                    for obs in t.steps[-1].next_observation
+                    if (
+                        isinstance(obs, ToolResponseMessage)
+                        and obs.name == GenerateAnswer.TOOL_FN_NAME
+                    )
                 )
-                for obs in t.steps[-1].next_observation
-                if (
-                    isinstance(obs, ToolResponseMessage)
-                    and obs.name == GenerateAnswer.TOOL_FN_NAME
-                )
+                # Filter for places where the regex split succeeded
+                if len(split_answers) >= 4  # noqa: PLR2004
             ]
             for i, metric_list in enumerate(
                 (total_paper_count, relevant_paper_count, evidence_count),


### PR DESCRIPTION
If the `re.split(pattern=GenerateAnswer.ANSWER_SPLIT_REGEX_PATTERN, ...)` doesn't give at least 4 values, the ensuing total paper count, relevant paper count, and evidence count summation will crash with an `IndexError`:

```none
  File "/path/to/.venv/lib/python3.12/site-packages/paperqa/agents/task.py", line 193, in compute_trajectory_metrics
    sum(int(sa[i]) for sa in split_answers) / len(split_answers)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/paperqa/agents/task.py", line 193, in <genexpr>
    sum(int(sa[i]) for sa in split_answers) / len(split_answers)
            ~~^^^
IndexError: list index out of range
```

This PR fixes that `IndexError`