### PR TITLE
Refactor to create `settings.agent.index` grouping

### DIFF
--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -121,7 +121,7 @@ def search_query(
         index_search(
             query,
             index_name=index_name,
-            index_directory=settings.index_directory,
+            index_directory=settings.agent.index.index_directory,
         )
     )
 
@@ -134,13 +134,13 @@ def build_index(
     """Build a PaperQA search index, this will also happen automatically upon using `ask`."""
     settings = get_settings(settings)
     if index_name == "default":
-        index_name = None
+        settings.agent.index.name = None
+    elif isinstance(index_name, str):
+        settings.agent.index.name = index_name
     configure_cli_logging(verbosity=settings.verbosity)
     if directory:
-        settings.paper_directory = directory
-    return get_loop().run_until_complete(
-        get_directory_index(index_name=index_name, settings=settings)
-    )
+        settings.agent.index.paper_directory = directory
+    return get_loop().run_until_complete(get_directory_index(settings=settings))
 
 
 def save_settings(

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -54,7 +54,7 @@ async def agent_query(
     search_index = SearchIndex(
         fields=[*SearchIndex.REQUIRED_FIELDS, "question"],
         index_name="answers",
-        index_directory=query.settings.index_directory,
+        index_directory=query.settings.agent.index.index_directory,
         storage=SearchDocumentStorage.JSON_MODEL_DUMP,
     )
 

--- a/paperqa/configs/contracrow.json
+++ b/paperqa/configs/contracrow.json
@@ -8,9 +8,7 @@
   "temperature": 0.0,
   "batch_size": 1,
   "texts_index_mmr_lambda": 1.0,
-  "index_absolute_directory": false,
   "verbosity": 0,
-  "manifest_file": null,
   "answer": {
     "evidence_k": 30,
     "evidence_detailed_citations": true,
@@ -51,7 +49,6 @@
     "wipe_context_on_answer_failure": true,
     "timeout": 500.0,
     "should_pre_search": false,
-    "tool_names": null,
-    "index_concurrency": 30
+    "tool_names": null
   }
 }

--- a/paperqa/configs/wikicrow.json
+++ b/paperqa/configs/wikicrow.json
@@ -8,9 +8,7 @@
   "temperature": 0.0,
   "batch_size": 1,
   "texts_index_mmr_lambda": 1.0,
-  "index_absolute_directory": false,
   "verbosity": 0,
-  "manifest_file": null,
   "answer": {
     "evidence_k": 25,
     "evidence_detailed_citations": true,
@@ -51,7 +49,6 @@
     "wipe_context_on_answer_failure": true,
     "timeout": 500.0,
     "should_pre_search": false,
-    "tool_names": null,
-    "index_concurrency": 30
+    "tool_names": null
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,9 @@ def fixture_stub_data_dir() -> Path:
 def agent_test_settings(agent_index_dir: Path, stub_data_dir: Path) -> Settings:
     # NOTE: originally here we had usage of embedding="sparse", but this was
     # shown to be too crappy of an embedding to get past the Obama article
-    settings = Settings(paper_directory=stub_data_dir, index_directory=agent_index_dir)
+    settings = Settings()
+    settings.agent.index.paper_directory = stub_data_dir
+    settings.agent.index.index_directory = agent_index_dir
     settings.agent.search_count = 2
     settings.answer.answer_max_sources = 2
     settings.answer.evidence_k = 10

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,8 +39,8 @@ def test_can_modify_settings() -> None:
 
 def test_cli_ask(agent_index_dir: Path, stub_data_dir: Path) -> None:
     settings = Settings.from_name("debug")
-    settings.index_directory = agent_index_dir
-    settings.paper_directory = stub_data_dir
+    settings.agent.index.index_directory = agent_index_dir
+    settings.agent.index.paper_directory = stub_data_dir
     response = ask(
         "How can you use XAI for chemical property prediction?", settings=settings
     )
@@ -60,7 +60,7 @@ def test_cli_can_build_and_search_index(
     agent_index_dir: Path, stub_data_dir: Path
 ) -> None:
     settings = Settings.from_name("debug")
-    settings.index_directory = agent_index_dir
+    settings.agent.index.index_directory = agent_index_dir
     index_name = "test"
     build_index(index_name, stub_data_dir, settings)
     search_result = search_query("XAI", index_name, settings)


### PR DESCRIPTION
This PR groups all index settings into an `AgentSettings` subset called `IndexSettings`.

To aid in this transition it:
- Starts a deprecation cycle for old versions
- Marks fields as `frozen` to flag a read-only type error in client code for `mypy` users

It also removes some defaulted fields from the configs