### PR TITLE
Made embedding default

### DIFF
--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -554,7 +554,7 @@ class Settings(BaseSettings):
         ),
     )
     embedding: str = Field(
-        "text-embedding-3-small",
+        default="text-embedding-3-small",
         description="Default embedding model for texts",
     )
     embedding_config: dict | None = Field(


### PR DESCRIPTION
mypy seems to be not liking this missing kwarg. It is present on all other fields, so just making them consistent. 