### PR TITLE
Resolving `evidence_detailed_citations` and `Answer` deprecations

### DIFF
--- a/paperqa/configs/contracrow.json
+++ b/paperqa/configs/contracrow.json
@@ -11,7 +11,6 @@
   "verbosity": 0,
   "answer": {
     "evidence_k": 30,
-    "evidence_detailed_citations": true,
     "evidence_retrieval": true,
     "evidence_summary_length": "about 300 words",
     "evidence_skip_summary": false,

--- a/paperqa/configs/debug.json
+++ b/paperqa/configs/debug.json
@@ -3,7 +3,6 @@
   "summary_llm": "text-completion-openai/babbage-002",
   "answer": {
     "evidence_k": 2,
-    "evidence_detailed_citations": false,
     "evidence_summary_length": "25 to 50 words",
     "answer_max_sources": 2,
     "answer_length": "50 to 100 words",
@@ -14,6 +13,7 @@
     "defer_embedding": true
   },
   "prompts": {
-    "use_json": false
+    "use_json": false,
+    "context_inner": "{name}: {text}"
   }
 }

--- a/paperqa/configs/fast.json
+++ b/paperqa/configs/fast.json
@@ -1,7 +1,6 @@
 {
   "answer": {
     "evidence_k": 5,
-    "evidence_detailed_citations": false,
     "evidence_summary_length": "25 to 50 words",
     "answer_max_sources": 3,
     "answer_length": "50 to 100 words",
@@ -11,7 +10,8 @@
     "use_doc_details": false
   },
   "prompts": {
-    "use_json": false
+    "use_json": false,
+    "context_inner": "{name}: {text}"
   },
   "agent": {
     "agent_type": "fake"

--- a/paperqa/configs/tier1_limits.json
+++ b/paperqa/configs/tier1_limits.json
@@ -1,7 +1,6 @@
 {
   "answer": {
     "evidence_k": 5,
-    "evidence_detailed_citations": false,
     "evidence_summary_length": "25 to 50 words",
     "answer_max_sources": 3,
     "answer_length": "50 to 100 words",
@@ -11,7 +10,8 @@
     "use_doc_details": false
   },
   "prompts": {
-    "use_json": true
+    "use_json": true,
+    "context_inner": "{name}: {text}"
   },
   "llm_config": {
     "rate_limit": {

--- a/paperqa/configs/wikicrow.json
+++ b/paperqa/configs/wikicrow.json
@@ -11,7 +11,6 @@
   "verbosity": 0,
   "answer": {
     "evidence_k": 25,
-    "evidence_detailed_citations": true,
     "evidence_retrieval": true,
     "evidence_summary_length": "about 300 words",
     "evidence_skip_summary": false,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -709,6 +709,7 @@ class Docs(BaseModel):
             not answer_config.evidence_detailed_citations
             and "\nFrom {citation}" in context_inner_prompt
         ):
+            # Only keep "\nFrom {citation}" if we are showing detailed citations
             context_inner_prompt = context_inner_prompt.replace("\nFrom {citation}", "")
 
         inner_context_strs = [

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -102,4 +102,5 @@ EVAL_PROMPT_TEMPLATE = (
 )
 
 CONTEXT_OUTER_PROMPT = "{context_str}\n\nValid Keys: {valid_keys}"
-CONTEXT_INNER_PROMPT = "{name}: {text}\nFrom {citation}"
+CONTEXT_INNER_PROMPT_NOT_DETAILED = "{name}: {text}"
+CONTEXT_INNER_PROMPT = f"{CONTEXT_INNER_PROMPT_NOT_DETAILED}\nFrom {{citation}}"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -43,6 +43,7 @@ from paperqa.agents.tools import (
     make_status,
 )
 from paperqa.docs import Docs
+from paperqa.prompts import CONTEXT_INNER_PROMPT_NOT_DETAILED
 from paperqa.settings import AgentSettings, IndexSettings, Settings
 from paperqa.types import Context, Doc, PQASession, Text
 from paperqa.utils import extract_thought, get_year, md5sum
@@ -381,8 +382,8 @@ async def test_propagate_options(agent_test_settings: Settings) -> None:
     agent_test_settings.answer.answer_length = "400 words"
     agent_test_settings.prompts.pre = None
     agent_test_settings.prompts.system = "End all responses with ###"
+    agent_test_settings.prompts.context_inner = CONTEXT_INNER_PROMPT_NOT_DETAILED
     agent_test_settings.answer.evidence_skip_summary = True
-    agent_test_settings.answer.evidence_detailed_citations = False
 
     query = QueryRequest(
         query="What is is a self-explanatory model?", settings=agent_test_settings

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1128,9 +1128,9 @@ def test_context_inner_outer_prompt(stub_data_dir: Path) -> None:
 
 
 def test_evidence_detailed_citations_shim(stub_data_dir: Path) -> None:
-
     # TODO: delete this test in v6
     settings = Settings.from_name("fast")
+    # NOTE: this bypasses DeprecationWarning, as the warning is done on construction
     settings.answer.evidence_detailed_citations = False
     docs = Docs()
     docs.add(stub_data_dir / "bates.txt", "WikiMedia Foundation, 2023, Accessed now")

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1144,9 +1144,13 @@ def test_case_insensitive_matching():
     assert strings_similarity("A B c d e", "a b c f") == 0.5
 
 
-def test_answer_rename():
+def test_answer_rename(recwarn) -> None:
+    # TODO: delete this test in v6
     answer = Answer(question="")
     assert isinstance(answer, PQASession)
+    assert len(recwarn) == 1
+    warning_msg = recwarn.pop(DeprecationWarning)
+    assert "'Answer' class is deprecated" in str(warning_msg.message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Seen in CI logs ([link](https://github.com/Future-House/paper-qa/actions/runs/11602509688/job/32307661430?pr=653)):

```none
tests/test_configs.py: 2 warnings
tests/test_paperqa.py: 26 warnings
tests/test_cli.py: 10 warnings
tests/test_agents.py: 2 warnings
  /home/runner/work/paper-qa/paper-qa/.venv/lib/python3.11/site-packages/pydantic/main.py:212: DeprecationWarning: The 'evidence_detailed_citations' field is deprecated and will be removed in version 6. Adjust 'PromptSettings.context_inner' to remove detailed citations.
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)

tests/test_paperqa.py::test_answer_rename
  /home/runner/work/paper-qa/paper-qa/tests/test_paperqa.py:1136: DeprecationWarning: The 'Answer' class is deprecated and will be removed in future versions. Use 'PQASession' instead.
    answer = Answer(question="")
```

This PR:
- Resolves `Answer` deprecation from https://github.com/Future-House/paper-qa/pull/653 by using `recwarn`
- Resolves `evidence_detailed_citations` deprecation from https://github.com/Future-House/paper-qa/pull/620 in our bundled configs and test suite

