### PR TITLE
Moved Pydantic `model_config` to top of each class

### DIFF
--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -53,6 +53,8 @@ class MismatchedModelsError(Exception):
 
 
 class QueryRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     query: str = ""
     id: UUID = Field(
         default_factory=uuid4,
@@ -63,8 +65,6 @@ class QueryRequest(BaseModel):
     # provides post-hoc linkage of request to a docs object
     # NOTE: this isn't a unique field, on the user to keep straight
     _docs_name: str | None = PrivateAttr(default=None)
-
-    model_config = ConfigDict(extra="forbid")
 
     @field_validator("settings")
     @classmethod

--- a/paperqa/clients/__init__.py
+++ b/paperqa/clients/__init__.py
@@ -38,10 +38,10 @@ ALL_CLIENTS: Collection[type[MetadataPostProcessor | MetadataProvider]] = {
 class DocMetadataTask(BaseModel):
     """Holder for provider and processor tasks."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     providers: Collection[MetadataProvider]
     processors: Collection[MetadataPostProcessor]
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def provider_queries(
         self, query: dict

--- a/paperqa/clients/client_models.py
+++ b/paperqa/clients/client_models.py
@@ -24,8 +24,9 @@ logger = logging.getLogger(__name__)
 
 # ClientQuery is a base class for all queries to the client_models
 class ClientQuery(BaseModel):
-    session: aiohttp.ClientSession
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    session: aiohttp.ClientSession
 
 
 class TitleAuthorQuery(ClientQuery):

--- a/paperqa/clients/unpaywall.py
+++ b/paperqa/clients/unpaywall.py
@@ -19,14 +19,17 @@ UNPAYWALL_TIMEOUT = float(os.environ.get("UNPAYWALL_TIMEOUT", "10.0"))  # second
 
 
 class Author(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     family: str | None = None
     given: str | None = None
     sequence: str | None = None
     affiliation: list[dict[str, str]] | None = None
-    model_config = ConfigDict(extra="allow")
 
 
 class BestOaLocation(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     updated: datetime | None = None
     url: str | None = None
     url_for_pdf: str | None = None
@@ -40,7 +43,6 @@ class BestOaLocation(BaseModel):
     endpoint_id: str | None = None
     repository_institution: str | None = None
     oa_date: str | None = None
-    model_config = ConfigDict(extra="allow")
 
 
 class UnpaywallResponse(BaseModel):

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -119,6 +119,8 @@ class ChunkingOptions(StrEnum):
 class ParsingSettings(BaseModel):
     """Settings relevant for parsing and chunking documents."""
 
+    model_config = ConfigDict(extra="forbid")
+
     chunk_size: int = Field(
         default=5000,
         description="Number of characters per chunk. If 0, no chunking will be done.",
@@ -162,7 +164,6 @@ class ParsingSettings(BaseModel):
         ),
     )
     chunking_algorithm: ChunkingOptions = ChunkingOptions.SIMPLE_OVERLAP
-    model_config = ConfigDict(extra="forbid")
 
     def chunk_type(self, chunking_selection: ChunkingOptions | None = None) -> str:
         """Future chunking implementations (i.e. by section) will get an elif clause here."""

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -152,6 +152,8 @@ class Context(BaseModel):
 class Answer(BaseModel):
     """A class to hold the answer to a question."""
 
+    model_config = ConfigDict(extra="ignore")
+
     id: UUID = Field(default_factory=uuid4)
     question: str
     answer: str = ""
@@ -170,7 +172,6 @@ class Answer(BaseModel):
             "MD5 hash of the settings used to generate the answer. Cannot change"
         ),
     )
-    model_config = ConfigDict(extra="ignore")
 
     def __str__(self) -> str:
         """Return the answer as a string."""


### PR DESCRIPTION
I think this "config info" should be:
- Is actually a `ClassVar`, so should be at the top of the class
- Kept separate from normal parameters