### PR TITLE
Cleaning up #489's implementation

### DIFF
--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -110,6 +110,8 @@ class ChunkingOptions(StrEnum):
 
 
 class ParsingSettings(BaseModel):
+    """Settings relevant for parsing and chunking documents."""
+
     chunk_size: int = Field(default=3000, description="Number of characters per chunk")
     use_doc_details: bool = Field(
         default=True, description="Whether to try to get metadata details for a Doc"


### PR DESCRIPTION
I felt my implementation in https://github.com/Future-House/paper-qa/pull/489 was bad:
- `_PAPERQA_ROOT_LOGGER` was a vague name -- unclear if `"root"` or `"paperqa"`
- It's not clear the `RichHandler` is getting installed, so I made a flag for it
- This was unintuitive, as it's true once at the start of CLI

   ```python
   if not is_running_under_cli():
       _PAPERQA_ROOT_LOGGER.addHandler(rich_handler)
   ```