### PR TITLE
Fixing crash due to `None` author

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -7,7 +7,7 @@ import re
 from collections.abc import Collection
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 from uuid import UUID, uuid4
 
 import litellm  # for cost
@@ -456,8 +456,11 @@ class DocDetails(Doc):
     def remove_invalid_authors(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Capture and cull strange author names."""
         if authors := data.get("authors"):
+            # On 10/29/2024 while indexing 19k PDFs, a provider (unclear which one)
+            # returned an author of None. The vast majority of the time authors are str
+            authors = cast(list[str | None], authors)
             data["authors"] = [
-                a for a in authors if a.lower() not in cls.AUTHOR_NAMES_TO_REMOVE
+                a for a in authors if a and a.lower() not in cls.AUTHOR_NAMES_TO_REMOVE
             ]
 
         return data


### PR DESCRIPTION
Seen last night when indexing 19k PDFs:

```none
    | Traceback (most recent call last):
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/agents/search.py", line 487, in process_file
    |     await tmp_docs.aadd(
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/docs.py", line 364, in aadd
    |     doc = await metadata_client.upgrade_doc_to_doc_details(
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 207, in upgrade_doc_to_doc_details
    |     0 if not extra_fields else DocDetails(**extra_fields)
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
    |     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/types.py", line 577, in validate_all_fields
    |     data = cls.remove_invalid_authors(data)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/path/to/.venv/lib/python3.12/site-packages/paperqa/types.py", line 458, in remove_invalid_authors
    |     a for a in authors if a.lower() not in cls.AUTHOR_NAMES_TO_REMOVE
    |                           ^^^^^^^
    | AttributeError: 'NoneType' object has no attribute 'lower'
    +------------------------------------
```