### PR TITLE
Removed `gen_answer`'s dead argument `question`

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -163,7 +163,7 @@ async def _run_with_timeout_failure(
         generate_answer_tool = next(
             filter(lambda x: x.info.name == GenerateAnswer.TOOL_FN_NAME, env.tools)
         )
-        await generate_answer_tool._tool_fn(question=query.query, state=env.state)
+        await generate_answer_tool._tool_fn(state=env.state)
     return env.state.session, status
 
 
@@ -216,7 +216,7 @@ async def run_fake_agent(
         ):
             await step(search_tool, query=search, min_year=None, max_year=None)
         await step(gather_evidence_tool, question=question)
-        await step(generate_answer_tool, question=question)
+        await step(generate_answer_tool)
         return AgentStatus.SUCCESS
 
     return await _run_with_timeout_failure(rollout, query, env)

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -268,19 +268,18 @@ class GenerateAnswer(NamedTool):
     summary_llm_model: LiteLLMModel
     embedding_model: EmbeddingModel
 
-    async def gen_answer(self, question: str, state: EnvironmentState) -> str:
+    async def gen_answer(self, state: EnvironmentState) -> str:
         """
-        Ask a model to propose an answer using current evidence.
+        Generate an answer using current evidence.
 
         The tool may fail, indicating that better or different evidence should be found.
         Aim for at least five pieces of evidence from multiple sources before invoking this tool.
         Feel free to invoke this tool in parallel with other tools, but do not call this tool in parallel with itself.
 
         Args:
-            question: Question to be answered.
             state: Current state.
         """
-        logger.info(f"Generating answer for '{question}'.")
+        logger.info(f"Generating answer for '{state.session.question}'.")
 
         if f"{self.TOOL_FN_NAME}_initialized" in self.settings.agent.callbacks:
             await asyncio.gather(
@@ -292,8 +291,6 @@ class GenerateAnswer(NamedTool):
                 )
             )
 
-        # TODO: Should we allow the agent to change the question?
-        # self.answer.question = query
         state.session = await state.docs.aquery(
             query=state.session,
             settings=self.settings,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -404,7 +404,7 @@ async def test_gather_evidence_rejects_empty_docs(
 ) -> None:
 
     @wraps(GenerateAnswer.gen_answer)
-    async def gen_answer(self, question: str, state) -> str:  # noqa: ARG001
+    async def gen_answer(self, state) -> str:  # noqa: ARG001
         return "I cannot answer."
 
     # Patch GenerateAnswerTool.gen_answer so that if this tool is chosen first,
@@ -525,7 +525,7 @@ async def test_agent_sharing_state(
             summary_llm_model=summary_llm_model,
             embedding_model=embedding_model,
         )
-        result = await generate_answer_tool.gen_answer(answer.question, state=env_state)
+        result = await generate_answer_tool.gen_answer(state=env_state)
 
         if callback_type == "async":
             gen_answer_initialized_callback.assert_awaited_once_with(env_state)
@@ -655,24 +655,14 @@ def test_tool_schema(agent_test_settings: Settings) -> None:
             "info": {
                 "name": "gen_answer",
                 "description": (
-                    "Ask a model to propose an answer using current"
-                    " evidence.\n\nThe tool may fail, indicating that better or"
-                    " different evidence should be found.\nAim for at least five"
-                    " pieces of evidence from multiple sources before invoking this"
-                    " tool.\nFeel free to invoke this tool in parallel with other"
-                    " tools, but do not call this tool in parallel with itself."
+                    "Generate an answer using current evidence.\n\nThe tool may fail,"
+                    " indicating that better or different evidence should be"
+                    " found.\nAim for at least five pieces of evidence from multiple"
+                    " sources before invoking this tool.\nFeel free to invoke this tool"
+                    " in parallel with other tools, but do not call this tool in"
+                    " parallel with itself."
                 ),
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "question": {
-                            "type": "string",
-                            "description": "Question to be answered.",
-                            "title": "Question",
-                        }
-                    },
-                    "required": ["question"],
-                },
+                "parameters": {"type": "object", "properties": {}, "required": []},
             },
         },
     ]
@@ -752,7 +742,7 @@ class TestGradablePaperQAEnvironment:
 
         # 3. Generate an answer for both, and confirm they are identical
         gen_answer_action = ToolRequestMessage(
-            tool_calls=[ToolCall.from_name("gen_answer", question=question)]
+            tool_calls=[ToolCall.from_name("gen_answer")]
         )
         _, _, done, _ = await env.step(gen_answer_action)
         assert done


### PR DESCRIPTION
The `gen_answer` tool has an unused `question` arg. This PR removes it.

---

I observed for the LitQA2 question:

> The gene EEF2 has introns 1 and 2, do they splice in a specific order?

The agent called `gen_answer` with the `question` arg:

> Does the gene EEF2 splice intron 1 and 2 in a specific order?

Whereas this is mostly the same question, it has a few problems:

- The innards of `gen_answer` use `state.session.question`, not the input `question`, so the logs were inaccurate
- Perhaps the agent could cycle `gen_answer` with different input `question`s, when actually nothing different happens
- It not ideal to have learned agents learning this argument, when it's actually dead code
    - This also wastes both prompt and completion tokens