### PR TITLE
For autogenerated `Router` kwargs, specifying `timeout` of 60-sec

### DIFF
--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -391,7 +391,7 @@ class LiteLLMModel(LLMModel):
                         ),
                     }
                 ],
-                "router_kwargs": {"num_retries": 3, "retry_after": 5},
+                "router_kwargs": {"num_retries": 3, "retry_after": 5, "timeout": 60},
             }
         # we only support one "model name" for now, here we validate
         model_list = data["config"]["model_list"]


### PR DESCRIPTION
I hit a loooong request to OpenAI (seeming 15 mins), and eventually hit a timeout:

```none
Traceback (most recent call last):
  File "/path/to/.venv/lib/python3.12/site-packages/litellm/llms/OpenAI/openai.py", line 944, in acompletion
    headers, response = await self.make_openai_chat_completion_request(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/litellm/llms/OpenAI/openai.py", line 639, in make_openai_chat_completion_request
    raise e
  File "/path/to/.venv/lib/python3.12/site-packages/litellm/llms/OpenAI/openai.py", line 627, in make_openai_chat_completion_request
    await openai_aclient.chat.completions.with_raw_response.create(
  File "/path/to/.venv/lib/python3.12/site-packages/openai/_legacy_response.py", line 370, in wrapped
    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/openai/resources/chat/completions.py", line 1412, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1821, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1515, in request
    return await self._request(
           ^^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/openai/_base_client.py", line 1616, in _request
    raise self._make_status_error_from_response(err.response) from None
openai.InternalServerError: Error code: 500 - {'error': {'message': 'Timed out generating response. Please try again with a shorter prompt or with `max_tokens` set to a lower value.', 'type': 'internal_error', 'param': None, 'code': 'request_timeout'}}
```

It seems LiteLLM has a request timeout configurable at `litellm.request_timeout`, but it's unclear the full scope of that parameter: https://github.com/BerriAI/litellm/blob/v1.48.2/litellm/__init__.py#L271 

This PR just specifies a `Router.timeout` of 60-sec for the default `Router` kwargs, hopefully this resolves the issue.