### PR TITLE
Moved `validate_sources` to include all `sources` not found

### DIFF
--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -107,7 +107,8 @@ class GradablePaperQAEnvironment(PaperQAEnvironment):
         not_found = [s for s in self.sources if s not in file_names and s not in dois]
         if not_found:
             raise ValueError(
-                f"Sources {not_found} of {self.sources} not found in the {entity}."
+                f"Sources {not_found} of {self.sources} not found in the {entity},"
+                f" the corresponding query was {self._query.query!r}."
             )
 
     async def step(

--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -104,9 +104,11 @@ class GradablePaperQAEnvironment(PaperQAEnvironment):
                 f" {entity}."
             )
             return
-        for source in self.sources:
-            if source not in file_names and source not in dois:
-                raise ValueError(f"Source {source!r} not found in the {entity}.")
+        not_found = [s for s in self.sources if s not in file_names and s not in dois]
+        if not_found:
+            raise ValueError(
+                f"Sources {not_found} of {self.sources} not found in the {entity}."
+            )
 
     async def step(
         self, action: ToolRequestMessage

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import Iterable
 from unittest.mock import patch
 
@@ -99,10 +100,10 @@ class TestTaskDataset:
     async def test_can_validate_stub_dataset_sources(
         self, base_query_request: QueryRequest
     ) -> None:
-        dataset = StubLitQADataset(base_query=base_query_request)
-        for i in range(len(dataset)):
-            env = dataset.get_new_env_by_idx(i)
-            await env.validate_sources()
+        ds = StubLitQADataset(base_query=base_query_request)
+        await asyncio.gather(
+            *(ds.get_new_env_by_idx(i).validate_sources() for i in range(len(ds)))
+        )
 
     @pytest.mark.asyncio
     async def test_evaluation(self, base_query_request: QueryRequest) -> None:


### PR DESCRIPTION
Instead of throwing for just the first unfound source, let's list them all at once