### PR TITLE
Retrying flaky test `test_propagate_options`

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -353,6 +353,7 @@ async def test_timeout(agent_test_settings: Settings, agent_type: str | type) ->
     assert "I cannot answer" in response.answer.answer
 
 
+@pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
 @pytest.mark.asyncio
 async def test_propagate_options(agent_test_settings: Settings) -> None:
     llm_name = "gpt-4o-mini"


### PR DESCRIPTION
In [this CI run](https://github.com/Future-House/paper-qa/actions/runs/11465694284/job/31904713529?pr=622), `test_propagate_options` seems to have flaked. This PR just adds a `pytest.mark.flaky` to it