### PR TITLE
Aviary agent `max_timesteps` and fixed `test_gather_evidence_rejects_empty_docs`

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -140,6 +140,11 @@ async def run_fake_agent(
     ) = None,
     **env_kwargs,
 ) -> tuple[Answer, AgentStatus]:
+    if query.settings.agent.max_timesteps is not None:
+        logger.warning(
+            f"Max timesteps (configured {query.settings.agent.max_timesteps}) is not"
+            " applicable with the fake agent, ignoring it."
+        )
     env = PaperQAEnvironment(query, docs, **env_kwargs)
     _, tools = await env.reset()
     if on_env_reset_callback:
@@ -209,7 +214,14 @@ async def run_aviary_agent(
                 tools=tools,
             )
 
+            timestep, max_timesteps = 0, query.settings.agent.max_timesteps
             while not done:
+                if max_timesteps is not None and timestep >= max_timesteps:
+                    logger.warning(
+                        f"Agent didn't finish within {max_timesteps} timesteps, just answering."
+                    )
+                    await tools[-1]._tool_fn(question=query.query, state=env.state)
+                    return env.state.answer, AgentStatus.FAIL
                 agent_state.messages += obs
                 for attempt in Retrying(
                     stop=stop_after_attempt(5),
@@ -226,6 +238,7 @@ async def run_aviary_agent(
                 obs, reward, done, truncated = await env.step(action)
                 if on_env_step_callback:
                     await on_env_step_callback(obs, reward, done, truncated)
+                timestep += 1
             status = AgentStatus.SUCCESS
     except TimeoutError:
         logger.warning(
@@ -250,6 +263,11 @@ async def run_ldp_agent(
     ) = None,
     **env_kwargs,
 ) -> tuple[Answer, AgentStatus]:
+    if query.settings.agent.max_timesteps is not None:
+        logger.warning(
+            f"Max timesteps (configured {query.settings.agent.max_timesteps}) is not"
+            " yet implemented with the ldp agent, ignoring it."
+        )
     env = PaperQAEnvironment(query, docs, **env_kwargs)
     done = False
 

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -39,8 +39,9 @@ class AgentStatus(StrEnum):
     FAIL = "fail"
     # SUCCESS - answer was generated
     SUCCESS = "success"
-    # TIMEOUT - agent took too long, but an answer was generated
-    TIMEOUT = "timeout"
+    # TRUNCATED - agent didn't finish naturally (e.g. timeout, too many actions),
+    # so we prematurely answered
+    TRUNCATED = "truncated"
     # UNSURE - the agent was unsure, but an answer is present
     UNSURE = "unsure"
 

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -406,6 +406,10 @@ class AgentSettings(BaseModel):
             " supplied."
         ),
     )
+    max_timesteps: int | None = Field(
+        default=None,
+        description="Optional upper limit on the number of environment steps.",
+    )
 
     index_concurrency: int = Field(
         default=30,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -287,9 +287,14 @@ async def test_gather_evidence_rejects_empty_docs() -> None:
     # lead to an unsure status, which will break this test's assertions. Since
     # this test is about a GatherEvidenceTool edge case, defeating
     # GenerateAnswerTool is fine
+    original_doc = GenerateAnswer.gen_answer.__doc__
     with patch.object(
-        GenerateAnswer, "gen_answer", return_value="Failed to answer question."
-    ):
+        GenerateAnswer,
+        "gen_answer",
+        return_value="Failed to answer question.",
+        autospec=True,
+    ) as mock_gen_answer:
+        mock_gen_answer.__doc__ = original_doc
         settings = Settings()
         settings.agent.tool_names = {"gather_evidence", "gen_answer"}
         response = await agent_query(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -295,8 +295,11 @@ async def test_gather_evidence_rejects_empty_docs() -> None:
         autospec=True,
     ) as mock_gen_answer:
         mock_gen_answer.__doc__ = original_doc
-        settings = Settings()
-        settings.agent.tool_names = {"gather_evidence", "gen_answer"}
+        settings = Settings(
+            agent=AgentSettings(
+                tool_names={"gather_evidence", "gen_answer"}, max_timesteps=3
+            )
+        )
         response = await agent_query(
             query=QueryRequest(
                 query="Are COVID-19 vaccines effective?", settings=settings

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -243,7 +243,7 @@ async def test_timeout(agent_test_settings: Settings, agent_type: str | type) ->
         agent_type=agent_type,
     )
     # ensure that GenerateAnswerTool was called
-    assert response.status == AgentStatus.TIMEOUT, "Agent did not timeout"
+    assert response.status == AgentStatus.TRUNCATED, "Agent did not timeout"
     assert "I cannot answer" in response.answer.answer
 
 
@@ -306,7 +306,9 @@ async def test_gather_evidence_rejects_empty_docs() -> None:
             ),
             docs=Docs(),
         )
-    assert response.status == AgentStatus.FAIL, "Agent should have registered a failure"
+    assert (
+        response.status == AgentStatus.TRUNCATED
+    ), "Agent should have hit its max timesteps"
 
 
 @pytest.mark.flaky(reruns=3, only_rerun=["AssertionError", "EmptyDocsError"])


### PR DESCRIPTION
Since its addition in https://github.com/Future-House/paper-qa/pull/309, `test_gather_evidence_rejects_empty_docs` was failing for the wrong reason. It was supposed to fail due to empty docs, but it was failing due to a bad `patch`:

```none
ERROR    paperqa.agents.main:main.py:237 Agent <aviary.tools.utils.ToolSelector object at 0x10d5a73b0> failed.
Traceback (most recent call last):
  File "/path/to/paper-qa/paperqa/agents/main.py", line 194, in run_aviary_agent
    obs, tools = await env.reset()
                 ^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/paperqa/agents/env.py", line 136, in reset
    self.state, self.tools = self.make_initial_state_and_tools()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/paperqa/agents/env.py", line 123, in make_initial_state_and_tools
    self.tools = settings_to_tools(
                 ^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/paperqa/agents/env.py", line 71, in settings_to_tools
    tool = Tool.from_function(
           ^^^^^^^^^^^^^^^^^^^
  File "/path/to/.venv/lib/python3.12/site-packages/aviary/tools/base.py", line 339, in from_function
    raise ValueError(f"Missing description for parameter {pname}.")
ValueError: Missing description for parameter args.
```

This PR:
- Properly propagates the `__doc__` onto the patched `gen_answer`, so `Tool.from_function` succeeds and the test fails as expected
- Implements `max_timesteps` so the test doesn't cycle forever until it times out
- Moves from `AgentStatus.TIMEOUT` to a more general `AgentStatus.TRUNCATED` to match aviary's general terminology