### PR TITLE
Renamed to PQASession type

### DIFF
--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -9,7 +9,7 @@ warnings.filterwarnings(
 from paperqa.agents import ask  # noqa: E402
 from paperqa.agents.main import agent_query  # noqa: E402
 from paperqa.agents.models import QueryRequest  # noqa: E402
-from paperqa.docs import Answer, Docs, print_callback  # noqa: E402
+from paperqa.docs import Docs, PQASession, print_callback  # noqa: E402
 from paperqa.llms import (  # noqa: E402
     EmbeddingModel,
     HybridEmbeddingModel,
@@ -23,7 +23,7 @@ from paperqa.llms import (  # noqa: E402
     embedding_model_factory,
 )
 from paperqa.settings import Settings, get_settings  # noqa: E402
-from paperqa.types import Context, Doc, DocDetails, Text  # noqa: E402
+from paperqa.types import Answer, Context, Doc, DocDetails, Text  # noqa: E402
 from paperqa.version import __version__  # noqa: E402
 
 __all__ = [
@@ -39,6 +39,7 @@ __all__ = [
     "LiteLLMEmbeddingModel",
     "LiteLLMModel",
     "NumpyVectorStore",
+    "PQASession",
     "QueryRequest",
     "SentenceTransformerEmbeddingModel",
     "Settings",

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -14,7 +14,7 @@ from aviary.core import (
 from paperqa.docs import Docs
 from paperqa.llms import EmbeddingModel, LiteLLMModel
 from paperqa.settings import Settings
-from paperqa.types import Answer
+from paperqa.types import PQASession
 from paperqa.utils import get_year
 
 from .models import QueryRequest
@@ -128,7 +128,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
     def make_initial_state(self) -> EnvironmentState:
         return EnvironmentState(
             docs=self._docs,
-            answer=Answer(
+            answer=PQASession(
                 question=self._query.query,
                 config_md5=self._query.settings.md5,
                 id=self._query.id,

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -145,7 +145,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
             [
                 Message(
                     content=self._query.settings.agent.agent_prompt.format(
-                        question=self.state.answer.question,
+                        question=self.state.session.question,
                         status=self.state.status,
                         gen_answer_tool_name=GenerateAnswer.TOOL_FN_NAME,
                     ),
@@ -160,7 +160,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
     async def step(
         self, action: ToolRequestMessage
     ) -> tuple[list[Message], float, bool, bool]:
-        self.state.answer.add_tokens(action)  # Add usage for action if present
+        self.state.session.add_tokens(action)  # Add usage for action if present
 
         # If the action has empty tool_calls, the agent can later take that into account
         msgs = cast(

--- a/paperqa/agents/helpers.py
+++ b/paperqa/agents/helpers.py
@@ -81,8 +81,8 @@ def table_formatter(
         table.add_column("Answer", style="magenta")
         for obj, _ in objects:
             table.add_row(
-                cast(AnswerResponse, obj).answer.question[:max_chars_per_column],
-                cast(AnswerResponse, obj).answer.answer[:max_chars_per_column],
+                cast(AnswerResponse, obj).session.question[:max_chars_per_column],
+                cast(AnswerResponse, obj).session.answer[:max_chars_per_column],
             )
         return table
     if isinstance(example_object, Docs):

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -32,7 +32,7 @@ except ImportError:
 
 from paperqa.docs import Docs
 from paperqa.settings import AgentSettings
-from paperqa.types import Answer
+from paperqa.types import PQASession
 
 from .env import PaperQAEnvironment
 from .helpers import litellm_get_search_query, table_formatter
@@ -154,7 +154,7 @@ async def run_fake_agent(
         Callable[[list[Message], float, bool, bool], Awaitable] | None
     ) = None,
     **env_kwargs,
-) -> tuple[Answer, AgentStatus]:
+) -> tuple[PQASession, AgentStatus]:
     if query.settings.agent.max_timesteps is not None:
         logger.warning(
             f"Max timesteps (configured {query.settings.agent.max_timesteps}) is not"
@@ -207,7 +207,7 @@ async def run_aviary_agent(
         Callable[[list[Message], float, bool, bool], Awaitable] | None
     ) = None,
     **env_kwargs,
-) -> tuple[Answer, AgentStatus]:
+) -> tuple[PQASession, AgentStatus]:
     env = env_class(query, docs, **env_kwargs)
     done = False
 
@@ -323,7 +323,7 @@ async def run_ldp_agent(
     ) = None,
     ldp_callback_type: type[LDPRolloutCallback] = LDPRolloutCallback,
     **env_kwargs,
-) -> tuple[Answer, AgentStatus]:
+) -> tuple[PQASession, AgentStatus]:
     env = env_class(query, docs, **env_kwargs)
     # NOTE: don't worry about ldp import checks, because we know Settings.make_ldp_agent
     # has already taken place, which checks that ldp is installed

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -85,7 +85,7 @@ class QueryRequest(BaseModel):
 
 
 class AnswerResponse(BaseModel):
-    answer: PQASession
+    session: PQASession = Field(alias="answer")
     bibtex: dict[str, str] | None = None
     status: AgentStatus
     timing_info: dict[str, dict[str, float]] | None = None
@@ -94,7 +94,7 @@ class AnswerResponse(BaseModel):
     # about the answer, such as the number of sources used, etc.
     stats: dict[str, str] | None = None
 
-    @field_validator("answer")
+    @field_validator("session")
     def strip_answer(
         cls, v: PQASession, info: ValidationInfo  # noqa: ARG002, N805
     ) -> PQASession:
@@ -114,7 +114,7 @@ class AnswerResponse(BaseModel):
         )
         result = await model.run_prompt(
             prompt="{question}\n\n{answer}",
-            data={"question": self.answer.question, "answer": self.answer.answer},
+            data={"question": self.session.question, "answer": self.session.answer},
             system_prompt=sys_prompt,
         )
         return result.text.strip()

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -85,6 +85,8 @@ class QueryRequest(BaseModel):
 
 
 class AnswerResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     session: PQASession = Field(alias="answer")
     bibtex: dict[str, str] | None = None
     status: AgentStatus

--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -20,7 +20,7 @@ from pydantic import (
 
 from paperqa.llms import LiteLLMModel, LLMModel
 from paperqa.settings import Settings
-from paperqa.types import Answer
+from paperqa.types import PQASession
 from paperqa.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class QueryRequest(BaseModel):
 
 
 class AnswerResponse(BaseModel):
-    answer: Answer
+    answer: PQASession
     bibtex: dict[str, str] | None = None
     status: AgentStatus
     timing_info: dict[str, dict[str, float]] | None = None
@@ -96,8 +96,8 @@ class AnswerResponse(BaseModel):
 
     @field_validator("answer")
     def strip_answer(
-        cls, v: Answer, info: ValidationInfo  # noqa: ARG002, N805
-    ) -> Answer:
+        cls, v: PQASession, info: ValidationInfo  # noqa: ARG002, N805
+    ) -> PQASession:
         # This modifies in place, this is fine
         # because when a response is being constructed,
         # we should be done with the Answer object

--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -46,7 +46,7 @@ from paperqa.litqa import (
     read_litqa_v2_from_hub,
 )
 from paperqa.llms import EmbeddingModel, LiteLLMModel, LLMModel
-from paperqa.types import Answer
+from paperqa.types import PQASession
 
 from .env import POPULATE_FROM_SETTINGS, PaperQAEnvironment
 from .models import QueryRequest
@@ -69,7 +69,7 @@ class GradablePaperQAEnvironment(PaperQAEnvironment):
         summary_llm_model: LiteLLMModel | None = POPULATE_FROM_SETTINGS,
         embedding_model: EmbeddingModel | None = POPULATE_FROM_SETTINGS,
         evaluation_from_answer: (
-            Callable[[Answer | str], Awaitable[LitQAEvaluation]] | None
+            Callable[[PQASession | str], Awaitable[LitQAEvaluation]] | None
         ) = None,
         sources: str | list[str] | None = None,
         rewards: Sequence[float] = DEFAULT_REWARD_DISTRIBUTION,

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -35,7 +35,7 @@ class EnvironmentState(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     docs: Docs
-    answer: PQASession
+    session: PQASession = Field(..., alias="answer")
 
     # SEE: https://regex101.com/r/RmuVdC/1
     STATUS_SEARCH_REGEX_PATTERN: ClassVar[str] = (
@@ -51,18 +51,18 @@ class EnvironmentState(BaseModel):
             relevant_paper_count=len(
                 {
                     c.text.doc.dockey
-                    for c in self.answer.contexts
+                    for c in self.session.contexts
                     if c.score > self.RELEVANT_SCORE_CUTOFF
                 }
             ),
             evidence_count=len(
                 [
                     c
-                    for c in self.answer.contexts
+                    for c in self.session.contexts
                     if c.score > self.RELEVANT_SCORE_CUTOFF
                 ]
             ),
-            cost=self.answer.cost,
+            cost=self.session.cost,
         )
 
 
@@ -202,16 +202,16 @@ class GatherEvidence(NamedTool):
             )
 
         logger.info(f"{self.TOOL_FN_NAME} starting for question {question!r}.")
-        original_question = state.answer.question
+        original_question = state.session.question
         try:
             # Swap out the question with the more specific question
             # TODO: remove this swap, as it prevents us from supporting parallel calls
-            state.answer.question = question
-            l0 = len(state.answer.contexts)
+            state.session.question = question
+            l0 = len(state.session.contexts)
 
             # TODO: refactor answer out of this...
-            state.answer = await state.docs.aget_evidence(
-                query=state.answer,
+            state.session = await state.docs.aget_evidence(
+                query=state.session,
                 settings=self.settings,
                 embedding_model=self.embedding_model,
                 summary_llm_model=self.summary_llm_model,
@@ -219,14 +219,14 @@ class GatherEvidence(NamedTool):
                     f"{self.TOOL_FN_NAME}_aget_evidence"
                 ),
             )
-            l1 = len(state.answer.contexts)
+            l1 = len(state.session.contexts)
         finally:
-            state.answer.question = original_question
+            state.session.question = original_question
 
         status = state.status
         logger.info(status)
         sorted_contexts = sorted(
-            state.answer.contexts, key=lambda x: x.score, reverse=True
+            state.session.contexts, key=lambda x: x.score, reverse=True
         )
         best_evidence = (
             f" Best evidence:\n\n{sorted_contexts[0].context}"
@@ -287,8 +287,8 @@ class GenerateAnswer(NamedTool):
 
         # TODO: Should we allow the agent to change the question?
         # self.answer.question = query
-        state.answer = await state.docs.aquery(
-            query=state.answer,
+        state.session = await state.docs.aquery(
+            query=state.session,
             settings=self.settings,
             llm_model=self.llm_model,
             summary_llm_model=self.summary_llm_model,
@@ -298,13 +298,13 @@ class GenerateAnswer(NamedTool):
             ),
         )
 
-        if state.answer.could_not_answer:
+        if state.session.could_not_answer:
             if self.settings.agent.wipe_context_on_answer_failure:
-                state.answer.contexts = []
-                state.answer.context = ""
+                state.session.contexts = []
+                state.session.context = ""
             answer = self.FAILED_TO_ANSWER
         else:
-            answer = state.answer.answer
+            answer = state.session.answer
         status = state.status
         logger.info(status)
 

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 from paperqa.docs import Docs
 from paperqa.llms import EmbeddingModel, LiteLLMModel
 from paperqa.settings import Settings
-from paperqa.types import Answer, DocDetails
+from paperqa.types import DocDetails, PQASession
 
 from .search import get_directory_index
 
@@ -35,7 +35,7 @@ class EnvironmentState(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     docs: Docs
-    answer: Answer
+    answer: PQASession
 
     # SEE: https://regex101.com/r/RmuVdC/1
     STATUS_SEARCH_REGEX_PATTERN: ClassVar[str] = (

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -34,11 +34,11 @@ from paperqa.paths import PAPERQA_DIR
 from paperqa.readers import read_doc
 from paperqa.settings import MaybeSettings, get_settings
 from paperqa.types import (
-    Answer,
     Doc,
     DocDetails,
     DocKey,
     LLMResult,
+    PQASession,
     Text,
     set_llm_answer_ids,
 )
@@ -512,13 +512,13 @@ class Docs(BaseModel):
 
     def get_evidence(
         self,
-        query: Answer | str,
+        query: PQASession | str,
         exclude_text_filter: set[str] | None = None,
         settings: MaybeSettings = None,
         callbacks: list[Callable] | None = None,
         embedding_model: EmbeddingModel | None = None,
         summary_llm_model: LLMModel | None = None,
-    ) -> Answer:
+    ) -> PQASession:
         return get_loop().run_until_complete(
             self.aget_evidence(
                 query=query,
@@ -532,20 +532,20 @@ class Docs(BaseModel):
 
     async def aget_evidence(
         self,
-        query: Answer | str,
+        query: PQASession | str,
         exclude_text_filter: set[str] | None = None,
         settings: MaybeSettings = None,
         callbacks: list[Callable] | None = None,
         embedding_model: EmbeddingModel | None = None,
         summary_llm_model: LLMModel | None = None,
-    ) -> Answer:
+    ) -> PQASession:
 
         evidence_settings = get_settings(settings)
         answer_config = evidence_settings.answer
         prompt_config = evidence_settings.prompts
 
         answer = (
-            Answer(question=query, config_md5=evidence_settings.md5)
+            PQASession(question=query, config_md5=evidence_settings.md5)
             if isinstance(query, str)
             else query
         )
@@ -626,13 +626,13 @@ class Docs(BaseModel):
 
     def query(
         self,
-        query: Answer | str,
+        query: PQASession | str,
         settings: MaybeSettings = None,
         callbacks: list[Callable] | None = None,
         llm_model: LLMModel | None = None,
         summary_llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
-    ) -> Answer:
+    ) -> PQASession:
         return get_loop().run_until_complete(
             self.aquery(
                 query,
@@ -646,13 +646,13 @@ class Docs(BaseModel):
 
     async def aquery(  # noqa: PLR0912
         self,
-        query: Answer | str,
+        query: PQASession | str,
         settings: MaybeSettings = None,
         callbacks: list[Callable] | None = None,
         llm_model: LLMModel | None = None,
         summary_llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
-    ) -> Answer:
+    ) -> PQASession:
 
         query_settings = get_settings(settings)
         answer_config = query_settings.answer
@@ -666,7 +666,7 @@ class Docs(BaseModel):
             embedding_model = query_settings.get_embedding_model()
 
         answer = (
-            Answer(question=query, config_md5=query_settings.md5)
+            PQASession(question=query, config_md5=query_settings.md5)
             if isinstance(query, str)
             else query
         )

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -40,7 +40,7 @@ from paperqa.types import (
     LLMResult,
     PQASession,
     Text,
-    set_llm_answer_ids,
+    set_llm_session_ids,
 )
 from paperqa.utils import (
     gather_with_concurrency,
@@ -544,14 +544,14 @@ class Docs(BaseModel):
         answer_config = evidence_settings.answer
         prompt_config = evidence_settings.prompts
 
-        answer = (
+        session = (
             PQASession(question=query, config_md5=evidence_settings.md5)
             if isinstance(query, str)
             else query
         )
 
         if not self.docs and len(self.texts_index) == 0:
-            return answer
+            return session
 
         if embedding_model is None:
             embedding_model = evidence_settings.get_embedding_model()
@@ -560,7 +560,7 @@ class Docs(BaseModel):
             summary_llm_model = evidence_settings.get_summary_llm()
 
         exclude_text_filter = exclude_text_filter or set()
-        exclude_text_filter |= {c.text.name for c in answer.contexts}
+        exclude_text_filter |= {c.text.name for c in session.contexts}
 
         _k = answer_config.evidence_k
         if exclude_text_filter:
@@ -570,7 +570,7 @@ class Docs(BaseModel):
 
         if answer_config.evidence_retrieval:
             matches = await self.retrieve_texts(
-                answer.question, _k, evidence_settings, embedding_model
+                session.question, _k, evidence_settings, embedding_model
             )
         else:
             matches = self.texts
@@ -599,13 +599,13 @@ class Docs(BaseModel):
                     system_prompt=prompt_config.system,
                 )
 
-        with set_llm_answer_ids(answer.id):
+        with set_llm_session_ids(session.id):
             results = await gather_with_concurrency(
                 answer_config.max_concurrent_requests,
                 [
                     map_fxn_summary(
                         text=m,
-                        question=answer.question,
+                        question=session.question,
                         prompt_runner=prompt_runner,
                         extra_prompt_data={
                             "summary_length": answer_config.evidence_summary_length,
@@ -619,10 +619,10 @@ class Docs(BaseModel):
             )
 
         for _, llm_result in results:
-            answer.add_tokens(llm_result)
+            session.add_tokens(llm_result)
 
-        answer.contexts += [r for r, _ in results if r is not None]
-        return answer
+        session.contexts += [r for r, _ in results if r is not None]
+        return session
 
     def query(
         self,
@@ -665,34 +665,34 @@ class Docs(BaseModel):
         if embedding_model is None:
             embedding_model = query_settings.get_embedding_model()
 
-        answer = (
+        session = (
             PQASession(question=query, config_md5=query_settings.md5)
             if isinstance(query, str)
             else query
         )
 
-        contexts = answer.contexts
+        contexts = session.contexts
 
         if not contexts:
-            answer = await self.aget_evidence(
-                answer,
+            session = await self.aget_evidence(
+                session,
                 callbacks=callbacks,
                 settings=settings,
                 embedding_model=embedding_model,
                 summary_llm_model=summary_llm_model,
             )
-            contexts = answer.contexts
+            contexts = session.contexts
         pre_str = None
         if prompt_config.pre is not None:
-            with set_llm_answer_ids(answer.id):
+            with set_llm_session_ids(session.id):
                 pre = await llm_model.run_prompt(
                     prompt=prompt_config.pre,
-                    data={"question": answer.question},
+                    data={"question": session.question},
                     callbacks=callbacks,
                     name="pre",
                     system_prompt=prompt_config.system,
                 )
-            answer.add_tokens(pre)
+            session.add_tokens(pre)
             pre_str = pre.text
 
         # sort by first score, then name
@@ -737,13 +737,13 @@ class Docs(BaseModel):
                 "I cannot answer this question due to insufficient information."
             )
         else:
-            with set_llm_answer_ids(answer.id):
+            with set_llm_session_ids(session.id):
                 answer_result = await llm_model.run_prompt(
                     prompt=prompt_config.qa,
                     data={
                         "context": context_str,
                         "answer_length": answer_config.answer_length,
-                        "question": answer.question,
+                        "question": session.question,
                         "example_citation": prompt_config.EXAMPLE_CITATION,
                     },
                     callbacks=callbacks,
@@ -751,7 +751,7 @@ class Docs(BaseModel):
                     system_prompt=prompt_config.system,
                 )
             answer_text = answer_result.text
-            answer.add_tokens(answer_result)
+            session.add_tokens(answer_result)
         # it still happens
         if prompt_config.EXAMPLE_CITATION in answer_text:
             answer_text = answer_text.replace(prompt_config.EXAMPLE_CITATION, "")
@@ -772,30 +772,30 @@ class Docs(BaseModel):
                 answer_text,
             )
 
-        formatted_answer = f"Question: {answer.question}\n\n{answer_text}\n"
+        formatted_answer = f"Question: {session.question}\n\n{answer_text}\n"
         if bib:
             formatted_answer += f"\nReferences\n\n{bib_str}\n"
 
         if prompt_config.post is not None:
-            with set_llm_answer_ids(answer.id):
+            with set_llm_session_ids(session.id):
                 post = await llm_model.run_prompt(
                     prompt=prompt_config.post,
-                    data=answer.model_dump(),
+                    data=session.model_dump(),
                     callbacks=callbacks,
                     name="post",
                     system_prompt=prompt_config.system,
                 )
             answer_text = post.text
-            answer.add_tokens(post)
-            formatted_answer = f"Question: {answer.question}\n\n{post}\n"
+            session.add_tokens(post)
+            formatted_answer = f"Question: {session.question}\n\n{post}\n"
             if bib:
                 formatted_answer += f"\nReferences\n\n{bib_str}\n"
 
         # now at end we modify, so we could have retried earlier
-        answer.answer = answer_text
-        answer.formatted_answer = formatted_answer
-        answer.references = bib_str
-        answer.contexts = contexts
-        answer.context = context_str
+        session.answer = answer_text
+        session.formatted_answer = formatted_answer
+        session.references = bib_str
+        session.contexts = contexts
+        session.context = context_str
 
-        return answer
+        return session

--- a/paperqa/litqa.py
+++ b/paperqa/litqa.py
@@ -17,7 +17,7 @@ except ImportError:
 from paperqa.llms import LiteLLMModel, LLMModel
 from paperqa.prompts import EVAL_PROMPT_TEMPLATE, QA_PROMPT_TEMPLATE
 from paperqa.settings import make_default_litellm_model_list_settings
-from paperqa.types import Answer
+from paperqa.types import PQASession
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -127,7 +127,7 @@ class LitQAEvaluation(IntEnum):
         use_unsure: bool = True,
         eval_model: LLMModel | str = DEFAULT_EVAL_MODEL_NAME,
         seed: int | None = None,
-    ) -> tuple[str, Callable[[Answer | str], Awaitable[LitQAEvaluation]]]:
+    ) -> tuple[str, Callable[[PQASession | str], Awaitable[LitQAEvaluation]]]:
         """
         Create a LitQA question and an answer-to-evaluation function.
 
@@ -158,8 +158,8 @@ class LitQAEvaluation(IntEnum):
                 config=make_default_litellm_model_list_settings(eval_model),
             )
 
-        async def llm_from_answer(answer: Answer | str) -> LitQAEvaluation:
-            if isinstance(answer, Answer):
+        async def llm_from_answer(answer: PQASession | str) -> LitQAEvaluation:
+            if isinstance(answer, PQASession):
                 answer = answer.answer
             eval_chunk = await eval_model.achat(
                 messages=[

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -302,9 +302,9 @@ class PromptSettings(BaseModel):
     def check_post(cls, v: str | None) -> str | None:
         if v is not None:
             # kind of a hack to get list of attributes in answer
-            from paperqa.types import Answer
+            from paperqa.types import PQASession
 
-            attrs = set(Answer.model_fields.keys())
+            attrs = set(PQASession.model_fields.keys())
             if not get_formatted_variables(v).issubset(attrs):
                 raise ValueError(f"Post prompt must have input variables: {attrs}")
         return v

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -69,6 +69,8 @@ class LLMResult(BaseModel):
     This can be combined with LLMModels `llm_result_callback` to store all LLMResults.
     """
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: UUID = Field(default_factory=uuid4)
     session_id: UUID | None = Field(
         default_factory=cvar_session_id.get,
@@ -154,7 +156,7 @@ class Context(BaseModel):
 class PQASession(BaseModel):
     """A class to hold session about researching/answering."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     id: UUID = Field(default_factory=uuid4)
     question: str

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -149,8 +149,8 @@ class Context(BaseModel):
         return self.context
 
 
-class Answer(BaseModel):
-    """A class to hold the answer to a question."""
+class PQASession(BaseModel):
+    """A class to hold session about researching/answering."""
 
     model_config = ConfigDict(extra="ignore")
 
@@ -246,6 +246,10 @@ class Answer(BaseModel):
     @property
     def could_not_answer(self) -> bool:
         return "cannot answer" in self.answer.lower()
+
+
+# for backwards compatibility
+Answer = PQASession
 
 
 class ChunkMetadata(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from paperqa.clients.crossref import CROSSREF_HEADER_KEY
 from paperqa.clients.semantic_scholar import SEMANTIC_SCHOLAR_HEADER_KEY
 from paperqa.settings import Settings
-from paperqa.types import Answer
+from paperqa.types import PQASession
 from paperqa.utils import setup_default_logs
 
 TESTS_DIR = Path(__file__).parent
@@ -92,8 +92,8 @@ def agent_test_settings(agent_index_dir: Path, stub_data_dir: Path) -> Settings:
 
 
 @pytest.fixture
-def agent_stub_answer() -> Answer:
-    return Answer(question="What is is a self-explanatory model?")
+def agent_stub_answer() -> PQASession:
+    return PQASession(question="What is is a self-explanatory model?")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def agent_test_settings(agent_index_dir: Path, stub_data_dir: Path) -> Settings:
 
 
 @pytest.fixture
-def agent_stub_answer() -> PQASession:
+def agent_stub_session() -> PQASession:
     return PQASession(question="What is is a self-explanatory model?")
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -695,7 +695,7 @@ def test_query_request_docs_name_serialized() -> None:
 
 def test_answers_are_striped() -> None:
     """Test that answers are striped."""
-    answer = PQASession(
+    session = PQASession(
         question="What is the meaning of life?",
         contexts=[
             Context(
@@ -715,7 +715,7 @@ def test_answers_are_striped() -> None:
             )
         ],
     )
-    response = AnswerResponse(answer=answer, bibtex={}, status="success")
+    response = AnswerResponse(session=session, bibtex={}, status="success")
 
     assert response.session.contexts[0].text.embedding is None
     assert response.session.contexts[0].text.text == ""  # type: ignore[unreachable,unused-ignore]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -251,20 +251,20 @@ async def test_agent_types(
     assert (
         mock_open.call_count <= 1
     ), "Expected one Index.open call, or possibly zero if multiprocessing tests"
-    assert response.answer.answer, "Answer not generated"
-    assert response.answer.answer != "I cannot answer", "Answer not generated"
-    assert response.answer.context, "No contexts were found"
-    assert response.answer.question == question
+    assert response.session.answer, "Answer not generated"
+    assert response.session.answer != "I cannot answer", "Answer not generated"
+    assert response.session.context, "No contexts were found"
+    assert response.session.question == question
     agent_llm = request.settings.agent.agent_llm
     # TODO: once LDP can track tokens, we can remove this check
     if agent_type not in {FAKE_AGENT_TYPE, SimpleAgent}:
         assert (
-            response.answer.token_counts[agent_llm][0] > 1000
+            response.session.token_counts[agent_llm][0] > 1000
         ), "Expected many prompt tokens"
         assert (
-            response.answer.token_counts[agent_llm][1] > 50
+            response.session.token_counts[agent_llm][1] > 50
         ), "Expected many completion tokens"
-        assert response.answer.cost > 0, "Expected nonzero cost"
+        assert response.session.cost > 0, "Expected nonzero cost"
 
 
 @pytest.mark.asyncio
@@ -360,7 +360,7 @@ async def test_timeout(agent_test_settings: Settings, agent_type: str | type) ->
     )
     # ensure that GenerateAnswerTool was called
     assert response.status == AgentStatus.TRUNCATED, "Agent did not timeout"
-    assert "I cannot answer" in response.answer.answer
+    assert "I cannot answer" in response.session.answer
 
 
 @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])
@@ -389,7 +389,7 @@ async def test_propagate_options(agent_test_settings: Settings) -> None:
     )
     response = await agent_query(query, agent_type=FAKE_AGENT_TYPE)
     assert response.status == AgentStatus.SUCCESS, "Agent did not succeed"
-    result = response.answer
+    result = response.session
     assert len(result.answer) > 200, "Answer did not return any results"
     assert "###" in result.answer, "Answer did not propagate system prompt"
     assert (
@@ -717,10 +717,10 @@ def test_answers_are_striped() -> None:
     )
     response = AnswerResponse(answer=answer, bibtex={}, status="success")
 
-    assert response.answer.contexts[0].text.embedding is None
-    assert response.answer.contexts[0].text.text == ""  # type: ignore[unreachable,unused-ignore]
-    assert response.answer.contexts[0].text.doc is not None
-    assert response.answer.contexts[0].text.doc.embedding is None
+    assert response.session.contexts[0].text.embedding is None
+    assert response.session.contexts[0].text.text == ""  # type: ignore[unreachable,unused-ignore]
+    assert response.session.contexts[0].text.doc is not None
+    assert response.session.contexts[0].text.doc.embedding is None
     # make sure it serializes
     response.model_dump_json()
 
@@ -778,12 +778,12 @@ async def test_deepcopy_env(agent_test_settings: Settings) -> None:
     )
     _, _, done, _ = await env.step(gen_answer_action)
     assert done
-    assert not env.state.answer.could_not_answer
-    assert env.state.answer.used_contexts
+    assert not env.state.session.could_not_answer
+    assert env.state.session.used_contexts
     _, _, done, _ = await env_copy.step(gen_answer_action)
     assert done
-    assert not env_copy.state.answer.could_not_answer
-    assert env_copy.state.answer.used_contexts
-    assert sorted(env.state.answer.used_contexts) == sorted(
-        env_copy.state.answer.used_contexts
+    assert not env_copy.state.session.could_not_answer
+    assert env_copy.state.session.used_contexts
+    assert sorted(env.state.session.used_contexts) == sorted(
+        env_copy.state.session.used_contexts
     )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -44,7 +44,7 @@ from paperqa.agents.tools import (
 )
 from paperqa.docs import Docs
 from paperqa.settings import AgentSettings, IndexSettings, Settings
-from paperqa.types import Answer, Context, Doc, Text
+from paperqa.types import Context, Doc, PQASession, Text
 from paperqa.utils import extract_thought, get_year, md5sum
 
 
@@ -463,7 +463,7 @@ async def test_agent_sharing_state(
 
     agent_test_settings.agent.callbacks = callbacks  # type: ignore[assignment]
 
-    answer = Answer(question="What is is a self-explanatory model?")
+    answer = PQASession(question="What is is a self-explanatory model?")
     query = QueryRequest(query=answer.question, settings=agent_test_settings)
     env_state = EnvironmentState(docs=Docs(), answer=answer)
     built_index = await get_directory_index(settings=agent_test_settings)
@@ -695,7 +695,7 @@ def test_query_request_docs_name_serialized() -> None:
 
 def test_answers_are_striped() -> None:
     """Test that answers are striped."""
-    answer = Answer(
+    answer = PQASession(
         question="What is the meaning of life?",
         contexts=[
             Context(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,10 +56,10 @@ def test_cli_ask(agent_index_dir: Path, stub_data_dir: Path) -> None:
     response = ask(
         "How can you use XAI for chemical property prediction?", settings=settings
     )
-    assert response.answer.formatted_answer
+    assert response.session.formatted_answer
 
     search_result = search_query(
-        " ".join(response.answer.formatted_answer.split()[:5]),
+        " ".join(response.session.formatted_answer.split()[:5]),
         "answers",
         settings,
     )

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -19,6 +19,7 @@ from paperqa import (
     DocDetails,
     Docs,
     NumpyVectorStore,
+    PQASession,
     Settings,
     Text,
     print_callback,
@@ -507,7 +508,7 @@ async def test_docs_lifecycle(subtests: SubTests, stub_data_dir: Path) -> None:
 def test_evidence(docs_fixture) -> None:
     debug_settings = Settings.from_name("debug")
     evidence = docs_fixture.get_evidence(
-        Answer(question="What does XAI stand for?"),
+        PQASession(question="What does XAI stand for?"),
         settings=debug_settings,
     ).contexts
     assert len(evidence) >= debug_settings.answer.evidence_k
@@ -527,7 +528,7 @@ def test_json_evidence(docs_fixture) -> None:
         " question (integer out of 10)."
     )
     evidence = docs_fixture.get_evidence(
-        Answer(question="Who wrote this article?"),
+        PQASession(question="Who wrote this article?"),
         settings=settings,
     ).contexts
     assert evidence[0].author_name
@@ -1129,3 +1130,8 @@ def test_case_insensitive_matching():
     assert strings_similarity("my test sentence", "My test sentence") == 1.0
     assert strings_similarity("a b c d e", "a b c f") == 0.5
     assert strings_similarity("A B c d e", "a b c f") == 0.5
+
+
+def test_answer_rename():
+    answer = Answer(question="")
+    assert type(answer) is PQASession

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1134,4 +1134,4 @@ def test_case_insensitive_matching():
 
 def test_answer_rename():
     answer = Answer(question="")
-    assert type(answer) is PQASession
+    assert isinstance(answer, PQASession)


### PR DESCRIPTION
This renames the `Answer` object to be a `PQASession` object. This reflects the fact that the object often doesn't contain an answer and contains much more than that.

I've aliased it in the file, so that the change should not affect users.
