### PR TITLE
Ability to zero-shot `gen_answer`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
           - aiohttp
           - coredis
           - fhaviary[llm]>=0.8.2 # Match pyproject.toml
-          - ldp>=0.9 # Match pyproject.toml
+          - ldp>=0.12 # Match pyproject.toml
           - html2text
           - httpx
           - limits

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -672,8 +672,7 @@ class Docs(BaseModel):
         )
 
         contexts = session.contexts
-
-        if not contexts:
+        if answer_config.get_evidence_if_no_contexts and not contexts:
             session = await self.aget_evidence(
                 session,
                 callbacks=callbacks,

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -93,6 +93,13 @@ class AnswerSettings(BaseModel):
         default=False,
         description="Whether to cite background information provided by model.",
     )
+    get_evidence_if_no_contexts: bool = Field(
+        default=True,
+        description=(
+            "Opt-out flag for allowing answer generation to lazily gather evidence if"
+            " called before evidence was gathered."
+        ),
+    )
 
     @model_validator(mode="after")
     def _deprecated_field(self) -> Self:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ datasets = [
     "datasets",
 ]
 ldp = [
-    "ldp>=0.9",  # For alg namespace grouping
+    "ldp>=0.12",  # For StoreTrajectoriesCallback
 ]
 local = [
     "sentence-transformers",

--- a/uv.lock
+++ b/uv.lock
@@ -1505,7 +1505,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.3.3.dev1+gdcb4fd4"
+version = "5.3.3.dev5+gc849dd1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1584,7 +1584,7 @@ requires-dist = [
     { name = "fhaviary", extras = ["llm"], specifier = ">=0.8.2" },
     { name = "html2text" },
     { name = "httpx" },
-    { name = "ldp", marker = "extra == 'ldp'", specifier = ">=0.9" },
+    { name = "ldp", marker = "extra == 'ldp'", specifier = ">=0.12" },
     { name = "limits" },
     { name = "litellm", specifier = ">=1.44" },
     { name = "numpy" },


### PR DESCRIPTION
Added a new answer setting `get_evidence_if_no_contexts` so we can skip the deferred gather evidence call for zero-shot usage of just the `gen_answer` tool