### PR TITLE
Fixing `test_evaluation` logic bugs

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -118,9 +118,6 @@ class TestTaskDataset:
         task_config = TaskConfig(
             name=STUB_TASK_DATASET_NAME,
             eval_kwargs={
-                "base_query": base_query_request.model_dump(
-                    exclude={"id", "settings", "docs_name"}
-                ),
                 "base_docs": docs.model_dump(
                     exclude={
                         "id",
@@ -131,6 +128,13 @@ class TestTaskDataset:
                     }
                 ),
             },
+        )
+        # NOTE: set base_query after construction of the TaskConfig. because in
+        # aviary 0.10 the TaskConfig Pydnatic model has types `BaseModel | JsonValue`,
+        # which lead to base_query being cast into a BaseModel. This is probably a bug
+        # in aviary, but for now let's just assign it after TaskConfig construction
+        task_config.eval_kwargs["base_query"] = base_query_request.model_dump(
+            exclude={"id", "docs_name"}
         )
         dataset = task_config.make_dataset(split="eval")  # noqa: FURB184
         metrics_callback = MeanMetricsCallback(eval_dataset=dataset)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -148,11 +148,9 @@ class TestTaskDataset:
         ), "Should not have mutated query in base request"
         assert not docs.docs, "Should not have mutated docs in base docs"
         assert (
-            isinstance(metrics_callback.eval_means["total_paper_count"], float) > 0
+            metrics_callback.eval_means["total_paper_count"] > 0
         ), "Expected some papers to help us answer questions"
-        assert (
-            isinstance(metrics_callback.eval_means["reward"], float) > 0
-        ), "Expected some wins"
+        assert metrics_callback.eval_means["reward"] > 0, "Expected some wins"
 
         with subtests.test(msg="zero-shot"):
             # Confirm we can just directly call gen_answer


### PR DESCRIPTION
There were two problems with this test:

- https://github.com/Future-House/paper-qa/pull/475 incorrectly moved from `isinstance` to `> 0` checks, forgetting to delete the `isinstance` part
- This mix up masked a bad change in https://github.com/Future-House/paper-qa/pull/494 where I mispropagated the index name

After this PR, we will correctly evaluate the `stub-litqa` dataset