### PR TITLE
Refactoring `LiteLLMModel` before removing `Router`

### DIFF
--- a/tests/cassettes/TestLiteLLMModel.test_max_token_truncation.yaml
+++ b/tests/cassettes/TestLiteLLMModel.test_max_token_truncation.yaml
@@ -1,0 +1,103 @@
+interactions:
+  - request:
+      body:
+        '{"messages": [{"role": "user", "content": "Please tell me a story"}], "model":
+        "gpt-4o-mini", "max_tokens": 3}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "110"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.46.1
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.46.1
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.5
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//bJBRT4MwFIXf+RVNn8EwxoTwNhezaDR7Meo0hnTlAp2lbWhZpsv+uymw
+          gdle+nDOPV/PvQcHIcwynCBMS2Jopbg3X5rpS7SMXtcPu+374v7x7mm3mL/9rp/3Hyvs2oTcbIGa
+          U+qGykpxMEyKzqY1EAOWOomCeBbHQThtjUpmwG2sUMYLpVcxwbzAD0LPj7xJ3KdLyShonKBPByGE
+          Du1re4oM9jhBvntSKtCaFICT8xBCuJbcKphozbQhwmB3MKkUBkRbfSUooEZJgch4ooa80cS2FA3n
+          vX48f8lloWq50b1/1nMmmC7TGoiWwuI5iMKUuPWPDkJf7XLNv75Y1bJSJjXyG4RFToIOiIeTDua0
+          94w0hI8yM/cKLM3AEMb16DaYElpCNiR9Z7Tb5ZfXEN1+TBQXFKcnYf2jDVRpzkQBtapZd+1cpXk8
+          2wC5jeIQO0fnDwAA//8DAHuAwiJ7AgAA
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8d08fd0aaeaf67c4-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 10 Oct 2024 19:24:04 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=BTdrirW_Guxpv.H.rPyazpVjfuD5kh2lWDDnQth1z4M-1728588244-1.0.1.1-W6yhhzCqXUjie6dbonmojEUTSHpKkrTd8f..HSkJUNVqCXeZNhD10LbAcC7HGtFW1gwFcDY36SlknE_MHO7ajQ;
+            path=/; expires=Thu, 10-Oct-24 19:54:04 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=LWX01ieVS4uvshESWXrymr6RrGTZy6Gj4GDJzGEDMG4-1728588244222-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "401"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999990"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_d8aeedcb649baad21ab2c3be58fe48cf
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -667,7 +667,7 @@ def test_hybrid_embedding(stub_data_dir: Path) -> None:
 def test_custom_llm(stub_data_dir: Path) -> None:
     from paperqa.llms import Chunk
 
-    class MyLLM(LLMModel):
+    class StubLLMModel(LLMModel):
         name: str = "myllm"
 
         async def acomplete(self, prompt: str) -> Chunk:  # noqa: ARG002
@@ -683,19 +683,19 @@ def test_custom_llm(stub_data_dir: Path) -> None:
         stub_data_dir / "bates.txt",
         citation="WikiMedia Foundation, 2023, Accessed now",
         dockey="test",
-        llm_model=MyLLM(),
+        llm_model=StubLLMModel(),
     )
     # ensure JSON summaries are not used
     no_json_settings = Settings(prompts={"use_json": False})
     evidence = docs.get_evidence(
-        "Echo", summary_llm_model=MyLLM(), settings=no_json_settings
+        "Echo", summary_llm_model=StubLLMModel(), settings=no_json_settings
     ).contexts
     assert "Echo" in evidence[0].context
 
     evidence = docs.get_evidence(
         "Echo",
         callbacks=[print_callback],
-        summary_llm_model=MyLLM(),
+        summary_llm_model=StubLLMModel(),
         settings=no_json_settings,
     ).contexts
     assert "Echo" in evidence[0].context


### PR DESCRIPTION
I wanted to make sure I am not going to be breaking anything, so I:
1. Made it clear what comes from `litellm`
2. Expanded `LiteLLMModel` tests to check the `config` is used for `acompletion`