### PR TITLE
Made it possible to skip chunking

### DIFF
--- a/paperqa/configs/debug.json
+++ b/paperqa/configs/debug.json
@@ -10,6 +10,7 @@
     "max_concurrent_requests": 5
   },
   "parsing": {
-    "use_doc_details": false
+    "use_doc_details": false,
+    "defer_embedding": true
   }
 }

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -401,7 +401,7 @@ class Docs(BaseModel):
         self,
         texts: list[Text],
         doc: Doc,
-        settings: MaybeSettings = None,  # noqa: ARG002 future proofing
+        settings: MaybeSettings = None,
         embedding_model: EmbeddingModel | None = None,
     ) -> bool:
         """
@@ -416,6 +416,12 @@ class Docs(BaseModel):
             return False
         if not texts:
             raise ValueError("No texts to add.")
+
+        all_settings = get_settings(settings)
+        if not all_settings.parsing.defer_embedding and not embedding_model:
+            # want to embed now!
+            embedding_model = all_settings.get_embedding_model()
+
         # 1. Calculate text embeddings if not already present, but don't set them into
         # the texts until we've set up the Doc's embedding, so callers can retry upon
         # OpenAI rate limit errors

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -74,7 +74,7 @@ class LiteLLMEmbeddingModel(EmbeddingModel):
     embedding_kwargs: dict = Field(default_factory=dict)
 
     def _truncate_if_large(self, texts: list[str]) -> list[str]:
-        """Truncate texts if they are too large specifically for an openai model."""
+        """Truncate texts if they are too large by using litellm cost map."""
         if self.name not in MODEL_COST_MAP:
             return texts
         max_tokens = MODEL_COST_MAP[self.name]["max_input_tokens"]

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -286,7 +286,6 @@ def read_doc(
     # start with parsing -- users may want to store this separately
     if str_path.endswith(".pdf"):
         parsed_text = parse_pdf_to_pages(path)
-
     elif str_path.endswith(".txt"):
         parsed_text = parse_text(path)
     elif str_path.endswith(".html"):
@@ -298,7 +297,14 @@ def read_doc(
         return parsed_text
 
     # next chunk the parsed text
-    if str_path.endswith(".pdf"):
+
+    # check if chunk is 0 (no chunking)
+    if chunk_chars == 0:
+        chunked_text = [
+            Text(text=parsed_text.reduce_content(), name=doc.docname, doc=doc)
+        ]
+        chunk_metadata = ChunkMetadata(chunk_chars=0, overlap=0, chunk_type="no_chunk")
+    elif str_path.endswith(".pdf"):
         chunked_text = chunk_pdf(
             parsed_text, doc, chunk_chars=chunk_chars, overlap=overlap
         )

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -115,7 +115,10 @@ class ChunkingOptions(StrEnum):
 class ParsingSettings(BaseModel):
     """Settings relevant for parsing and chunking documents."""
 
-    chunk_size: int = Field(default=3000, description="Number of characters per chunk")
+    chunk_size: int = Field(
+        default=3000,
+        description="Number of characters per chunk. If 0, no chunking will be done.",
+    )
     use_doc_details: bool = Field(
         default=True, description="Whether to try to get metadata details for a Doc"
     )

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -142,6 +142,13 @@ class ParsingSettings(BaseModel):
             " correctly)"
         ),
     )
+    defer_embedding: bool = Field(
+        default=False,
+        description=(
+            "Whether to embed documents immediately as they are added, or defer until"
+            " summarization."
+        ),
+    )
     chunking_algorithm: ChunkingOptions = ChunkingOptions.SIMPLE_OVERLAP
     model_config = ConfigDict(extra="forbid")
 

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -284,6 +284,14 @@ class ParsedText(BaseModel):
                 "Encoding only implemented for str and list[str] content."
             )
 
+    def reduce_content(self):
+        """Reduce any content to a single string."""
+        if isinstance(self.content, str):
+            return self.content
+        if isinstance(self.content, list):
+            return "\n\n".join(self.content)
+        return "\n\n".join(self.content.values())
+
 
 # We use these integer values
 # as defined in https://jfp.csc.fi/en/web/haku/kayttoohje

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -818,8 +818,9 @@ def test_pdf_reader_w_no_chunks(stub_data_dir: Path) -> None:
     docs = Docs()
     settings = Settings.from_name("debug")
     settings.parsing.chunk_size = 0
-    # don't want to shove whole document into llm to get citation
+    # don't want to shove whole document into llm to get citation or embedding
     settings.parsing.use_doc_details = False
+    settings.parsing.defer_embedding = True
     # need larger context window
     settings.summary_llm = "gpt-4o-mini"
     docs.add(
@@ -828,6 +829,10 @@ def test_pdf_reader_w_no_chunks(stub_data_dir: Path) -> None:
         settings=settings,
     )
     assert len(docs.texts) == 1
+
+    # make sure we deferred embedding
+    assert docs.texts[0].embedding is None
+
     # now check we can get evidence (namely embed very long document)
     docs.get_evidence("What is XAI?", settings=settings)
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -814,6 +814,24 @@ def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path) -> None:
     )
 
 
+def test_pdf_reader_w_no_chunks(stub_data_dir: Path) -> None:
+    docs = Docs()
+    settings = Settings.from_name("debug")
+    settings.parsing.chunk_size = 0
+    # don't want to shove whole document into llm to get citation
+    settings.parsing.use_doc_details = False
+    # need larger context window
+    settings.summary_llm = "gpt-4o-mini"
+    docs.add(
+        stub_data_dir / "paper.pdf",
+        "Wellawatte et al, XAI Review, 2023",
+        settings=settings,
+    )
+    assert len(docs.texts) == 1
+    # now check we can get evidence (namely embed very long document)
+    docs.get_evidence("What is XAI?", settings=settings)
+
+
 # SEE: https://github.com/kevin1024/vcrpy/blob/v6.0.1/vcr/config.py#L43
 VCR_DEFAULT_MATCH_ON = "method", "scheme", "host", "port", "path", "query"
 


### PR DESCRIPTION
Made a few changes to get closer to using Gemini, where we do not chunk and work with whole documents.

* a chunk_size of `0` will trigger skipping chunking
* deferred embedding documents until retrieval, to avoid embedding docs all the time in tests (or in cases like when you're not doing vector retrieval)
* added a small helper function to truncate before embedding, in case a text is too long