### PR TITLE
Catch edge case where externalIds field is None

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -483,8 +483,8 @@ class DocDetails(Doc):
     ) -> dict[str, Any]:
         if not data.get("journal"):
             doi = data.get("doi", "") or ""
-            if "10.48550/" in doi or "ArXiv" in (data.get("other", {}) or {}).get(
-                "externalIds", ""
+            if "10.48550/" in doi or "ArXiv" in (
+                (data.get("other", {}) or {}).get("externalIds", {}) or {}
             ):
                 data["journal"] = "ArXiv"
             elif "10.26434/" in doi:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1156,7 +1156,12 @@ def test_answer_rename():
         {"doi": "10.26434/chemrxiv-2021-hz0qp", "journal": "ChemRxiv"},
         {"doi": "https://doi.org/10.1101/2024.11.04.621790", "journal": "BioRxiv"},
         {"doi": "10.1101/2024.11.02.24316629", "journal": "MedRxiv"},
-        {"doi": "https://doi.org/10.48550/arXiv.2407.10362", "journal": "ArXiv"},
+        # ensure we don't crash when externalIds key is included, but it's None
+        {
+            "doi": "https://doi.org/10.48550/arXiv.2407.10362",
+            "journal": "ArXiv",
+            "other": {"externalIds": None},
+        },
     ],
 )
 def test_dois_resolve_to_correct_journals(doi_journals):


### PR DESCRIPTION
S2 can evidently provide this field, but its value can be None. This prevents an exception in that case, and adds a test. 