### PR TITLE
Moved `fake` agent to LLM propose `complete` tool

### DIFF
--- a/paperqa/agents/helpers.py
+++ b/paperqa/agents/helpers.py
@@ -41,6 +41,7 @@ async def litellm_get_search_query(
             " Ignoring template and using default search prompt."
         )
     if not search_prompt:
+        # TODO: move to use tools instead of DIY schema in prompt
         search_prompt = (
             "We want to answer the following question: {question}\nProvide"
             " {count} unique keyword searches (one search per line) and year ranges"

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -211,6 +211,7 @@ async def run_fake_agent(
 
     async def rollout() -> AgentStatus:
         # Seed docs with a few keyword searches
+        # TODO: make properly support year ranges
         for search in await litellm_get_search_query(
             question, llm=query.settings.get_llm(), count=3
         ):

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -573,7 +573,7 @@ def get_litellm_retrying_config(timeout: float = 60.0) -> dict[str, Any]:
     return {"num_retries": 3, "timeout": timeout}
 
 
-class PassThroughRouter(litellm.Router):
+class PassThroughRouter(litellm.Router):  # TODO: add rate_limited
     """Router that is just a wrapper on LiteLLM's normal free functions."""
 
     def __init__(self, **kwargs):

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -21,6 +21,7 @@ from typing import Any, TypeVar, cast
 import litellm
 import numpy as np
 import tiktoken
+from aviary.core import ToolRequestMessage, ToolSelector
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -752,6 +753,15 @@ class LiteLLMModel(LLMModel):
 
     def count_tokens(self, text: str) -> int:
         return litellm.token_counter(model=self.name, text=text)
+
+    async def select_tool(
+        self, *selection_args, **selection_kwargs
+    ) -> ToolRequestMessage:
+        """Shim to aviary.core.ToolSelector that supports tool schemae."""
+        tool_selector = ToolSelector(
+            model_name=self.name, acompletion=self.router.acompletion
+        )
+        return await tool_selector(*selection_args, **selection_kwargs)
 
 
 def cosine_similarity(a, b):


### PR DESCRIPTION
In future work, the `complete` tool will have arguments that cannot be specified a-priori. Thus we need to keep a message history, and have an LLM propose the `complete` tool call.

So, this PR:
- Adds the message history and LLM proposal of a `complete` tool call
    - Shims `aviary.core.ToolSelector` and `LiteLLMModel` since the aviary one supports tool calls
- Notates some TODOs related to tech debt here (e.g. DIY forming `paper_search` in the `fake` agent)