### PR TITLE
Removed `GenerateAnswer.FAILED_TO_ANSWER` as its unnecessary

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -15,7 +15,7 @@ from aviary.core import (
 from paperqa.docs import Docs
 from paperqa.llms import EmbeddingModel, LiteLLMModel
 from paperqa.settings import Settings
-from paperqa.types import PQASession
+from paperqa.types import PQASession, check_could_not_answer
 from paperqa.utils import get_year
 
 from .models import QueryRequest
@@ -193,7 +193,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
             any(
                 isinstance(msg, ToolResponseMessage)
                 and msg.name == GenerateAnswer.gen_answer.__name__
-                and GenerateAnswer.did_not_fail_to_answer(msg.content)
+                and not check_could_not_answer(msg.content)
                 for msg in response_messages
             )
             or self._has_excess_answer_failures(),

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -158,6 +158,10 @@ class Context(BaseModel):
         return self.context
 
 
+def check_could_not_answer(answer: str) -> bool:
+    return "cannot answer" in answer.lower()
+
+
 class PQASession(BaseModel):
     """A class to hold session about researching/answering."""
 
@@ -254,7 +258,7 @@ class PQASession(BaseModel):
 
     @property
     def could_not_answer(self) -> bool:
-        return "cannot answer" in self.answer.lower()
+        return check_could_not_answer(self.answer)
 
 
 # for backwards compatibility

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -44,7 +44,7 @@ from paperqa.agents.tools import (
 from paperqa.docs import Docs
 from paperqa.prompts import CONTEXT_INNER_PROMPT_NOT_DETAILED
 from paperqa.settings import AgentSettings, IndexSettings, Settings
-from paperqa.types import Context, Doc, PQASession, Text
+from paperqa.types import Context, Doc, PQASession, Text, check_could_not_answer
 from paperqa.utils import extract_thought, get_year, md5sum
 
 
@@ -784,7 +784,7 @@ class TestGradablePaperQAEnvironment:
         obs, _, done, truncated = await env.step(ToolRequestMessage())
         assert len(obs) == 1
         assert obs[0].content
-        assert GenerateAnswer.did_not_fail_to_answer(obs[0].content)
+        assert not check_could_not_answer(obs[0].content)
         assert "0 tool calls" in obs[0].content
         assert done
         assert not truncated

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 import time
 from copy import deepcopy
+from functools import wraps
 from pathlib import Path
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -401,19 +402,14 @@ async def test_propagate_options(agent_test_settings: Settings) -> None:
 async def test_gather_evidence_rejects_empty_docs(
     agent_test_settings: Settings,
 ) -> None:
+
+    @wraps(GenerateAnswer.gen_answer)
+    async def gen_answer(self, question: str, state) -> str:  # noqa: ARG001
+        return "I cannot answer."
+
     # Patch GenerateAnswerTool.gen_answer so that if this tool is chosen first,
-    # we don't give a 'cannot answer' response. A 'cannot answer' response can
-    # lead to an unsure status, which will break this test's assertions. Since
-    # this test is about a GatherEvidenceTool edge case, defeating
-    # GenerateAnswerTool is fine
-    original_doc = GenerateAnswer.gen_answer.__doc__
-    with patch.object(
-        GenerateAnswer,
-        "gen_answer",
-        return_value="Failed to answer question.",
-        autospec=True,
-    ) as mock_gen_answer:
-        mock_gen_answer.__doc__ = original_doc
+    # we keep running until we get truncated
+    with patch.object(GenerateAnswer, "gen_answer", gen_answer):
         agent_test_settings.agent = AgentSettings(
             tool_names={"gather_evidence", "gen_answer"},
             max_timesteps=3,


### PR DESCRIPTION
So we had a constant `GenerateAnswer.FAILED_TO_ANSWER` that was a derived value for a `"cannot answer"` answer.

This PR basically removes that derived value, choosing to stick with the vanilla answer. Less statefulness, less constants, less code