### PR TITLE
Make string similarity case insensitive by default

### DIFF
--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -75,12 +75,14 @@ def maybe_is_html(file: BinaryIO) -> bool:
     return magic_number in {b"<htm", b"<!DO", b"<xsl", b"<!X"}
 
 
-def strings_similarity(s1: str, s2: str) -> float:
+def strings_similarity(s1: str, s2: str, case_insensitive: bool = True) -> float:
     if not s1 or not s2:
         return 0
+
     # break the strings into words
-    ss1 = set(s1.split())
-    ss2 = set(s2.split())
+    ss1 = set(s1.lower().split()) if case_insensitive else set(s1.split())
+    ss2 = set(s2.lower().split()) if case_insensitive else set(s2.split())
+
     # return the similarity ratio
     return len(ss1.intersection(ss2)) / len(ss1.union(ss2))
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -38,6 +38,7 @@ from paperqa.utils import (
     maybe_is_html,
     maybe_is_text,
     name_in_text,
+    strings_similarity,
     strip_citations,
 )
 from tests.conftest import VCR_DEFAULT_MATCH_ON
@@ -1118,3 +1119,9 @@ def test_evidence_detailed_citations_shim(stub_data_dir: Path) -> None:
     docs.add(stub_data_dir / "bates.txt", "WikiMedia Foundation, 2023, Accessed now")
     response = docs.query("What country is Bates from?", settings=settings)
     assert "WikiMedia Foundation, 2023, Accessed now" not in response.context
+
+
+def test_case_insensitive_matching():
+    assert strings_similarity("my test sentence", "My test sentence") == 1.0
+    assert strings_similarity("a b c d e", "a b c f") == 0.5
+    assert strings_similarity("A B c d e", "a b c f") == 0.5


### PR DESCRIPTION
We were losing Crossref title-matched articles because they return titles with different casings than we expected, this makes us safe against that. 