### PR TITLE
Making parsing resistant to failed inference of citations

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -314,13 +314,13 @@ class Docs(BaseModel):
                 data={"citation": citation},
                 skip_system=True,
             )
-            clean_text = result.text.strip("`")
-            if clean_text.startswith("json"):
-                clean_text = clean_text.replace("json", "", 1)
-            # there should be no nesting here, so we can just split on curlies
-            # Note - this is why we cannot extract it to a general method
-            # because JSON in general has nested curlies
-            clean_text = clean_text.split("{", 1)[-1].split("}", 1)[0]
+            # This code below tries to isolate the JSON
+            # based on observed messages from LLMs
+            # it does so by isolating the content between
+            # the first { and last } in the response.
+            # Since the anticipated structure should  not be nested,
+            # we don't have to worry about nested curlies.
+            clean_text = result.text.split("{", 1)[-1].split("}", 1)[0]
             clean_text = "{" + clean_text + "}"
             try:
                 citation_json = json.loads(clean_text)

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -318,10 +318,12 @@ class Docs(BaseModel):
             if clean_text.startswith("json"):
                 clean_text = clean_text.replace("json", "", 1)
             # there should be no nesting here, so we can just split on curlies
+            # Note - this is why we cannot extract it to a general method
+            # because JSON in general has nested curlies
             clean_text = clean_text.split("{", 1)[-1].split("}", 1)[0]
             clean_text = "{" + clean_text + "}"
             try:
-                citation_json = json.loads(clean_text.split("}", 1)[0] + "}")
+                citation_json = json.loads(clean_text)
                 if citation_title := citation_json.get("title"):
                     title = citation_title
                 if citation_doi := citation_json.get("doi"):


### PR DESCRIPTION
Fixes #546.

Tried to improve JSON extraction and reduced exception to warning (@mskarlin  - not sure why this was an exception?).

Example colab
https://colab.research.google.com/drive/1dXEuhvmnC-0Pzwedy0HIEt6TRli7k3kB#scrollTo=vbOB5XjbO2dd