### PR TITLE
Validating for broken index

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -535,6 +535,10 @@ async def get_directory_index(  # noqa: PLR0912
     # NOTE: if the index was not previously built, its index_files will be empty.
     # Otherwise, the index_files will not be empty
     if not build:
+        if not await search_index.index_files:
+            raise RuntimeError(
+                f"Index {search_index.index_name} was empty, please rebuild it."
+            )
         return search_index
 
     if not sync_index_w_directory:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -94,6 +94,11 @@ async def test_get_directory_index(agent_test_settings: Settings) -> None:
         assert len(await index.index_files) == len(path_to_id) - 1
         mock_aadd.assert_not_awaited(), "Expected we didn't re-add files"
 
+        # Note let's delete files.zip, and confirm we can't load the index
+        await (await index.file_index_filename).unlink()
+        with pytest.raises(RuntimeError, match="please rebuild"):
+            await get_directory_index(settings=agent_test_settings, build=False)
+
 
 EXPECTED_STUB_DATA_FILES = {
     "bates.txt",


### PR DESCRIPTION
If the `files.zip` is not present, the index will be empty. Then with an empty index, our environment will complete a rollout with 0% performance.

This PR add a validation to `build=False` for `paper_search` that the index actually has files present, preventing silent failures.