### PR TITLE
Deprecation cycle for `AgentSettings.should_pre_search`

### DIFF
--- a/paperqa/configs/contracrow.json
+++ b/paperqa/configs/contracrow.json
@@ -48,7 +48,6 @@
     "search_count": 12,
     "wipe_context_on_answer_failure": true,
     "timeout": 500.0,
-    "should_pre_search": false,
     "tool_names": null
   }
 }

--- a/paperqa/configs/wikicrow.json
+++ b/paperqa/configs/wikicrow.json
@@ -48,7 +48,6 @@
     "search_count": 12,
     "wipe_context_on_answer_failure": true,
     "timeout": 500.0,
-    "should_pre_search": false,
     "tool_names": null
   }
 }

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -563,6 +563,18 @@ class AgentSettings(BaseModel):
                 setattr(self.index, new_name, value)  # Propagate to new location
         return self
 
+    @field_validator("should_pre_search")
+    @classmethod
+    def _deprecated_should_pre_search(cls, value: bool) -> bool:
+        if value:  # Default is False, so we only warn if it's True
+            warnings.warn(
+                "The 'should_pre_search' field is dead code, and will be"
+                " removed in version 6.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+        return value
+
 
 def make_default_litellm_model_list_settings(
     llm: str, temperature: float = 0.0


### PR DESCRIPTION
Starting a deprecation cycle for a dead agent setting that should have been removed within https://github.com/Future-House/paper-qa/pull/358