### PR TITLE
Retrying on `aiohttp.ClientConnectionResetError`

### DIFF
--- a/paperqa/clients/exceptions.py
+++ b/paperqa/clients/exceptions.py
@@ -11,6 +11,7 @@ class DOINotFoundError(Exception):
 
 def make_flaky_ssl_error_predicate(host: str) -> Callable[[BaseException], bool]:
     def predicate(exc: BaseException) -> bool:
+        # Seen with both Semantic Scholar and Crossref:
         # > aiohttp.client_exceptions.ClientConnectorError:
         # > Cannot connect to host api.host.org:443 ssl:default [nodename nor servname provided, or not known]
         # SEE: https://github.com/aio-libs/aiohttp/blob/v3.10.5/aiohttp/client_exceptions.py#L193-L196


### PR DESCRIPTION
Another exception crashed indexing last night:

```none
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 220, in s2_title_search
    |     data = await _get_with_retrying(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    |     self._add_action_func(lambda rs: rs.outcome.result())
    |                                      ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    |     return self.__get_result()
    |            ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    |     raise self._exception
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 413, in _get_with_retrying
    |     async with session.get(
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 1355, in __aenter__
    |     self._resp: _RetType = await self._coro
    |                            ^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 684, in _request
    |     resp = await req.send(conn)
    |            ^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 748, in send
    |     await writer.write_headers(status_line, self.headers)
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/http_writer.py", line 131, in write_headers
    |     self._write(buf)
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/http_writer.py", line 76, in _write
    |     raise ClientConnectionResetError("Cannot write to closing transport")
    | aiohttp.client_exceptions.ClientConnectionResetError: Cannot write to closing transport
```

This PR:
- Adds `aiohttp.ClientConnectionResetError` to the retry-able errors
- Documents it