### PR TITLE
Fixing `PaperQAEnvironment.reset` respecting `mmr_lambda` and `text_hashes`

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -113,6 +113,7 @@ class Docs(BaseModel):
         self.texts = []
         self.docs = {}
         self.docnames = set()
+        self.texts_index.clear()
 
     def _get_unique_name(self, docname: str) -> str:
         """Create a unique name given proposed name."""

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -80,6 +80,28 @@ class Docs(BaseModel):
     )
     deleted_dockeys: set[DocKey] = Field(default_factory=set)
 
+    def __eq__(self, other) -> bool:
+        if (
+            not isinstance(other, type(self))
+            or not isinstance(self.texts_index, NumpyVectorStore)
+            or not isinstance(other.texts_index, NumpyVectorStore)
+        ):
+            return NotImplemented
+        return (
+            self.docs == other.docs
+            and len(self.texts) == len(other.texts)
+            and all(  # TODO: implement Text.__eq__
+                getattr(self_text, attr) == getattr(other_text, attr)
+                for attr in ("text", "name", "doc")
+                for self_text, other_text in zip(self.texts, other.texts, strict=True)
+            )
+            and self.docnames == other.docnames
+            and self.texts_index == other.texts_index
+            and self.name == other.name
+            and self.index_path == other.index_path
+            # NOTE: ignoring deleted_dockeys
+        )
+
     @field_validator("index_path")
     @classmethod
     def handle_default(cls, value: Path | None, info: ValidationInfo) -> Path | None:

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -775,7 +775,11 @@ class VectorStore(BaseModel, ABC):
     model_config = ConfigDict(extra="forbid")
 
     # can be tuned for different tasks
-    mmr_lambda: float = Field(default=0.9)
+    mmr_lambda: float = Field(
+        default=1.0,
+        ge=0.0,
+        description="MMR lambda value, a value above 1 disables MMR search.",
+    )
     texts_hashes: set[int] = Field(default_factory=set)
 
     def __contains__(self, item) -> bool:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,16 +1,18 @@
 import asyncio
 from collections.abc import Iterable
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
 from aviary.env import TASK_DATASET_REGISTRY, TaskConfig, TaskDataset
 from ldp.agent import SimpleAgent
-from ldp.alg.callbacks import MeanMetricsCallback, StoreTrajectoriesCallback
+from ldp.alg.callbacks import Callback, MeanMetricsCallback, StoreTrajectoriesCallback
 from ldp.alg.runners import Evaluator, EvaluatorConfig
 from pytest_subtests import SubTests
 
 from paperqa import Docs, QueryRequest, Settings
 from paperqa.agents import get_directory_index
+from paperqa.agents.env import PaperQAEnvironment
 from paperqa.agents.task import (
     GradablePaperQAEnvironment,
     LitQATaskDataset,
@@ -74,6 +76,27 @@ TASK_DATASET_REGISTRY[STUB_TASK_DATASET_NAME] = (
 )
 
 
+class StoreEnvCallback(Callback):
+    """Test utility to store instantiated environments."""
+
+    def __init__(self):
+        super().__init__()
+        # NOTE: using question-to-env because too lazy to implement __hash__
+        # for this being a set of envs
+        self.query_to_envs: dict[str, PaperQAEnvironment] = {}
+
+    async def before_transition(
+        self, traj_id, agent, env, agent_state, obs  # noqa: ARG002
+    ) -> None:
+        if not isinstance(env, PaperQAEnvironment):
+            raise NotImplementedError(
+                f"Didn't yet handle environment type {type(env).__name__}."
+            )
+        question = env._query.query
+        if env not in self.query_to_envs:
+            self.query_to_envs[question] = env
+
+
 class TestTaskDataset:
 
     @pytest.mark.parametrize(
@@ -113,6 +136,7 @@ class TestTaskDataset:
     ) -> None:
         await get_directory_index(settings=base_query_request.settings)  # Build
         docs = Docs()
+        raw_docs_deepcopy = deepcopy(docs)  # Preserve for later assertions
         # Why are we constructing a TaskConfig here using a serialized QueryRequest and
         # Docs? It's to confirm everything works as if hydrating from a YAML config file
         task_config = TaskConfig(
@@ -139,12 +163,13 @@ class TestTaskDataset:
         dataset = task_config.make_dataset(split="eval")  # noqa: FURB184
         assert isinstance(dataset, StubLitQADataset), "Test assertions depend on this"
         metrics_callback = MeanMetricsCallback(eval_dataset=dataset)
+        store_env_callback = StoreEnvCallback()
 
         evaluator = Evaluator(
             config=EvaluatorConfig(batch_size=len(dataset.data), max_rollout_steps=10),
             agent=SimpleAgent(),
             dataset=dataset,
-            callbacks=[metrics_callback],
+            callbacks=[metrics_callback, store_env_callback],
         )
         await evaluator.evaluate()
 
@@ -156,6 +181,12 @@ class TestTaskDataset:
             metrics_callback.eval_means["total_paper_count"] > 0
         ), "Expected some papers to help us answer questions"
         assert metrics_callback.eval_means["reward"] > 0, "Expected some wins"
+
+        with subtests.test(msg="confirming-reset-works"):
+            assert len(store_env_callback.query_to_envs) == len(dataset)
+            for env in store_env_callback.query_to_envs.values():
+                await env.reset()
+                assert env.state.docs == raw_docs_deepcopy
 
         with subtests.test(msg="zero-shot"):
             # Confirm we can just directly call gen_answer

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -137,10 +137,11 @@ class TestTaskDataset:
             exclude={"id", "docs_name"}
         )
         dataset = task_config.make_dataset(split="eval")  # noqa: FURB184
+        assert isinstance(dataset, StubLitQADataset), "Test assertions depend on this"
         metrics_callback = MeanMetricsCallback(eval_dataset=dataset)
 
         evaluator = Evaluator(
-            config=EvaluatorConfig(batch_size=3, max_rollout_steps=10),
+            config=EvaluatorConfig(batch_size=len(dataset.data), max_rollout_steps=10),
             agent=SimpleAgent(),
             dataset=dataset,
             callbacks=[metrics_callback],


### PR DESCRIPTION
This PR started as a regression test of `PaperQAEnvironment.reset`, then we found out some bugs were present.

So it writes the unit test, and to make it pass:
- Adds `Docs.__eq__` so we can compare `Docs` in unit tests
- Consolidates `mmr_lambda` defaults to 1.0 (disabled)
- Fixes `Docs.clear_docs` calling `texts_index.clear`
