### PR TITLE
Implemented `__deepcopy__` on all `Environment`s

### DIFF
--- a/paperqa/litqa.py
+++ b/paperqa/litqa.py
@@ -128,7 +128,22 @@ class LitQAEvaluation(IntEnum):
         eval_model: LLMModel | str = DEFAULT_EVAL_MODEL_NAME,
         seed: int | None = None,
     ) -> tuple[str, Callable[[Answer | str], Awaitable[LitQAEvaluation]]]:
-        """Create a LitQA question and an evaluation callback."""
+        """
+        Create a LitQA question and an answer-to-evaluation function.
+
+        Args:
+            ideal: Ideal answer term's text (not a multiple choice letter).
+            distractors: Distractor terms' text (not multiple choice letters).
+            question: Question text.
+            use_unsure: Flag (default is enabled) to add an 'insufficient answer' term.
+            eval_model: Evaluation model to use for multiple choice letter extraction
+                from a text answer.
+            seed: Optional seed to use in randomization of multiple choice letters.
+
+        Returns:
+            Two-tuple of created LitQA question, function (that can be thought of as
+                stateless) to use to extract an evaluation result from an answer.
+        """
         text, ideal_answer, unsure_answer = make_mc_options(
             ideal=ideal,
             distractors=distractors,

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -261,6 +261,7 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
 
 class Chunk(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
+
     text: str | None
     prompt_tokens: int
     completion_tokens: int
@@ -768,9 +769,10 @@ def cosine_similarity(a, b):
 class VectorStore(BaseModel, ABC):
     """Interface for vector store - very similar to LangChain's VectorStore to be compatible."""
 
+    model_config = ConfigDict(extra="forbid")
+
     # can be tuned for different tasks
     mmr_lambda: float = Field(default=0.9)
-    model_config = ConfigDict(extra="forbid")
     texts_hashes: set[int] = Field(default_factory=set)
 
     def __contains__(self, item) -> bool:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -618,9 +618,7 @@ def test_docs_with_custom_embedding(subtests: SubTests, stub_data_dir: Path) -> 
         async def embed_documents(self, texts):
             return [[1, 2, 3] for _ in texts]
 
-    docs = Docs(
-        texts_index=NumpyVectorStore(),
-    )
+    docs = Docs(texts_index=NumpyVectorStore())
     docs.add(
         stub_data_dir / "bates.txt",
         citation="WikiMedia Foundation, 2023, Accessed now",
@@ -658,9 +656,7 @@ def test_docs_with_custom_embedding(subtests: SubTests, stub_data_dir: Path) -> 
 
 
 def test_sparse_embedding(stub_data_dir: Path) -> None:
-    docs = Docs(
-        texts_index=NumpyVectorStore(),
-    )
+    docs = Docs(texts_index=NumpyVectorStore())
     docs.add(
         stub_data_dir / "bates.txt",
         citation="WikiMedia Foundation, 2023, Accessed now",
@@ -681,9 +677,7 @@ def test_hybrid_embedding(stub_data_dir: Path) -> None:
     emb_model = HybridEmbeddingModel(
         models=[LiteLLMEmbeddingModel(), SparseEmbeddingModel()]
     )
-    docs = Docs(
-        texts_index=NumpyVectorStore(),
-    )
+    docs = Docs(texts_index=NumpyVectorStore())
     docs.add(
         stub_data_dir / "bates.txt",
         citation="WikiMedia Foundation, 2023, Accessed now",


### PR DESCRIPTION
- Implemented `__deepcopy__` on `PaperQAEnvironment` and `GradablePaperQAEnvironment`, with a test
    - This needed a `make_tools`, so I decomposed `PaperQAEnvironment.make_initial_state_and_tools` for it. Note this is a breaking change
- Documented `LitQAEvaluation.from_question`, as its inner workings were requiring too much thought
- Fixed another `model_config` not being at the top I missed in https://github.com/Future-House/paper-qa/pull/607
