### PR TITLE
Fixing flaky tests `test_code` and `test_minimal_fields_filtering`

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -320,12 +320,20 @@ async def test_minimal_fields_filtering() -> None:
             "semantic_scholar",
             "crossref",
         }, "Should be from two sources"
-        assert details.citation == (
+        citation_boilerplate = (
             "Unknown author(s). Augmenting large language models with chemistry tools."
             " Unknown journal, Unknown year. URL:"
-            " https://doi.org/10.1038/s42256-024-00832-8,"
-            " doi:10.1038/s42256-024-00832-8."
-        ), "Citation should be populated"
+        )
+        assert details.citation in {
+            (  # Match in Nature Machine Intelligence
+                f"{citation_boilerplate} https://doi.org/10.1038/s42256-024-00832-8,"
+                " doi:10.1038/s42256-024-00832-8."
+            ),
+            (  # Match in arXiv
+                f"{citation_boilerplate} https://doi.org/10.48550/arxiv.2304.05376,"
+                " doi:10.48550/arxiv.2304.05376."
+            ),
+        }, "Citation should be populated"
         assert not details.source_quality, "No source quality data should exist"
 
 


### PR DESCRIPTION
- In [this CI run](https://github.com/Future-House/paper-qa/actions/runs/11579872611/job/32237115333?pr=651), `test_code` failed with `"I cannot answer."`, so this PR adds retrying for that
- In [this CI run](https://github.com/Future-House/paper-qa/actions/runs/11580158588/job/32238038336?pr=648) after https://github.com/Future-House/paper-qa/pull/651, it showed the `test_minimal_fields_filtering` is flaky, so this PR beefs up its assertion