### PR TITLE
Add router_kwargs in separate control flow step

### DIFF
--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -524,8 +524,15 @@ class LiteLLMModel(LLMModel):
                         ),
                     }
                 ],
-                "router_kwargs": {"num_retries": 3, "retry_after": 5, "timeout": 60},
             } | data.get("config", {})
+
+        if "router_kwargs" not in data.get("config", {}):
+            data["config"]["router_kwargs"] = {
+                "num_retries": 3,
+                "retry_after": 5,
+                "timeout": 60,
+            }
+
         # we only support one "model name" for now, here we validate
         model_list = data["config"]["model_list"]
         if IS_PYTHON_BELOW_312:

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -64,3 +64,9 @@ def test_index_naming(subtests: SubTests) -> None:
     with subtests.test(msg="with name"):
         settings = Settings(agent=AgentSettings(index=IndexSettings(name="test")))
         assert settings.agent.index.get_named_index_directory().name == "test"
+
+
+def test_router_kwargs_present_in_models() -> None:
+    settings = Settings()
+    assert settings.get_llm().config["router_kwargs"] is not None
+    assert settings.get_summary_llm().config["router_kwargs"] is not None


### PR DESCRIPTION
We had coupled the default `router_kwargs` insertion with the presence of the `model_list` key -- but we needed to do a separate check for it. 

Adds a test that ensures it's present via the defaults. 