### PR TITLE
Empty tool calls leading to `done` condition

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import Any, Self, cast
+from typing import Any, ClassVar, Self, cast
 
 from aviary.core import (
     Environment,
@@ -169,10 +169,24 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
             > self._query.settings.answer.max_answer_attempts
         )
 
+    USE_POST_PROCESSED_REWARD: ClassVar[float] = 0.0
+
     async def step(
         self, action: ToolRequestMessage
     ) -> tuple[list[Message], float, bool, bool]:
         self.state.record_action(action)
+        if not action.tool_calls:
+            return (
+                # NOTE: don't put:
+                # - GenerateAnswer.FAILED_TO_ANSWER here because this wasn't a failure
+                # - 'cannot answer' because that information belongs in
+                #   PQASession.answer, not in the message history
+                # Let's just put a nice message about being done :)
+                [Message(content="Agent specified 0 tool calls, which means done.")],
+                self.USE_POST_PROCESSED_REWARD,
+                True,  # Matching LangChain: https://github.com/langchain-ai/langchain/blob/langchain%3D%3D0.2.17/libs/langchain/langchain/agents/output_parsers/openai_functions.py#L38-L77
+                False,  # Let caller determine truncations
+            )
 
         response_messages = cast(
             list[Message],
@@ -184,7 +198,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
         )
         return (
             response_messages,
-            0,  # Reward is computed in post-processing, use 0 as a placeholder
+            self.USE_POST_PROCESSED_REWARD,
             any(
                 isinstance(msg, ToolResponseMessage)
                 and msg.name == GenerateAnswer.gen_answer.__name__
@@ -192,7 +206,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
                 for msg in response_messages
             )
             or self._has_excess_answer_failures(),
-            False,
+            False,  # Let caller determine truncations
         )
 
     def __deepcopy__(self, memo) -> Self:

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -6,6 +6,7 @@ from aviary.core import (
     Environment,
     Frame,
     Message,
+    Messages,
     Tool,
     ToolRequestMessage,
     ToolResponseMessage,
@@ -173,7 +174,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
 
     async def step(
         self, action: ToolRequestMessage
-    ) -> tuple[list[Message], float, bool, bool]:
+    ) -> tuple[Messages, float, bool, bool]:
         self.state.record_action(action)
         if not action.tool_calls:
             return (
@@ -190,11 +191,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
 
         response_messages = cast(
             list[Message],
-            await self.exec_tool_calls(
-                action,
-                state=self.state,
-                handle_tool_exc=True,
-            ),
+            await self.exec_tool_calls(action, state=self.state, handle_tool_exc=True),
         )
         return (
             response_messages,

--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Self, assert_never
 from aviary.core import (
     TASK_DATASET_REGISTRY,
     Frame,
-    Message,
+    Messages,
     TaskDataset,
     ToolRequestMessage,
     ToolResponseMessage,
@@ -126,7 +126,7 @@ class GradablePaperQAEnvironment(PaperQAEnvironment):
 
     async def step(
         self, action: ToolRequestMessage
-    ) -> tuple[list[Message], float, bool, bool]:
+    ) -> tuple[Messages, float, bool, bool]:
         messages, reward, done, truncated = await super().step(action)
         if not done or not self._evaluation_from_answer:
             return messages, reward, done, truncated

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -271,8 +271,8 @@ class GenerateAnswer(NamedTool):
     FAILED_TO_ANSWER: ClassVar[str] = "Failed to answer question."
 
     @classmethod
-    def did_not_fail_to_answer(cls, message: str) -> bool:
-        return not message.startswith(cls.FAILED_TO_ANSWER)
+    def did_not_fail_to_answer(cls, message: str | None) -> bool:
+        return not (message or "").startswith(cls.FAILED_TO_ANSWER)
 
     async def gen_answer(self, question: str, state: EnvironmentState) -> str:
         """

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -268,6 +268,8 @@ class GenerateAnswer(NamedTool):
     summary_llm_model: LiteLLMModel
     embedding_model: EmbeddingModel
 
+    # This is not an answer to assign to the current PQASession,
+    # but a status for the agent message history
     FAILED_TO_ANSWER: ClassVar[str] = "Failed to answer question."
 
     @classmethod

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -455,8 +455,10 @@ class AgentSettings(BaseModel):
     agent_prompt: str = (
         "Use the tools to answer the question: {question}\n\nThe {gen_answer_tool_name}"
         " tool output is visible to the user, so you do not need to restate the answer"
-        " and can simply terminate if the answer looks sufficient. The current status"
-        " of evidence/papers/cost is {status}"
+        " and can simply terminate if the answer looks sufficient. If the answer does"
+        " not look sufficient, and you have already tried to answer several times, you"
+        " can terminate the question by specifying 0 tool calls."
+        " The current status of evidence/papers/cost is {status}"
     )
     return_paper_metadata: bool = Field(
         default=False,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -788,3 +788,22 @@ class TestGradablePaperQAEnvironment:
         assert sorted(env.state.session.used_contexts) == sorted(
             env_copy.state.session.used_contexts
         )
+
+    @pytest.mark.asyncio
+    async def test_empty_tool_calls(self, agent_test_settings: Settings) -> None:
+        env = GradablePaperQAEnvironment(
+            query=QueryRequest(
+                query="How can you use XAI for chemical property prediction?",
+                settings=agent_test_settings,
+            ),
+            docs=Docs(),
+        )
+
+        await env.reset()
+        obs, _, done, truncated = await env.step(ToolRequestMessage())
+        assert len(obs) == 1
+        assert obs[0].content
+        assert GenerateAnswer.did_not_fail_to_answer(obs[0].content)
+        assert "0 tool calls" in obs[0].content
+        assert done
+        assert not truncated


### PR DESCRIPTION
This PR brings `PaperQAEnvironment` to support empty tool calls leading to the environment being done. This creates a back door for the agent to trigger a rollout to conclude.