### PR TITLE
Retrying on known Semantic Scholar flaky SSL error in `get_s2_doc_details_from_doi`

### DIFF
--- a/paperqa/clients/exceptions.py
+++ b/paperqa/clients/exceptions.py
@@ -1,4 +1,19 @@
+from collections.abc import Callable
+
+import aiohttp
+
+
 class DOINotFoundError(Exception):
     def __init__(self, message="DOI not found") -> None:
         self.message = message
         super().__init__(self.message)
+
+
+def make_flaky_ssl_error_predicate(host: str) -> Callable[[BaseException], bool]:
+    def predicate(exc: BaseException) -> bool:
+        # > aiohttp.client_exceptions.ClientConnectorError:
+        # > Cannot connect to host api.host.org:443 ssl:default [nodename nor servname provided, or not known]
+        # SEE: https://github.com/aio-libs/aiohttp/blob/v3.10.5/aiohttp/client_exceptions.py#L193-L196
+        return isinstance(exc, aiohttp.ClientConnectorError) and exc.host == host
+
+    return predicate


### PR DESCRIPTION
I hit this flaky SSL error last night, now with Semantic Scholar:

```none
    | Traceback (most recent call last):
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 407, in process_file
    |     await tmp_docs.aadd(
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/docs.py", line 360, in aadd
    |     doc = await metadata_client.upgrade_doc_to_doc_details(
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 202, in upgrade_doc_to_doc_details
    |     if doc_details := await self.query(**kwargs):
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 150, in query
    |     await gather_with_concurrency(
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 111, in gather_with_concurrency
    |     return await asyncio.gather(*(sem_coro(c) for c in coros))
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 109, in sem_coro
    |     return await coro
    |            ^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/clients/client_models.py", line 108, in query
    |     return await self._query(client_query)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 325, in _query
    |     return await get_s2_doc_details_from_doi(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 273, in get_s2_doc_details_from_doi
    |     details = await _get_with_retrying(
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    |     self._add_action_func(lambda rs: rs.outcome.result())
    |                                      ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/jamesbraza/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    |     return self.__get_result()
    |            ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/jamesbraza/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    |     raise self._exception
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 413, in _get_with_retrying
    |     async with session.get(
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 1355, in __aenter__
    |     self._resp: _RetType = await self._coro
    |                            ^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 659, in _request
    |     conn = await self._connector.connect(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 557, in connect
    |     proto = await self._create_connection(req, traces, timeout)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1002, in _create_connection
    |     _, proto = await self._create_direct_connection(req, traces, timeout)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1293, in _create_direct_connection
    |     raise ClientConnectorError(req.connection_key, exc) from exc
    | aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host api.semanticscholar.org:443 ssl:default [nodename nor servname provided, or not known]
    +------------------------------------
```

Applying the fix from https://github.com/Future-House/paper-qa/pull/444 to Semantic Scholar `get_s2_doc_details_from_doi`