### PR TITLE
Optional `AnswerSetting.max_answer_attempts` to allow a new unsure branch

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -160,7 +160,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
     async def step(
         self, action: ToolRequestMessage
     ) -> tuple[list[Message], float, bool, bool]:
-        self.state.session.add_tokens(action)  # Add usage for action if present
+        self.state.record_action(action)
 
         # If the action has empty tool_calls, the agent can later take that into account
         msgs = cast(

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -157,6 +157,18 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
     def export_frame(self) -> Frame:
         return Frame(state=self.state, info={"query": self._query})
 
+    def _has_excess_answer_failures(self) -> bool:
+        if self._query.settings.answer.max_answer_attempts is None:
+            return False
+        return (
+            sum(
+                tn == GenerateAnswer.gen_answer.__name__
+                for s in self.state.tool_history
+                for tn in s
+            )
+            > self._query.settings.answer.max_answer_attempts
+        )
+
     async def step(
         self, action: ToolRequestMessage
     ) -> tuple[list[Message], float, bool, bool]:
@@ -175,7 +187,8 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
                 and msg.name == GenerateAnswer.gen_answer.__name__
                 and GenerateAnswer.did_not_fail_to_answer(msg.content)
                 for msg in msgs
-            ),
+            )
+            or self._has_excess_answer_failures(),
             False,
         )
 

--- a/paperqa/agents/task.py
+++ b/paperqa/agents/task.py
@@ -130,24 +130,30 @@ class GradablePaperQAEnvironment(PaperQAEnvironment):
         messages, reward, done, truncated = await super().step(action)
         if not done or not self._evaluation_from_answer:
             return messages, reward, done, truncated
-        # Filter out non-answer messages (in case parallel tool calls)
-        answer_tool_messages = [
-            m
-            for m in messages
-            if isinstance(m, ToolResponseMessage)
-            and m.name == GenerateAnswer.gen_answer.__name__
-        ]
-        if not answer_tool_messages:  # No answer, so no positive reward
+        valid_answers, failed_answer_messages = [], []
+        for m in messages:
+            if (
+                not isinstance(m, ToolResponseMessage)
+                or m.name != GenerateAnswer.gen_answer.__name__
+            ):
+                continue  # Filter out non-answer messages (in case parallel tool calls)
+            if answer := GenerateAnswer.extract_answer_from_message(content=m.content):
+                valid_answers.append(answer)
+            else:
+                failed_answer_messages.append(m)
+        if not valid_answers:  # No answer, so no positive reward
             return messages, reward, done, truncated
-        if len(answer_tool_messages) != 1:
+        if len(valid_answers) != 1:
             raise NotImplementedError(
-                f"Expected just one answer message, got {messages}."
+                f"Expected just one answer message, got more than one in {messages}."
             )
-        answer = GenerateAnswer.extract_answer_from_message(
-            content=answer_tool_messages[0].content
-        )
-        if not answer:
-            return messages, reward, done, truncated
+        answer = valid_answers[0]
+        if failed_answer_messages:
+            logger.warning(
+                "More than one answer detected, discarding failed answer messages"
+                f" {failed_answer_messages}, continuing with answer {answer}."
+            )
+        # Okay, so we have one answer that was not a failed answer. Let's evaluate it
         evaluation = await self._evaluation_from_answer(answer)
         if evaluation_callback := self._evaluation_callback:
             await evaluation_callback(evaluation)

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -83,6 +83,13 @@ class AnswerSettings(BaseModel):
     answer_max_sources: int = Field(
         default=5, description="Max number of sources to use for an answer"
     )
+    max_answer_attempts: int | None = Field(
+        default=None,
+        description=(
+            "Optional (exclusive) max number (default is no max) of attempts to"
+            " generate an answer before declaring a failure."
+        ),
+    )
     answer_length: str = Field(
         "about 200 words, but can be longer", description="Length of final answer"
     )


### PR DESCRIPTION
This PR adds in an optional `AnswerSetting.max_answer_attempts` so we can declare ourselves as unsure if we attempt `gen_answer` too many times, with test coverage.

To do so, it tracks a tool names used in environment state as `tool_history`