### PR TITLE
Propagating `AgentSettings.agent_type` default for synchrony

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -27,6 +27,7 @@ except ImportError:
     RolloutManager = None  # type: ignore[assignment,misc]
 
 from paperqa.docs import Docs
+from paperqa.settings import AgentSettings
 from paperqa.types import Answer
 
 from .env import PaperQAEnvironment
@@ -42,7 +43,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 agent_logger = logging.getLogger(__name__ + ".agent_callers")
 
-DEFAULT_AGENT_TYPE = ToolSelector
+DEFAULT_AGENT_TYPE = AgentSettings.model_fields["agent_type"].default
 
 
 async def agent_query(


### PR DESCRIPTION
Before https://github.com/Future-House/paper-qa/pull/520 we had:
- `settings.AgentSettings.agent_type` default was `fake` agent
- `agents.main` default was `ToolSelector` agent

https://github.com/Future-House/paper-qa/pull/520 moved the defaults to match, this PR just uses a programmatic reference to ensure synchrony and DRY the code