### PR TITLE
Downloading `Package` artifact for `pypa/gh-action-pypi-publish`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - id: build
         uses: hynek/build-and-inspect-python-package@v2
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.build.outputs.artifact-name }}
+          path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: ${{ steps.build.outputs.dist }}
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
1. https://github.com/Future-House/paper-qa/pull/564 added https://github.com/hynek/build-and-inspect-python-package, but did not understand its output would not auto-propagate to `pypa/gh-action-pypi-publish`, leading to [this CI failure](https://github.com/Future-House/paper-qa/actions/runs/11284538443/job/31385884056)
2. https://github.com/Future-House/paper-qa/pull/565 tried to propagate the output, but sadly `/tmp` does not propagate across steps, leading to [this CI failure](https://github.com/Future-House/paper-qa/actions/runs/11284666032/job/31386215628)
3. After reviewing https://github.com/pypa/cibuildwheel/blob/v2.21.3/.github/workflows/release.yml#L16-L33, I realized I need to actually download the artifact after the step.

This PR uses `actions/download-artifact` to propagate the artifact