### PR TITLE
Default to ordered tool calls, w env variable control

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from copy import deepcopy
 from typing import Any, ClassVar, Self, cast
 
@@ -95,11 +94,6 @@ def settings_to_tools(
     return tools
 
 
-ALLOW_PARALLEL_TOOL_CALLS: bool = os.environ.get(
-    "PQA_ALLOW_PARALLEL_TOOL_CALLS", ""
-).lower() in {"true", "1"}
-
-
 class PaperQAEnvironment(Environment[EnvironmentState]):
     """Environment connecting paper-qa's tools with state."""
 
@@ -184,7 +178,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
             list[Message],
             await self.exec_tool_calls(
                 action,
-                ordered=not ALLOW_PARALLEL_TOOL_CALLS,
+                ordered=True,  # PQA Environment currently not safe for parallel tool calls
                 state=self.state,
                 handle_tool_exc=True,
             ),

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import itertools
 import json
@@ -26,7 +27,7 @@ from pytest_subtests import SubTests
 from tantivy import Index
 
 from paperqa.agents import SearchIndex, agent_query
-from paperqa.agents.env import settings_to_tools
+from paperqa.agents.env import PaperQAEnvironment, settings_to_tools
 from paperqa.agents.main import FAKE_AGENT_TYPE
 from paperqa.agents.models import AgentStatus, AnswerResponse, QueryRequest
 from paperqa.agents.search import (
@@ -747,6 +748,67 @@ def test_answers_are_striped() -> None:
     assert response.session.contexts[0].text.doc.embedding is None
     # make sure it serializes
     response.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_sequential_tool_calls(agent_test_settings: Settings):
+
+    SLEEP_TIME = 2.0
+
+    async def fake_gather_evidence(*args, **kwargs) -> str:  # noqa: ARG001
+        await asyncio.sleep(SLEEP_TIME)
+        return "fake evidence"
+
+    question = "How can you use XAI for chemical property prediction?"
+    env = PaperQAEnvironment(
+        query=QueryRequest(query=question, settings=agent_test_settings),
+        docs=Docs(),
+    )
+    await env.reset()
+
+    gather_tool = next(
+        tool for tool in env.tools if tool.info.name == GatherEvidence.TOOL_FN_NAME
+    )
+
+    with patch.object(gather_tool, "_tool_fn", fake_gather_evidence):
+        tic = time.time()
+        await env.step(
+            ToolRequestMessage(
+                tool_calls=[
+                    ToolCall.from_name(
+                        "gather_evidence",
+                        question="XAI for chemical property prediction",
+                    ),
+                    ToolCall.from_name(
+                        "gather_evidence",
+                        question="XAI for chemical property prediction",
+                    ),
+                ]
+            )
+        )
+
+        assert time.time() - tic > 2 * SLEEP_TIME  # since they are sequential
+
+        with patch(
+            "paperqa.agents.env.ALLOW_PARALLEL_TOOL_CALLS", True  # noqa: FBT003
+        ):
+            tic = time.time()
+            await env.step(
+                ToolRequestMessage(
+                    tool_calls=[
+                        ToolCall.from_name(
+                            "gather_evidence",
+                            question="XAI for chemical property prediction",
+                        ),
+                        ToolCall.from_name(
+                            "gather_evidence",
+                            question="XAI for chemical property prediction",
+                        ),
+                    ]
+                )
+            )
+
+            assert time.time() - tic < SLEEP_TIME * 1.05  # since they are parallel
 
 
 class TestGradablePaperQAEnvironment:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -789,27 +789,6 @@ async def test_sequential_tool_calls(agent_test_settings: Settings):
 
         assert time.time() - tic > 2 * SLEEP_TIME  # since they are sequential
 
-        with patch(
-            "paperqa.agents.env.ALLOW_PARALLEL_TOOL_CALLS", True  # noqa: FBT003
-        ):
-            tic = time.time()
-            await env.step(
-                ToolRequestMessage(
-                    tool_calls=[
-                        ToolCall.from_name(
-                            "gather_evidence",
-                            question="XAI for chemical property prediction",
-                        ),
-                        ToolCall.from_name(
-                            "gather_evidence",
-                            question="XAI for chemical property prediction",
-                        ),
-                    ]
-                )
-            )
-
-            assert time.time() - tic < SLEEP_TIME * 1.05  # since they are parallel
-
 
 class TestGradablePaperQAEnvironment:
     @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError"])


### PR DESCRIPTION
We've been seeing a production bug where parallel gather_evidence tool calls are clobbering our environment state. We can try to prompt engineer our way out of this, but deterministically forcing ordered tool calls feels safer. 

This change forces them into ordered calls along with a test. We can turn it off with an env var if we'd like in the future. I don't think this should go into settings since it's effectively a bug to turn on for now. 