### PR TITLE
Fixing `Settings` propagation and always configuring LiteLLM retrying

### DIFF
--- a/paperqa/agents/helpers.py
+++ b/paperqa/agents/helpers.py
@@ -8,7 +8,7 @@ from typing import cast
 from rich.table import Table
 
 from paperqa.docs import Docs
-from paperqa.llms import LiteLLMModel
+from paperqa.llms import LiteLLMModel, LLMModel
 
 from .models import AnswerResponse
 
@@ -26,7 +26,7 @@ async def litellm_get_search_query(
     question: str,
     count: int,
     template: str | None = None,
-    llm: str = "gpt-4o-mini",
+    llm: LLMModel | str = "gpt-4o-mini",
     temperature: float = 1.0,
 ) -> list[str]:
     search_prompt = ""
@@ -51,8 +51,13 @@ async def litellm_get_search_query(
             f" is optional. The current year is {get_year()}."
         )
 
-    model = LiteLLMModel(name=llm)
-    model.config["model_list"][0]["litellm_params"].update({"temperature": temperature})
+    if isinstance(llm, str):
+        model: LLMModel = LiteLLMModel(name=llm)
+        model.config["model_list"][0]["litellm_params"].update(
+            {"temperature": temperature}
+        )
+    else:
+        model = llm
     result = await model.run_prompt(
         prompt=search_prompt,
         data={"question": question, "count": count},

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -176,7 +176,7 @@ async def run_fake_agent(
 
     # Seed docs with a few keyword searches
     for search in await litellm_get_search_query(
-        question, llm=query.settings.llm, count=3
+        question, llm=query.settings.get_llm(), count=3
     ):
         await step(search_tool, query=search, min_year=None, max_year=None)
     await step(gather_evidence_tool, question=question)

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -18,7 +18,7 @@ from pydantic import (
     field_validator,
 )
 
-from paperqa.llms import LiteLLMModel
+from paperqa.llms import LiteLLMModel, LLMModel
 from paperqa.settings import Settings
 from paperqa.types import Answer
 from paperqa.version import __version__
@@ -104,12 +104,14 @@ class AnswerResponse(BaseModel):
         v.filter_content_for_user()
         return v
 
-    async def get_summary(self, llm_model: str = "gpt-4o") -> str:
+    async def get_summary(self, llm_model: LLMModel | str = "gpt-4o") -> str:
         sys_prompt = (
             "Revise the answer to a question to be a concise SMS message. "
             "Use abbreviations or emojis if necessary."
         )
-        model = LiteLLMModel(name=llm_model)
+        model = (
+            LiteLLMModel(name=llm_model) if isinstance(llm_model, str) else llm_model
+        )
         result = await model.run_prompt(
             prompt="{question}\n\n{answer}",
             data={"question": self.answer.question, "answer": self.answer.answer},


### PR DESCRIPTION
- Makes sure `Settings` can be used to generate all LLM calls
    - Resolves https://github.com/Future-House/paper-qa/issues/568
- Now with `LiteLLMModel`, we auto-set retrying parameters even if you did specify `router_kwargs`