### PR TITLE
Removed `tool_names` validation for `gen_answer` being present

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -47,7 +47,6 @@ def settings_to_tools(
     summary_llm_model = summary_llm_model or settings.get_summary_llm()
     embedding_model = embedding_model or settings.get_embedding_model()
     tools: list[Tool] = []
-    has_answer_tool = False
     for tool_type in (
         (PaperSearch, GatherEvidence, GenerateAnswer)
         if settings.agent.tool_names is None
@@ -86,14 +85,9 @@ def settings_to_tools(
         else:
             raise NotImplementedError(f"Didn't handle tool type {tool_type}.")
         if tool.info.name == GenerateAnswer.gen_answer.__name__:
-            tools.append(tool)
-            has_answer_tool = True
+            tools.append(tool)  # Place at the end
         else:
             tools.insert(0, tool)
-    if not has_answer_tool:
-        raise ValueError(
-            f"{GenerateAnswer.gen_answer.__name__} must be one of the tools."
-        )
     return tools
 
 

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -523,21 +523,6 @@ class AgentSettings(BaseModel):
         exclude=True,
     )
 
-    @field_validator("tool_names")
-    @classmethod
-    def validate_tool_names(cls, v: set[str] | None) -> set[str] | None:
-        if v is None:
-            return None
-        # imported here to avoid circular imports
-        from paperqa.agents.tools import GenerateAnswer
-
-        answer_tool_name = GenerateAnswer.TOOL_FN_NAME
-        if answer_tool_name not in v:
-            raise ValueError(
-                f"If using an override, must contain at least the {answer_tool_name}."
-            )
-        return v
-
     @model_validator(mode="after")
     def _deprecated_field(self) -> Self:
         for deprecated_field_name, new_name in (("index_concurrency", "concurrency"),):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -21,7 +21,6 @@ from ldp.agent import MemoryAgent, SimpleAgent
 from ldp.graph.memory import Memory, UIndexMemoryModel
 from ldp.graph.ops import OpResult
 from ldp.llms import EmbeddingModel, MultipleCompletionLLMModel
-from pydantic import ValidationError
 from pytest_subtests import SubTests
 from tantivy import Index
 
@@ -724,25 +723,6 @@ def test_answers_are_striped() -> None:
     assert response.session.contexts[0].text.doc.embedding is None
     # make sure it serializes
     response.model_dump_json()
-
-
-@pytest.mark.parametrize(
-    ("kwargs", "result"),
-    [
-        ({}, None),
-        ({"tool_names": {GenerateAnswer.TOOL_FN_NAME}}, None),
-        ({"tool_names": set()}, ValidationError),
-        ({"tool_names": {PaperSearch.TOOL_FN_NAME}}, ValidationError),
-    ],
-)
-def test_agent_prompt_collection_validations(
-    kwargs: dict[str, Any], result: type[Exception] | None
-) -> None:
-    if result is None:
-        AgentSettings(**kwargs)
-    else:
-        with pytest.raises(result):
-            AgentSettings(**kwargs)
 
 
 class TestGradablePaperQAEnvironment:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -402,8 +402,8 @@ async def test_propagate_options(agent_test_settings: Settings) -> None:
 async def test_gather_evidence_rejects_empty_docs(
     agent_test_settings: Settings,
 ) -> None:
-    # Patch GenerateAnswerTool._arun so that if this tool is chosen first, we
-    # don't give a 'cannot answer' response. A 'cannot answer' response can
+    # Patch GenerateAnswerTool.gen_answer so that if this tool is chosen first,
+    # we don't give a 'cannot answer' response. A 'cannot answer' response can
     # lead to an unsure status, which will break this test's assertions. Since
     # this test is about a GatherEvidenceTool edge case, defeating
     # GenerateAnswerTool is fine


### PR DESCRIPTION
If any of the tools are excluded, PaperQA will not function. They all play a distinct and required role (`paper_search` to get new papers, `gather_evidence` to get relevant evidence, and `gen_answer` for answering), and none are optional.

We can either:
- Validate for all required tools, leading to an explicit failure
    - Perhaps in the future when we add the citation traversal tool, this tool will be optional.
- Validate for none of them, leading to an implicit failure, as if any tools are unspecified the agent will either get truncated or fail

We can YAGNI on the first route, so this PR takes the second route as suggested in this PR comment: https://github.com/Future-House/paper-qa/pull/684#discussion_r1841332919