### PR TITLE
Increased retry count for `ClientConnectorDNSError` errors

### DIFF
--- a/paperqa/clients/crossref.py
+++ b/paperqa/clients/crossref.py
@@ -107,7 +107,7 @@ def get_crossref_mailto() -> str:
 @retry(
     retry=retry_if_exception(make_flaky_ssl_error_predicate(CROSSREF_HOST)),
     before_sleep=before_sleep_log(logger, logging.WARNING),
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(5),
 )
 async def doi_to_bibtex(
     doi: str,
@@ -239,7 +239,7 @@ async def parse_crossref_to_doc_details(
 @retry(
     retry=retry_if_exception(make_flaky_ssl_error_predicate(CROSSREF_HOST)),
     before_sleep=before_sleep_log(logger, logging.WARNING),
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(5),
 )
 async def get_doc_details_from_crossref(  # noqa: PLR0912
     session: aiohttp.ClientSession,

--- a/paperqa/clients/semantic_scholar.py
+++ b/paperqa/clients/semantic_scholar.py
@@ -113,7 +113,7 @@ class SematicScholarSearchType(IntEnum):
 @retry(
     retry=retry_if_exception(make_flaky_ssl_error_predicate(SEMANTIC_SCHOLAR_HOST)),
     before_sleep=before_sleep_log(logger, logging.WARNING),
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(5),
 )
 async def _s2_get_with_retrying(url: str, **get_kwargs) -> dict[str, Any]:
     return await _get_with_retrying(
@@ -270,7 +270,7 @@ async def s2_title_search(
 @retry(
     retry=retry_if_exception(make_flaky_ssl_error_predicate(SEMANTIC_SCHOLAR_HOST)),
     before_sleep=before_sleep_log(logger, logging.WARNING),
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(5),
 )
 async def get_s2_doc_details_from_doi(
     doi: str | None,


### PR DESCRIPTION
We just crashed after retrying a flaky DNS error with Semantic Scholar (see below), so this PR increases the retry count a bit:

```none
  |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 675, in get_directory_index
  |     async with anyio.create_task_group() as tg:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 763, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1317, in _create_direct_connection
    |     hosts = await self._resolve_host(host, port, traces=traces)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 971, in _resolve_host
    |     return await asyncio.shield(resolved_host_task)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1002, in _resolve_host_with_throttle
    |     addrs = await self._resolver.resolve(host, port, family=self._family)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/resolver.py", line 38, in resolve
    |     infos = await self._loop.getaddrinfo(
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/asyncio/base_events.py", line 901, in getaddrinfo
    |     return await self.run_in_executor(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/thread.py", line 58, in run
    |     result = self.fn(*self.args, **self.kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/socket.py", line 976, in getaddrinfo
    |     for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | socket.gaierror: [Errno 8] nodename nor servname provided, or not known
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 119, in _s2_get_with_retrying
    |     return await _get_with_retrying(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    |     self._add_action_func(lambda rs: rs.outcome.result())
    |                                      ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    |     return self.__get_result()
    |            ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    |     raise self._exception
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 448, in _get_with_retrying
    |     async with session.get(url, **get_kwargs) as response:
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 1359, in __aenter__
    |     self._resp: _RetType = await self._coro
    |                            ^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 663, in _request
    |     conn = await self._connector.connect(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 563, in connect
    |     proto = await self._create_connection(req, traces, timeout)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1032, in _create_connection
    |     _, proto = await self._create_direct_connection(req, traces, timeout)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1323, in _create_direct_connection
    |     raise ClientConnectorDNSError(req.connection_key, exc) from exc
    | aiohttp.client_exceptions.ClientConnectorDNSError: Cannot connect to host api.semanticscholar.org:443 ssl:default [nodename nor servname provided, or not known]
    |
    | The above exception was the direct cause of the following exception:
    |
    | Traceback (most recent call last):
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 487, in process_file
    |     await tmp_docs.aadd(
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/docs.py", line 364, in aadd
    |     doc = await metadata_client.upgrade_doc_to_doc_details(
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 210, in upgrade_doc_to_doc_details
    |     if doc_details := await self.query(**kwargs):
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 153, in query
    |     await gather_with_concurrency(
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 112, in gather_with_concurrency
    |     return await asyncio.gather(*(sem_coro(c) for c in coros))
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 110, in sem_coro
    |     return await coro
    |            ^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/client_models.py", line 109, in query
    |     return await self._query(client_query)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 346, in _query
    |     return await get_s2_doc_details_from_doi(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    |     self._add_action_func(lambda rs: rs.outcome.result())
    |                                      ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    |     return self.__get_result()
    |            ^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/.pyenv/versions/3.12.7/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    |     raise self._exception
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    |     result = await fn(*args, **kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 296, in get_s2_doc_details_from_doi
    |     paper_data=await _s2_get_with_retrying(
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    |     return await copy(fn, *args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    |     do = await self.iter(retry_state=retry_state)
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    |     result = await action(retry_state)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    |     return call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/user/code/repo/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 419, in exc_check
    |     raise retry_exc from fut.exception()
    | tenacity.RetryError: RetryError[<Future at 0x159970a40 state=finished raised ClientConnectorDNSError>]
    +------------------------------------
```