### PR TITLE
`rich.Progress` bar for monitoring index builds

### DIFF
--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -6,7 +6,6 @@ import os
 from typing import Any
 
 from pydantic_settings import CliSettingsSource
-from rich.console import Console
 from rich.logging import RichHandler
 
 from paperqa.settings import Settings, get_settings
@@ -65,11 +64,7 @@ def is_running_under_cli() -> bool:
 def set_up_rich_handler(install: bool = True) -> RichHandler:
     """Add a RichHandler to the paper-qa "root" logger, and return it."""
     rich_handler = RichHandler(
-        rich_tracebacks=True,
-        markup=True,
-        show_path=False,
-        show_level=False,
-        console=Console(force_terminal=True),
+        rich_tracebacks=True, markup=True, show_path=False, show_level=False
     )
     rich_handler.setFormatter(logging.Formatter("%(message)s", datefmt="[%X]"))
     if install and not any(


### PR DESCRIPTION
Last week an index build went on for longer than 12 hours, and I had to stop it because i didn't know how close it was.

This PR adds a `rich.Progress` bar, with env var enable/disables, to make index builds slightly more user friendly.