### PR TITLE
Fixed `NumpyVectorStore.__eq__`'s `NotImplemented` case

### DIFF
--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -845,13 +845,21 @@ class NumpyVectorStore(VectorStore):
     _embeddings_matrix: np.ndarray | None = None
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, type(self)):
-            raise NotImplementedError
+        if not isinstance(other, type(self)):
+            return NotImplemented
         return (
             self.texts == other.texts
             and self.texts_hashes == other.texts_hashes
             and self.mmr_lambda == other.mmr_lambda
-            and self._embeddings_matrix == other._embeddings_matrix
+            and (
+                other._embeddings_matrix is None
+                if self._embeddings_matrix is None
+                else (
+                    False
+                    if other._embeddings_matrix is None
+                    else np.allclose(self._embeddings_matrix, other._embeddings_matrix)
+                )
+            )
         )
 
     def clear(self) -> None:


### PR DESCRIPTION
I got burned by treating https://github.com/Future-House/paper-qa/pull/608 like a `git rebase` checkpoint instead of including tests of `NumpyVectorStore.__eq__`