### PR TITLE
Limiting parsed page size to 1.28 million chars

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -269,6 +269,7 @@ class Docs(BaseModel):
                 Doc(docname="", citation="", dockey=dockey),  # Fake doc
                 chunk_chars=parse_config.chunk_size,
                 overlap=parse_config.overlap,
+                page_limit=parse_config.page_limit,
             )
             if not texts:
                 raise ValueError(f"Could not read document {path}. Is it empty?")
@@ -369,6 +370,7 @@ class Docs(BaseModel):
             doc,
             chunk_chars=parse_config.chunk_size,
             overlap=parse_config.overlap,
+            page_limit=parse_config.page_limit,
         )
         # loose check to see if document was loaded
         if (

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -269,7 +269,7 @@ class Docs(BaseModel):
                 Doc(docname="", citation="", dockey=dockey),  # Fake doc
                 chunk_chars=parse_config.chunk_size,
                 overlap=parse_config.overlap,
-                page_limit=parse_config.page_limit,
+                page_size_limit=parse_config.page_size_limit,
             )
             if not texts:
                 raise ValueError(f"Could not read document {path}. Is it empty?")
@@ -370,7 +370,7 @@ class Docs(BaseModel):
             doc,
             chunk_chars=parse_config.chunk_size,
             overlap=parse_config.overlap,
-            page_limit=parse_config.page_limit,
+            page_size_limit=parse_config.page_size_limit,
         )
         # loose check to see if document was loaded
         if (

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -15,7 +15,7 @@ from paperqa.utils import ImpossibleParsingError
 from paperqa.version import __version__ as pqa_version
 
 
-def parse_pdf_to_pages(path: Path) -> ParsedText:
+def parse_pdf_to_pages(path: str | os.PathLike) -> ParsedText:
 
     with pymupdf.open(path) as file:
         pages: dict[str, str] = {}
@@ -218,7 +218,7 @@ def chunk_code_text(
 
 @overload
 def read_doc(
-    path: Path,
+    path: str | os.PathLike,
     doc: Doc,
     parsed_text_only: Literal[False],
     include_metadata: Literal[False],
@@ -229,7 +229,7 @@ def read_doc(
 
 @overload
 def read_doc(
-    path: Path,
+    path: str | os.PathLike,
     doc: Doc,
     parsed_text_only: Literal[False] = ...,
     include_metadata: Literal[False] = ...,
@@ -240,7 +240,7 @@ def read_doc(
 
 @overload
 def read_doc(
-    path: Path,
+    path: str | os.PathLike,
     doc: Doc,
     parsed_text_only: Literal[True],
     include_metadata: bool = ...,
@@ -251,7 +251,7 @@ def read_doc(
 
 @overload
 def read_doc(
-    path: Path,
+    path: str | os.PathLike,
     doc: Doc,
     parsed_text_only: Literal[False],
     include_metadata: Literal[True],
@@ -261,7 +261,7 @@ def read_doc(
 
 
 def read_doc(
-    path: Path,
+    path: str | os.PathLike,
     doc: Doc,
     parsed_text_only: bool = False,
     include_metadata: bool = False,

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -244,6 +244,7 @@ def read_doc(
     include_metadata: Literal[False],
     chunk_chars: int = ...,
     overlap: int = ...,
+    page_limit: int | None = ...,
 ) -> list[Text]: ...
 
 
@@ -255,6 +256,7 @@ def read_doc(
     include_metadata: Literal[False] = ...,
     chunk_chars: int = ...,
     overlap: int = ...,
+    page_limit: int | None = ...,
 ) -> list[Text]: ...
 
 
@@ -266,6 +268,7 @@ def read_doc(
     include_metadata: bool = ...,
     chunk_chars: int = ...,
     overlap: int = ...,
+    page_limit: int | None = ...,
 ) -> ParsedText: ...
 
 
@@ -277,6 +280,7 @@ def read_doc(
     include_metadata: Literal[True],
     chunk_chars: int = ...,
     overlap: int = ...,
+    page_limit: int | None = ...,
 ) -> tuple[list[Text], ParsedMetadata]: ...
 
 
@@ -287,6 +291,7 @@ def read_doc(
     include_metadata: bool = False,
     chunk_chars: int = 3000,
     overlap: int = 100,
+    page_limit: int | None = None,
 ) -> list[Text] | ParsedText | tuple[list[Text], ParsedMetadata]:
     """Parse a document and split into chunks.
 
@@ -295,23 +300,26 @@ def read_doc(
     Args:
         path: local document path
         doc: object with document metadata
-        chunk_chars: size of chunks
-        overlap: size of overlap between chunks
         parsed_text_only: return parsed text without chunking
         include_metadata: return a tuple
+        chunk_chars: size of chunks
+        overlap: size of overlap between chunks
+        page_limit: optional limit on the number of characters per page
     """
     str_path = str(path)
     parsed_text = None
 
     # start with parsing -- users may want to store this separately
     if str_path.endswith(".pdf"):
-        parsed_text = parse_pdf_to_pages(path)
+        parsed_text = parse_pdf_to_pages(path, page_limit=page_limit)
     elif str_path.endswith(".txt"):
-        parsed_text = parse_text(path)
+        parsed_text = parse_text(path, page_limit=page_limit)
     elif str_path.endswith(".html"):
-        parsed_text = parse_text(path, html=True)
+        parsed_text = parse_text(path, html=True, page_limit=page_limit)
     else:
-        parsed_text = parse_text(path, split_lines=True, use_tiktoken=False)
+        parsed_text = parse_text(
+            path, split_lines=True, use_tiktoken=False, page_limit=page_limit
+        )
 
     if parsed_text_only:
         return parsed_text

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -108,7 +108,8 @@ def parse_text(
         html: flag to use html2text library for parsing.
         split_lines: flag to split lines into a list.
         use_tiktoken: flag to use tiktoken library to encode text.
-        page_size_limit: optional limit on the number of characters per page.
+        page_size_limit: optional limit on the number of characters per page. Only
+            relevant when split_lines is True.
     """
     path = Path(path)
     try:
@@ -129,15 +130,17 @@ def parse_text(
         parsing_libraries.append(f"html2text ({html2text_version})")
     else:
         parse_type = "txt"
-
-    texts = [text] if isinstance(text, str) else text
-    total_length = sum(len(t) for t in texts)
-    for i, t in enumerate(texts):
-        if page_size_limit and len(text) > page_size_limit:
-            raise ImpossibleParsingError(
-                f"The {parse_type} on page {i} of {len(texts)} was {len(t)} chars long,"
-                f" which exceeds the {page_size_limit} char limit at path {path}."
-            )
+    if isinstance(text, str):
+        total_length: int = len(text)
+    else:
+        total_length = sum(len(t) for t in text)
+        for i, t in enumerate(text):
+            if page_size_limit and len(text) > page_size_limit:
+                raise ImpossibleParsingError(
+                    f"The {parse_type} on page {i} of {len(text)} was {len(t)} chars"
+                    f" long, which exceeds the {page_size_limit} char limit at path"
+                    f" {path}."
+                )
     return ParsedText(
         content=text,
         metadata=ParsedMetadata(

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -119,6 +119,14 @@ class ParsingSettings(BaseModel):
         default=5000,
         description="Number of characters per chunk. If 0, no chunking will be done.",
     )
+    page_limit: int | None = Field(
+        default=1_280_000,
+        description=(
+            "Optional limit on the number of characters to parse in one 'page', default"
+            " is 1.28 million chars, 10X larger than a 128k tokens context limit"
+            " (ignoring chars vs tokens difference)."
+        ),
+    )
     use_doc_details: bool = Field(
         default=True, description="Whether to try to get metadata details for a Doc"
     )

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -119,7 +119,7 @@ class ParsingSettings(BaseModel):
         default=5000,
         description="Number of characters per chunk. If 0, no chunking will be done.",
     )
-    page_limit: int | None = Field(
+    page_size_limit: int | None = Field(
         default=1_280_000,
         description=(
             "Optional limit on the number of characters to parse in one 'page', default"

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -946,7 +946,9 @@ def test_zotero() -> None:
         ZoteroDB()  # "group" if group library
 
 
-def test_too_much_evidence(stub_data_dir: Path, stub_data_dir_w_near_dupes) -> None:
+def test_too_much_evidence(
+    stub_data_dir: Path, stub_data_dir_w_near_dupes: Path
+) -> None:
     doc_path = stub_data_dir / "obama.txt"
     mini_settings = Settings(llm="gpt-4o-mini", summary_llm="gpt-4o-mini")
     docs = Docs()


### PR DESCRIPTION
We encountered a PDF (for DOI `10.1038/s41593-019-0491-3`) with `PyMuPDF==1.24.11` where one of the pages was parsed to about 400 million characters, of junk (mainly whitespace). This didn't actually crash us, but takes hours to index.

As this was junk, this PR moves us to discard PDF that we fail to parse to be a reasonable amount of text (1.28 million chars), which is already 10X greater than a 128k token context window (and let's ignore chars != tokens in this 10X)