### PR TITLE
Caching opened `tantivy.Index`es in the package

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -135,13 +135,17 @@ class SearchIndex:
         self.storage = storage
 
     @property
-    async def index_directory(self) -> anyio.Path:
+    async def index_directory(  # TODO: rename to index_root_directory
+        self,
+    ) -> anyio.Path:
         directory = anyio.Path(self._index_directory).joinpath(self.index_name)
         await directory.mkdir(parents=True, exist_ok=True)
         return directory
 
     @property
-    async def index_filename(self) -> anyio.Path:  # TODO: rename to index_directory
+    async def index_filename(  # TODO: rename to index_meta_directory
+        self,
+    ) -> anyio.Path:
         """Directory to store files used to house index internals."""
         index_dir = (await self.index_directory) / "index"
         await index_dir.mkdir(exist_ok=True)

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -200,6 +200,12 @@ class SearchIndex:
                     self._index = Index.open(path=str(index_meta_directory))
                 else:
                     key = self.index_name, str(await index_meta_directory.absolute())
+                    # NOTE: now we know we're using the cache and have created the cache
+                    # key. And we know we're in asyncio.gather race condition risk land.
+                    # All of the following operations are *synchronous* so we are not
+                    # giving the opportunity for an await to switch to another parallel
+                    # version of this code. Otherwise, we risk counts being incorrect
+                    # due to race conditions
                     if key not in _OPENED_INDEX_CACHE:  # open a new Index
                         self._index = Index.open(path=str(index_meta_directory))
                         prev_count: int = 0

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -7,14 +7,14 @@ import re
 import sys
 from typing import ClassVar, cast
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from paperqa.docs import Docs
 from paperqa.llms import EmbeddingModel, LiteLLMModel
 from paperqa.settings import Settings
 from paperqa.types import Answer, DocDetails
 
-from .search import SearchIndex, get_directory_index
+from .search import get_directory_index
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,6 @@ class PaperSearch(NamedTool):
     settings: Settings
     embedding_model: EmbeddingModel
     previous_searches: dict[tuple[str, str | None], int] = Field(default_factory=dict)
-    _search_index: SearchIndex | None = PrivateAttr(default=None)
 
     async def paper_search(
         self,
@@ -126,15 +125,12 @@ class PaperSearch(NamedTool):
             offset = self.previous_searches[search_key] = 0
 
         logger.info(f"Starting paper search for {query!r}.")
-        if self._search_index is None:
-            self._search_index = await get_directory_index(
-                settings=self.settings, build=False
-            )
-        results: list[Docs] = await self._search_index.query(
+        index = await get_directory_index(settings=self.settings, build=False)
+        results: list[Docs] = await index.query(
             query,
             top_n=self.settings.agent.search_count,
             offset=offset,
-            field_subset=[f for f in self._search_index.fields if f != "year"],
+            field_subset=[f for f in index.fields if f != "year"],
         )
         logger.info(
             f"{self.TOOL_FN_NAME} for query {query!r} and offset {offset} returned"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -23,6 +23,7 @@ from ldp.graph.ops import OpResult
 from ldp.llms import EmbeddingModel, MultipleCompletionLLMModel
 from pydantic import ValidationError
 from pytest_subtests import SubTests
+from tantivy import Index
 
 from paperqa.agents import SearchIndex, agent_query
 from paperqa.agents.env import settings_to_tools
@@ -240,7 +241,11 @@ async def test_agent_types(
         " accept the answer for now, as we're in debug mode."
     )
     request = QueryRequest(query=question, settings=agent_test_settings)
-    response = await agent_query(request, agent_type=agent_type)
+    with patch.object(
+        Index, "open", side_effect=Index.open, autospec=True
+    ) as mock_open:
+        response = await agent_query(request, agent_type=agent_type)
+    mock_open.assert_called_once()
     assert response.answer.answer, "Answer not generated"
     assert response.answer.answer != "I cannot answer", "Answer not generated"
     assert response.answer.context, "No contexts were found"
@@ -463,20 +468,34 @@ async def test_agent_sharing_state(
         search_tool = PaperSearch(
             settings=agent_test_settings, embedding_model=embedding_model
         )
-        with patch.object(
-            SearchIndex, "save_index", autospec=True, wraps=SearchIndex.save_index
-        ) as mock_save_index:
+        with (
+            patch.object(
+                SearchIndex, "save_index", wraps=SearchIndex.save_index, autospec=True
+            ) as mock_save_index,
+            patch.object(
+                Index, "open", side_effect=Index.open, autospec=True
+            ) as mock_open,
+        ):
             await search_tool.paper_search(
                 "XAI self explanatory model",
                 min_year=None,
                 max_year=None,
                 state=env_state,
             )
-        assert env_state.docs.docs, "Search did not add any papers"
-        mock_save_index.assert_not_awaited(), "Search shouldn't try to update the index"
-        assert all(
-            isinstance(d, Doc) for d in env_state.docs.docs.values()
-        ), "Document type or DOI propagation failure"
+            assert env_state.docs.docs, "Search did not add any papers"
+            mock_open.assert_called_once()
+            assert all(
+                isinstance(d, Doc) for d in env_state.docs.docs.values()
+            ), "Document type or DOI propagation failure"
+
+            await search_tool.paper_search(
+                "XAI for chemical property prediction",
+                min_year=2018,
+                max_year=2024,
+                state=env_state,
+            )
+            mock_open.assert_called_once()
+            mock_save_index.assert_not_awaited()
 
     with subtests.test(msg=GatherEvidence.__name__):
         assert not answer.contexts, "No contexts is required for a later assertion"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -245,7 +245,9 @@ async def test_agent_types(
         Index, "open", side_effect=Index.open, autospec=True
     ) as mock_open:
         response = await agent_query(request, agent_type=agent_type)
-    mock_open.assert_called_once()
+    assert (
+        mock_open.call_count <= 1
+    ), "Expected one Index.open call, or possibly zero if multiprocessing tests"
     assert response.answer.answer, "Answer not generated"
     assert response.answer.answer != "I cannot answer", "Answer not generated"
     assert response.answer.context, "No contexts were found"
@@ -483,7 +485,9 @@ async def test_agent_sharing_state(
                 state=env_state,
             )
             assert env_state.docs.docs, "Search did not add any papers"
-            mock_open.assert_called_once()
+            assert (
+                mock_open.call_count <= 1
+            ), "Expected one Index.open call, or possibly zero if multiprocessing tests"
             assert all(
                 isinstance(d, Doc) for d in env_state.docs.docs.values()
             ), "Document type or DOI propagation failure"
@@ -494,7 +498,9 @@ async def test_agent_sharing_state(
                 max_year=2024,
                 state=env_state,
             )
-            mock_open.assert_called_once()
+            assert (
+                mock_open.call_count <= 1
+            ), "Expected one Index.open call, or possibly zero if multiprocessing tests"
             mock_save_index.assert_not_awaited()
 
     with subtests.test(msg=GatherEvidence.__name__):


### PR DESCRIPTION
### Motivation

https://github.com/quickwit-oss/tantivy-py/issues/359#issuecomment-2428087169 reveals that one of our servers can only handle three opened indexes at once. The reason why remains unclear, but this PR at least reacts to the issue by caching opened indexes in the `search.py` module's scope. Now we can invoke `await SearchIndex(index_name="normal-index").index` as many times as desired within one Python process.

### Implementation Details

Why a global scope? We want to accommodate caching the `Index` across:
- Across `deepcopy` of an `PaperQAEnvironment`, whose `tools` which contains a `PaperSearch` tool instance.
    - So we can't cache the `Index` in `PaperSearch`, or else we'd be making `Index` copies (and the side effects of this are unknown)
- Across a `Trajectory`, where we (1) build the index and (2) use the index in 0+ paper searches
- Across a `TaskDataset`, where we (1) build the index and (2) run 0+ envs for one trajectory each
- Across many `TaskDataset`, for larger experiments

This can only be accomplished using global scope, whose lifetime matches the entire Python process. This unfortunately requires callers to invoke the newly added `reap_opened_index_cache` at runtime if intermediary cleaning of the cache is desired.

The caching added here can be disabled by setting `1` or `true` (case insensitive) to the newly-added environment variable `PQA_INDEX_DONT_CACHE_INDEXES`.

### Risks

- Race conditions if invoking `reap_opened_index_cache` while also using `PaperSearch`
    - Our test suite intentionally doesn't use `reap_opened_index_cache` to avoid this, but the tradeoff is our testing slowly accrues indexes across cases
- Since caching is enabled by default, if the clients aren't aware of this, it can be considered unexpected statefulness