### PR TITLE
Refactor to remove `skip_system` from `LLMModel.run_prompt`

### DIFF
--- a/paperqa/agents/helpers.py
+++ b/paperqa/agents/helpers.py
@@ -61,7 +61,7 @@ async def litellm_get_search_query(
     result = await model.run_prompt(
         prompt=search_prompt,
         data={"question": question, "count": count},
-        skip_system=True,
+        system_prompt=None,
     )
     search_query = result.text
     queries = [s for s in search_query.split("\n") if len(s) > 3]  # noqa: PLR2004

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -276,7 +276,7 @@ class Docs(BaseModel):
             result = await llm_model.run_prompt(
                 prompt=parse_config.citation_prompt,
                 data={"text": texts[0].text},
-                skip_system=True,  # skip system because it's too hesitant to answer
+                system_prompt=None,  # skip system because it's too hesitant to answer
             )
             citation = result.text
             if (
@@ -313,7 +313,7 @@ class Docs(BaseModel):
             result = await llm_model.run_prompt(
                 prompt=parse_config.structured_citation_prompt,
                 data={"citation": citation},
-                skip_system=True,
+                system_prompt=None,
             )
             # This code below tries to isolate the JSON
             # based on observed messages from LLMs

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -59,7 +59,7 @@ class TestLiteLLMModel:
         completion = await llm.run_prompt(
             prompt="The {animal} says",
             data={"animal": "duck"},
-            skip_system=True,
+            system_prompt=None,
             callbacks=[accum],
         )
         assert completion.model == "gpt-4o-mini"
@@ -72,7 +72,7 @@ class TestLiteLLMModel:
         completion = await llm.run_prompt(
             prompt="The {animal} says",
             data={"animal": "duck"},
-            skip_system=True,
+            system_prompt=None,
         )
         assert completion.seconds_to_first_token == 0
         assert completion.seconds_to_last_token > 0
@@ -85,7 +85,7 @@ class TestLiteLLMModel:
         completion = await llm.run_prompt(
             prompt="The {animal} says",
             data={"animal": "duck"},
-            skip_system=True,
+            system_prompt=None,
             callbacks=[accum, ac],
         )
         assert completion.cost > 0

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -423,7 +423,7 @@ async def test_chain_completion() -> None:
     completion = await llm.run_prompt(
         prompt="The {animal} says",
         data={"animal": "duck"},
-        skip_system=True,
+        system_prompt=None,
         callbacks=[accum],
     )
     assert completion.seconds_to_first_token > 0
@@ -432,7 +432,7 @@ async def test_chain_completion() -> None:
     assert str(completion) == "".join(outputs)
 
     completion = await llm.run_prompt(
-        prompt="The {animal} says", data={"animal": "duck"}, skip_system=True
+        prompt="The {animal} says", data={"animal": "duck"}, system_prompt=None
     )
     assert completion.seconds_to_first_token == 0
     assert completion.seconds_to_last_token > 0
@@ -453,7 +453,7 @@ async def test_anthropic_chain(stub_data_dir: Path) -> None:
     completion = await llm.run_prompt(
         prompt="The {animal} says",
         data={"animal": "duck"},
-        skip_system=True,
+        system_prompt=None,
         callbacks=[accum],
     )
     assert completion.seconds_to_first_token > 0
@@ -464,7 +464,7 @@ async def test_anthropic_chain(stub_data_dir: Path) -> None:
     assert completion.cost > 0
 
     completion = await llm.run_prompt(
-        prompt="The {animal} says", data={"animal": "duck"}, skip_system=True
+        prompt="The {animal} says", data={"animal": "duck"}, system_prompt=None
     )
     assert completion.seconds_to_first_token == 0
     assert completion.seconds_to_last_token > 0

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -165,7 +165,7 @@ async def test_rate_limit_on_run_prompt(
         3,
         prompt="The {animal} says",
         data={"animal": "duck"},
-        skip_system=True,
+        system_prompt=None,
         callbacks=[accum],
     )
 
@@ -192,7 +192,7 @@ async def test_rate_limit_on_run_prompt(
         use_gather=True,
         prompt="The {animal} says",
         data={"animal": "duck"},
-        skip_system=True,
+        system_prompt=None,
         callbacks=[accum2],
     )
 


### PR DESCRIPTION
When reading through our various control flows here, I found the presence of a system prompt coupled with a `skip_system` flag to add more thought and complexity. We don't need to cart around two separate pieces of information here, we can just make `system_prompt` be an optional variable and one source of truth.

This PR is a refactor that removes `skip_system` in favor of `bool` checks directly on `system_prompt`. Yes it's a breaking change, but I don't think our `LLMModel` implementation is really imported and used by our users.