### PR TITLE
`fake` agent allowing timeouts or exceptions, 

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -349,9 +349,13 @@ async def run_ldp_agent(
                 )
             ],
         )
-        await rollout_manager.sample_trajectories(
+        trajs = await rollout_manager.sample_trajectories(
             environments=[env], max_steps=query.settings.agent.max_timesteps
         )
+        traj = trajs[0]
+        if traj.steps[-1].truncated:
+            nonlocal status
+            status = AgentStatus.TRUNCATED
 
     try:
         async with asyncio.timeout(query.settings.agent.timeout):


### PR DESCRIPTION
Easier to read diff: https://github.com/Future-House/paper-qa/compare/standard-rollouts?expand=1&w=1

This PR:
- Creates a helper function `run_with_timeout_failure` that runs a rollout with `AgentStatus.TRUNCATED` (timeout) or `AgentStatus.FAIL` (`Exception`) support
- Moves all three runners (fake, aviary, LDP) to use it
    - Now the fake agent supports timeouts or failures 🥳 
- Adds `AgentStatus.TRUNCATED` support for the LDP agent runner