### PR TITLE
Fixed crash due to DOI being a `list`

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -384,11 +384,20 @@ class DocDetails(Doc):
 
     @classmethod
     def lowercase_doi_and_populate_doc_id(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if doi := data.get("doi"):
-            remove_urls = cls.DOI_URL_FORMATS
-            for url in remove_urls:
-                if doi.startswith(url):
-                    doi = doi.replace(url, "")
+        doi: str | list[str] | None = data.get("doi")
+        if isinstance(doi, list):
+            if len(doi) != 1:
+                logger.warning(
+                    f"Discarding list of DOIs {doi} due to it not having one value,"
+                    f" full data was {data}."
+                )
+                doi = None
+            else:
+                doi = doi[0]
+        if doi:
+            for url_prefix_to_remove in cls.DOI_URL_FORMATS:
+                if doi.startswith(url_prefix_to_remove):
+                    doi = doi.replace(url_prefix_to_remove, "")
             data["doi"] = doi.lower()
             data["doc_id"] = encode_id(doi.lower())
         else:


### PR DESCRIPTION
I hit a new crash today:

```none
    | Traceback (most recent call last):
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 438, in process_file
    |     await tmp_docs.aadd(
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/docs.py", line 364, in aadd
    |     doc = await metadata_client.upgrade_doc_to_doc_details(
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 207, in upgrade_doc_to_doc_details
    |     0 if not extra_fields else DocDetails(**extra_fields)
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
    |     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/types.py", line 567, in validate_all_fields
    |     data = cls.lowercase_doi_and_populate_doc_id(data)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/types.py", line 390, in lowercase_doi_and_populate_doc_id
    |     if doi.startswith(url):
    |        ^^^^^^^^^^^^^^
    | AttributeError: 'list' object has no attribute 'startswith'
    +------------------------------------
```

Somehow it looks like the `DocDetails` input data for DOI was a `list` not a `str` (as expected).

This PR handles this new edge case