### PR TITLE
Fixed yet another `api.semanticscholar.org:443 ssl:default` error via retrying

### DIFF
--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -409,20 +409,13 @@ def is_retryable(exc: BaseException) -> bool:
 )
 async def _get_with_retrying(
     url: str,
-    params: dict[str, Any],
     session: aiohttp.ClientSession,
-    headers: dict[str, str] | None = None,
-    timeout: float = 10.0,  # noqa: ASYNC109
     http_exception_mappings: dict[HTTPStatus | int, Exception] | None = None,
+    **get_kwargs,
 ) -> dict[str, Any]:
     """Get from a URL with retrying protection."""
     try:
-        async with session.get(
-            url,
-            params=params,
-            headers=headers,
-            timeout=aiohttp.ClientTimeout(timeout),
-        ) as response:
+        async with session.get(url, **get_kwargs) as response:
             response.raise_for_status()
             return await response.json()
     except aiohttp.ClientResponseError as e:


### PR DESCRIPTION
I hit another `Cannot connect to host api.semanticscholar.org:443 ssl:default` in a new place in `semantic_scholar.py` last night:

```none
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 335, in _query                        06:38:07 [12/1869]
    |     return await get_s2_doc_details_from_title(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 320, in get_s2_doc_details_from_title
    |     return await s2_title_search(
    |            ^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 220, in s2_title_search
    |     data = await _get_with_retrying(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    |     self._add_action_func(lambda rs: rs.outcome.result())
    |                                      ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    |     return self.__get_result()
    |            ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.5/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    |     raise self._exception
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 420, in _get_with_retrying
    |     async with session.get(
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 1355, in __aenter__
    |     self._resp: _RetType = await self._coro
    |                            ^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 659, in _request
    |     conn = await self._connector.connect(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 557, in connect
    |     proto = await self._create_connection(req, traces, timeout)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1002, in _create_connection
    |     _, proto = await self._create_direct_connection(req, traces, timeout)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1293, in _create_direct_connection
    |     raise ClientConnectorError(req.connection_key, exc) from exc
    | aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host api.semanticscholar.org:443 ssl:default [nodename nor servname provided, or not known]
    +------------------------------------
```

So this PR:

- Expands the retrying from https://github.com/Future-House/paper-qa/pull/444 to another place
- Refactors a `_s2_get_with_retrying` to consolidate the S2 HTTP GET logic, to ensure the SSL error retrying is applied to all HTTP callers