### PR TITLE
Refreshed test cassettes, fixed flaky test `test_search`, and fixed test type ignores

### DIFF
--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[didnt-match-and-llm-has-innate-knowledge].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[didnt-match-and-llm-has-innate-knowledge].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -84\n\nProposed Answer:
-        14\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream":
-        false, "temperature": 0.0}'
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD) Insufficient
+        information to answer this question\nE) -84\n\nProposed Answer: 14\n\nSingle
+        Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "566"
+          - "556"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:31 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Newark</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200b1f6f41f5</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200b1f6f41f5-EWR
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6323"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:31 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=0dYACpCqq_LN4J9dvo5sRc65zjmRj.2lPyixw.__aZc-1732647691599-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -84\n\nProposed Answer:
-        14\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream":
-        false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "566"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSsU7DMBTc8xWW5walpTRqNybEwtShAqHIfX5JDY6fZb8gEOq/I6ehSQVILB7u
-          3p3vnf2ZCSGNlhsh4aAYWm/z293banevt44f5rcA/vURHsC16mVLd6WcJQXtXxD4W3UF1HqLbMid
-          aAioGJPrvLxerJblal32REsabZI1nvNlzl3YU74oFsu8WObFelAfyABGuRFPmRBCfPZnyuk0vsuN
-          KGbfSIsxqgbl5jwkhAxkEyJVjCaycixnIwnkGF0fvZjiAesuqpTNddYO+PF8kaXGB9rHgT/jtXEm
-          HqqAKpJLppHJy549ZkI89wt1FxmlD9R6rphe0SXDebE++cmxxwk7cEys7ASeDy1c2lUaWRkbJ41I
-          UHBAPUrH+lSnDU2IbLL0zzC/eZ8WN675j/1IAKBn1JUPqA1cLjyOBUy/7K+xc8l9YBk/ImNb1cY1
-          GHwwpzeufQX1/qZeY61KmR2zLwAAAP//AwAYjuMi8QIAAA==
+          H4sIAAAAAAAAA4xSy07DMBC85yssnxuUpmlpcwNRlQNIXBBCCEWuvUndOrZlb8Sj6r8jp6FJBUhc
+          fJjZGc+OvY8IoVLQnFC+Ychrq+IrNnvKnm9XE9y93YnV5255vX14vKyn0+X9DR0FhVlvgeO36oKb
+          2ipAafSR5g4YQnAdX04m49k8TZOWqI0AFWSVxTiLsXFrE6dJmsVJFieLTr0xkoOnOXmJCCFk354h
+          pxbwTnPSerVIDd6zCmh+GiKEOqMCQpn30iPTSEc9yY1G0G30ZIg7KBvPQjbdKNXhh9NFylTWmbXv
+          +BNeSi39pnDAvNHB1KOxtGUPESGv7ULNWUZqnaktFmh2oIPhOFkc/Wjf44DtODTI1AAedy2c2xUC
+          kEnlB41QzvgGRC/t62ONkGZARIOlf4b5zfu4uNTVf+x7gnOwCKKwDoTk5wv3Yw7CL/tr7FRyG5j6
+          D49QF6XUFTjr5PGNS1uIqZhns/liBjQ6RF8AAAD//wMAnklv2vECAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c20c85905424a-EWR
+          - 8ebdc4e01dd067f1-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:37 GMT
+          - Mon, 02 Dec 2024 19:37:00 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=Z3fX3RDRMdlpVcEOPZ1qhNpWe0oN23hHw8fiPfY2odY-1732647697-1.0.1.1-zurbiijhTnvodnIoLpXYkAcE52q5Iwj0NGFYmNTW1kSlfwbRpSTcKbNR66OycmOKmXgviGpyUxJ.d1wOnvPdnw;
-            path=/; expires=Tue, 26-Nov-24 19:31:37 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=vZeUXuKzXGlTvGNDDI78lb7iSc.Dz21L1huvaOj1zPU-1733168220-1.0.1.1-cgolr8AYpa.cWBTXmhqGXfr5z.zXLcaBJln0Sy7jAv5HVoy25AIiflpgogGhxXyDB8fk8C8nhVXUAaucD91cwA;
+            path=/; expires=Mon, 02-Dec-24 20:07:00 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=WO3yeg8lJRreEeikJdcUM0a.ujR17DflBsTAmSyI2xY-1733168220738-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "256"
+          - "453"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -260,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 3ms
         x-request-id:
-          - req_9f17b75142761b19a9577203f61510a9
+          - req_859411710c54de9ff232d54ae4a41070
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[didnt-match-and-no-llm-innate-knowledge].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[didnt-match-and-no-llm-innate-knowledge].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 14004\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        the answer is 14004\n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "589"
+          - "579"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,87 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503
-          Service Temporarily Unavailable</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e8c200b0c394cae-PHL
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "190"
-        Content-Type:
-          - text/html
-        Date:
-          - Tue, 26 Nov 2024 19:01:06 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=t5Fu8IdE2eRZrdqgG4nm9umYrqAXYoqLY0TEikQqX_Y-1732647666-1.0.1.1-FUyvUJNxQMAgWBL5P1GWPv9_rVZufdee0aa955TpkQpofUDP.ze9SjGsLFamInqIjn0mZxgJxrIMdag.MGaA2Q;
-            path=/; expires=Tue, 26-Nov-24 19:31:06 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=_nGQk9L_67Ieg0rZvDRT40.cwdICkI9gcnjdodRCcys-1732647666433-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        X-Content-Type-Options:
-          - nosniff
-        alt-svc:
-          - h3=":443"; ma=86400
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-      status:
-        code: 503
-        message: Service Unavailable
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 14004\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "589"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -127,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySP0/DMBDF93wKy3ODkjakbTZEBwY6IDGAEIoc+5oaHNvYF/6o6ndHTkqTiiKx
-          ZHi/ey/vLtlFhFApaEEo3zLkjVXx1cN7frfO/Xr1uEL5kS3WTL2Bv7ld3K+v6SQ4TPUCHH9cF9w0
-          VgFKo3vMHTCEkJrOZ9M8m+fLpAONEaCCrbYYZzG2rjLxNJlmcZLFyfLg3hrJwdOCPEWEELLrnqGn
-          FvBJC9JldUoD3rMaaHEcIoQ6o4JCmffSI9NIJwPkRiPornoy1h1sWs9CN90qddD3xxcpU1tnKn/g
-          R30jtfTb0gHzRodQj8bSju4jQp67hdqTjtQ601gs0byCDoFpmvd5dLjjiB4YGmRqbJpPzsSVApBJ
-          5UcXoZzxLYjBOpyPtUKaEYhGS/8ucy67X1zq+j/xA+AcLIIorQMh+enCw5iD8Jf9NXY8cleY+i+P
-          0JQbqWtw1sn+G29sKS4rNhOQCk6jffQNAAD//wMASaZB8vECAAA=
+          H4sIAAAAAAAAA4yST0+EMBDF73yKpufFwO667nJT78aTHowhpR2gWtraGfwTs9/dFHYXjJp44fB+
+          8x5vBj4TxrhWvGBctoJk5016KTZ3FbTbt809vly/Uq7ur1Z3b0u8eb9FvogOVz2BpKPrTLrOGyDt
+          7IhlAEEQU/OL1SrfbPNdPoDOKTDR1nhK1yn1oXLpMluu02ydZruDu3VaAvKCPSSMMfY5PGNPq+Cd
+          FyxbHJUOEEUDvDgNMcaDM1HhAlEjCUt8MUHpLIEdqmdzPUDdo4jdbG/MQd+fXmRc44Or8MBPeq2t
+          xrYMINDZGIrkPB/oPmHscVio/9aR++A6TyW5Z7AxMM83Yx6f7jijB0aOhJmbLha/xJUKSGiDs4tw
+          KWQLarJO5xO90m4GktnSP8v8lj0urm3zn/gJSAmeQJU+gNLy+8LTWID4l/01djryUJjjBxJ0Za1t
+          A8EHPX7j2pfqvBIrBbmSPNknXwAAAP//AwAh8Hyj8QIAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c202aff624243-EWR
+          - 8ebdc42bfcb717d1-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -146,9 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:38 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Server:
           - cloudflare
+        Set-Cookie:
+          - __cf_bm=V9JKZaPgzRXm2xl88rELAhZRtOsnKi8.awEARdtwPRc-1733168191-1.0.1.1-y_01lbvDs5D4yaR_XsSiJ003kKGFo3ffzaIBXcejk7i4A0VjnMOmICblQ.auCgaeqM6BDkb3Tr7pUQNyXRhCgw;
+            path=/; expires=Mon, 02-Dec-24 20:06:31 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=99aBS7wrE5xqZSJQs.R0NgU46C3gmCn3IV6gKlmxQhQ-1733168191813-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -160,13 +85,25 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "611"
+          - "327"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
           - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "2000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "1999868"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 3ms
         x-request-id:
-          - req_95e8b707bcf849265f9e0a60b02b4f16
+          - req_c879ae4928bc5c3d47beece7d7bbeeae
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer1].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer1].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream": false,
-        "temperature": 0.0}'
+        \n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "570"
+          - "560"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Newark</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200b0c4641ec</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200b0c4641ec-EWR
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6323"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=8jz3Hg0lMMt1bINOE7dKCyUEzrSyvaMymgyBUYfpkRk-1732647682640-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream": false,
-        "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "570"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySy07DMBBF9/kKy+sGpSWkIbsCEiyQkHgIJIQi154mBse27AlP9d+R07RJBUhs
-          vJgzd3zv2F8RIVQKWhDKa4a8sSpePLxmV7c5O0vni8+T87uL+vQ2f7nWh/fZ5ZJOgsIsn4HjVnXA
-          TWMVoDR6g7kDhhCmTueHsyydZ3negcYIUEFWWYzTGFu3NPEsmaVxksbJca+ujeTgaUEeI0II+erO
-          4FMLeKcFSSbbSgPeswposWsihDqjQoUy76VHppFOBsiNRtCd9RupKwXkEhDBkYX2b+AKkoy7Haxa
-          z4Jj3SrV19e765WprDNL3/NdfSW19HXpgHmjw1UejaUdXUeEPHUx2z3n1DrTWCzRvIAOA6fTPiYd
-          tjvQrGdokKmxaAv2xpUCkEnlR3uinPEaxCAdlspaIc0IRKPQP838NnsTXOrqP+MHwDlYBFFaB0Ly
-          /cBDm4Pw9/5q2y25M0z9h0doypXUFTjr5OblV7YURyJPs/w4Axqto28AAAD//wMAopcoTAcDAAA=
+          H4sIAAAAAAAAA4ySMU/DMBCF9/wKy3ODkqa0NFsnhIQ6gBBSEYpc+5K6OLaxLxRU9b8jp2mTCpBY
+          PNx37/ze2fuIECoFzQnlG4a8tipesOlzNlnyFbD3h0bc7T62YpzZp9XtMkvoKCjMegscT6orbmqr
+          AKXRR8wdMIQwNZ1lWTq9GafzFtRGgAqyymI8ibFxaxOPk/EkTiZxMu/UGyM5eJqTl4gQQvbtGXxq
+          AZ80J8noVKnBe1YBzc9NhFBnVKhQ5r30yDTSUQ+50Qi6tf4odaWA3AMiOLLQfgcuJ8mw20HZeBYc
+          60aprn44X69MZZ1Z+46f66XU0m8KB8wbHa7yaCxt6SEi5LWN2Vw4p9aZ2mKB5g10GJimXUzab7en
+          046hQaaGohO4GFcIQCaVH+yJcsY3IHppv1TWCGkGIBqE/mnmt9nH4FJX/xnfA87BIojCOhCSXwbu
+          2xyEv/dX23nJrWHqvzxCXZRSV+Csk8eXL23By/V1OYeSzWh0iL4BAAD//wMAmkjESAcDAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c20905c6242c2-EWR
+          - 8ebdc4dafba615d4-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:28 GMT
+          - Mon, 02 Dec 2024 19:37:00 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=O36._49hQljLfe4iPhRzk_bUQ82WISLrKod6z8E0FGI-1732647688-1.0.1.1-Wq41m5b1.3LxKL3zIft.uAnTTGjs5eQLs4TLxtcIh3WMTKmpSqsTPqnICyj8yVoFkTvVIe.m_1G8bXZQYQiTDA;
-            path=/; expires=Tue, 26-Nov-24 19:31:28 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=wBTlSfGtDvKNN8jl8xswUs6UcECqQrm_fJoNEYSBrug-1733168220-1.0.1.1-X2dfHY.vvzeugDTi45QjaaLr9lcQkkXqod1iU5dQBniNuy_stNSQrWf09Tl57pbgRW9.IHqI2kq_X.Tr.MLfuw;
+            path=/; expires=Mon, 02-Dec-24 20:07:00 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=YNYTg.AWA5kJFJigiVFr54YVb2POOVGjpxb4QL4a3wQ-1733168220064-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "538"
+          - "571"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -252,15 +95,15 @@ interactions:
         x-ratelimit-limit-tokens:
           - "2000000"
         x-ratelimit-remaining-requests:
-          - "9996"
+          - "9999"
         x-ratelimit-remaining-tokens:
-          - "1999419"
+          - "1999872"
         x-ratelimit-reset-requests:
-          - 23ms
+          - 6ms
         x-ratelimit-reset-tokens:
-          - 17ms
+          - 3ms
         x-request-id:
-          - req_ee77f1f2eea7896162caa21b791256bb
+          - req_3743d264e856a555d4f8901037e493b2
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer2].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer2].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -84\n\nProposed Answer:
-        \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream": false,
-        "temperature": 0.0}'
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD) Insufficient
+        information to answer this question\nE) -84\n\nProposed Answer: \n\nSingle Letter
+        Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "564"
+          - "554"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Newark</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200affd54229</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200affd54229-EWR
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6323"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=nhNQ4dAzcTITyKfgbVBRdm0yJdrIbh8aD.JgcOZRv5w-1732647682636-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is the meaning of life?\n\nOptions:\nA) 42\nB) 11\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -84\n\nProposed Answer:
-        \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09", "stream": false,
-        "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "564"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySTUvEMBCG7/0VIeetdNd1q70pghdRwQ8EkZJNpm00zYRkun6x/13SXbcVFbzk
-          MM+8b96Z5CNhjGvFC8ZlI0i2zqTH96vF5c3V6UWDd3Rye6ZWB9fv96u3u5scbvkkKnD5BJK+VHsS
-          W2eANNoNlh4EQXSd5vuzxTxfHB72oEUFJspqR+k8pc4vMZ1ls3mazdPsaKtuUEsIvGAPCWOMffRn
-          zGkVvPKCZZOvSgshiBp4sWtijHs0scJFCDqQsMQnA5RoCWwf/Vrb2gA7ByLw7NiGF/AFy8bdHqou
-          iJjYdsZs6+vd9QZr53EZtnxXr7TVoSk9iIA2XhUIHe/pOmHssR+z+5acO4+to5LwGWw0nGb5xo8P
-          2x3oYssISZiRaLo/+cWuVEBCmzDaE5dCNqAG6bBU0SmNI5CMhv4Z5jfvzeDa1v+xH4CU4AhU6Two
-          Lb8PPLR5iH/vr7bdkvvAPLwFgrastK3BO683L1+5UlbLg+oIKpHzZJ18AgAA//8DALyLdCoHAwAA
+          H4sIAAAAAAAAA4ySy07DMBBF9/kKy+sGJU0fNLuyogIJRCuBhFDkOpPUxbGNPRGFqv+OnD6SiiKx
+          8WLO3Os7Y28DQqjIaUooXzHklZHhlI2eh6Pvcg0f1/PZ0+LlZvZ4t7mtkmTxMKQ9r9DLNXA8qq64
+          rowEFFrtMbfAELxrPE6SeHTd78cNqHQO0stKg+EgxNouddiP+oMwGoTR5KBeacHB0ZS8BoQQsm1O
+          n1PlsKEpiXrHSgXOsRJoemoihFotfYUy54RDppD2Wsi1QlBN9LlQpQRyD4hgyVS5T7ApibrdFora
+          MZ9Y1VIe6rvT9VKXxuqlO/BTvRBKuFVmgTmt/FUOtaEN3QWEvDVj1mfJqbG6MpihfgflDeNovPej
+          7XZbOjow1MhkRxQnvQt2WQ7IhHSdPVHO+AryVtouldW50B0QdIb+HeaS935wocr/2LeAczAIeWYs
+          5IKfD9y2WfB/76+205KbwNR9OYQqK4QqwRor9i9fmIwXy2ExgYKNabALfgAAAP//AwCQnpIiBwMA
+          AA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c2090790b41e6-EWR
+          - 8ebdc4e40cbeebef-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +66,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:28 GMT
+          - Mon, 02 Dec 2024 19:37:01 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=Qu8e_7SZNpM.B1gFAHol_PkHyUz2mREva4soLaRUS4o-1732647688-1.0.1.1-rGw0qTWkgbTO99ryzFLMJc6KrK5nFwP8jaNYzOMzDwQ77N3DkvE4Z864AchR5BJs6ANqBgUeDJma517Fdhoejg;
-            path=/; expires=Tue, 26-Nov-24 19:31:28 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=gKZRkJSnKuXb_v5JVJ7xxZjNRqsAQaFPrcryBjCscKI-1733168221-1.0.1.1-QbSpSCz3awZY_V6nCNvMPPVQ.sSw1I.UYH4M6dC9Qc0TF3flmjNjKPwMYq8ENaNjYeEuvaGcXSbbqsawrPYV3g;
+            path=/; expires=Mon, 02-Dec-24 20:07:01 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=270CDl2oje.MGzvngrvJ.xeVblAaBip9MF1qilNDwgk-1733168221399-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +86,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "338"
+          - "468"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -260,7 +104,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 3ms
         x-request-id:
-          - req_d4c108f67f43de089bd34d9f9675e2d9
+          - req_a870aecb0f702ad4607d4a1f4c8f151f
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer3].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[empty-answer3].yaml
@@ -1,15 +1,14 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What method was used to demonstrate that the enzyme PafA is stable after
-        incubation with 4M urea for 14 days?\n\nOptions:\nA) circular dichroism\nB)
-        x-ray crystallography\nC) NMR\nD) Insufficient information to answer this question\nE)
-        cryo EM\n\nProposed Answer: \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What method was used to demonstrate that the enzyme PafA is stable after incubation
+        with 4M urea for 14 days?\n\nOptions:\nA) circular dichroism\nB) x-ray crystallography\nC)
+        NMR\nD) Insufficient information to answer this question\nE) cryo EM\n\nProposed
+        Answer: \n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -18,13 +17,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "677"
+          - "667"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -34,166 +33,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Newark</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200afcb24257</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200afcb24257-EWR
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6323"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=zIQRRmAT5b1FMGI6jfEN3ejN2Mj380BChOONlmoe13A-1732647682633-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What method was used to demonstrate that the enzyme PafA is stable after
-        incubation with 4M urea for 14 days?\n\nOptions:\nA) circular dichroism\nB)
-        x-ray crystallography\nC) NMR\nD) Insufficient information to answer this question\nE)
-        cryo EM\n\nProposed Answer: \n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "677"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -207,18 +47,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySQUvDQBCF7/kVy54bSZs2am8WRRBET1IRCdvdSbq62Vl2J6KU/nfZtDYpVvCS
-          w/vmvbyZZJMwxrXic8blWpBsnEmvlh/Fw9d4+Sxv8am5vvq8voPZ4uZeLx4XBR9FB67eQNKP60xi
-          4wyQRrvD0oMgiKnj83xSTM+Li4sONKjARFvtKJ2m1PoVppNsMk2zaZpd7t1r1BICn7OXhDHGNt0z
-          9rQKPvmcZaMfpYEQRA18fhhijHs0UeEiBB1IWOKjHkq0BLarng11D1UbROxmW2P2+vbwIoO187gK
-          e37QK211WJceREAbQwOh4x3dJoy9dgu1Rx2589g4KgnfwcbAcT7b5fH+jgO6Z4QkzNBUjE7ElQpI
-          aBMGF+FSyDWo3tqfT7RK4wAkg6V/lzmVvVtc2/o/8T2QEhyBKp0HpeXxwv2Yh/iX/TV2OHJXmIev
-          QNCUlbY1eOf17htXrpypVZ7lRV5VPNkm3wAAAP//AwARR+0r8QIAAA==
+          H4sIAAAAAAAAA4ySS2vDMBCE7/4VQue4OM47t0If9NRTKaUUo8hrW62sFdK6SQj570XOww5NoRcf
+          5tsZz669ixjjKudLxmUlSNZWx7di+jpJcZvM7x7etkY/bp6+X57X6n6dbCo+CA5cfYKkk+tGYm01
+          kEJzwNKBIAipw9loNJzO03TYghpz0MFWWorHMTVuhXGapOM4GcfJ4uiuUEnwfMneI8YY27XP0NPk
+          sOFLlgxOSg3eixL48jzEGHeog8KF98qTMMQHHZRoCExbPenrDorGi9DNNFof9f35RRpL63Dlj/ys
+          F8ooX2UOhEcTQj2h5S3dR4x9tAs1Fx25dVhbygi/wITA4WhyyOPdHXv0yAhJ6L5pOrgSl+VAQmnf
+          uwiXQlaQd9bufKLJFfZA1Fv6d5lr2YfFlSn/E98BKcES5Jl1kCt5uXA35iD8ZX+NnY/cFuZ+6wnq
+          rFCmBGedOnzjwmayWE2KBRRixqN99AMAAP//AwAsQ90A8QIAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c209058395e79-EWR
+          - 8ebdc4e88da5238f-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -226,13 +66,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:28 GMT
+          - Mon, 02 Dec 2024 19:37:01 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=zpuqNZxJkYadCqA3k6ayBeseRuCRxfT2CnyXIN2ZvKw-1732647688-1.0.1.1-8A2dXW5U9653mretW49FkvQJb6.OrLraHyLV5qqHDEEj3pBkZbr_4jKvuYlxE0.1W4AZ5Yv5uZ0dBFMBBzAdQg;
-            path=/; expires=Tue, 26-Nov-24 19:31:28 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=l2GDwTQqXcf9PRuyB33XWLYqQyxiku4vFlwrzyqgDO8-1733168221-1.0.1.1-TbtBsB4YgRI7y02aw5xi4pJpDD9e_k6ZEfnZxbc5qvr6W0NhAGHWj4T7k8HDvVDn7G92rHwAwEYiogqWVvznxw;
+            path=/; expires=Mon, 02-Dec-24 20:07:01 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=mFKER3h1hKhiQeldGvjSCPyrcF8CGVx8tiCye437UMU-1733168221960-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -244,7 +86,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "726"
+          - "313"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -254,15 +96,15 @@ interactions:
         x-ratelimit-limit-tokens:
           - "2000000"
         x-ratelimit-remaining-requests:
-          - "9998"
+          - "9999"
         x-ratelimit-remaining-tokens:
-          - "1999718"
+          - "1999846"
         x-ratelimit-reset-requests:
-          - 11ms
+          - 6ms
         x-ratelimit-reset-tokens:
-          - 8ms
+          - 4ms
         x-request-id:
-          - req_f3b51d9536ccc779f527cce78346290c
+          - req_75f75842d38bf10216b08bbdc5a03dd7
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-correct-option].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-correct-option].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 94107\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        the answer is 94107\n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "589"
+          - "579"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Newark</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200b180a4229</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200b180a4229-EWR
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6323"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=AVpoauttF9krgy.gcYP1ggw5d5eVqa.IN6ikQ3ptogI-1732647682638-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 94107\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "589"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySzWrDMBCE734KoXNc7NhxUt8CpYdCKfQUKMUo0tpRI0tCWpemIe9e5PzYoSn0
-          4sN8O+PZtfcRIVQKWhLKNwx5a1W8XH0WL4+vYvWcpls2xRzs907Nnxo+e8joJDjM+gM4nl133LRW
-          AUqjj5g7YAghNZ1n0yKfF4tFD1ojQAVbYzHOY+zc2sTTZJrHSR4n9yf3xkgOnpbkLSKEkH3/DD21
-          gC9akmRyVlrwnjVAy8sQIdQZFRTKvJcemUY6GSA3GkH31Zdj3UHdeRa66U6pk364vEiZxjqz9id+
-          0Wuppd9UDpg3OoR6NJb29BAR8t4v1F11pNaZ1mKFZgs6BKZpccyjwx1H9MTQIFNj03xyI64SgEwq
-          P7oI5YxvQAzW4XysE9KMQDRa+neZW9nHxaVu/hM/AM7BIojKOhCSXy88jDkIf9lfY5cj94Wp33mE
-          tqqlbsBZJ4/fuLbVTKyzJCuyuqbRIfoBAAD//wMAzruVKPECAAA=
+          H4sIAAAAAAAAA4ySS2+DMBCE7/wKy+dQhbzDLZf2UOWUqg9VFTL2hrg1tmUvVaoo/70yUCBqKvXC
+          Yb6dYXbhFBFCpaApofzAkJdWxRu2eMx323tYPeNLebub3202T7A9Pvii/KSj4DD5O3D8cd1wU1oF
+          KI1uMHfAEEJqspxOk8UqWSc1KI0AFWyFxXgWY+VyE0/Gk1k8nsXjdes+GMnB05S8RoQQcqqfoacW
+          cKQpGY9+lBK8ZwXQtBsihDqjgkKZ99Ij00hHPeRGI+i6+maoO9hXnoVuulKq1c/di5QprDO5b3mn
+          76WW/pA5YN7oEOrRWFrTc0TIW71QddGRWmdKixmaD9AhMEkWTR7t7zigLUODTA1Ny9GVuEwAMqn8
+          4CKUM34A0Vv787FKSDMA0WDp32WuZTeLS138J74HnINFEJl1ICS/XLgfcxD+sr/GuiPXhan/8ghl
+          tpe6AGedbL7x3mZinrOpgERwGp2jbwAAAP//AwCnlqq88QIAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c20905f2c42d7-EWR
+          - 8ebdc428bea1964b-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:29 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=2TOcE3uI79cmoBb6r0fWyU117NVYW0DwJuA2MGXkNws-1732647689-1.0.1.1-Pljk78Eg80ZB7ma_h7Degc3wPyVOqPBaDCGWxoKYLDxnF6M3GcxRE7cI6TaAqdnrSg2.snIXrBhJFo4z5QaCLA;
-            path=/; expires=Tue, 26-Nov-24 19:31:29 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=Gyw7sgsmFPryW8QrU_7lxgmhzAdr1OAJsVFq3ZuZJts-1733168191-1.0.1.1-4_kodzTQ9Th6gB3N8tFztkAadZqqAiDSnFYuMUB3WCqAp2KtMiawGX1gjXKgXHg78eWv4DScN1Lzff80oXyr1g;
+            path=/; expires=Mon, 02-Dec-24 20:06:31 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=.gC13jY.ZG1jX1VQNJJcltQ8RZU8QW7ovC91jdDYhWY-1733168191240-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "1033"
+          - "284"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -260,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 3ms
         x-request-id:
-          - req_6799bdcf73f041209c2b633a6f104111
+          - req_b7550c223d2f5e7b7626c531699b271c
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-incorrect-option].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-incorrect-option].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 94106\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        the answer is 94106\n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "589"
+          - "579"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Philadelphia</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200afdd832cc</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200afdd832cc-PHL
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6329"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=qgWQk8IZ7fiZMm.ZLHtQppK_G2FEhWRqdor8vWMZpx4-1732647682626-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 94106\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "589"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySX0vDMBTF3/spQp5bWbe6sb4pQxR8EAYqiJQsue2ypUlMbqcy9t0l3Z92OMGX
-          PpzfPafn3nYbEUKloDmhfMmQ11YlN6+bcZ0+PN3N5+nnfbP6WM+mz3LzaLPZ9IXGwWEWK+B4dF1x
-          U1sFKI3eY+6AIYTUdDIajrPJJB22oDYCVLBVFpMswcYtTDIcDLNkkCWD6cG9NJKDpzl5iwghZNs+
-          Q08t4IvmZBAflRq8ZxXQ/DRECHVGBYUy76VHppHGHeRGI+i2+m1fd1A2noVuulHqoO9OL1Kmss4s
-          /IGf9FJq6ZeFA+aNDqEejaUt3UWEvLcLNWcdqXWmtligWYMOgWk63ufR7o49emBokKm+aRJfiCsE
-          IJPK9y5COeNLEJ21Ox9rhDQ9EPWW/l3mUvZ+camr/8R3gHOwCKKwDoTk5wt3Yw7CX/bX2OnIbWHq
-          vz1CXZRSV+Csk/tvXNpCXC/YSEAqOI120Q8AAAD//wMAGLb3GfECAAA=
+          H4sIAAAAAAAAA4ySUU+DMBSF3/kVTZ+HgYGb4409Gx8W44zGkNLeQbW0TXtJNMv+uymbg8WZ+MLD
+          +e45nHthHxFCpaAFobxlyDur4pItnnj5sJyXNt8mddaUG7jfluvN48tzS2fBYep34PjjuuGmswpQ
+          Gn3E3AFDCKnpMsvSxV26mg+gMwJUsDUW4zzG3tUmnifzPE7yOFmd3K2RHDwtyGtECCH74Rl6agGf
+          tCDJ7EfpwHvWAC3OQ4RQZ1RQKPNeemQa6WyE3GgEPVRfT3UHu96z0E33Sp30w/lFyjTWmdqf+Fnf
+          SS19Wzlg3ugQ6tFYOtBDRMjbsFB/0ZFaZzqLFZoP0CEwTRfHPDrecUJPDA0yNTUtZ1fiKgHIpPKT
+          i1DOeAtitI7nY72QZgKiydK/y1zLPi4udfOf+BFwDhZBVNaBkPxy4XHMQfjL/ho7H3koTP2XR+iq
+          ndQNOOvk8RvvbCVua5YJSAWn0SH6BgAA//8DALuNgObxAgAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c209058556a59-EWR
+          - 8ebdc42fbb281742-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:02:10 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=m0b7OJYgg2DDqBCBomdHB2iYL5..pN8k9GyRXzZqSco-1732647730-1.0.1.1-ac5SXwcHefqhEp7gjxBU0x938UVZQKGta7IIuBGTbRu_pAEtYThSnX81gNN3rkyMB2Ha9yTw30PgxdRc7ymEiA;
-            path=/; expires=Tue, 26-Nov-24 19:32:10 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=1GPMhubL9vKvXQD.DNfWWh56oMYzMEj_.8x_p5x4lQI-1733168192-1.0.1.1-q9hcVlLWzmSFj.Q80_dj9o_hIuRaJj_zX6nQVQKcKSTP_DYhitXnt9YMq7YZL.MN5Q__gFpA_m4M48_B7NerQA;
+            path=/; expires=Mon, 02-Dec-24 20:06:32 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=3Xu4dyJ7_C4d4q06U4cgBwE8RvSpdQrVraJaT_0CQ54-1733168192525-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "598"
+          - "454"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -260,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 3ms
         x-request-id:
-          - req_11e26ff75774c600c7f34210eaed478c
+          - req_834876824ddf40dd05daae621e6f2874
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-several-options].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-several-options].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        the answer is 94106 or 94107\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        the answer is 94106 or 94107\n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "598"
+          - "588"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,7 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -47,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySP2+DMBDFdz6F5TlUhJLSZOvQsVOWSlWFjH0QN8Zn2UfUP8p3r0xIIGordWG4
-          373HewdfCWNcK75hXO4Eyc6Z9OH5UN71T4f94+qwDW/7bd199st7wkJ1gS+iAus3kHRW3UjsnAHS
-          aE9YehAE0XVZ3uZ3RVne5gPoUIGJstZRWqTU+xrTPMuLNCvSbD2qd6glBL5hLwljjH0Nz5jTKnjn
-          G5YtzpMOQhAt8M1liTHu0cQJFyHoQMISX0xQoiWwQ/RsPvfQ9EHEbLY3ZpwfLy8y2DqPdRj5Zd5o
-          q8Ou8iAC2mgaCB0f6DFh7HUo1F9l5M5j56gi3IONhst8LMSnO87oyAhJmLnoDK7sKgUktAmzi3Ap
-          5A7UJJ3OJ3qlcQaSWemfYX7zPhXXtv2P/QSkBEegKudBaXldeFrzEP+yv9YuRx4C8/ARCLqq0bYF
-          77w+fePGVbKpV80aGlHy5Jh8AwAA//8DABWfzVXxAgAA
+          H4sIAAAAAAAAA4ySMU/DMBCF9/wKy3ODkrSkoRswIBgQC2JAKHLta2pwfMa+SCDU/46cpk0qQGLJ
+          cN+9l/cu+UoY41rxFeNyK0i2zqSXonwqiqt7LKubx0bO8+Ut3F2Hp+Jq+f7AZ1GB61eQdFCdSWyd
+          AdJo91h6EATRNV/O53lZFXnVgxYVmChrHKWLlDq/xrTIikWaLdLsYlBvUUsIfMWeE8YY++qfMadV
+          8MFXLJsdJi2EIBrgq+MSY9yjiRMuQtCBhCU+G6FES2D76Nl07mHTBRGz2c6YYb47vshg4zyuw8CP
+          8422OmxrDyKgjaaB0PGe7hLGXvpC3UlG7jy2jmrCN7DRMC+GQny844QOjJCEmYoO4MSuVkBCmzC5
+          CJdCbkGN0vF8olMaJyCZlP4Z5jfvfXFtm//Yj0BKcASqdh6UlqeFxzUP8S/7a+145D4wD5+BoK03
+          2jbgndf7b7xxtTpX1aKsLkrgyS75BgAA//8DAD28CxvxAgAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c21a28f18429b-EWR
+          - 8ebdc4d69ed6f941-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -66,14 +65,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:02:14 GMT
+          - Mon, 02 Dec 2024 19:36:59 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=EYz9EPsIcb_puw0EaFtGJP0L2Oz2bsckWORdVwM89LA-1732647734-1.0.1.1-KxiRRHNmDPRpVG9.I.itASx7AW.kSnOujS.T9gxjqa1n.wr6q9Nk4wJvrfnZJ0BC9OMFytuwbb_scu4woP6mGQ;
-            path=/; expires=Tue, 26-Nov-24 19:32:14 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=q1achQ2DhvfUCf9YfRRWrnzfiZlHl3yIKXSHQh.rYYk-1733168219-1.0.1.1-yt39A8.3jTWPqoP69SznEXfgHAEYHVMHuXBp_iVhuCTXvlywcwr2yT4PGACuI.TxtmM9IGb0dmLul9lECL_wLg;
+            path=/; expires=Mon, 02-Dec-24 20:06:59 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=.sHv4O1PQgZFSMV69oCX2aL8YldpRNp9SLhQ6cM9lHY-1732647734165-0.0.1.1-604800000;
+          - _cfuvid=YHCVFzv_sX7q121rDyczLFm6e.KbSZ3U_f4SD7cYXcA-1733168219252-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -86,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "298"
+          - "463"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -104,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 4ms
         x-request-id:
-          - req_7ee5e606d55bfef04d4abcb8e4c8aa45
+          - req_1e7e9f6fee63ff5c55df5c931cb87393
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-unsure-option].yaml
+++ b/tests/cassettes/TestLitQAEvaluation.test_from_question[matched-unsure-option].yaml
@@ -1,14 +1,13 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
+        '{"messages":[{"role":"user","content":"Given the following question and
+        a proposed answer to the question, return the single-letter choice in the question
+        that matches the proposed answer. If the proposed answer is blank or an empty
+        string, or multiple options are matched, respond with ''0''.\n\nQuestion: Q:
+        What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
         Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        Insufficient information\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
+        Insufficient information\n\nSingle Letter Answer:"}],"model":"gpt-4-turbo-2024-04-09","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -17,13 +16,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "594"
+          - "584"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.1
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -33,165 +32,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.1
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string:
-          "<!DOCTYPE html>\n<!--[if lt IE 7]> <html class=\"no-js ie6 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 7]>    <html class=\"no-js ie7 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if IE 8]>    <html class=\"no-js ie8 oldie\"
-          lang=\"en-US\"> <![endif]-->\n<!--[if gt IE 8]><!--> <html class=\"no-js\"
-          lang=\"en-US\"> <!--<![endif]-->\n<head>\n\n\n<title>api.openai.com | 502:
-          Bad gateway</title>\n<meta charset=\"UTF-8\" />\n<meta http-equiv=\"Content-Type\"
-          content=\"text/html; charset=UTF-8\" />\n<meta http-equiv=\"X-UA-Compatible\"
-          content=\"IE=Edge\" />\n<meta name=\"robots\" content=\"noindex, nofollow\"
-          />\n<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"
-          />\n<link rel=\"stylesheet\" id=\"cf_styles-css\" href=\"/cdn-cgi/styles/main.css\"
-          />\n\n\n</head>\n<body>\n<div id=\"cf-wrapper\">\n    <div id=\"cf-error-details\"
-          class=\"p-0\">\n        <header class=\"mx-auto pt-10 lg:pt-6 lg:px-8 w-240
-          lg:w-full mb-8\">\n            <h1 class=\"inline-block sm:block sm:mb-2 font-light
-          text-60 lg:text-4xl text-black-dark leading-tight mr-2\">\n              <span
-          class=\"inline-block\">Bad gateway</span>\n              <span class=\"code-label\">Error
-          code 502</span>\n            </h1>\n            <div>\n               Visit
-          <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">cloudflare.com</a> for more
-          information.\n            </div>\n            <div class=\"mt-3\">2024-11-26
-          19:01:22 UTC</div>\n        </header>\n        <div class=\"my-8 bg-gradient-gray\">\n
-          \           <div class=\"w-240 lg:w-full mx-auto\">\n                <div
-          class=\"clearfix md:px-8\">\n                  \n<div id=\"cf-browser-status\"
-          class=\" relative w-1/3 md:w-full py-15 md:p-0 md:py-8 md:text-left md:border-solid
-          md:border-0 md:border-b md:border-gray-400 overflow-hidden float-left md:float-none
-          text-center\">\n  <div class=\"relative mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-browser
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">You</span>\n  <h3
-          class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light leading-1.3\">\n
-          \   \n    Browser\n    \n  </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-cloudflare-status\" class=\" relative w-1/3 md:w-full py-15 md:p-0
-          md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    <span class=\"cf-icon-cloud
-          block md:hidden h-20 bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-ok
-          w-12 h-12 absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   </a>\n  </div>\n  <span class=\"md:block w-full truncate\">Philadelphia</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    <a href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          target=\"_blank\" rel=\"noopener noreferrer\">\n    Cloudflare\n    </a>\n
-          \ </h3>\n  <span class=\"leading-1.3 text-2xl text-green-success\">Working</span>\n</div>\n\n<div
-          id=\"cf-host-status\" class=\"cf-error-source relative w-1/3 md:w-full py-15
-          md:p-0 md:py-8 md:text-left md:border-solid md:border-0 md:border-b md:border-gray-400
-          overflow-hidden float-left md:float-none text-center\">\n  <div class=\"relative
-          mb-10 md:m-0\">\n    \n    <span class=\"cf-icon-server block md:hidden h-20
-          bg-center bg-no-repeat\"></span>\n    <span class=\"cf-icon-error w-12 h-12
-          absolute left-1/2 md:left-auto md:right-0 md:top-0 -ml-6 -bottom-4\"></span>\n
-          \   \n  </div>\n  <span class=\"md:block w-full truncate\">api.openai.com</span>\n
-          \ <h3 class=\"md:inline-block mt-3 md:mt-0 text-2xl text-gray-600 font-light
-          leading-1.3\">\n    \n    Host\n    \n  </h3>\n  <span class=\"leading-1.3
-          text-2xl text-red-error\">Error</span>\n</div>\n\n                </div>\n
-          \           </div>\n        </div>\n\n        <div class=\"w-240 lg:w-full
-          mx-auto mb-8 lg:px-8\">\n            <div class=\"clearfix\">\n                <div
-          class=\"w-1/2 md:w-full float-left pr-6 md:pb-10 md:pr-0 leading-relaxed\">\n
-          \                   <h2 class=\"text-3xl font-normal leading-1.3 mb-4\">What
-          happened?</h2>\n                    <p>The web server reported a bad gateway
-          error.</p>\n                </div>\n                <div class=\"w-1/2 md:w-full
-          float-left leading-relaxed\">\n                    <h2 class=\"text-3xl font-normal
-          leading-1.3 mb-4\">What can I do?</h2>\n                    <p class=\"mb-6\">Please
-          try again in a few minutes.</p>\n                </div>\n            </div>\n
-          \       </div>\n\n        <div class=\"cf-error-footer cf-wrapper w-240 lg:w-full
-          py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0
-          border-t border-gray-300\">\n  <p class=\"text-13\">\n    <span class=\"cf-footer-item
-          sm:block sm:mb-1\">Cloudflare Ray ID: <strong class=\"font-semibold\">8e8c200aef1c4cb1</strong></span>\n
-          \   <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    <span
-          id=\"cf-footer-item-ip\" class=\"cf-footer-item hidden sm:block sm:mb-1\">\n
-          \     Your IP:\n      <button type=\"button\" id=\"cf-footer-ip-reveal\" class=\"cf-footer-ip-reveal-btn\">Click
-          to reveal</button>\n      <span class=\"hidden\" id=\"cf-footer-ip\">108.36.166.32</span>\n
-          \     <span class=\"cf-footer-separator sm:hidden\">&bull;</span>\n    </span>\n
-          \   <span class=\"cf-footer-item sm:block sm:mb-1\"><span>Performance &amp;
-          security by</span> <a rel=\"noopener noreferrer\" href=\"https://www.cloudflare.com/5xx-error-landing?utm_source=errorcode_502&utm_campaign=api.openai.com\"
-          id=\"brand_link\" target=\"_blank\">Cloudflare</a></span>\n    \n  </p>\n
-          \ <script>(function(){function d(){var b=a.getElementById(\"cf-footer-item-ip\"),c=a.getElementById(\"cf-footer-ip-reveal\");b&&\"classList\"in
-          b&&(b.classList.remove(\"hidden\"),c.addEventListener(\"click\",function(){c.classList.add(\"hidden\");a.getElementById(\"cf-footer-ip\").classList.remove(\"hidden\")}))}var
-          a=document;document.addEventListener&&a.addEventListener(\"DOMContentLoaded\",d)})();</script>\n</div><!--
-          /.error-footer -->\n\n\n    </div>\n</div>\n</body>\n</html>\n"
-      headers:
-        CF-RAY:
-          - 8e8c200aef1c4cb1-PHL
-        Cache-Control:
-          - private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "6329"
-        Content-Type:
-          - text/html; charset=UTF-8
-        Date:
-          - Tue, 26 Nov 2024 19:01:22 GMT
-        Expires:
-          - Thu, 01 Jan 1970 00:00:01 GMT
-        Referrer-Policy:
-          - same-origin
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - _cfuvid=44sHfYfJ3ynTe.FCBn5jWmzTy6fZPJYst0MIsLAb3WY-1732647682631-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Strict-Transport-Security:
-          - max-age=31536000; includeSubDomains; preload
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        alt-svc:
-          - h3=":443"; ma=86400
-      status:
-        code: 502
-        message: Bad Gateway
-  - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Given the following question
-        and a proposed answer to the question, return the single-letter choice in the
-        question that matches the proposed answer. If the proposed answer is blank or
-        an empty string, or multiple options are matched, respond with ''0''.\n\nQuestion:
-        Q: What is my office''s zip code?\n\nOptions:\nA) 94107\nB) 94106\nC) cheesecake\nD)
-        Insufficient information to answer this question\nE) -8\n\nProposed Answer:
-        Insufficient information\n\nSingle Letter Answer:"}], "model": "gpt-4-turbo-2024-04-09",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "594"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.1
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.1
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -205,18 +46,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySzU7DMBCE73kKy+cGpW36ewOhIg6FEwKKUOQ6m9TUsS17UwpV3x05bZNUFIlL
-          DvPtTGY32QWEUJHSKaF8xZAXRobXL5vh43O8XszirTCLzXx2//n0/fpwcxcN5rTjHXr5ARxPriuu
-          CyMBhVYHzC0wBJ/aHfV7w3g0HI8rUOgUpLflBsM4xNIuddiLenEYxWE0ObpXWnBwdEreAkII2VVP
-          31OlsKVTEnVOSgHOsRzotB4ihFotvUKZc8IhU0g7DeRaIaiq+m1bt5CVjvluqpTyqO/rF0mdG6uX
-          7shrPRNKuFVigTmtfKhDbWhF9wEh79VC5VlHaqwuDCao16B8YLfbP+TR5o4temSokcm2Ke5ciEtS
-          QCaka12EcsZXkDbW5nysTIVugaC19O8yl7IPiwuV/ye+AZyDQUgTYyEV/HzhZsyC/8v+GquPXBWm
-          7sshFEkmVA7WWHH4xplJeLYcZBPI2IgG++AHAAD//wMA677grvECAAA=
+          H4sIAAAAAAAAA4ySS0/DMBCE7/kVls8NSvqkvSFxoTcoggNCkeNsUoPjde2NeFT978jpI6koEpcc
+          5tuZzG6yjRjjquALxuVakKytjm/E9El+P+Jy+VA9Tzaz5O5jBffLSk5XsOGD4MD8DSQdXVcSa6uB
+          FJo9lg4EQUhNZ6NROr1O58MW1FiADrbKUjyOqXE5xsNkOI6TcZzMD+41KgmeL9hLxBhj2/YZepoC
+          PvmCJYOjUoP3ogK+OA0xxh3qoHDhvfIkDPFBByUaAtNWv+3rDsrGi9DNNFof9N3pRRor6zD3B37S
+          S2WUX2cOhEcTQj2h5S3dRYy9tgs1Zx25dVhbygjfwYTANB3t83h3xx49MEISum8aDy7EZQWQUNr3
+          LsKlkGsoOmt3PtEUCnsg6i39u8yl7P3iylT/ie+AlGAJisw6KJQ8X7gbcxD+sr/GTkduC3P/5Qnq
+          rFSmAmed2n/j0mayzCflHEox49Eu+gEAAP//AwAfYxlP8QIAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e8c209059be42de-EWR
+          - 8ebdc4343b0467f1-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -224,13 +65,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Tue, 26 Nov 2024 19:01:28 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=PKFOb7ob8VKYLIBBYui.qQX8jxIz1TYv8aozr.ZUtak-1732647688-1.0.1.1-XnVH_jPEP5cODPb1s6ufihNjJJix319g4hOdXmoaIhEv5LRNHAhZQ7CDVo_DO3FrSprKmbJMAlNkm4DyA7AT3g;
-            path=/; expires=Tue, 26-Nov-24 19:31:28 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=WKdWEMcWB7VttbXpVPGUNCMW3X3Z6hQi1UOw52AIOFI-1733168193-1.0.1.1-Y7XAZOnTarPbBFBTIROpuJd9dFRPm8zDAnQ_pyvRfVZe8Q57yv_1o55UQhLILVF6hxOyPhPsYjcN8Xdq0yMrdQ;
+            path=/; expires=Mon, 02-Dec-24 20:06:33 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
+          - _cfuvid=LWtD7Yaqkdqq2aDhxauMxYyiCCxIUOtv1icz4qp3FBc-1733168193095-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -242,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "362"
+          - "304"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -260,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 3ms
         x-request-id:
-          - req_9231dba350e8199d6ec4a7e278f58c76
+          - req_e86eb9a25d48d749eca9d93edfe72af2
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLiteLLMModel.test_max_token_truncation[with-router].yaml
+++ b/tests/cassettes/TestLiteLLMModel.test_max_token_truncation[with-router].yaml
@@ -1,8 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Please tell me a story"}], "model":
-        "gpt-4o-mini", "max_tokens": 3}'
+      body: '{"messages":[{"role":"user","content":"Please tell me a story"}],"model":"gpt-4o-mini","max_tokens":3}'
       headers:
         accept:
           - application/json
@@ -11,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "110"
+          - "102"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -27,7 +25,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -41,18 +39,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4ySzU7DMBCE73kKy+cGJWlKS28U1BOoEhwAIRS59iYxdbzGdiQQ6rsjpz9JRZG4
-          +LDfznh27e+IECoFnRPKa+Z5Y1R8/fD4dD9j9oo/5/xueftyebNYrprF5mOFNR0FBa7fgfuD6oJj
-          YxR4iXqHuQXmIbim03GaJtPZJO9AgwJUkFXGxznGjdQyzpIsj5NpnM726holB0fn5DUihJDv7gw5
-          tYBPOifJ6FBpwDlWAZ0fmwihFlWoUOacdJ5pT0c95Kg96C76SnMgrUFN2LDDQtk6FlLqVql9fXu8
-          UmFlLK7dnh/rpdTS1YUF5lAHewW68jXt+DYi5K0brj3JS43FxvjC4wZ0sEyznSHtV9rD8Z559EwN
-          NJPRGbNCgGdSucFuKGe8BtEr+0WyVkgcgGgw9O8s57x3g0td/ce+B5yD8SAKY0FIfjpv32Yh/Le/
-          2o4r7gJT9+U8NEUpdQXWWLl77dIUyZolIs3yMqXRNvoBAAD//wMAvrJH0vsCAAA=
+          H4sIAAAAAAAAA4ySy07DMBBF9/kKy+sE5dE2ITvYIBY8JCQWIBS5ziQxOLZrOypQ9d+RkzZJRZHY
+          eDFn7vWdsXceQpiVOEeYNsTSVvHgiqyeWfzyRJLN4128hc13nfLbLrqPbrbX2HcKuX4Hao+qCypb
+          xcEyKQZMNRALzjVKkyRaZdFl1oNWlsCdrFY2WMigZYIFcRgvgjANouygbiSjYHCOXj2EENr1p8sp
+          SvjEOQr9Y6UFY0gNOB+bEMJaclfBxBhmLBEW+xOkUlgQffQHQQF1SgpE5h0aqs4Ql1J0nB/q+/FK
+          Lmul5doc+FivmGCmKTQQI4Wz5yBq2+Ce7z2E3vrhupO8WGnZKltY+QHCWUbxYIinlU4wOTArLeEz
+          zdI/Y1aUYAnjZrYbTAltoJyU0yJJVzI5A95s6N9ZznkPgzNR/8d+ApSCslAWSkPJ6Om8U5sG99/+
+          ahtX3AfG5stYaIuKiRq00mx47UoVYRou11WW0hB7e+8HAAD//wMALERyAfsCAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946f7b869967f-SJC
+          - 8ebdc4544d45159c-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -60,14 +58,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:34 GMT
+          - Mon, 02 Dec 2024 19:36:38 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=4Hfn3z1hBbF21VTNTfj0la4U1FprfYGMuW6SJFHFMTk-1731107854-1.0.1.1-IlnK_DV2fPFFo1K.4nwWKrmX7j5rphJ64Dwu4loRbItMxBR3qlUVv5M37TM5si058nrMVjH1XmIwkAsKrnSH3g;
-            path=/; expires=Fri, 08-Nov-24 23:47:34 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=oW7puVMoQxr5tfjOcrapj0cZDKsrgYGaypvH9Uy3hSI-1733168198-1.0.1.1-uJC65w6KU6H27oReIU5GNAQPRZ4qPR3j9dIaq2hz6jVoKgdGs7ORtYIpVqMZj.wvHiGRmjqwMgLXFbenTXS.hw;
+            path=/; expires=Mon, 02-Dec-24 20:06:38 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=8iYvs22_cvb6pdXrAvFmyv9mDiYXEZlmkBAqOnqXYM0-1731107854556-0.0.1.1-604800000;
+          - _cfuvid=1WbywTWsVng0pYLbjxFjjVkHNIA_Tp7Yyi2qWtRgTRA-1733168198303-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -80,7 +78,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "417"
+          - "355"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -92,13 +90,13 @@ interactions:
         x-ratelimit-remaining-requests:
           - "29999"
         x-ratelimit-remaining-tokens:
-          - "149999990"
+          - "149999989"
         x-ratelimit-reset-requests:
           - 2ms
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_191720674eda0126fcb1971a5d9a3bf9
+          - req_821f2596e6f5471e8d9b50ea7c01c3b1
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLiteLLMModel.test_max_token_truncation[without-router].yaml
+++ b/tests/cassettes/TestLiteLLMModel.test_max_token_truncation[without-router].yaml
@@ -1,8 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "Please tell me a story"}], "model":
-        "gpt-4o-mini", "max_tokens": 3}'
+      body: '{"messages":[{"role":"user","content":"Please tell me a story"}],"model":"gpt-4o-mini","max_tokens":3}'
       headers:
         accept:
           - application/json
@@ -11,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "110"
+          - "102"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -27,7 +25,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -41,18 +39,18 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4yST0sDMRDF7/spQs5d2W0rLb156EFQiv8QFFnSZHY3NZuJySyopd9dsq3dLSp4
-          yWF+817eTLJNGONa8QXjshYkG2fSi9u7x+slra7wYYaT+yfxduOuy8/lK60uN3wUFbjegKRv1ZnE
-          xhkgjXaPpQdBEF3z2STPs9n8fNqBBhWYKKscpVNMG211Os7G0zSbpfn8oK5RSwh8wZ4TxhjbdmfM
-          aRW88wXLRt+VBkIQFfDFsYkx7tHEChch6EDCEh/1UKIlsF30lZXAWoeWiWGHh7INIqa0rTGH+u54
-          pcHKeVyHAz/WS211qAsPIqCN9gZsRTXv+C5h7KUbrj3Jy53HxlFB+Ao2WubjvSHvV9rDyYERkjAD
-          zfnoF7NCAQltwmA3XApZg+qV/SJFqzQOQDIY+meW37z3g2tb/ce+B1KCI1CF86C0PJ23b/MQ/9tf
-          bccVd4F5+AgETVFqW4F3Xu9fu3RFthaZysfTMufJLvkCAAD//wMA1oGV8vsCAAA=
+          H4sIAAAAAAAAA4ySzU7DMBCE73kKy+cGJf1Lya2HAqISHEBICKHIdTaJwbEte1NRob47ctI2qSgS
+          Fx/22xnPrv0dEEJFTlNCecWQ10aGSzZ/qZ63D6ubaPmktnfrdX17v3ptCnR8R0deoTcfwPGouuK6
+          NhJQaNVhboEheNc4mUzi+SK+TlpQ6xykl5UGw6kOa6FEOI7G0zBKwnhxUFdacHA0JW8BIYR8t6fP
+          qXL4oimJRsdKDc6xEmh6aiKEWi19hTLnhEOmkI56yLVCUG30R8WBNEYrwoYdForGMZ9SNVIe6vvT
+          lVKXxuqNO/BTvRBKuCqzwJxW3l6CKrGiLd8HhLy3wzVneamxujaYof4E5S3jcWdI+5X2cHJgqJHJ
+          gWY2umCW5YBMSDfYDeWMV5D3yn6RrMmFHoBgMPTvLJe8u8GFKv9j3wPOwSDkmbGQC34+b99mwf+3
+          v9pOK24DU7dzCHVWCFWCNVZ0r12YLEqi2aZYJDyiwT74AQAA//8DANjahjr7AgAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946fb4e2015ce-SJC
+          - 8ebdc45119526892-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -60,14 +58,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:34 GMT
+          - Mon, 02 Dec 2024 19:36:37 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=xkxfETfBzpHDuqFJV0tC1eKsyciCodPhcMeEya_5fpo-1731107854-1.0.1.1-5OyfhxnkxN8WLYXSC_WUrt31uiERNfmJ48ELADXD7xqKyaoAnhFM0GlJa85UvNpNtzM1.EPdKyRUrbY4ctXPUQ;
-            path=/; expires=Fri, 08-Nov-24 23:47:34 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=B4EmoPZ6h4dq4c2NuwMouXS.M.3etMDSaWSw2BxuW9s-1733168197-1.0.1.1-gm.BSZHRSUJO2qBgm_uGGCEXncRIw5.cDOUKDp.XyI5jwqwxiNQJvblmx9R3W6oyuZgF3Ki_2rYH7FH1gHaD3Q;
+            path=/; expires=Mon, 02-Dec-24 20:06:37 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=7HAFOyODvsZiujM1_CURuA67gABnusKWhReCZS4OwNk-1731107854972-0.0.1.1-604800000;
+          - _cfuvid=ZfFIlaLbyji77NOD0shqvQ5zf8MiR4dOnvSu62_Zhns-1733168197643-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -80,7 +78,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "253"
+          - "234"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -98,7 +96,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_350352413fa3353c4cee3df455587525
+          - req_b1a892225ab26d3f234d45c6781778a1
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLiteLLMModel.test_run_prompt[with-router].yaml
+++ b/tests/cassettes/TestLiteLLMModel.test_run_prompt[with-router].yaml
@@ -1,9 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "stream": true, "stream_options": {"include_usage": true},
-        "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"stream":true,"stream_options":{"include_usage":true},"temperature":0}'
       headers:
         accept:
           - application/json
@@ -12,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "179"
+          - "164"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -28,7 +25,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -42,134 +39,123 @@ interactions:
     response:
       body:
         string:
-          'data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+          'data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           duck"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           says"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          Ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          It''s"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          are"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          a"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          known"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          classic"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          for"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          their"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          distinctive"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          qu"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"acking"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           sound"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          associated"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          Is"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          with"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          there"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          something"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          specific"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          you"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          would"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          like"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          to"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          know"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
-          about"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          Is"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          there"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          something"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          specific"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          you''d"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          like"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          to"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          know"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          about"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           or"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           their"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           sounds"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWLpAtsgZ3hpa51k54JFdY22PWX","object":"chat.completion.chunk","created":1731107853,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_9b78b61c52","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":32,"total_tokens":42,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+          data: {"id":"chatcmpl-Aa6VduB9wkGpejmsiNpaAGNJDeOfC","object":"chat.completion.chunk","created":1733168193,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":29,"total_tokens":39,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
           data: [DONE]
@@ -180,20 +166,20 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946f3ca10fac2-SJC
+          - 8ebdc438396e943e-SJC
         Connection:
           - keep-alive
         Content-Type:
           - text/event-stream; charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:33 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=15Wx.aGifiEsnOo10jdimLTJ23s._JT7MhVaRu.U8lg-1731107853-1.0.1.1-Jq3nQzX.ckLI68dz6oJTd6aO6yuIucm.M6I8fBiNhpvtml3dLpzOJ8.ZTe8uECcWa_iStEWxE5B.S1jUM8GHeA;
-            path=/; expires=Fri, 08-Nov-24 23:47:33 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=2u1fngKgS6Tlm2tXKnmb6nYHLypr6koX7LxGGLHM94E-1733168193-1.0.1.1-9Ca4qFYZ67jPTZEwesj0rWuNqb9Cjejd4S6or1N1Mfwm0rzWwIrVyoZCJLX.X9wrZbVsYNGU2WYU1h4nrIsqmQ;
+            path=/; expires=Mon, 02-Dec-24 20:06:33 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=EMrZITzWWuQ1vT7DmNMdRpKWl9md2FrvNKb.7Dw0zVY-1731107853816-0.0.1.1-604800000;
+          - _cfuvid=ZbU5wT.mgiGZXJsNyN9s.Wz.dHC7TPnaSAbYQRtrLUE-1733168193723-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -206,7 +192,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "308"
+          - "307"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -224,14 +210,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_b1e2631585fdd80cf560b251f9d150d7
+          - req_fdfe606307e41fe10b36661d69fa89c8
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "stream": false, "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"stream":false,"temperature":0}'
       headers:
         accept:
           - application/json
@@ -240,13 +224,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "137"
+          - "125"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -256,7 +240,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -270,19 +254,20 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSy27bMBC86yu2PFuF5Niw4UvhUy4JULRFfWgKgSZXEmOKy3BJpG7gfy8kP2Qj
-          LdALDzM7w5kl3zIAYbRYgVCtjKrzNl9/+bp5JH6cL+5f1u1zR8vNQ1h//k71b5yLSa+g7TOqeFZ9
-          VNR5i9GQO9IqoIzYu5aLu7IsFsv5bCA60mh7WeNjPqO8M87k02I6y4tFXi5P6paMQhYr+JEBALwN
-          Z5/TafwlVlBMzkiHzLJBsboMAYhAtkeEZDYcpYtiMpKKXEQ3RP/WIuikdsByz/AkXpJUuw9PAjat
-          jICWEV4pWQ17SmDNDiES7By9gtxSioOWgQLEFk0ApuQ0f7q+LGCdWPaFXbL2hB8u6S01PtCWT/wF
-          r40z3FYBJZPrk3IkLwb2kAH8HLaUbooLH6jzsYq0Q9cblqclifFtRnJ6JiNFaUf87ozfuFUaozSW
-          r7YslFQt6lE5PolM2tAVkV11fh/mb97H3sY1/2M/Ekqhj6grH1AbdVt4HAvY/9x/jV12PAQWvOeI
-          XVUb12DwwRz/Te2rYisLXU5ndSmyQ/YHAAD//wMAaabeVkUDAAA=
+          H4sIAAAAAAAAA4xSy27bMBC86yu2vORiBfKjseNL0UuB3HoIihRNIdDkSmJNcVXuCokb+N8Lyg/Z
+          aAv0osPMzmhml28ZgHJWrUGZRotpO59/1HdfsBb7VDerX4/+9Q6fFubr54Y/Vf1GTZKCNj/QyEl1
+          a6jtPIqjcKBNRC2YXKfL+Xx6t5reLwaiJYs+yepO8gXlrQsunxWzRV4s8+nqqG7IGWS1hm8ZAMDb
+          8E05g8VXtYZickJaZNY1qvV5CEBF8glRmtmx6CBqMpKGgmAYoj82CLY3W2C9Y3hWP3tttu+eFTzI
+          DYMG45ODAaY+WNDMZFyqBS9OmkHJt/DAIA1GBKYWpXGhBu7QuMoZ2FF/Y8G7LYIQbAO9gN5QLwct
+          UExSFw8/4A+XMSNWPeu0qtB7f8T3596e6i7Sho/8Ga9ccNyUETVTSB1ZqFMDu88Avg/77a9WprpI
+          bSel0BZDMpwe16vGq47k7P5ICon2Iz4/4VdupUXRzvPFfZTRpkE7Ksdj6t46uiCyi85/hvmb96G3
+          C/X/2I+EMdgJ2rKLaJ25LjyORUxv/l9j5x0PgRXvWLAtKxdqjF10hxdXdWWxLN5vqtXSFCrbZ78B
+          AAD//wMAnaJn838DAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946fb0847cf0e-SJC
+          - 8ebdc43cfd522519-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -290,14 +275,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:35 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=y1Q1ERgXEKDkEzap4NpM101lOfXxO2ZeqN1fg7NF_VE-1731107855-1.0.1.1-K24OYJupHAnx91TgXTNsJ0EfbRlibU9GDPX8TwrnrO8RM.obCJXTDmM7IQV4Wz46PWbhN6L9BH5m4gPqfb1yLw;
-            path=/; expires=Fri, 08-Nov-24 23:47:35 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=mxHyJRRzx5XnR1YSAPyEP8_FWVKULqXtm.SncxAybbA-1733168194-1.0.1.1-ixMAgpoHzk9MZm7qpDH2HRcGzXSu3ZZV3G7WwBvmyuVtX.CpqBy6t2.R6_LUbfs22Qa_MDouPUB7N_xMdsoZZw;
+            path=/; expires=Mon, 02-Dec-24 20:06:34 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=3evjgXXQlk7Q60MHMKVPMDZv24QQ04AE1E9MHjEY1ls-1731107855132-0.0.1.1-604800000;
+          - _cfuvid=r2_TJDNuRJlCyaPCVZrbNqjA0_iJaBdR5ZL0vLtcm5U-1733168194665-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -310,7 +295,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "481"
+          - "469"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -328,15 +313,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_c086cdb8a344306adf935cdeebc219e8
+          - req_f412130829f1cc797f0a6fc2d9f56963
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "stream": true, "stream_options": {"include_usage": true},
-        "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"stream":true,"stream_options":{"include_usage":true},"temperature":0}'
       headers:
         accept:
           - application/json
@@ -345,13 +327,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "179"
+          - "164"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -361,7 +343,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -375,88 +357,123 @@ interactions:
     response:
       body:
         string:
-          'data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+          'data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           duck"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           says"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          What"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          It''s"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          else"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          a"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          would"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          classic"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          you"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          sound"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          like"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          associated"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          to"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          with"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          know"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
-          about"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          Is"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          there"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          something"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          specific"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          you''d"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          like"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          to"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          know"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          about"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           or"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           their"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           sounds"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWNHKwOLONV2RvnkY5Dmx2jlLpD","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_f59a81427f","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+          data: {"id":"chatcmpl-Aa6VelKYT2pbhd9IkijQAtDOaYXeX","object":"chat.completion.chunk","created":1733168194,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":29,"total_tokens":39,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
           data: [DONE]
@@ -467,13 +484,13 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946feaed6fac2-SJC
+          - 8ebdc440cacb943e-SJC
         Connection:
           - keep-alive
         Content-Type:
           - text/event-stream; charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:35 GMT
+          - Mon, 02 Dec 2024 19:36:35 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -487,7 +504,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "117"
+          - "194"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -505,7 +522,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_048651465f682dd8101aa7ff5158b18a
+          - req_875d8ee546e576d5ab2b8f441cef6877
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestLiteLLMModel.test_run_prompt[without-router].yaml
+++ b/tests/cassettes/TestLiteLLMModel.test_run_prompt[without-router].yaml
@@ -1,9 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "stream": true, "stream_options": {"include_usage": true},
-        "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"stream":true,"stream_options":{"include_usage":true},"temperature":0}'
       headers:
         accept:
           - application/json
@@ -12,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "179"
+          - "164"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -28,7 +25,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -42,88 +39,119 @@ interactions:
     response:
       body:
         string:
-          'data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+          'data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           duck"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           says"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          What"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          It''s"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          else"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          a"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          would"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          classic"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          you"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          sound"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          like"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          associated"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          to"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          with"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          know"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          about"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          Is"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          there"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          something"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          specific"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          you''d"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          like"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          to"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          know"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
           or"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          their"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          discuss"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"
-          sounds"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          about"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"
+          ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWN8Mc8EAvq80JokpGvgrKIYm6g","object":"chat.completion.chunk","created":1731107855,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_8bfc6a7dc2","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+
+
+          data: {"id":"chatcmpl-Aa6VfqUEKPJQbxDIxOGKc1lzJNUn7","object":"chat.completion.chunk","created":1733168195,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0705bf87c0","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":28,"total_tokens":38,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
           data: [DONE]
@@ -134,20 +162,20 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df947021db47aca-SJC
+          - 8ebdc4464aa996e7-SJC
         Connection:
           - keep-alive
         Content-Type:
           - text/event-stream; charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:35 GMT
+          - Mon, 02 Dec 2024 19:36:35 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=BxHVxT_w09oYBcxXX4G5MI1esS8GPjidlHURUj_WP5c-1731107855-1.0.1.1-BuQ1GQx0bUQ16XVApA.nQqyvH.KjRY3sLD0LwrqircJ7Moko1bYfjS8SLBLkngJCUKcJQsNIBDTAk.6YgXnBrQ;
-            path=/; expires=Fri, 08-Nov-24 23:47:35 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=_gkOw42xVwtkT5Lqo._EV8hz4KREzv7MJ5LRkRuMTx0-1733168195-1.0.1.1-2x6g0IN12YWmP7EGeieGZjmoUqQ2fKDJP3K6aOPZPlPK8oq1l3Ivx85Cos6gdRBnyCYIs86dN0Yqp4w_OYp1uQ;
+            path=/; expires=Mon, 02-Dec-24 20:06:35 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=C75b1_zyc9QyhmQvdtA0a.VlRf86Eupk012nxHXNxdQ-1731107855904-0.0.1.1-604800000;
+          - _cfuvid=zJTgrmJydAc3CnSp71j2RyGg1Uw3UQZUkWHg71cZce4-1733168195882-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -160,7 +188,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "110"
+          - "210"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -178,14 +206,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_9a65d929342ea06db74e3248d109fcc4
+          - req_63ac217726eef46346c28c69db3e5536
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"temperature":0}'
       headers:
         accept:
           - application/json
@@ -194,13 +220,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "120"
+          - "110"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -210,7 +236,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -224,19 +250,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSTY/TMBS851c8fG5Q0nbp0gsCcUXLLqDVwqLItV8abxw/42drW63631HSj7QC
-          JC4+zLwZzzz7JQMQRoslCNXIqDpv8/d3X+5v7m6vHj5+e9iEp1Z94rffbz7o2cbefhaTXkGrJ1Tx
-          qHqtqPMWoyG3p1VAGbF3LRezsiwW11dvBqIjjbaXrX3M55R3xpl8WkznebHIy+uDuiGjkMUSfmQA
-          AC/D2ed0GjdiCcXkiHTILNcolqchABHI9oiQzIajdFFMRlKRi+iG6F8bBJ1UCyy3DI/iV5KqffUo
-          4L6REdAywjMlq2FLCaxpESJB6+gZ5IpSHLQMFCA2aAIwJaf53fllAevEsi/skrUHfHdKb2ntA634
-          wJ/w2jjDTRVQMrk+KUfyYmB3GcDPYUvporjwgTofq0gtut6wPCxJjG8zktMjGSlKO+KzI37hVmmM
-          0lg+27JQUjWoR+X4JDJpQ2dEdtb5zzB/8973Nm79P/YjoRT6iLryAbVRl4XHsYD9z/3X2GnHQ2DB
-          W47YVbVxaww+mP2/qX1VrGShy+m8LkW2y34DAAD//wMAf0GgrEUDAAA=
+          H4sIAAAAAAAAA4xSXY/TMBB8z69Y/NygpK16R18QEkJInAQ6wSHgUOTY28QXx2u8to7q1P9+SvqR
+          VoDEix9mdsYzaz9lAMJosQahWhlV723+Rq7umi/1Yvn+7l3zcNPffnz76bbt2g/fvt/0YjYoqH5A
+          FY+ql4p6bzEacntaBZQRB9fyarEoV9flq9VI9KTRDrLGx3xJeW+cyefFfJkXV3l5fVC3ZBSyWMOP
+          DADgaTyHnE7jb7GGYnZEemSWDYr1aQhABLIDIiSz4ShdFLOJVOQiujH65xZBJ9UByy3DvfiVpOpe
+          3Av42soIaBnhkZLVsKUE1nQIkaBz9AiyphRHLQMFiC2aAEzJaX59flnATWI5FHbJ2gO+O6W31PhA
+          NR/4E74xznBbBZRMbkjKkbwY2V0G8HPcUrooLnyg3scqUoduMCwPSxLT20zk/EhGitJO+OKIX7hV
+          GqM0ls+2LJRULepJOT2JTNrQGZGddf4zzN+8972Na/7HfiKUQh9RVz6gNuqy8DQWcPi5/xo77XgM
+          LHjLEftqY1yDwQez/zcbXxW1LHQ5X25Kke2yZwAAAP//AwD2l3q3RQMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df94704e8ec7aca-SJC
+          - 8ebdc44aaf1496e7-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -244,7 +270,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:36 GMT
+          - Mon, 02 Dec 2024 19:36:36 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -258,7 +284,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "579"
+          - "548"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -276,15 +302,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_0e3c8436f89ddbe05aa61550a958ada4
+          - req_7c6f3ec236d583a022058d3ddf4fc52c
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"messages": [{"role": "user", "content": "The duck says"}], "model": "gpt-4o-mini",
-        "max_tokens": 56, "stream": true, "stream_options": {"include_usage": true},
-        "temperature": 0}'
+      body: '{"messages":[{"role":"user","content":"The duck says"}],"model":"gpt-4o-mini","max_tokens":56,"stream":true,"stream_options":{"include_usage":true},"temperature":0}'
       headers:
         accept:
           - application/json
@@ -293,13 +316,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "179"
+          - "164"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -309,7 +332,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -323,123 +346,123 @@ interactions:
     response:
       body:
         string:
-          'data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+          'data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           duck"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           says"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"qu"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"ack"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           It''s"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           a"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           classic"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           sound"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           associated"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           with"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           Is"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           there"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           something"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           specific"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           you''d"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           like"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           to"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           know"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           about"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           ducks"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           or"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           their"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"
           sounds"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
 
 
-          data: {"id":"chatcmpl-ARSWOP6iZd8RHyYT6sIVKnDlTMZ4x","object":"chat.completion.chunk","created":1731107856,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_0ba0d124f1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":29,"total_tokens":39,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+          data: {"id":"chatcmpl-Aa6Vhd4X0PLP7nPSajlxJOOHsDQ3L","object":"chat.completion.chunk","created":1733168197,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_3de1288069","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":29,"total_tokens":39,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
           data: [DONE]
@@ -450,13 +473,13 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df947093df97aca-SJC
+          - 8ebdc44ecb5f96e7-SJC
         Connection:
           - keep-alive
         Content-Type:
           - text/event-stream; charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:37 GMT
+          - Mon, 02 Dec 2024 19:36:37 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -470,7 +493,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "170"
+          - "293"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -488,7 +511,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_4f45826ac261e479f76b20e2d8b4a5a6
+          - req_7b72df27e5fc6e0577d8dc5b06d15236
       status:
         code: 200
         message: OK

--- a/tests/cassettes/TestTaskDataset.test_tool_failure.yaml
+++ b/tests/cassettes/TestTaskDataset.test_tool_failure.yaml
@@ -1,55 +1,44 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Use the tools to answer the
-        question: Q: Who is Frederick Bates?\n\nOptions:\nA) Plumber\nB) Insufficient
-        information to answer this question\nC) Politician\nD) Technologist\n\nWhen
-        the answer looks sufficient, you can terminate by calling the complete tool.
-        If the answer does not look sufficient, and you have already tried to answer
-        several times with different evidence, terminate by calling the complete tool.
-        The current status of evidence/papers/cost is Status: Paper Count=0 | Relevant
-        Papers=0 | Current Evidence=0 | Current Cost=$0.0000"}], "model": "gpt-4o-2024-08-06",
-        "temperature": 0.1, "tool_choice": "required", "tools": [{"type": "function",
-        "function": {"name": "reset", "description": "Reset by clearing all current
-        evidence from the system.\n\nThis tool is useful when repeatedly failing to
-        answer because new evidence can give new perspective.\nIt does not make sense
-        to call this tool in parallel with other tools, as its resetting all state.\nOnly
-        invoke this tool when the current evidence is above zero, or this tool will
-        be useless.", "parameters": {"type": "object", "properties": {}, "required":
-        []}}}, {"type": "function", "function": {"name": "gen_answer", "description":
-        "Generate an answer using current evidence.\n\nThe tool may fail, indicating
-        that better or different evidence should be found.\nAim for at least five pieces
-        of evidence from multiple sources before invoking this tool.\nFeel free to invoke
-        this tool in parallel with other tools, but do not call this tool in parallel
-        with itself.", "parameters": {"type": "object", "properties": {}, "required":
-        []}}}, {"type": "function", "function": {"name": "gather_evidence", "description":
-        "Gather evidence from previous papers given a specific question to increase
-        evidence and relevant paper counts.\n\nA valuable time to invoke this tool is
-        right after another tool increases paper count.\nFeel free to invoke this tool
-        in parallel with other tools, but do not call this tool in parallel with itself.\nOnly
-        invoke this tool when the paper count is above zero, or this tool will be useless.",
-        "parameters": {"type": "object", "properties": {"question": {"description":
-        "Specific question to gather evidence for.", "title": "Question", "type": "string"}},
-        "required": ["question"]}}}, {"type": "function", "function": {"name": "paper_search",
-        "description": "Search for papers to increase the paper count.\n\nRepeat previous
-        calls with the same query and years to continue a search. Only repeat a maximum
-        of twice.\nThis tool can be called concurrently.\nThis tool introduces novel
-        papers, so invoke this tool when just beginning or when unsatisfied with the
-        current evidence.", "parameters": {"type": "object", "properties": {"query":
-        {"description": "A search query, which can be a specific phrase, complete sentence,
-        or general keywords, e.g. ''machine learning for immunology''. Also can be given
-        search operators.", "title": "Query", "type": "string"}, "min_year": {"anyOf":
-        [{"type": "integer"}, {"type": "null"}], "description": "Filter for minimum
-        publication year, or None for no minimum year. The current year is 2024.", "title":
-        "Min Year"}, "max_year": {"anyOf": [{"type": "integer"}, {"type": "null"}],
-        "description": "Filter for maximum publication year, or None for no maximum
-        year. The current year is 2024.", "title": "Max Year"}}, "required": ["query",
-        "min_year", "max_year"]}}}, {"type": "function", "function": {"name": "complete",
-        "description": "Terminate using the last proposed answer.\n\nDo not invoke this
-        tool in parallel with other tools or itself.", "parameters": {"type": "object",
-        "properties": {"is_sure": {"description": "Set True if sure of the answer, otherwise
-        False if there remains some uncertainty.", "title": "Is Sure", "type": "boolean"}},
-        "required": ["is_sure"]}}}]}'
+        '{"messages":[{"role":"user","content":"Use the tools to answer the question:
+        Q: Who is Frederick Bates?\n\nOptions:\nA) Insufficient information to answer
+        this question\nB) Technologist\nC) Plumber\nD) Politician\n\nWhen the answer
+        looks sufficient, you can terminate by calling the complete tool. If the answer
+        does not look sufficient, and you have already tried to answer several times
+        with different evidence, terminate by calling the complete tool. The current
+        status of evidence/papers/cost is Status: Paper Count=0 | Relevant Papers=0
+        | Current Evidence=0 | Current Cost=$0.0000"}],"model":"gpt-4o-2024-08-06","temperature":0.1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"reset","description":"Reset
+        by clearing all current evidence from the system.\n\nThis tool is useful when
+        repeatedly failing to answer because the existing evidence may unsuitable for
+        the question.\nIt does not make sense to call this tool in parallel with other
+        tools, as its resetting all state.\nOnly invoke this tool when the current evidence
+        is above zero, or this tool will be useless.","parameters":{"type":"object","properties":{},"required":[]}}},{"type":"function","function":{"name":"gen_answer","description":"Generate
+        an answer using current evidence.\n\nThe tool may fail, indicating that better
+        or different evidence should be found.\nAim for at least five pieces of evidence
+        from multiple sources before invoking this tool.\nFeel free to invoke this tool
+        in parallel with other tools, but do not call this tool in parallel with itself.","parameters":{"type":"object","properties":{},"required":[]}}},{"type":"function","function":{"name":"gather_evidence","description":"Gather
+        evidence from previous papers given a specific question to increase evidence
+        and relevant paper counts.\n\nA valuable time to invoke this tool is right after
+        another tool increases paper count.\nFeel free to invoke this tool in parallel
+        with other tools, but do not call this tool in parallel with itself.\nOnly invoke
+        this tool when the paper count is above zero, or this tool will be useless.","parameters":{"type":"object","properties":{"question":{"description":"Specific
+        question to gather evidence for.","title":"Question","type":"string"}},"required":["question"]}}},{"type":"function","function":{"name":"paper_search","description":"Search
+        for papers to increase the paper count.\n\nRepeat previous calls with the same
+        query and years to continue a search. Only repeat a maximum of twice.\nThis
+        tool can be called concurrently.\nThis tool introduces novel papers, so invoke
+        this tool when just beginning or when unsatisfied with the current evidence.","parameters":{"type":"object","properties":{"query":{"description":"A
+        search query, which can be a specific phrase, complete sentence, or general
+        keywords, e.g. ''machine learning for immunology''. Also can be given search
+        operators.","title":"Query","type":"string"},"min_year":{"anyOf":[{"type":"integer"},{"type":"null"}],"description":"Filter
+        for minimum publication year, or None for no minimum year. The current year
+        is 2024.","title":"Min Year"},"max_year":{"anyOf":[{"type":"integer"},{"type":"null"}],"description":"Filter
+        for maximum publication year, or None for no maximum year. The current year
+        is 2024.","title":"Max Year"}},"required":["query","min_year","max_year"]}}},{"type":"function","function":{"name":"complete","description":"Terminate
+        using the last proposed answer.\n\nDo not invoke this tool in parallel with
+        other tools or itself.","parameters":{"type":"object","properties":{"has_successful_answer":{"description":"Set
+        True if an answer that addresses all parts of the task has been generated, otherwise
+        set False to indicate unsureness.","title":"Has Successful Answer","type":"boolean"}},"required":["has_successful_answer"]}}}]}'
       headers:
         accept:
           - application/json
@@ -58,13 +47,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "3843"
+          - "3820"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -74,11 +63,11 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
-          - "0"
+          - "2"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
@@ -88,21 +77,20 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xT72vbMBD97r9C3OdkxE6aH/7WQcq2sq5jGZTNxSjS2dEqS4ok05qQ/33YSWwn
-          zWD+YMQ9vXd37067gBAQHGICbEM9K4wc3v7E9efV8n7ycPsUVk+vJf56rfQdlz9W9ysY1Ay9/oPM
-          n1gfmC6MRC+0OsDMIvVYq4azcTifLqJZ1ACF5ihrWm78cKKH0SiaDEfz4Wh6JG60YOggJr8DQgjZ
-          Nf+6RMXxDWIyGpwiBTpHc4S4vUQIWC3rCFDnhPNUeRh0INPKo6qrVqWUPcBrLVNGpewSH75d79z5
-          RKVMH+yWLfVXv/z26ftjdJNn2fbLI46jXr6DdGWagrJSsdafHt7G44tkhICiRcM11KBNHVLLNhd8
-          QoDavCxQ+bp22CWwLdFWCcQJ3FnkaAV7IR+pR5fAIIFCqLRCahOIGxMSKOhbP7KHswT74Nr5uWee
-          xax0VB5dPcb37Zikzo3Va3fhOmRCCbdJLVLXdN8fQnDK1uSB8mzOYKwujE+9fkFVy07DxUEVujXs
-          0Gh2BL32VPZYk+ngil7K0VPRLEK7e4yyDfKO2u0gLbnQPSDo9f6+mmvah/6Fyv9HvgMYQ+ORp8Yi
-          F+y84+6axfqV/uta63JTMLjKeSzSTKgcrbGieSiQmTS8WfD5eBIyBsE++AsAAP//AwBBMkn3MQQA
-          AA==
+          H4sIAAAAAAAAA4xTTW/bMAy9+1cIPCeDEzdfvrXAtmKHFRhWtMM8GKxM21plSZHkIWmQ/17YSWwn
+          y4D5YAh8eo/kI7ULGAORQcyAl+h5ZeT4FufP+f362w/xSE/8+eNk9Ydms3D9ZbN9eINRw9Avv4n7
+          E+sD15WR5IVWB5hbQk+N6mQRRZP5MpqsWqDSGcmGVhg/vtHjaTi9GYfLcTg/EkstODmI2c+AMcZ2
+          7b8pUWW0gZiFo1OkIuewIIi7S4yB1bKJADonnEflYdSDXCtPqqla1VIOAK+1TDlK2Sc+fLvBufcJ
+          pUy/r+4X9NXjY1HP8tvy6e2u/lxH4mGQ7yC9NW1Bea14588A7+LxRTLGQGHVcg0asqkjtLy84DMG
+          aIu6IuWb2mGXwLomu00gTuCTpYys4K/sDj25BEYJVEKlW0KbQNyakECFm2FkD2cJ9sG186+BeZby
+          2qE8unqM77sxSV0Yq1/cheuQCyVcmVpC13Y/HEJwytbmgfpszmCsroxPvX4l1cjOo+lBFfo17NHp
+          4gh67VEOWLPV6IpempFH0S5Ct3sceUlZT+13EOtM6AEQDHr/u5pr2of+hSr+R74HOCfjKUuNpUzw
+          8477a5aaV/qva53LbcHgts5TleZCFWSNFe1Dgdyky2hC4XyRLacQ7IN3AAAA//8DAHEjanQxBAAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e41e44318f2faa2-SJC
+          - 8ebdc74a5a00aab2-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -110,15 +98,9 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Sun, 17 Nov 2024 18:47:52 GMT
+          - Mon, 02 Dec 2024 19:38:39 GMT
         Server:
           - cloudflare
-        Set-Cookie:
-          - __cf_bm=jhfMKZjWPLSsKzx_16Vo.PS7MbK.m2Yv2L6xzSxiDLs-1731869272-1.0.1.1-Sxas2qCf5B05jFaCrMqoQZxRAFtpXmFYsRvOUMr83Qlzp2abESZKw.Qohl5XoWpbz3QMm9dYwsjMG5nvP_LkDw;
-            path=/; expires=Sun, 17-Nov-24 19:17:52 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=n6noIFkeSNQpekR.9MXcMne3C0jT870V1bj.C6UuKIA-1731869272492-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -130,7 +112,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "485"
+          - "754"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -148,66 +130,52 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_e548c88c9a6d130fa58ff0484a6ce9f9
+          - req_49c6030ccc52c2847bcf4a075f0271dc
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Use the tools to answer the
-        question: Q: Who is Frederick Bates?\n\nOptions:\nA) Plumber\nB) Insufficient
-        information to answer this question\nC) Politician\nD) Technologist\n\nWhen
-        the answer looks sufficient, you can terminate by calling the complete tool.
-        If the answer does not look sufficient, and you have already tried to answer
-        several times with different evidence, terminate by calling the complete tool.
-        The current status of evidence/papers/cost is Status: Paper Count=0 | Relevant
-        Papers=0 | Current Evidence=0 | Current Cost=$0.0000"}, {"role": "assistant",
-        "content": null, "function_call": null, "tool_calls": [{"id": "call_NrqcEoMtEOHQP25gffqJPe32",
-        "type": "function", "function": {"arguments": "{\"query\": \"Frederick Bates\",
-        \"min_year\": null, \"max_year\": null}", "name": "paper_search"}}]}, {"role":
-        "tool", "content": "Encountered exception during tool call: Totally unexpected
-        but retryable error.", "name": "paper_search", "tool_call_id": "call_NrqcEoMtEOHQP25gffqJPe32"}],
-        "model": "gpt-4o-2024-08-06", "temperature": 0.1, "tool_choice": "required",
-        "tools": [{"type": "function", "function": {"name": "reset", "description":
-        "Reset by clearing all current evidence from the system.\n\nThis tool is useful
-        when repeatedly failing to answer because new evidence can give new perspective.\nIt
-        does not make sense to call this tool in parallel with other tools, as its resetting
-        all state.\nOnly invoke this tool when the current evidence is above zero, or
-        this tool will be useless.", "parameters": {"type": "object", "properties":
-        {}, "required": []}}}, {"type": "function", "function": {"name": "gen_answer",
-        "description": "Generate an answer using current evidence.\n\nThe tool may fail,
-        indicating that better or different evidence should be found.\nAim for at least
-        five pieces of evidence from multiple sources before invoking this tool.\nFeel
-        free to invoke this tool in parallel with other tools, but do not call this
-        tool in parallel with itself.", "parameters": {"type": "object", "properties":
-        {}, "required": []}}}, {"type": "function", "function": {"name": "gather_evidence",
-        "description": "Gather evidence from previous papers given a specific question
-        to increase evidence and relevant paper counts.\n\nA valuable time to invoke
-        this tool is right after another tool increases paper count.\nFeel free to invoke
-        this tool in parallel with other tools, but do not call this tool in parallel
-        with itself.\nOnly invoke this tool when the paper count is above zero, or this
-        tool will be useless.", "parameters": {"type": "object", "properties": {"question":
-        {"description": "Specific question to gather evidence for.", "title": "Question",
-        "type": "string"}}, "required": ["question"]}}}, {"type": "function", "function":
-        {"name": "paper_search", "description": "Search for papers to increase the paper
-        count.\n\nRepeat previous calls with the same query and years to continue a
-        search. Only repeat a maximum of twice.\nThis tool can be called concurrently.\nThis
-        tool introduces novel papers, so invoke this tool when just beginning or when
-        unsatisfied with the current evidence.", "parameters": {"type": "object", "properties":
-        {"query": {"description": "A search query, which can be a specific phrase, complete
-        sentence, or general keywords, e.g. ''machine learning for immunology''. Also
-        can be given search operators.", "title": "Query", "type": "string"}, "min_year":
-        {"anyOf": [{"type": "integer"}, {"type": "null"}], "description": "Filter for
-        minimum publication year, or None for no minimum year. The current year is 2024.",
-        "title": "Min Year"}, "max_year": {"anyOf": [{"type": "integer"}, {"type": "null"}],
-        "description": "Filter for maximum publication year, or None for no maximum
-        year. The current year is 2024.", "title": "Max Year"}}, "required": ["query",
-        "min_year", "max_year"]}}}, {"type": "function", "function": {"name": "complete",
-        "description": "Terminate using the last proposed answer.\n\nDo not invoke this
-        tool in parallel with other tools or itself.", "parameters": {"type": "object",
-        "properties": {"is_sure": {"description": "Set True if sure of the answer, otherwise
-        False if there remains some uncertainty.", "title": "Is Sure", "type": "boolean"}},
-        "required": ["is_sure"]}}}]}'
+        '{"messages":[{"role":"user","content":"Use the tools to answer the question:
+        Q: Who is Frederick Bates?\n\nOptions:\nA) Insufficient information to answer
+        this question\nB) Technologist\nC) Plumber\nD) Politician\n\nWhen the answer
+        looks sufficient, you can terminate by calling the complete tool. If the answer
+        does not look sufficient, and you have already tried to answer several times
+        with different evidence, terminate by calling the complete tool. The current
+        status of evidence/papers/cost is Status: Paper Count=0 | Relevant Papers=0
+        | Current Evidence=0 | Current Cost=$0.0000"},{"role":"assistant","content":null,"function_call":null,"tool_calls":[{"id":"call_T9H7eNtaUgu5fAhWzBuGu3iO","type":"function","function":{"arguments":"{\"query\":
+        \"Frederick Bates\", \"min_year\": null, \"max_year\": null}","name":"paper_search"}}]},{"role":"tool","content":"Encountered
+        exception during tool call: Totally unexpected but retryable error.","name":"paper_search","tool_call_id":"call_T9H7eNtaUgu5fAhWzBuGu3iO"}],"model":"gpt-4o-2024-08-06","temperature":0.1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"reset","description":"Reset
+        by clearing all current evidence from the system.\n\nThis tool is useful when
+        repeatedly failing to answer because the existing evidence may unsuitable for
+        the question.\nIt does not make sense to call this tool in parallel with other
+        tools, as its resetting all state.\nOnly invoke this tool when the current evidence
+        is above zero, or this tool will be useless.","parameters":{"type":"object","properties":{},"required":[]}}},{"type":"function","function":{"name":"gen_answer","description":"Generate
+        an answer using current evidence.\n\nThe tool may fail, indicating that better
+        or different evidence should be found.\nAim for at least five pieces of evidence
+        from multiple sources before invoking this tool.\nFeel free to invoke this tool
+        in parallel with other tools, but do not call this tool in parallel with itself.","parameters":{"type":"object","properties":{},"required":[]}}},{"type":"function","function":{"name":"gather_evidence","description":"Gather
+        evidence from previous papers given a specific question to increase evidence
+        and relevant paper counts.\n\nA valuable time to invoke this tool is right after
+        another tool increases paper count.\nFeel free to invoke this tool in parallel
+        with other tools, but do not call this tool in parallel with itself.\nOnly invoke
+        this tool when the paper count is above zero, or this tool will be useless.","parameters":{"type":"object","properties":{"question":{"description":"Specific
+        question to gather evidence for.","title":"Question","type":"string"}},"required":["question"]}}},{"type":"function","function":{"name":"paper_search","description":"Search
+        for papers to increase the paper count.\n\nRepeat previous calls with the same
+        query and years to continue a search. Only repeat a maximum of twice.\nThis
+        tool can be called concurrently.\nThis tool introduces novel papers, so invoke
+        this tool when just beginning or when unsatisfied with the current evidence.","parameters":{"type":"object","properties":{"query":{"description":"A
+        search query, which can be a specific phrase, complete sentence, or general
+        keywords, e.g. ''machine learning for immunology''. Also can be given search
+        operators.","title":"Query","type":"string"},"min_year":{"anyOf":[{"type":"integer"},{"type":"null"}],"description":"Filter
+        for minimum publication year, or None for no minimum year. The current year
+        is 2024.","title":"Min Year"},"max_year":{"anyOf":[{"type":"integer"},{"type":"null"}],"description":"Filter
+        for maximum publication year, or None for no maximum year. The current year
+        is 2024.","title":"Max Year"}},"required":["query","min_year","max_year"]}}},{"type":"function","function":{"name":"complete","description":"Terminate
+        using the last proposed answer.\n\nDo not invoke this tool in parallel with
+        other tools or itself.","parameters":{"type":"object","properties":{"has_successful_answer":{"description":"Set
+        True if an answer that addresses all parts of the task has been generated, otherwise
+        set False to indicate unsureness.","title":"Has Successful Answer","type":"boolean"}},"required":["has_successful_answer"]}}}]}'
       headers:
         accept:
           - application/json
@@ -216,13 +184,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "4295"
+          - "4248"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -232,7 +200,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -246,20 +214,20 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xTTY+bMBC98yusOSdVYLP54Naq3VV7qLpVV2pVKmTsAbxrbNc2EijKf6+ABEia
-          SuWArHl+b2bejA8BISA4xARYST2rjFy+fcbs4/MTp/yx+ZFh2Xz6INj7l4fv2TZaw6Jj6OwFmT+z
-          3jBdGYleaDXAzCL12KmG27twt9lH26gHKs1RdrTC+OVaL6NVtF6udsvV5kQstWDoICY/A0IIOfT/
-          rkTFsYGYrBbnSIXO0QIhHi8RAlbLLgLUOeE8VR4WE8i08qi6qlUt5QzwWsuUUSmnxMN3mJ0nn6iU
-          6ZdWfwtD/zX8XLR5FsrmqbSPnPNZvkG6NX1Bea3Y6M8MH+PxVTJCQNGq5xpq0KYOqWXlFZ8QoLao
-          K1S+qx0OCfyu0bYJxAk8WORoBXsl76hHl8AigUqotEVqE4h7ExKoaDOPHOEiwTG4df41M89iXjsq
-          T66e4sdxTFIXxurMXbkOuVDClalF6vru50MIztn6PFBfzBmM1ZXxqdevqDrZzWY3qMK0hhMabU+g
-          157KGWt/v7ihl3L0VPSLMO4eo6xEPlGnHaQ1F3oGBLPe/67mlvbQv1DF/8hPAGNoPPLUWOSCXXY8
-          XbPYvdJ/XRtd7gsG1zqPVZoLVaA1VvQPBXKThvd7vrtbh4xBcAz+AAAA//8DABdHIWoxBAAA
+          H4sIAAAAAAAAA4xTy66bMBDd8xXWrJOKPJQgdkTqY1Wp3bRRqdDEDOBeY7u2UZNG+fcKJxdImkpl
+          gaw5PmdmzozPEWMgSkgZ8AY9b42cZ7j5Wv/+tTbJ7u1uxzH7WH3JPlf10QnRwKxn6MMP4v6V9Ybr
+          1kjyQqsrzC2hp151sV2tFptktYwD0OqSZE+rjZ+v9XwZL9fzOJnHmxux0YKTg5R9ixhj7Bz+fYmq
+          pCOkLMiESEvOYU2QDpcYA6tlHwF0TjiPysNsBLlWnlRfteqknABea1lwlHJMfP3Ok/PoE0pZvK+q
+          /aEu97tEyYPMth/260R/qrNJvqv0yYSCqk7xwZ8JPsTTh2SMgcI2cA0asoUjtLx54DMGaOuuJeX7
+          2uGcw8+O7CmHNId3lkqygr+wHXpyOcxyaIUqToQ2hzSYkEOLx2nkAncJLtGz8/eJeZaqzqG8uXqL
+          X4YxSV0bqw/uwXWohBKuKSyhC91PhxC9Zgt5oLubMxirW+MLr19I9bKbZHFVhXENR3S5vYFee5Rj
+          fBsnsyd6RUkeRViEYfc48obKkTruIHal0BMgmvT+dzXPtK/9C1X/j/wIcE7GU1kYS6Xg9x2P1yz1
+          r/Rf1waXQ8HgTs5TW1RC1WSNFeGhQGWKZLWgeLMtkyVEl+gPAAAA//8DABRwDu0xBAAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e41e4496df2faa2-SJC
+          - 8ebdc74fef19aab2-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -267,7 +235,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Sun, 17 Nov 2024 18:47:53 GMT
+          - Mon, 02 Dec 2024 19:38:40 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -281,7 +249,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "387"
+          - "673"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -293,13 +261,13 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "29999826"
+          - "29999825"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_a581b64c34b927f0214d7195d6a4cdff
+          - req_4c7f5e8097ad25ebed8c019e58c65207
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_arxiv_doi_is_used_when_available.yaml
+++ b/tests/cassettes/test_arxiv_doi_is_used_when_available.yaml
@@ -7,15 +7,15 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5119,"items":[{"indexed":{"date-parts":[[2024,10,6]],"date-time":"2024-10-06T00:54:43Z","timestamp":1728176083535},"publisher-location":"Stroudsburg,
-          PA, USA","reference-count":0,"publisher":"Association for Computational Linguistics","content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2018]]},"DOI":"10.18653\/v1\/n18-2074","type":"proceedings-article","created":{"date-parts":[[2018,5,30]],"date-time":"2018-05-30T00:40:41Z","timestamp":1527640841000},"source":"Crossref","is-referenced-by-count":932,"title":["Self-Attention
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5149,"items":[{"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T17:32:03Z","timestamp":1732037523793},"publisher-location":"Stroudsburg,
+          PA, USA","reference-count":0,"publisher":"Association for Computational Linguistics","content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2018]]},"DOI":"10.18653\/v1\/n18-2074","type":"proceedings-article","created":{"date-parts":[[2018,5,30]],"date-time":"2018-05-30T00:40:41Z","timestamp":1527640841000},"source":"Crossref","is-referenced-by-count":977,"title":["Self-Attention
           with Relative Position Representations"],"prefix":"10.18653","author":[{"given":"Peter","family":"Shaw","sequence":"first","affiliation":[]},{"given":"Jakob","family":"Uszkoreit","sequence":"additional","affiliation":[]},{"given":"Ashish","family":"Vaswani","sequence":"additional","affiliation":[]}],"member":"1643","event":{"name":"Proceedings
           of the 2018 Conference of the North American Chapter of\n          the Association
           for Computational Linguistics: Human Language\n          Technologies, Volume
           2 (Short Papers)","location":"New Orleans, Louisiana","start":{"date-parts":[[2018,6]]},"end":{"date-parts":[[2018,6]]}},"container-title":["Proceedings
           of the 2018 Conference of the North American Chapter of\n          the Association
           for Computational Linguistics: Human Language\n          Technologies, Volume
-          2 (Short Papers)"],"deposited":{"date-parts":[[2018,5,30]],"date-time":"2018-05-30T00:41:11Z","timestamp":1527640871000},"score":53.646477,"resource":{"primary":{"URL":"http:\/\/aclweb.org\/anthology\/N18-2074"}},"issued":{"date-parts":[[2018]]},"references-count":0,"URL":"http:\/\/dx.doi.org\/10.18653\/v1\/n18-2074","published":{"date-parts":[[2018]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          2 (Short Papers)"],"deposited":{"date-parts":[[2018,5,30]],"date-time":"2018-05-30T00:41:11Z","timestamp":1527640871000},"score":53.66346,"resource":{"primary":{"URL":"http:\/\/aclweb.org\/anthology\/N18-2074"}},"issued":{"date-parts":[[2018]]},"references-count":0,"URL":"http:\/\/dx.doi.org\/10.18653\/v1\/n18-2074","published":{"date-parts":[[2018]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -33,7 +33,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -65,8 +65,8 @@ interactions:
           {"ArXiv": "1706.03762", "MAG": "2963403868", "DBLP": "conf/nips/VaswaniSPUJGKP17",
           "CorpusId": 13756489}, "url": "https://www.semanticscholar.org/paper/204e3073870fae3d05bcbc2f6a8e263d9b72e776",
           "title": "Attention is All you Need", "venue": "Neural Information Processing
-          Systems", "year": 2017, "citationCount": 109518, "influentialCitationCount":
-          15738, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle",
+          Systems", "year": 2017, "citationCount": 111096, "influentialCitationCount":
+          15817, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle",
           "Conference"], "publicationDate": "2017-06-12", "journal": {"pages": "5998-6008"},
           "citationStyles": {"bibtex": "@Article{Vaswani2017AttentionIA,\n author =
           {Ashish Vaswani and Noam M. Shazeer and Niki Parmar and Jakob Uszkoreit and
@@ -78,7 +78,7 @@ interactions:
           "39328010", "name": "Jakob Uszkoreit"}, {"authorId": "145024664", "name":
           "Llion Jones"}, {"authorId": "19177000", "name": "Aidan N. Gomez"}, {"authorId":
           "40527594", "name": "Lukasz Kaiser"}, {"authorId": "3443442", "name": "Illia
-          Polosukhin"}], "matchScore": 133.67908}]}
+          Polosukhin"}], "matchScore": 132.86658}]}
 
           '
       headers:
@@ -91,27 +91,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Via:
-          - 1.1 412c0797c582f734d2a53446693c889e.cloudfront.net (CloudFront)
+          - 1.1 b0797f10be715dcb685d992d17347df4.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - FTdytrxN8nHeYwbKsKNVNzHulrNVuSxVNUc3KpvJbY2seIEnWozfCQ==
+          - YXhlsselRJsF-N4f9LB_GT1-eoWDqvkGRxlzyDOliDw0OplCI5ilgw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PoFLgPHcEgdg=
+          - CLbZvF46vHcEmxw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1420"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 9f078670-a0ac-4382-a040-29a976e38df3
+          - 4453c88e-aacd-4150-bfaa-5d2f1894058c
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_author_matching.yaml
+++ b/tests/cassettes/test_author_matching.yaml
@@ -7,7 +7,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4038,"items":[{"DOI":"10.4337\/cilj.2023.02.08","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-2467-681X","authenticated-orcid":true,"given":"Jack
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4067,"items":[{"DOI":"10.4337\/cilj.2023.02.08","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-2467-681X","authenticated-orcid":true,"given":"Jack
           Wright","family":"Nelson","sequence":"first","affiliation":[{"name":"Doctoral
           Candidate, McGill University Faculty of Law, Montreal, QC, Canada"},{"name":"Adjunct
           Research Fellow, National University of Singapore Faculty of Law, Singapore"}]}],"title":["Large
@@ -25,7 +25,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -61,7 +61,7 @@ interactions:
           "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773", "name": "Oliver
           Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"}, {"authorId":
           "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853", "name":
-          "P. Schwaller"}], "matchScore": 176.78436}]}
+          "P. Schwaller"}], "matchScore": 176.67178}]}
 
           '
       headers:
@@ -74,27 +74,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Via:
-          - 1.1 0113a71a4be95c1ea6c4a193aad565aa.cloudfront.net (CloudFront)
+          - 1.1 42e027e0a25dba57ed6be490a4389144.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - _-OZO0fRyGEzT2D_Nr2fyfQjYnjK-7ulNWryozB_SajlRFgLQsAy0A==
+          - IsbRpJs-6dJesYURz0pMaebcWTWrxJgr4K0youJEPblH2gBzJPfJbw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81P5GD3PHcEfSg=
+          - CLbZ9Hr0vHcEfHg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "684"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 32af7b91-efaf-4905-b650-0a8c559fae51
+          - b5ecf5b2-034c-4d9a-af12-6de8ada94eef
       status:
         code: 200
         message: OK
@@ -114,7 +114,7 @@ interactions:
           "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773", "name": "Oliver
           Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"}, {"authorId":
           "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853", "name":
-          "P. Schwaller"}], "matchScore": 176.78436}]}
+          "P. Schwaller"}], "matchScore": 178.39174}]}
 
           '
       headers:
@@ -127,27 +127,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Via:
-          - 1.1 0113a71a4be95c1ea6c4a193aad565aa.cloudfront.net (CloudFront)
+          - 1.1 42e027e0a25dba57ed6be490a4389144.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - UVqCCLXLgrUygXOnemudQET7cDjPC_U2FNqS9HJErbo00mX4RVxRuw==
+          - EHoVfVgHE9RbrbRi4uuINY4X-WQoORnvqlRHgMG5LRdxwMp9dqjMjg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81P-GfMvHcEQrA=
+          - CLbaDFLKvHcEZrw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "684"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 4d65b1f2-c33b-449c-aafb-97a39f59e3fd
+          - bfd45f5b-35bc-42d1-a1f9-011832c60b9a
       status:
         code: 200
         message: OK
@@ -172,7 +172,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_bad_dois.yaml
+++ b/tests/cassettes/test_bad_dois.yaml
@@ -20,7 +20,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -60,27 +60,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 0ac5a786563da4ae2e2a28a1fe210e04.cloudfront.net (CloudFront)
+          - 1.1 9a448e42428e8683fe0fc64dff7a7112.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - KUeZ0SEFgg_9gPur2IKQZQDJYJNnUhRsDepc4vdri-RYASUCWRl8SQ==
+          - dJJiheReRCjAl_NBvaMUlQvMmxJlVJRtbkWbkWZNKIaKC9WhocQMLQ==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Error from cloudfront
         x-amz-apigw-id:
-          - A81QAFNcPHcEFPQ=
+          - CLbaSFnKPHcEVYA=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "34"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 3e50819d-9f35-4b12-8feb-7f3a99c68073
+          - 273a4cdb-290d-4be7-8b94-fd99f060314a
       status:
         code: 404
         message: Not Found

--- a/tests/cassettes/test_bad_titles.yaml
+++ b/tests/cassettes/test_bad_titles.yaml
@@ -20,7 +20,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -60,27 +60,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Via:
-          - 1.1 05704fecd1992557082ae04fd0558b5e.cloudfront.net (CloudFront)
+          - 1.1 6269ff653a8a0b71d436afa999909318.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - _t9sKSwSVTZvlKV8nOB7qLcnLOraZ8-4T9-3B_33DDy-g7mFJ2YxUA==
+          - 23LQTAbY-GOpXw7rdGeve6k9Iu5qPcKgF2Gqe-JqghainPW6xYS65Q==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Error from cloudfront
         x-amz-apigw-id:
-          - A81PnHvfvHcEYeQ=
+          - CLbZzGCDPHcEJHA=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "34"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 46574793-b139-4a7f-bab1-eef285ab234c
+          - 496fbdea-7d75-41d0-b4c6-a6e41dd33e80
       status:
         code: 404
         message: Not Found
@@ -106,7 +106,7 @@ interactions:
           tensile properties: A reactive molecular dynamics study},\n volume = {118},\n
           year = {2015}\n}\n"}, "authors": [{"authorId": "9821934", "name": "Michael
           Skarlinski"}, {"authorId": "37723150", "name": "D. Quesnel"}], "matchScore":
-          208.0851}]}
+          208.18822}]}
 
           '
       headers:
@@ -115,31 +115,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "1108"
+          - "1109"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Via:
-          - 1.1 05704fecd1992557082ae04fd0558b5e.cloudfront.net (CloudFront)
+          - 1.1 6269ff653a8a0b71d436afa999909318.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - doFFvfqxmGDOMYYDGfx1bxIhjNCB0WdZlKU2xbC7jvhXV3JTN_nqfQ==
+          - KME2flM8pQX1d5YEFoIovnbF-dvc_4Y6VJPE9VHcHZN2C5NAbx2MCA==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PsHdjPHcEVeQ=
+          - CLbaBEbUPHcEQQw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "1108"
+          - "1109"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - d142ab3d-5bb3-4778-b900-6cc01d651816
+          - f9601898-5b74-4dc7-8f0f-b538148b091b
       status:
         code: 200
         message: OK
@@ -151,7 +151,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":10475211,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":10527747,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
           Publishing","issue":"23","funder":[{"DOI":"10.13039\/100000006","name":"Office
           of Naval Research","doi-asserted-by":"publisher","award":["N00014-12-1-0542"],"id":[{"id":"10.13039\/100000006","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["pubs.aip.org"],"crossmark-restriction":true},"published-print":{"date-parts":[[2015,12,21]]},"abstract":"<jats:p>Metal-oxide
           layers are likely to be present on metallic nano-structures due to either
@@ -245,7 +245,7 @@ interactions:
           Sci. Eng. A"},{"key":"2023062402360541600_c55","doi-asserted-by":"publisher","first-page":"057129","DOI":"10.1063\/1.4880241","volume":"4","year":"2014","journal-title":"AIP
           Adv."},{"key":"2023062402360541600_c56","doi-asserted-by":"publisher","first-page":"94","DOI":"10.1016\/j.susc.2014.10.017","volume":"633","year":"2015","journal-title":"Surf.
           Sci."},{"key":"2023062402360541600_c57","doi-asserted-by":"publisher","first-page":"710","DOI":"10.1016\/j.pmatsci.2010.04.001","volume":"55","year":"2010","journal-title":"Prog.
-          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":49.303417,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":49.320198,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -259,11 +259,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3946"
+          - "3945"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -310,7 +310,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_bulk_doi_search.yaml
+++ b/tests/cassettes/test_bulk_doi_search.yaml
@@ -3,60 +3,6 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/DOI:10.1007/s40278-023-41815-2?fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"paperId": "e0d2719e49ad216f98ed640864cdacd1c20f53e6", "externalIds":
-          {"DOI": "10.1007/s40278-023-41815-2", "CorpusId": 259225376}, "url": "https://www.semanticscholar.org/paper/e0d2719e49ad216f98ed640864cdacd1c20f53e6",
-          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "venue": "Reactions
-          weekly", "year": 2023, "citationCount": 0, "influentialCitationCount": 0,
-          "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
-          "publicationDate": "2023-06-01", "journal": {"name": "Reactions Weekly", "pages":
-          "145 - 145", "volume": "1962"}, "citationStyles": {"bibtex": "@Article{None,\n
-          booktitle = {Reactions weekly},\n journal = {Reactions Weekly},\n pages =
-          {145 - 145},\n title = {Convalescent-anti-sars-cov-2-plasma/immune-globulin},\n
-          volume = {1962},\n year = {2023}\n}\n"}, "authors": []}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "837"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Via:
-          - 1.1 6778e3146eb385e3772c8de867b2c290.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - wlDzXReYDL0I_0zlObiXpxLElVYt0TlSLsAnaDKRRpKbfNO1jr9Jeg==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PnGRcvHcEEzg=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "837"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 3ef6cd80-c029-4c68-9037-16076db74aa8
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
       uri: https://api.semanticscholar.org/graph/v1/paper/DOI:10.1023/a:1007154515475?fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
     response:
       body:
@@ -92,27 +38,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 05704fecd1992557082ae04fd0558b5e.cloudfront.net (CloudFront)
+          - 1.1 a2df2413207d4bf6462c2592b304bffe.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - 2BMktHrqlLzVgyiPKleAUAXHRi6v6cC3lTiyWKGi7422kuSNWi-YZQ==
+          - NEut-36VxSMoPxHlUIhVYjmEyhXH8sGrw5b7AhQSivFxVoptvst0zQ==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PnF8LPHcEecg=
+          - CLbaUG-OPHcEPHQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1446"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 7979fac5-7896-48b3-a1bc-1a4acb6deaf6
+          - 6b0b285e-d39c-49fb-abd1-9a7463a0a30f
       status:
         code: 200
         message: OK
@@ -128,7 +74,7 @@ interactions:
           {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
           "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
           "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
-          "venue": "arXiv.org", "year": 2023, "citationCount": 37, "influentialCitationCount":
+          "venue": "arXiv.org", "year": 2023, "citationCount": 38, "influentialCitationCount":
           1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
           "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
           "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
@@ -153,90 +99,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 d52f5364539f50d2591f4996970cf25e.cloudfront.net (CloudFront)
+          - 1.1 edc643c7c426bec36e205453aa531064.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - EzEzCYmXyZR9bePpH3qzdSPOtWFrxycJVBxvADXazKJsdkeAhaceBw==
+          - BJMVtl0bQexs_8MKzynDoISVeAOY6Dmjh42kOeiI0CVG7oiOvkvyIg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PnFScvHcEvCQ=
+          - CLbaUEVuvHcEuoQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1349"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 6bf437cc-d42b-4f25-b23a-0c556c688bd6
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/DOI:10.1038/s42256-024-00832-8?fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
-          "title": "Augmenting large language models with chemistry tools", "venue":
-          "Nat. Mac. Intell.", "year": 2023, "citationCount": 225, "influentialCitationCount":
-          11, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
-          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
-          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
-          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
-          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
-          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
-          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
-          {Augmenting large language models with chemistry tools},\n volume = {6},\n
-          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
-          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
-          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
-          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
-          "name": "P. Schwaller"}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1514"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Via:
-          - 1.1 6778e3146eb385e3772c8de867b2c290.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - fQXJJrPt10Pjx_O9_y20Hvq0WUUd7e5GpFKR-GCux4R6Agx7rdwgYg==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PoGrvvHcEDrg=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1514"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 86c6ad31-1f88-425c-bcfd-3a729d479851
+          - 281bb9f2-8f8b-4d79-b0a4-ed211de711de
       status:
         code: 200
         message: OK
@@ -274,27 +157,90 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 29474fd3a24c6552dfdc04ee03c03aa2.cloudfront.net (CloudFront)
+          - 1.1 d52f5364539f50d2591f4996970cf25e.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - YqFJiqOHCSE8d_sUFSUyLPAx4WxxieHGPf42MuBbvST63Txe3IS6Ug==
+          - Y99gR9VYT8YWDUqh7L4bEVoAf4MH3DGZEt2MVYrjdacWp1jFE_qXwQ==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PoFitPHcEAJQ=
+          - CLbaUEIFvHcEcAQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1072"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 3130cf65-362a-44c6-8d98-46efdc879e7b
+          - bf5034e9-ea26-4682-86de-f3d91b081c32
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/DOI:10.1038/s42256-024-00832-8?fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
+          "title": "Augmenting large language models with chemistry tools", "venue":
+          "Nat. Mac. Intell.", "year": 2023, "citationCount": 230, "influentialCitationCount":
+          12, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
+          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
+          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
+          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
+          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
+          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
+          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
+          {Augmenting large language models with chemistry tools},\n volume = {6},\n
+          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
+          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
+          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
+          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
+          "name": "P. Schwaller"}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1514"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        Via:
+          - 1.1 6cbbecc3198d4b8fe84dc82e5f121ae6.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - TzSN9WnJ59KrmMqUwS_O-d5TqAlrV10i-_UeJ0tN_aRbs1hLHgdnbg==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbaUHWiPHcEgnQ=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1514"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 1f87b5fc-c926-44f6-87d9-33160b476857
       status:
         code: 200
         message: OK
@@ -333,27 +279,81 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 1401c4844b3ea759244fef5091fc307a.cloudfront.net (CloudFront)
+          - 1.1 fd0518257f901c4d9c7dc3b36830c8be.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - B2b9NAIOhQaEyGUh9Mktx5Z4kSlaU4DeoOrzJeAjYrI4sLoYUybW7g==
+          - OiVBx8zA1SoYaeKV8uM9KIWQtn1bc__J-2pkQFwN4v_PQkI2iRLUhw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PoEw2PHcEIbw=
+          - CLbaUFMZPHcEBPw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1325"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 1c4391e1-3aa4-48b2-8ae1-7362eaea43f5
+          - 8d517af7-efcb-455b-abc6-2ded172a57a8
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/DOI:10.1007/s40278-023-41815-2?fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"paperId": "e0d2719e49ad216f98ed640864cdacd1c20f53e6", "externalIds":
+          {"DOI": "10.1007/s40278-023-41815-2", "CorpusId": 259225376}, "url": "https://www.semanticscholar.org/paper/e0d2719e49ad216f98ed640864cdacd1c20f53e6",
+          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "venue": "Reactions
+          weekly", "year": 2023, "citationCount": 0, "influentialCitationCount": 0,
+          "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
+          "publicationDate": "2023-06-01", "journal": {"name": "Reactions Weekly", "pages":
+          "145 - 145", "volume": "1962"}, "citationStyles": {"bibtex": "@Article{None,\n
+          booktitle = {Reactions weekly},\n journal = {Reactions Weekly},\n pages =
+          {145 - 145},\n title = {Convalescent-anti-sars-cov-2-plasma/immune-globulin},\n
+          volume = {1962},\n year = {2023}\n}\n"}, "authors": []}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "837"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        Via:
+          - 1.1 05704fecd1992557082ae04fd0558b5e.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - c6hk0wGttCBqK4PnVzZtzYAfGyVXG7WoDBAyCXeJjbfWURuATCcvbg==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbaUF0JvHcEQQg=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "837"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - eaca2b8d-d07e-4517-a6f6-83cffee25e3c
       status:
         code: 200
         message: OK
@@ -378,7 +378,7 @@ interactions:
         Content-Type:
           - text/plain
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -402,14 +402,57 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.crossref.org/works/10.1023%2Fa:1007154515475?mailto=example@papercrow.ai
+      uri: https://api.crossref.org/works/10.1101%2F2024.04.01.587366?mailto=example@papercrow.ai
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2024,1,21]],"date-time":"2024-01-21T17:53:48Z","timestamp":1705859628791},"reference-count":0,"publisher":"Springer
-          Science and Business Media LLC","issue":"1\/2","content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":[],"published-print":{"date-parts":[[2001]]},"DOI":"10.1023\/a:1007154515475","type":"journal-article","created":{"date-parts":[[2002,12,22]],"date-time":"2002-12-22T09:07:15Z","timestamp":1040548035000},"page":"1-11","source":"Crossref","is-referenced-by-count":6,"title":[],"prefix":"10.1007","volume":"218","author":[{"given":"Subrata","family":"Adak","sequence":"first","affiliation":[]},{"given":"Debashis","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"Uday","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"Ranajit
-          K.","family":"Banerjee","sequence":"additional","affiliation":[]}],"member":"297","container-title":["Molecular
-          and Cellular Biochemistry"],"original-title":[],"deposited":{"date-parts":[[2012,12,27]],"date-time":"2012-12-27T23:10:34Z","timestamp":1356649834000},"score":1,"resource":{"primary":{"URL":"http:\/\/link.springer.com\/10.1023\/A:1007154515475"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2001]]},"references-count":0,"journal-issue":{"issue":"1\/2"},"alternative-id":["271450"],"URL":"http:\/\/dx.doi.org\/10.1023\/a:1007154515475","relation":{},"ISSN":["0300-8177"],"issn-type":[{"value":"0300-8177","type":"print"}],"subject":[],"published":{"date-parts":[[2001]]}}}'
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:09:55Z","timestamp":1732043395754},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
+          Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":[],"accepted":{"date-parts":[[2024,4,1]]},"abstract":"<jats:title>ABSTRACT<\/jats:title><jats:p>Understanding
+          the effects of rare genetic variants remains challenging, both in coding and
+          non-coding regions. While multiplexed assays of variant effect (MAVEs) have
+          enabled scalable functional assessment of variants, established MAVEs are
+          limited by either exogenous expression of variants or constraints of genome
+          editing. Here, we introduce a pooled prime editing (PE) platform in haploid
+          human cells to scalably assay variants in their endogenous context. We first
+          optimized delivery of variants to HAP1 cells, defining optimal pegRNA designs
+          and establishing a co-selection strategy for improved efficiency. We characterize
+          our platform in the context of negative selection by testing over 7,500 pegRNAs
+          targeting<jats:italic>SMARCB1<\/jats:italic>for editing activity and observing
+          depletion of highly active pegRNAs installing loss-of-function variants. We
+          next assess variants in<jats:italic>MLH1<\/jats:italic>via 6-thioguanine selection,
+          assaying 65.3% of all possible SNVs in a 200-bp region spanning exon 10 and
+          distinguishing LoF variants with high accuracy. Lastly, we assay 362 non-coding<jats:italic>MLH1<\/jats:italic>variants
+          across a 60 kb region in a single experiment, identifying pathogenic variants
+          acting via multiple mechanisms with high specificity. Our analyses detail
+          how filtering for highly active pegRNAs can facilitate both positive and negative
+          selection screens. Accordingly, our platform promises to enable highly scalable
+          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":1,"title":["High-throughput
+          screening of human genetic variants by pooled prime editing"],"prefix":"10.1101","author":[{"given":"Michael","family":"Herger","sequence":"first","affiliation":[]},{"given":"Christina
+          M.","family":"Kajba","sequence":"additional","affiliation":[]},{"given":"Megan","family":"Buckley","sequence":"additional","affiliation":[]},{"given":"Ana","family":"Cunha","sequence":"additional","affiliation":[]},{"given":"Molly","family":"Strom","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7767-8608","authenticated-orcid":false,"given":"Gregory
+          M.","family":"Findlay","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2024040415500652000_2024.04.01.587366v1.1","doi-asserted-by":"publisher","DOI":"10.1038\/gim.2015.30"},{"key":"2024040415500652000_2024.04.01.587366v1.2","doi-asserted-by":"crossref","first-page":"116","DOI":"10.1016\/j.cels.2017.11.003","article-title":"Quantitative
+          Missense Variant Effect Prediction Using Large-Scale Mutagenesis Data","volume":"6","year":"2018","journal-title":"Cell
+          Syst"},{"key":"2024040415500652000_2024.04.01.587366v1.3","doi-asserted-by":"publisher","DOI":"10.1126\/science.abi8207"},{"key":"2024040415500652000_2024.04.01.587366v1.4","doi-asserted-by":"publisher","DOI":"10.1016\/J.CELL.2018.12.015"},{"key":"2024040415500652000_2024.04.01.587366v1.5","doi-asserted-by":"crossref","first-page":"eabn8153","DOI":"10.1126\/science.abn8197","article-title":"The
+          landscape of tolerated genetic variation in humans and primates","volume":"380","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.6","doi-asserted-by":"crossref","first-page":"eadg7492","DOI":"10.1126\/science.adg7492","article-title":"Accurate
+          proteome-wide missense variant effect prediction with AlphaMissense","volume":"381","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.7","doi-asserted-by":"publisher","DOI":"10.1093\/nar\/gkv1222"},{"key":"2024040415500652000_2024.04.01.587366v1.8","doi-asserted-by":"crossref","first-page":"1381","DOI":"10.1038\/s41436-021-01172-3","article-title":"ACMG
+          SF v3.0 list for reporting of secondary findings in clinical exome and genome
+          sequencing: a policy statement of the American College of Medical Genetics
+          and Genomics (ACMG)","volume":"23","year":"2021","journal-title":"Genet. Med"},{"key":"2024040415500652000_2024.04.01.587366v1.9","doi-asserted-by":"publisher","DOI":"10.1038\/nprot.2016.135"},{"key":"2024040415500652000_2024.04.01.587366v1.10","doi-asserted-by":"publisher","DOI":"10.1093\/hmg\/ddab219"},{"key":"2024040415500652000_2024.04.01.587366v1.11","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-11526-w"},{"key":"2024040415500652000_2024.04.01.587366v1.12","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-022-02839-z"},{"key":"2024040415500652000_2024.04.01.587366v1.13","doi-asserted-by":"crossref","first-page":"2248","DOI":"10.1016\/j.ajhg.2021.11.001","article-title":"Closing
+          the gap: Systematic integration of multiplexed functional data resolves variants
+          of uncertain significance in BRCA1, TP53, and PTEN","volume":"108","year":"2021","journal-title":"Am.
+          J. Hum. Genet."},{"key":"2024040415500652000_2024.04.01.587366v1.14","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-018-0461-z"},{"key":"2024040415500652000_2024.04.01.587366v1.15","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.10.015"},{"key":"2024040415500652000_2024.04.01.587366v1.16","doi-asserted-by":"crossref","first-page":"7702","DOI":"10.1038\/s41467-023-43041-4","article-title":"Saturation
+          genome editing of DDX3X clarifies pathogenicity of germline and somatic variation","volume":"14","year":"2023","journal-title":"Nat.
+          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.17","doi-asserted-by":"publisher","DOI":"10.1038\/nature13695"},{"key":"2024040415500652000_2024.04.01.587366v1.18","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.012"},{"key":"2024040415500652000_2024.04.01.587366v1.19","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.041"},{"key":"2024040415500652000_2024.04.01.587366v1.20","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-019-1711-4"},{"key":"2024040415500652000_2024.04.01.587366v1.21","doi-asserted-by":"crossref","first-page":"288","DOI":"10.1016\/j.ccell.2022.12.009","article-title":"Base
+          editing screens map mutations affecting interferon-\u03b3 signaling in cancer","volume":"41","year":"2023","journal-title":"Cancer
+          Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.22","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.09.018"},{"key":"2024040415500652000_2024.04.01.587366v1.23","doi-asserted-by":"crossref","first-page":"402","DOI":"10.1038\/s41587-021-01039-7","article-title":"Engineered
+          pegRNAs improve prime editing efficiency","volume":"40","year":"2022","journal-title":"Nat.
+          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.24","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01201-1"},{"key":"2024040415500652000_2024.04.01.587366v1.25","doi-asserted-by":"publisher","DOI":"10.1016\/j.molcel.2023.11.021"},{"key":"2024040415500652000_2024.04.01.587366v1.26","doi-asserted-by":"publisher","DOI":"10.1038\/nature10348"},{"key":"2024040415500652000_2024.04.01.587366v1.27","doi-asserted-by":"publisher","DOI":"10.1126\/science.1247005"},{"key":"2024040415500652000_2024.04.01.587366v1.28","doi-asserted-by":"crossref","first-page":"1151","DOI":"10.1038\/s41587-022-01613-7","article-title":"Predicting
+          prime editing efficiency and product purity by deep learning","volume":"41","year":"2023","journal-title":"Nat.
+          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.29","doi-asserted-by":"crossref","first-page":"2256","DOI":"10.1016\/j.cell.2023.03.034","article-title":"Prediction
+          of efficiencies for diverse prime editing systems in multiple cell types","volume":"186","year":"2023","journal-title":"Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.30","doi-asserted-by":"publisher","DOI":"10.1101\/2022.10.26.513842"},{"key":"2024040415500652000_2024.04.01.587366v1.31","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01172-3"},{"key":"2024040415500652000_2024.04.01.587366v1.32","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-020-0677-y"},{"key":"2024040415500652000_2024.04.01.587366v1.33","doi-asserted-by":"publisher","DOI":"10.1016\/j.tibtech.2018.07.017"},{"key":"2024040415500652000_2024.04.01.587366v1.34","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-020-20810-z"},{"key":"2024040415500652000_2024.04.01.587366v1.35","doi-asserted-by":"crossref","first-page":"5909","DOI":"10.1038\/s41467-022-33669-z","article-title":"Marker-free
+          co-selection for successive rounds of prime editing in human cells","volume":"13","year":"2022","journal-title":"Nat.
+          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.36","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2013.12.001"},{"key":"2024040415500652000_2024.04.01.587366v1.37","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-018-02974-x"},{"key":"2024040415500652000_2024.04.01.587366v1.38","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-021-27838-9"},{"key":"2024040415500652000_2024.04.01.587366v1.39","doi-asserted-by":"publisher","DOI":"10.1126\/science.1225829"},{"key":"2024040415500652000_2024.04.01.587366v1.40","doi-asserted-by":"publisher","DOI":"10.3390\/cancers14153645"},{"key":"2024040415500652000_2024.04.01.587366v1.41","doi-asserted-by":"publisher","DOI":"10.1126\/science.aac7557"},{"key":"2024040415500652000_2024.04.01.587366v1.42","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-10849-y"},{"key":"2024040415500652000_2024.04.01.587366v1.43","doi-asserted-by":"publisher","DOI":"10.1038\/nbt.3437"},{"key":"2024040415500652000_2024.04.01.587366v1.44","doi-asserted-by":"publisher","DOI":"10.1136\/jmg.2007.056499"},{"key":"2024040415500652000_2024.04.01.587366v1.45","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.12.003"},{"key":"2024040415500652000_2024.04.01.587366v1.46","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-019-0032-3"},{"key":"2024040415500652000_2024.04.01.587366v1.47","doi-asserted-by":"publisher","DOI":"10.1038\/nmeth.3047"},{"key":"2024040415500652000_2024.04.01.587366v1.48","doi-asserted-by":"crossref","first-page":"96","DOI":"10.1089\/hgtb.2017.198","article-title":"Determination
+          of Lentiviral Infectious Titer by a Novel Droplet Digital PCR Method","volume":"29","year":"2018","journal-title":"Hum.
+          Gene Ther. Methods"},{"key":"2024040415500652000_2024.04.01.587366v1.49","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-020-02091-3"},{"key":"2024040415500652000_2024.04.01.587366v1.50","doi-asserted-by":"publisher","DOI":"10.1186\/s13073-021-00835-9"}],"container-title":[],"original-title":[],"link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1101\/2024.04.01.587366","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,4,4]],"date-time":"2024-04-04T22:50:19Z","timestamp":1712271019000},"score":1,"resource":{"primary":{"URL":"http:\/\/biorxiv.org\/lookup\/doi\/10.1101\/2024.04.01.587366"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2024,4,1]]},"references-count":50,"URL":"http:\/\/dx.doi.org\/10.1101\/2024.04.01.587366","relation":{},"subject":[],"published":{"date-parts":[[2024,4,1]]},"subtype":"preprint"}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -423,11 +466,66 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "762"
+          - "3221"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Vary:
+          - Accept-Encoding
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2?mailto=example@papercrow.ai
+    response:
+      body:
+        string:
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T04:17:17Z","timestamp":1687580237047},"reference-count":1,"publisher":"Springer
+          Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"},{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Reactions
+          Weekly"],"DOI":"10.1007\/s40278-023-41815-2","type":"journal-article","created":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T18:42:29Z","timestamp":1687545749000},"page":"145-145","source":"Crossref","is-referenced-by-count":0,"title":["Convalescent-anti-sars-cov-2-plasma\/immune-globulin"],"prefix":"10.1007","volume":"1962","member":"297","published-online":{"date-parts":[[2023,6,24]]},"reference":[{"key":"41815_CR1","doi-asserted-by":"crossref","unstructured":"Delgado-Fernandez
+          M, et al. Treatment of COVID-19 with convalescent plasma in patients with
+          humoral immunodeficiency - Three consecutive cases and review of the literature.
+          Enfermedades Infecciosas Y Microbiologia Clinica 40\n: 507-516, No. 9, Nov
+          2022. Available from: URL: \nhttps:\/\/seimc.org\/","DOI":"10.1016\/j.eimce.2021.01.009"}],"container-title":["Reactions
+          Weekly"],"original-title":[],"language":"en","link":[{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/article\/10.1007\/s40278-023-41815-2\/fulltext.html","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T19:23:18Z","timestamp":1687548198000},"score":1,"resource":{"primary":{"URL":"https:\/\/link.springer.com\/10.1007\/s40278-023-41815-2"}},"subtitle":["Fever
+          and mild decrease in baseline oxygen saturation following off-label use: 3
+          case reports"],"short-title":[],"issued":{"date-parts":[[2023,6,24]]},"references-count":1,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,6]]}},"alternative-id":["41815"],"URL":"http:\/\/dx.doi.org\/10.1007\/s40278-023-41815-2","relation":{},"ISSN":["1179-2051"],"issn-type":[{"value":"1179-2051","type":"electronic"}],"subject":[],"published":{"date-parts":[[2023,6,24]]}}}'
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "1163"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -567,7 +665,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -591,20 +689,14 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2?mailto=example@papercrow.ai
+      uri: https://api.crossref.org/works/10.1023%2Fa:1007154515475?mailto=example@papercrow.ai
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T04:17:17Z","timestamp":1687580237047},"reference-count":1,"publisher":"Springer
-          Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"},{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Reactions
-          Weekly"],"DOI":"10.1007\/s40278-023-41815-2","type":"journal-article","created":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T18:42:29Z","timestamp":1687545749000},"page":"145-145","source":"Crossref","is-referenced-by-count":0,"title":["Convalescent-anti-sars-cov-2-plasma\/immune-globulin"],"prefix":"10.1007","volume":"1962","member":"297","published-online":{"date-parts":[[2023,6,24]]},"reference":[{"key":"41815_CR1","doi-asserted-by":"crossref","unstructured":"Delgado-Fernandez
-          M, et al. Treatment of COVID-19 with convalescent plasma in patients with
-          humoral immunodeficiency - Three consecutive cases and review of the literature.
-          Enfermedades Infecciosas Y Microbiologia Clinica 40\n: 507-516, No. 9, Nov
-          2022. Available from: URL: \nhttps:\/\/seimc.org\/","DOI":"10.1016\/j.eimce.2021.01.009"}],"container-title":["Reactions
-          Weekly"],"original-title":[],"language":"en","link":[{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/article\/10.1007\/s40278-023-41815-2\/fulltext.html","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T19:23:18Z","timestamp":1687548198000},"score":1,"resource":{"primary":{"URL":"https:\/\/link.springer.com\/10.1007\/s40278-023-41815-2"}},"subtitle":["Fever
-          and mild decrease in baseline oxygen saturation following off-label use: 3
-          case reports"],"short-title":[],"issued":{"date-parts":[[2023,6,24]]},"references-count":1,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,6]]}},"alternative-id":["41815"],"URL":"http:\/\/dx.doi.org\/10.1007\/s40278-023-41815-2","relation":{},"ISSN":["1179-2051"],"issn-type":[{"value":"1179-2051","type":"electronic"}],"subject":[],"published":{"date-parts":[[2023,6,24]]}}}'
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2024,1,21]],"date-time":"2024-01-21T17:53:48Z","timestamp":1705859628791},"reference-count":0,"publisher":"Springer
+          Science and Business Media LLC","issue":"1\/2","content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":[],"published-print":{"date-parts":[[2001]]},"DOI":"10.1023\/a:1007154515475","type":"journal-article","created":{"date-parts":[[2002,12,22]],"date-time":"2002-12-22T09:07:15Z","timestamp":1040548035000},"page":"1-11","source":"Crossref","is-referenced-by-count":6,"title":[],"prefix":"10.1007","volume":"218","author":[{"given":"Subrata","family":"Adak","sequence":"first","affiliation":[]},{"given":"Debashis","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"Uday","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"Ranajit
+          K.","family":"Banerjee","sequence":"additional","affiliation":[]}],"member":"297","container-title":["Molecular
+          and Cellular Biochemistry"],"original-title":[],"deposited":{"date-parts":[[2012,12,27]],"date-time":"2012-12-27T23:10:34Z","timestamp":1356649834000},"score":1,"resource":{"primary":{"URL":"http:\/\/link.springer.com\/10.1023\/A:1007154515475"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2001]]},"references-count":0,"journal-issue":{"issue":"1\/2"},"alternative-id":["271450"],"URL":"http:\/\/dx.doi.org\/10.1023\/a:1007154515475","relation":{},"ISSN":["0300-8177"],"issn-type":[{"value":"0300-8177","type":"print"}],"subject":[],"published":{"date-parts":[[2001]]}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -618,103 +710,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "1163"
+          - "762"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Vary:
-          - Accept-Encoding
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1101%2F2024.04.01.587366?mailto=example@papercrow.ai
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,4,5]],"date-time":"2024-04-05T00:42:23Z","timestamp":1712277743507},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
-          Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":[],"accepted":{"date-parts":[[2024,4,1]]},"abstract":"<jats:title>ABSTRACT<\/jats:title><jats:p>Understanding
-          the effects of rare genetic variants remains challenging, both in coding and
-          non-coding regions. While multiplexed assays of variant effect (MAVEs) have
-          enabled scalable functional assessment of variants, established MAVEs are
-          limited by either exogenous expression of variants or constraints of genome
-          editing. Here, we introduce a pooled prime editing (PE) platform in haploid
-          human cells to scalably assay variants in their endogenous context. We first
-          optimized delivery of variants to HAP1 cells, defining optimal pegRNA designs
-          and establishing a co-selection strategy for improved efficiency. We characterize
-          our platform in the context of negative selection by testing over 7,500 pegRNAs
-          targeting<jats:italic>SMARCB1<\/jats:italic>for editing activity and observing
-          depletion of highly active pegRNAs installing loss-of-function variants. We
-          next assess variants in<jats:italic>MLH1<\/jats:italic>via 6-thioguanine selection,
-          assaying 65.3% of all possible SNVs in a 200-bp region spanning exon 10 and
-          distinguishing LoF variants with high accuracy. Lastly, we assay 362 non-coding<jats:italic>MLH1<\/jats:italic>variants
-          across a 60 kb region in a single experiment, identifying pathogenic variants
-          acting via multiple mechanisms with high specificity. Our analyses detail
-          how filtering for highly active pegRNAs can facilitate both positive and negative
-          selection screens. Accordingly, our platform promises to enable highly scalable
-          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":0,"title":["High-throughput
-          screening of human genetic variants by pooled prime editing"],"prefix":"10.1101","author":[{"given":"Michael","family":"Herger","sequence":"first","affiliation":[]},{"given":"Christina
-          M.","family":"Kajba","sequence":"additional","affiliation":[]},{"given":"Megan","family":"Buckley","sequence":"additional","affiliation":[]},{"given":"Ana","family":"Cunha","sequence":"additional","affiliation":[]},{"given":"Molly","family":"Strom","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7767-8608","authenticated-orcid":false,"given":"Gregory
-          M.","family":"Findlay","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2024040415500652000_2024.04.01.587366v1.1","doi-asserted-by":"publisher","DOI":"10.1038\/gim.2015.30"},{"key":"2024040415500652000_2024.04.01.587366v1.2","doi-asserted-by":"crossref","first-page":"116","DOI":"10.1016\/j.cels.2017.11.003","article-title":"Quantitative
-          Missense Variant Effect Prediction Using Large-Scale Mutagenesis Data","volume":"6","year":"2018","journal-title":"Cell
-          Syst"},{"key":"2024040415500652000_2024.04.01.587366v1.3","doi-asserted-by":"publisher","DOI":"10.1126\/science.abi8207"},{"key":"2024040415500652000_2024.04.01.587366v1.4","doi-asserted-by":"publisher","DOI":"10.1016\/J.CELL.2018.12.015"},{"key":"2024040415500652000_2024.04.01.587366v1.5","doi-asserted-by":"crossref","first-page":"eabn8153","DOI":"10.1126\/science.abn8197","article-title":"The
-          landscape of tolerated genetic variation in humans and primates","volume":"380","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.6","doi-asserted-by":"crossref","first-page":"eadg7492","DOI":"10.1126\/science.adg7492","article-title":"Accurate
-          proteome-wide missense variant effect prediction with AlphaMissense","volume":"381","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.7","doi-asserted-by":"publisher","DOI":"10.1093\/nar\/gkv1222"},{"key":"2024040415500652000_2024.04.01.587366v1.8","doi-asserted-by":"crossref","first-page":"1381","DOI":"10.1038\/s41436-021-01172-3","article-title":"ACMG
-          SF v3.0 list for reporting of secondary findings in clinical exome and genome
-          sequencing: a policy statement of the American College of Medical Genetics
-          and Genomics (ACMG)","volume":"23","year":"2021","journal-title":"Genet. Med"},{"key":"2024040415500652000_2024.04.01.587366v1.9","doi-asserted-by":"publisher","DOI":"10.1038\/nprot.2016.135"},{"key":"2024040415500652000_2024.04.01.587366v1.10","doi-asserted-by":"publisher","DOI":"10.1093\/hmg\/ddab219"},{"key":"2024040415500652000_2024.04.01.587366v1.11","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-11526-w"},{"key":"2024040415500652000_2024.04.01.587366v1.12","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-022-02839-z"},{"key":"2024040415500652000_2024.04.01.587366v1.13","doi-asserted-by":"crossref","first-page":"2248","DOI":"10.1016\/j.ajhg.2021.11.001","article-title":"Closing
-          the gap: Systematic integration of multiplexed functional data resolves variants
-          of uncertain significance in BRCA1, TP53, and PTEN","volume":"108","year":"2021","journal-title":"Am.
-          J. Hum. Genet."},{"key":"2024040415500652000_2024.04.01.587366v1.14","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-018-0461-z"},{"key":"2024040415500652000_2024.04.01.587366v1.15","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.10.015"},{"key":"2024040415500652000_2024.04.01.587366v1.16","doi-asserted-by":"crossref","first-page":"7702","DOI":"10.1038\/s41467-023-43041-4","article-title":"Saturation
-          genome editing of DDX3X clarifies pathogenicity of germline and somatic variation","volume":"14","year":"2023","journal-title":"Nat.
-          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.17","doi-asserted-by":"publisher","DOI":"10.1038\/nature13695"},{"key":"2024040415500652000_2024.04.01.587366v1.18","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.012"},{"key":"2024040415500652000_2024.04.01.587366v1.19","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.041"},{"key":"2024040415500652000_2024.04.01.587366v1.20","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-019-1711-4"},{"key":"2024040415500652000_2024.04.01.587366v1.21","doi-asserted-by":"crossref","first-page":"288","DOI":"10.1016\/j.ccell.2022.12.009","article-title":"Base
-          editing screens map mutations affecting interferon-\u03b3 signaling in cancer","volume":"41","year":"2023","journal-title":"Cancer
-          Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.22","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.09.018"},{"key":"2024040415500652000_2024.04.01.587366v1.23","doi-asserted-by":"crossref","first-page":"402","DOI":"10.1038\/s41587-021-01039-7","article-title":"Engineered
-          pegRNAs improve prime editing efficiency","volume":"40","year":"2022","journal-title":"Nat.
-          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.24","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01201-1"},{"key":"2024040415500652000_2024.04.01.587366v1.25","doi-asserted-by":"publisher","DOI":"10.1016\/j.molcel.2023.11.021"},{"key":"2024040415500652000_2024.04.01.587366v1.26","doi-asserted-by":"publisher","DOI":"10.1038\/nature10348"},{"key":"2024040415500652000_2024.04.01.587366v1.27","doi-asserted-by":"publisher","DOI":"10.1126\/science.1247005"},{"key":"2024040415500652000_2024.04.01.587366v1.28","doi-asserted-by":"crossref","first-page":"1151","DOI":"10.1038\/s41587-022-01613-7","article-title":"Predicting
-          prime editing efficiency and product purity by deep learning","volume":"41","year":"2023","journal-title":"Nat.
-          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.29","doi-asserted-by":"crossref","first-page":"2256","DOI":"10.1016\/j.cell.2023.03.034","article-title":"Prediction
-          of efficiencies for diverse prime editing systems in multiple cell types","volume":"186","year":"2023","journal-title":"Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.30","doi-asserted-by":"publisher","DOI":"10.1101\/2022.10.26.513842"},{"key":"2024040415500652000_2024.04.01.587366v1.31","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01172-3"},{"key":"2024040415500652000_2024.04.01.587366v1.32","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-020-0677-y"},{"key":"2024040415500652000_2024.04.01.587366v1.33","doi-asserted-by":"publisher","DOI":"10.1016\/j.tibtech.2018.07.017"},{"key":"2024040415500652000_2024.04.01.587366v1.34","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-020-20810-z"},{"key":"2024040415500652000_2024.04.01.587366v1.35","doi-asserted-by":"crossref","first-page":"5909","DOI":"10.1038\/s41467-022-33669-z","article-title":"Marker-free
-          co-selection for successive rounds of prime editing in human cells","volume":"13","year":"2022","journal-title":"Nat.
-          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.36","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2013.12.001"},{"key":"2024040415500652000_2024.04.01.587366v1.37","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-018-02974-x"},{"key":"2024040415500652000_2024.04.01.587366v1.38","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-021-27838-9"},{"key":"2024040415500652000_2024.04.01.587366v1.39","doi-asserted-by":"publisher","DOI":"10.1126\/science.1225829"},{"key":"2024040415500652000_2024.04.01.587366v1.40","doi-asserted-by":"publisher","DOI":"10.3390\/cancers14153645"},{"key":"2024040415500652000_2024.04.01.587366v1.41","doi-asserted-by":"publisher","DOI":"10.1126\/science.aac7557"},{"key":"2024040415500652000_2024.04.01.587366v1.42","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-10849-y"},{"key":"2024040415500652000_2024.04.01.587366v1.43","doi-asserted-by":"publisher","DOI":"10.1038\/nbt.3437"},{"key":"2024040415500652000_2024.04.01.587366v1.44","doi-asserted-by":"publisher","DOI":"10.1136\/jmg.2007.056499"},{"key":"2024040415500652000_2024.04.01.587366v1.45","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.12.003"},{"key":"2024040415500652000_2024.04.01.587366v1.46","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-019-0032-3"},{"key":"2024040415500652000_2024.04.01.587366v1.47","doi-asserted-by":"publisher","DOI":"10.1038\/nmeth.3047"},{"key":"2024040415500652000_2024.04.01.587366v1.48","doi-asserted-by":"crossref","first-page":"96","DOI":"10.1089\/hgtb.2017.198","article-title":"Determination
-          of Lentiviral Infectious Titer by a Novel Droplet Digital PCR Method","volume":"29","year":"2018","journal-title":"Hum.
-          Gene Ther. Methods"},{"key":"2024040415500652000_2024.04.01.587366v1.49","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-020-02091-3"},{"key":"2024040415500652000_2024.04.01.587366v1.50","doi-asserted-by":"publisher","DOI":"10.1186\/s13073-021-00835-9"}],"container-title":[],"original-title":[],"link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1101\/2024.04.01.587366","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,4,4]],"date-time":"2024-04-04T22:50:19Z","timestamp":1712271019000},"score":1,"resource":{"primary":{"URL":"http:\/\/biorxiv.org\/lookup\/doi\/10.1101\/2024.04.01.587366"}},"subtitle":[],"short-title":[],"issued":{"date-parts":[[2024,4,1]]},"references-count":50,"URL":"http:\/\/dx.doi.org\/10.1101\/2024.04.01.587366","relation":{},"subject":[],"published":{"date-parts":[[2024,4,1]]},"subtype":"preprint"}}'
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "3214"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -742,7 +742,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2024,9,20]],"date-time":"2024-09-20T17:08:43Z","timestamp":1726852123984},"reference-count":103,"publisher":"Springer
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:11:02Z","timestamp":1732043462673},"reference-count":103,"publisher":"Springer
           Science and Business Media LLC","issue":"5","license":[{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"},{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"}],"funder":[{"DOI":"10.13039\/501100001711","name":"Schweizerischer
           Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","doi-asserted-by":"publisher","award":["180544","180544","180544"],"id":[{"id":"10.13039\/501100001711","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000001","name":"National
           Science Foundation","doi-asserted-by":"publisher","award":["1751471","1751471"],"id":[{"id":"10.13039\/100000001","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"short-container-title":["Nat
@@ -759,7 +759,7 @@ interactions:
           both LLM and expert assessments, demonstrates ChemCrow\u2019s effectiveness
           in automating a diverse set of chemical tasks. Our work not only aids expert
           chemists and lowers barriers for non-experts but also fosters scientific advancement
-          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":21,"title":["Augmenting
+          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":36,"title":["Augmenting
           large language models with chemistry tools"],"prefix":"10.1038","volume":"6","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"member":"297","published-online":{"date-parts":[[2024,5,8]]},"reference":[{"key":"832_CR1","unstructured":"Devlin,
@@ -1069,59 +1069,15 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "10522"
+          - "10524"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
           - Accept-Encoding
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1023%2Fa:1007154515475/transform/application/x-bibtex
-    response:
-      body:
-        string:
-          " @article{Adak_2001, volume={218}, ISSN={0300-8177}, url={http://dx.doi.org/10.1023/a:1007154515475},
-          DOI={10.1023/a:1007154515475}, number={1/2}, journal={Molecular and Cellular
-          Biochemistry}, publisher={Springer Science and Business Media LLC}, author={Adak,
-          Subrata and Bandyopadhyay, Debashis and Bandyopadhyay, Uday and Banerjee,
-          Ranajit K.}, year={2001}, pages={1\u201311} }\n"
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
         permissions-policy:
           - interest-cohort=()
         x-api-pool:
@@ -1160,7 +1116,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -1207,7 +1163,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -1253,7 +1209,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -1299,7 +1255,51 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1023%2Fa:1007154515475/transform/application/x-bibtex
+    response:
+      body:
+        string:
+          " @article{Adak_2001, volume={218}, ISSN={0300-8177}, url={http://dx.doi.org/10.1023/a:1007154515475},
+          DOI={10.1023/a:1007154515475}, number={1/2}, journal={Molecular and Cellular
+          Biochemistry}, publisher={Springer Science and Business Media LLC}, author={Adak,
+          Subrata and Bandyopadhyay, Debashis and Bandyopadhyay, Uday and Banerjee,
+          Ranajit K.}, year={2001}, pages={1\u201311} }\n"
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_bulk_title_search.yaml
+++ b/tests/cassettes/test_bulk_title_search.yaml
@@ -3,27 +3,19 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Convalescent-anti-sars-cov-2-plasma/immune-globulin&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
     response:
       body:
         string:
-          '{"data": [{"paperId": "7e55d8701785818776323b4147cb13354c820469", "externalIds":
-          {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
-          "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
-          "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
-          "venue": "arXiv.org", "year": 2023, "citationCount": 37, "influentialCitationCount":
-          1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
-          "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
-          "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
-          L''ala and Odhran O''Donoghue and Aleksandar Shtedritski and Sam Cox and Samuel
-          G. Rodriques and Andrew D. White},\n booktitle = {arXiv.org},\n journal =
-          {ArXiv},\n title = {PaperQA: Retrieval-Augmented Generative Agent for Scientific
-          Research},\n volume = {abs/2312.07559},\n year = {2023}\n}\n"}, "authors":
-          [{"authorId": "2219926382", "name": "Jakub L''ala"}, {"authorId": "2258961056",
-          "name": "Odhran O''Donoghue"}, {"authorId": "2258961451", "name": "Aleksandar
-          Shtedritski"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId":
-          "2258964497", "name": "Samuel G. Rodriques"}, {"authorId": "2273941271", "name":
-          "Andrew D. White"}], "matchScore": 247.60916}]}
+          '{"data": [{"paperId": "762ceacc20db232d3f6bcda6e867eb8148848ced", "externalIds":
+          {"DOI": "10.1007/s40278-023-33114-1", "CorpusId": 256742540}, "url": "https://www.semanticscholar.org/paper/762ceacc20db232d3f6bcda6e867eb8148848ced",
+          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "venue": "Reactions
+          weekly", "year": 2023, "citationCount": 0, "influentialCitationCount": 0,
+          "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": null, "publicationDate":
+          "2023-02-01", "journal": {"name": "Reactions Weekly", "pages": "229", "volume":
+          "1943"}, "citationStyles": {"bibtex": "@Article{None,\n booktitle = {Reactions
+          weekly},\n journal = {Reactions Weekly},\n pages = {229},\n title = {Convalescent-anti-sars-cov-2-plasma/immune-globulin},\n
+          volume = {1943},\n year = {2023}\n}\n"}, "authors": [], "matchScore": 239.18658}]}
 
           '
       headers:
@@ -32,94 +24,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "1386"
+          - "848"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Via:
-          - 1.1 b0ed8f5cd57ec24ce179421915a813d6.cloudfront.net (CloudFront)
+          - 1.1 6778e3146eb385e3772c8de867b2c290.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - Ipwhq_IVrvHZTzS0PCEx1vBpc_dAXTehzQ6khOjDnMqn3_HuTMXEKg==
+          - 6gj0f3exL8mzUZQ3DVHsGsDh0OZYgn2vnceemcD2OQSANE1tUw8oGg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PvEVQPHcENIg=
+          - CLbZTE8aPHcEA5Q=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "1386"
+          - "848"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 266bd8e4-a63f-4271-983d-0a8dc8a0c37b
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
-          "title": "Augmenting large language models with chemistry tools", "venue":
-          "Nat. Mac. Intell.", "year": 2023, "citationCount": 225, "influentialCitationCount":
-          11, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
-          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
-          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
-          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
-          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
-          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
-          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
-          {Augmenting large language models with chemistry tools},\n volume = {6},\n
-          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
-          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
-          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
-          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
-          "name": "P. Schwaller"}], "matchScore": 176.3838}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1550"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        Via:
-          - 1.1 f8b122b964bc12ee7f052daf895c865c.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - ImsOwA_7avf3DJhurD4q2e9ddfoWikAZayRvqgFPeVX3-xetOJTf4Q==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PwGrevHcEImg=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1550"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 2dd88b2c-07a0-457e-8398-94247f74da3a
+          - 2c564990-bd04-42aa-8480-6a748409c785
       status:
         code: 200
         message: OK
@@ -145,7 +74,7 @@ interactions:
           tensile properties: A reactive molecular dynamics study},\n volume = {118},\n
           year = {2015}\n}\n"}, "authors": [{"authorId": "9821934", "name": "Michael
           Skarlinski"}, {"authorId": "37723150", "name": "D. Quesnel"}], "matchScore":
-          283.3764}]}
+          283.44385}]}
 
           '
       headers:
@@ -154,31 +83,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "1108"
+          - "1109"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Via:
-          - 1.1 8aa9515f0608451f7f77b7d0095beae0.cloudfront.net (CloudFront)
+          - 1.1 b0797f10be715dcb685d992d17347df4.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - FwtYX26DJkUTsbzpo8C79RwojcxaOto0PcKk0gqUKjJV21fs3EFwGg==
+          - GX8EekzuF6a_nhl2spAX8cvKRJli7xqP1aYR65YID_IgGJRH0maD8g==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PwGksvHcEvYQ=
+          - CLbZTFJ2vHcEhuw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "1108"
+          - "1109"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 4556aa7f-3f3d-43ed-97ef-23422817462f
+          - 30a64d52-0c0e-455c-8fda-e7a4e13c0ba0
       status:
         code: 200
         message: OK
@@ -186,151 +115,20 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Convalescent-anti-sars-cov-2-plasma/immune-globulin&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Convalescent-anti-sars-cov-2-plasma/immune-globulin&rows=1
     response:
       body:
         string:
-          '{"data": [{"paperId": "762ceacc20db232d3f6bcda6e867eb8148848ced", "externalIds":
-          {"DOI": "10.1007/s40278-023-33114-1", "CorpusId": 256742540}, "url": "https://www.semanticscholar.org/paper/762ceacc20db232d3f6bcda6e867eb8148848ced",
-          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "venue": "Reactions
-          weekly", "year": 2023, "citationCount": 0, "influentialCitationCount": 0,
-          "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": null, "publicationDate":
-          "2023-02-01", "journal": {"name": "Reactions Weekly", "pages": "229", "volume":
-          "1943"}, "citationStyles": {"bibtex": "@Article{None,\n booktitle = {Reactions
-          weekly},\n journal = {Reactions Weekly},\n pages = {229},\n title = {Convalescent-anti-sars-cov-2-plasma/immune-globulin},\n
-          volume = {1943},\n year = {2023}\n}\n"}, "authors": [], "matchScore": 240.13841}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "848"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        Via:
-          - 1.1 28da7b50b2dbdddfb257605df1527026.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - Yb4yRHNhZLQZPvcttu77G20xo7AUzm3UnokJ8hgs4CgJz7RRqU-pXg==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PvEzuvHcEFoQ=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "848"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - bd5c5963-ab7e-40b4-b16f-3008e7251259
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&rows=1
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2053545,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
-          University Press (OUP)","issue":"1","license":[{"start":{"date-parts":[[2024,2,21]],"date-time":"2024-02-21T00:00:00Z","timestamp":1708473600000},"content-version":"vor","delay-in-days":48,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"funder":[{"DOI":"10.13039\/100000092","name":"National
-          Library of Medicine","doi-asserted-by":"publisher","award":["R01LM009886","R01LM014344"],"id":[{"id":"10.13039\/100000092","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100006108","name":"National
-          Center for Advancing Translational Sciences","doi-asserted-by":"publisher","award":["UL1TR001873"],"id":[{"id":"10.13039\/100006108","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000002","name":"National
-          Institutes of Health","doi-asserted-by":"publisher","id":[{"id":"10.13039\/100000002","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2024,1,4]]},"abstract":"<jats:title>Abstract<\/jats:title>\n               <jats:sec>\n                  <jats:title>Objective<\/jats:title>\n                  <jats:p>To
-          automate scientific claim verification using PubMed abstracts.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Materials
-          and Methods<\/jats:title>\n                  <jats:p>We developed CliVER,
-          an end-to-end scientific Claim VERification system that leverages retrieval-augmented
-          techniques to automatically retrieve relevant clinical trial abstracts, extract
-          pertinent sentences, and use the PICO framework to support or refute a scientific
-          claim. We also created an ensemble of three state-of-the-art deep learning
-          models to classify rationale of support, refute, and neutral. We then constructed
-          CoVERt, a new COVID VERification dataset comprising 15 PICO-encoded drug claims
-          accompanied by 96 manually selected and labeled clinical trial abstracts that
-          either support or refute each claim. We used CoVERt and SciFact (a public
-          scientific claim verification dataset) to assess CliVER\u2019s performance
-          in predicting labels. Finally, we compared CliVER to clinicians in the verification
-          of 19 claims from 6 disease domains, using 189\u00a0648 PubMed abstracts extracted
-          from January 2010 to October 2021.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Results<\/jats:title>\n                  <jats:p>In
-          the evaluation of label prediction accuracy on CoVERt, CliVER achieved a notable
-          F1 score of 0.92, highlighting the efficacy of the retrieval-augmented models.
-          The ensemble model outperforms each individual state-of-the-art model by an
-          absolute increase from 3% to 11% in the F1 score. Moreover, when compared
-          with four clinicians, CliVER achieved a precision of 79.0% for abstract retrieval,
-          67.4% for sentence selection, and 63.2% for label prediction, respectively.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Conclusion<\/jats:title>\n                  <jats:p>CliVER
-          demonstrates its early potential to automate scientific claim verification
-          using retrieval-augmented strategies to harness the wealth of clinical trial
-          abstracts in PubMed. Future studies are warranted to further test its clinical
-          utility.<\/jats:p>\n               <\/jats:sec>","DOI":"10.1093\/jamiaopen\/ooae021","type":"journal-article","created":{"date-parts":[[2024,2,22]],"date-time":"2024-02-22T01:48:17Z","timestamp":1708566497000},"source":"Crossref","is-referenced-by-count":0,"title":["Retrieval
-          augmented scientific claim verification"],"prefix":"10.1093","volume":"7","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-1975-1272","authenticated-orcid":false,"given":"Hao","family":"Liu","sequence":"first","affiliation":[{"name":"School
-          of Computing, Montclair State University , Montclair, NJ 07043, United States"}]},{"given":"Ali","family":"Soroush","sequence":"additional","affiliation":[{"name":"Department
-          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0003-1418-3103","authenticated-orcid":false,"given":"Jordan
-          G","family":"Nestor","sequence":"additional","affiliation":[{"name":"Department
-          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"given":"Elizabeth","family":"Park","sequence":"additional","affiliation":[{"name":"Department
-          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0002-4318-5987","authenticated-orcid":false,"given":"Betina","family":"Idnay","sequence":"additional","affiliation":[{"name":"Department
-          of Biomedical Informatics, Columbia University , New York, NY 10027, United
-          States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0002-2681-1931","authenticated-orcid":false,"given":"Yilu","family":"Fang","sequence":"additional","affiliation":[{"name":"Department
-          of Biomedical Informatics, Columbia University , New York, NY 10027, United
-          States"}]},{"given":"Jane","family":"Pan","sequence":"additional","affiliation":[{"name":"Department
-          of Applied Physics and Applied Mathematics, Columbia University , New York,
-          NY 10027, United States"}]},{"given":"Stan","family":"Liao","sequence":"additional","affiliation":[{"name":"Department
-          of Applied Physics and Applied Mathematics, Columbia University , New York,
-          NY 10027, United States"}]},{"given":"Marguerite","family":"Bernard","sequence":"additional","affiliation":[{"name":"Institute
-          of Human Nutrition, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0001-9309-8331","authenticated-orcid":false,"given":"Yifan","family":"Peng","sequence":"additional","affiliation":[{"name":"Department
-          of Population Health Sciences, Weill Cornell Medicine , New York, NY 10065,
-          United States"}]},{"given":"Chunhua","family":"Weng","sequence":"additional","affiliation":[{"name":"Department
-          of Biomedical Informatics, Columbia University , New York, NY 10027, United
-          States"}]}],"member":"286","published-online":{"date-parts":[[2024,2,21]]},"reference":[{"issue":"6","key":"2024030720490192400_ooae021-B1","doi-asserted-by":"crossref","first-page":"1192","DOI":"10.1093\/jamia\/ocx050","article-title":"Evidence
-          appraisal: a scoping review, conceptual framework, and research agenda","volume":"24","author":"Goldstein","year":"2017","journal-title":"J
-          Am Med Inform Assoc"},{"issue":"D1","key":"2024030720490192400_ooae021-B2","doi-asserted-by":"crossref","first-page":"D1534","DOI":"10.1093\/nar\/gkaa952","article-title":"LitCovid:
-          an open database of COVID-19 literature","volume":"49","author":"Chen","year":"2021","journal-title":"Nucleic
-          Acids Res"},{"key":"2024030720490192400_ooae021-B3","author":"Medicine NLo"},{"issue":"1","key":"2024030720490192400_ooae021-B4","doi-asserted-by":"crossref","first-page":"6","DOI":"10.1038\/s41591-020-01203-7","article-title":"Automated
-          screening of COVID-19 preprints: can we help authors to improve transparency
-          and reproducibility?","volume":"27","author":"Weissgerber","year":"2021","journal-title":"Nat
-          Med"},{"issue":"2","key":"2024030720490192400_ooae021-B5","doi-asserted-by":"crossref","first-page":"218","DOI":"10.1001\/jama.294.2.218","article-title":"Contradicted
-          and initially stronger effects in highly cited clinical research","volume":"294","author":"Ioannidis","year":"2005","journal-title":"JAMA"},{"issue":"1","key":"2024030720490192400_ooae021-B6","doi-asserted-by":"crossref","first-page":"63","DOI":"10.1162\/coli.2007.33.1.63","article-title":"Answering
-          clinical questions with knowledge-based and statistical techniques","volume":"33","author":"Demner-Fushman","year":"2007","journal-title":"Comput
-          Linguist"},{"issue":"6","key":"2024030720490192400_ooae021-B7","doi-asserted-by":"crossref","first-page":"772","DOI":"10.1197\/jamia.M2407","article-title":"Knowledge-based
-          methods to help clinicians find answers in MEDLINE","volume":"14","author":"Sneiderman","year":"2007","journal-title":"J
-          Am Med Inform Assoc"},{"issue":"5","key":"2024030720490192400_ooae021-B8","doi-asserted-by":"crossref","first-page":"232","DOI":"10.1186\/cc5045","article-title":"Evidence-based
-          medicine: classifying the evidence from clinical trials\u2013the need to consider
-          other dimensions","volume":"10","author":"Bellomo","year":"2006","journal-title":"Crit
-          Care"},{"issue":"1","key":"2024030720490192400_ooae021-B9","doi-asserted-by":"crossref","first-page":"6","DOI":"10.1002\/clc.4960220106","article-title":"The
-          importance of randomized clinical trials and evidence-based medicine: a clinician''s
-          perspective","volume":"22","author":"Kennedy","year":"1999","journal-title":"Clin
-          Cardiol"},{"key":"2024030720490192400_ooae021-B10","first-page":"493","author":"Hanselowski","year":"2019"},{"key":"2024030720490192400_ooae021-B11","first-page":"809","author":"Thorne","year":"2018"},{"key":"2024030720490192400_ooae021-B12","first-page":"7534","author":"Wadden","year":"2020"},{"key":"2024030720490192400_ooae021-B13","first-page":"94","author":"Pradeep","year":"2021"},{"key":"2024030720490192400_ooae021-B14","first-page":"5485","article-title":"Exploring
-          the limits of transfer learning with a unified text-to-text transformer","volume":"140","author":"Raffel","year":"2020","journal-title":"J.
-          Mach. Learn. Res"},{"key":"2024030720490192400_ooae021-B15","author":"Li","year":"2021"},{"key":"2024030720490192400_ooae021-B16","first-page":"61","author":"Wadden","year":"2022"},{"key":"2024030720490192400_ooae021-B17","author":"Beltagy","year":"2020"},{"issue":"7256","key":"2024030720490192400_ooae021-B18","doi-asserted-by":"crossref","first-page":"255","DOI":"10.1136\/bmj.321.7256.255","article-title":"Which
-          clinical studies provide the best evidence?: the best RCT still trumps the
-          best observational study","volume":"321","author":"Barton","year":"2000","journal-title":"BMJ"},{"key":"2024030720490192400_ooae021-B19","doi-asserted-by":"crossref","first-page":"103717","DOI":"10.1016\/j.jbi.2021.103717","article-title":"Toward
-          assessing clinical trial publications for reporting transparency","volume":"116","author":"Kilicoglu","year":"2021","journal-title":"J
-          Biomed Inform"},{"key":"2024030720490192400_ooae021-B20","first-page":"1253","author":"Yang","year":"2017"},{"key":"2024030720490192400_ooae021-B21","first-page":"39","author":"Khattab","year":"2020"},{"key":"2024030720490192400_ooae021-B22","first-page":"19","author":"Yilmaz","year":"2019"},{"key":"2024030720490192400_ooae021-B23","author":"Kuzi","year":"2020"},{"key":"2024030720490192400_ooae021-B24","volume-title":"The
-          Probabilistic Relevance Framework: BM25 and Beyond","author":"Robertson","year":"2009"},{"key":"2024030720490192400_ooae021-B25","first-page":"105","author":"Wang","year":"2011"},{"key":"2024030720490192400_ooae021-B26","first-page":"7740","author":"Kotonya","year":"2020"},{"issue":"1","key":"2024030720490192400_ooae021-B27","doi-asserted-by":"crossref","first-page":"36","DOI":"10.1186\/s13326-016-0083-z","article-title":"A
-          corpus of potentially contradictory research claims from cardiovascular research
-          abstracts","volume":"7","author":"Alamri","year":"2016","journal-title":"J
-          Biomed Semantics"},{"key":"2024030720490192400_ooae021-B28","first-page":"3499","author":"Sarrouti","year":"2021"},{"issue":"9","key":"2024030720490192400_ooae021-B29","doi-asserted-by":"crossref","first-page":"1431","DOI":"10.1093\/jamia\/ocaa091","article-title":"TREC-COVID:
-          rationale and structure of an information retrieval shared task for COVID-19","volume":"27","author":"Roberts","year":"2020","journal-title":"J
-          Am Med Inform Assoc"},{"key":"2024030720490192400_ooae021-B30","author":"Wang","year":"2020"},{"key":"2024030720490192400_ooae021-B31","first-page":"2116","author":"Saakyan","year":"2021"},{"key":"2024030720490192400_ooae021-B32","first-page":"359","author":"Huang","year":"2006"},{"key":"2024030720490192400_ooae021-B33","first-page":"708","author":"Nogueira","year":"2020"},{"key":"2024030720490192400_ooae021-B34","doi-asserted-by":"crossref","first-page":"baw065","DOI":"10.1093\/database\/baw065","article-title":"Mining
-          chemical patents with an ensemble of open systems","volume":"2016","author":"Leaman","year":"2016","journal-title":"Database"},{"key":"2024030720490192400_ooae021-B35","doi-asserted-by":"crossref","first-page":"bay073","DOI":"10.1093\/database\/bay073","article-title":"Extracting
-          chemical\u2013protein relations with ensembles of SVM and deep learning models","volume":"2018","author":"Peng","year":"2018","journal-title":"Database"},{"key":"2024030720490192400_ooae021-B36","author":"Liu","year":"2019"},{"issue":"1","key":"2024030720490192400_ooae021-B37","doi-asserted-by":"crossref","first-page":"1","DOI":"10.1145\/3458754","article-title":"Domain-specific
-          language model pretraining for biomedical natural language processing","volume":"3","author":"Gu","year":"2021","journal-title":"ACM
-          Trans Comput Healthc"},{"issue":"3","key":"2024030720490192400_ooae021-B38","doi-asserted-by":"crossref","first-page":"A12","DOI":"10.7326\/ACPJC-1995-123-3-A12","article-title":"The
-          well-built clinical question: a key to evidence-based decisions","volume":"123","author":"Richardson","year":"1995","journal-title":"ACP
-          J Club"},{"key":"2024030720490192400_ooae021-B39","first-page":"1971","author":"Lee","year":"2021"},{"key":"2024030720490192400_ooae021-B40","author":"Loshchilov","year":"2019"},{"key":"2024030720490192400_ooae021-B41","first-page":"13","author":"Kingma","year":"2015"},{"key":"2024030720490192400_ooae021-B42","first-page":"38","author":"Wolf","year":"2020"},{"key":"2024030720490192400_ooae021-B43","first-page":"2356","author":"Lin","year":"2021"},{"key":"2024030720490192400_ooae021-B44","first-page":"243","author":"J\u00e4rvelin","year":"2017"},{"issue":"4","key":"2024030720490192400_ooae021-B45","doi-asserted-by":"crossref","first-page":"422","DOI":"10.1145\/582415.582418","article-title":"Cumulated
-          gain-based evaluation of IR techniques","volume":"20","author":"J\u00e4rvelin","year":"2002","journal-title":"ACM
-          Trans Inf Syst"},{"key":"2024030720490192400_ooae021-B46","volume-title":"Evidence-Based
-          Practice in Nursing & Healthcare: A Guide to Best Practice","author":"Melnyk","year":"2022"},{"key":"2024030720490192400_ooae021-B47","first-page":"206","author":"Gupta","year":"2017"},{"key":"2024030720490192400_ooae021-B48","first-page":"1","author":"Park","year":"2012"}],"container-title":["JAMIA
-          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":27.876652,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":1513586,"items":[{"indexed":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T04:17:17Z","timestamp":1687580237047},"reference-count":1,"publisher":"Springer
+          Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"},{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Reactions
+          Weekly"],"DOI":"10.1007\/s40278-023-41815-2","type":"journal-article","created":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T18:42:29Z","timestamp":1687545749000},"page":"145-145","source":"Crossref","is-referenced-by-count":0,"title":["Convalescent-anti-sars-cov-2-plasma\/immune-globulin"],"prefix":"10.1007","volume":"1962","member":"297","published-online":{"date-parts":[[2023,6,24]]},"reference":[{"key":"41815_CR1","doi-asserted-by":"crossref","unstructured":"Delgado-Fernandez
+          M, et al. Treatment of COVID-19 with convalescent plasma in patients with
+          humoral immunodeficiency - Three consecutive cases and review of the literature.
+          Enfermedades Infecciosas Y Microbiologia Clinica 40\n: 507-516, No. 9, Nov
+          2022. Available from: URL: \nhttps:\/\/seimc.org\/","DOI":"10.1016\/j.eimce.2021.01.009"}],"container-title":["Reactions
+          Weekly"],"language":"en","link":[{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/article\/10.1007\/s40278-023-41815-2\/fulltext.html","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T19:23:18Z","timestamp":1687548198000},"score":57.92144,"resource":{"primary":{"URL":"https:\/\/link.springer.com\/10.1007\/s40278-023-41815-2"}},"subtitle":["Fever
+          and mild decrease in baseline oxygen saturation following off-label use: 3
+          case reports"],"issued":{"date-parts":[[2023,6,24]]},"references-count":1,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,6]]}},"alternative-id":["41815"],"URL":"http:\/\/dx.doi.org\/10.1007\/s40278-023-41815-2","ISSN":["1179-2051"],"issn-type":[{"value":"1179-2051","type":"electronic"}],"published":{"date-parts":[[2023,6,24]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -344,11 +142,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "4503"
+          - "1207"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -372,11 +170,258 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=High-throughput+screening+of+human+genetic+variants+by+pooled+prime+editing&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "7e5d4466c8b85f93775fe183e1a318a3e65ac8e4", "externalIds":
+          {"DOI": "10.1101/2024.04.01.587366", "CorpusId": 268890006}, "url": "https://www.semanticscholar.org/paper/7e5d4466c8b85f93775fe183e1a318a3e65ac8e4",
+          "title": "High-throughput screening of human genetic variants by pooled prime
+          editing", "venue": "bioRxiv", "year": 2024, "citationCount": 1, "influentialCitationCount":
+          0, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
+          "status": "GREEN"}, "publicationTypes": null, "publicationDate": "2024-04-01",
+          "journal": {"name": "bioRxiv"}, "citationStyles": {"bibtex": "@Article{Herger2024HighthroughputSO,\n
+          author = {Michael Herger and Christina M. Kajba and Megan Buckley and Ana
+          Cunha and Molly Strom and Gregory M. Findlay},\n booktitle = {bioRxiv},\n
+          journal = {bioRxiv},\n title = {High-throughput screening of human genetic
+          variants by pooled prime editing},\n year = {2024}\n}\n"}, "authors": [{"authorId":
+          "2294884120", "name": "Michael Herger"}, {"authorId": "2163800172", "name":
+          "Christina M. Kajba"}, {"authorId": "2120283350", "name": "Megan Buckley"},
+          {"authorId": "2294861709", "name": "Ana Cunha"}, {"authorId": "2294881320",
+          "name": "Molly Strom"}, {"authorId": "145686550", "name": "Gregory M. Findlay"}],
+          "matchScore": 251.94705}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1362"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:27 GMT
+        Via:
+          - 1.1 cb0f9f6369baeebf7c66aebe4cb453ac.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - MW1BYpJqae4SSpfUxxfV9XdsuHAHyErmqFiORnlDgNAHWbqyL2Yw8A==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbZTHqgvHcEaCA=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1362"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:27 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - e259beb0-2b2d-4d0e-b922-15de842b7ef9
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "7e55d8701785818776323b4147cb13354c820469", "externalIds":
+          {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
+          "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
+          "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
+          "venue": "arXiv.org", "year": 2023, "citationCount": 38, "influentialCitationCount":
+          1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
+          "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
+          "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
+          L''ala and Odhran O''Donoghue and Aleksandar Shtedritski and Sam Cox and Samuel
+          G. Rodriques and Andrew D. White},\n booktitle = {arXiv.org},\n journal =
+          {ArXiv},\n title = {PaperQA: Retrieval-Augmented Generative Agent for Scientific
+          Research},\n volume = {abs/2312.07559},\n year = {2023}\n}\n"}, "authors":
+          [{"authorId": "2219926382", "name": "Jakub L''ala"}, {"authorId": "2258961056",
+          "name": "Odhran O''Donoghue"}, {"authorId": "2258961451", "name": "Aleksandar
+          Shtedritski"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId":
+          "2258964497", "name": "Samuel G. Rodriques"}, {"authorId": "2273941271", "name":
+          "Andrew D. White"}], "matchScore": 247.75336}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1386"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:27 GMT
+        Via:
+          - 1.1 496003b8c4e3056a62dc655a8393be56.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - VkLf8zDf5qhfCnwcwfFm5_csZ48wIJxd6rNRyYTIh-_vq0-wusZ8Jw==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbZTE-SPHcECfw=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1386"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:27 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - a391a28e-27f6-4319-b05d-474ecba4363e
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
+          "title": "Augmenting large language models with chemistry tools", "venue":
+          "Nat. Mac. Intell.", "year": 2023, "citationCount": 230, "influentialCitationCount":
+          12, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
+          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
+          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
+          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
+          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
+          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
+          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
+          {Augmenting large language models with chemistry tools},\n volume = {6},\n
+          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
+          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
+          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
+          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
+          "name": "P. Schwaller"}], "matchScore": 176.67178}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1551"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Via:
+          - 1.1 29474fd3a24c6552dfdc04ee03c03aa2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - vkMTG0CNavGcrF4zPA0lsD_54ChRZVPW379cf4fdF8m2McaZZEleyg==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbZTFF5vHcErVQ=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1551"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 04c49623-df16-4825-b543-ee36cb9ee8c5
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=An+essential+role+of+active+site+arginine+residue+in+iodide+binding+and+histidine+residue+in+electron+transfer+for+iodide+oxidation+by+horseradish+peroxidase&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "19807da5b11f3e641535cb72e465001b49b48ee5", "externalIds":
+          {"MAG": "1554322594", "DOI": "10.1023/A:1007154515475", "CorpusId": 22646521,
+          "PubMed": "11330823"}, "url": "https://www.semanticscholar.org/paper/19807da5b11f3e641535cb72e465001b49b48ee5",
+          "title": "An essential role of active site arginine residue in iodide binding
+          and histidine residue in electron transfer for iodide oxidation by horseradish
+          peroxidase", "venue": "Molecular and Cellular Biochemistry", "year": 2001,
+          "citationCount": 7, "influentialCitationCount": 0, "isOpenAccess": false,
+          "openAccessPdf": null, "publicationTypes": ["JournalArticle", "Study"], "publicationDate":
+          "2001-02-01", "journal": {"name": "Molecular and Cellular Biochemistry", "pages":
+          "1-11", "volume": "218"}, "citationStyles": {"bibtex": "@Article{Adak2001AnER,\n
+          author = {S. Adak and D. Bandyopadhyay and U. Bandyopadhyay and R. Banerjee},\n
+          booktitle = {Molecular and Cellular Biochemistry},\n journal = {Molecular
+          and Cellular Biochemistry},\n pages = {1-11},\n title = {An essential role
+          of active site arginine residue in iodide binding and histidine residue in
+          electron transfer for iodide oxidation by horseradish peroxidase},\n volume
+          = {218},\n year = {2001}\n}\n"}, "authors": [{"authorId": "1940081", "name":
+          "S. Adak"}, {"authorId": "1701389", "name": "D. Bandyopadhyay"}, {"authorId":
+          "5343877", "name": "U. Bandyopadhyay"}, {"authorId": "32656528", "name": "R.
+          Banerjee"}], "matchScore": 386.4782}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1482"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Via:
+          - 1.1 42e027e0a25dba57ed6be490a4389144.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - PRH6qSzotcJCBozUE6JJWapjzFuzpkCBiPzes0w013Up9gBY5uwo3Q==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbZTHGNPHcEcIw=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1482"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - ea348bbb-d16e-4fb1-880d-00155cc12907
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"indexed":{"date-parts":[[2024,9,20]],"date-time":"2024-09-20T17:08:43Z","timestamp":1726852123984},"reference-count":103,"publisher":"Springer
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:11:02Z","timestamp":1732043462673},"reference-count":103,"publisher":"Springer
           Science and Business Media LLC","issue":"5","license":[{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"},{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"}],"funder":[{"DOI":"10.13039\/501100001711","name":"Schweizerischer
           Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","doi-asserted-by":"publisher","award":["180544","180544","180544"],"id":[{"id":"10.13039\/501100001711","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000001","name":"National
           Science Foundation","doi-asserted-by":"publisher","award":["1751471","1751471"],"id":[{"id":"10.13039\/100000001","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"short-container-title":["Nat
@@ -393,7 +438,7 @@ interactions:
           both LLM and expert assessments, demonstrates ChemCrow\u2019s effectiveness
           in automating a diverse set of chemical tasks. Our work not only aids expert
           chemists and lowers barriers for non-experts but also fosters scientific advancement
-          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":21,"title":["Augmenting
+          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":36,"title":["Augmenting
           large language models with chemistry tools"],"prefix":"10.1038","volume":"6","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"member":"297","published-online":{"date-parts":[[2024,5,8]]},"reference":[{"key":"832_CR1","unstructured":"Devlin,
@@ -682,7 +727,7 @@ interactions:
           (2024).","DOI":"10.5281\/zenodo.10884645"},{"key":"832_CR103","doi-asserted-by":"publisher","unstructured":"Bran,
           A., Cox, S., White, A. & Schwaller, P. ur-whitelab\/chemcrow-public: v0.3.24.
           Zenodo https:\/\/doi.org\/10.5281\/zenodo.10884639 (2024).","DOI":"10.5281\/zenodo.10884639"}],"container-title":["Nature
-          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.40466,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
+          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.44983,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
           September 2023","order":1,"name":"received","label":"Received","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"27 March 2024","order":2,"name":"accepted","label":"Accepted","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"8 May 2024","order":3,"name":"first_online","label":"First
@@ -703,11 +748,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "10574"
+          - "10576"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -731,83 +776,98 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=An+essential+role+of+active+site+arginine+residue+in+iodide+binding+and+histidine+residue+in+electron+transfer+for+iodide+oxidation+by+horseradish+peroxidase&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&rows=1
     response:
       body:
         string:
-          '{"data": [{"paperId": "19807da5b11f3e641535cb72e465001b49b48ee5", "externalIds":
-          {"MAG": "1554322594", "DOI": "10.1023/A:1007154515475", "CorpusId": 22646521,
-          "PubMed": "11330823"}, "url": "https://www.semanticscholar.org/paper/19807da5b11f3e641535cb72e465001b49b48ee5",
-          "title": "An essential role of active site arginine residue in iodide binding
-          and histidine residue in electron transfer for iodide oxidation by horseradish
-          peroxidase", "venue": "Molecular and Cellular Biochemistry", "year": 2001,
-          "citationCount": 7, "influentialCitationCount": 0, "isOpenAccess": false,
-          "openAccessPdf": null, "publicationTypes": ["JournalArticle", "Study"], "publicationDate":
-          "2001-02-01", "journal": {"name": "Molecular and Cellular Biochemistry", "pages":
-          "1-11", "volume": "218"}, "citationStyles": {"bibtex": "@Article{Adak2001AnER,\n
-          author = {S. Adak and D. Bandyopadhyay and U. Bandyopadhyay and R. Banerjee},\n
-          booktitle = {Molecular and Cellular Biochemistry},\n journal = {Molecular
-          and Cellular Biochemistry},\n pages = {1-11},\n title = {An essential role
-          of active site arginine residue in iodide binding and histidine residue in
-          electron transfer for iodide oxidation by horseradish peroxidase},\n volume
-          = {218},\n year = {2001}\n}\n"}, "authors": [{"authorId": "1940081", "name":
-          "S. Adak"}, {"authorId": "1701389", "name": "D. Bandyopadhyay"}, {"authorId":
-          "5343877", "name": "U. Bandyopadhyay"}, {"authorId": "32656528", "name": "R.
-          Banerjee"}], "matchScore": 386.2602}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1482"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        Via:
-          - 1.1 a2df2413207d4bf6462c2592b304bffe.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - gLW3vdZGQHyuTR-Z7bSvzT4Ni0OFrzQYA2f0YFxo7OxVrzAB3JPKLQ==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PwFDJPHcEGcQ=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1482"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 59d7076b-955d-463f-bf78-de7cdb7dde5b
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Convalescent-anti-sars-cov-2-plasma/immune-globulin&rows=1
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":1506625,"items":[{"indexed":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T04:17:17Z","timestamp":1687580237047},"reference-count":1,"publisher":"Springer
-          Science and Business Media LLC","issue":"1","license":[{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"},{"start":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T00:00:00Z","timestamp":1687564800000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/www.springernature.com\/gp\/researchers\/text-and-data-mining"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Reactions
-          Weekly"],"DOI":"10.1007\/s40278-023-41815-2","type":"journal-article","created":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T18:42:29Z","timestamp":1687545749000},"page":"145-145","source":"Crossref","is-referenced-by-count":0,"title":["Convalescent-anti-sars-cov-2-plasma\/immune-globulin"],"prefix":"10.1007","volume":"1962","member":"297","published-online":{"date-parts":[[2023,6,24]]},"reference":[{"key":"41815_CR1","doi-asserted-by":"crossref","unstructured":"Delgado-Fernandez
-          M, et al. Treatment of COVID-19 with convalescent plasma in patients with
-          humoral immunodeficiency - Three consecutive cases and review of the literature.
-          Enfermedades Infecciosas Y Microbiologia Clinica 40\n: 507-516, No. 9, Nov
-          2022. Available from: URL: \nhttps:\/\/seimc.org\/","DOI":"10.1016\/j.eimce.2021.01.009"}],"container-title":["Reactions
-          Weekly"],"language":"en","link":[{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/article\/10.1007\/s40278-023-41815-2\/fulltext.html","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/link.springer.com\/content\/pdf\/10.1007\/s40278-023-41815-2.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,23]],"date-time":"2023-06-23T19:23:18Z","timestamp":1687548198000},"score":57.865536,"resource":{"primary":{"URL":"https:\/\/link.springer.com\/10.1007\/s40278-023-41815-2"}},"subtitle":["Fever
-          and mild decrease in baseline oxygen saturation following off-label use: 3
-          case reports"],"issued":{"date-parts":[[2023,6,24]]},"references-count":1,"journal-issue":{"issue":"1","published-online":{"date-parts":[[2023,6]]}},"alternative-id":["41815"],"URL":"http:\/\/dx.doi.org\/10.1007\/s40278-023-41815-2","ISSN":["1179-2051"],"issn-type":[{"value":"1179-2051","type":"electronic"}],"published":{"date-parts":[[2023,6,24]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2066122,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
+          University Press (OUP)","issue":"1","license":[{"start":{"date-parts":[[2024,2,21]],"date-time":"2024-02-21T00:00:00Z","timestamp":1708473600000},"content-version":"vor","delay-in-days":48,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"funder":[{"DOI":"10.13039\/100000092","name":"National
+          Library of Medicine","doi-asserted-by":"publisher","award":["R01LM009886","R01LM014344"],"id":[{"id":"10.13039\/100000092","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100006108","name":"National
+          Center for Advancing Translational Sciences","doi-asserted-by":"publisher","award":["UL1TR001873"],"id":[{"id":"10.13039\/100006108","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000002","name":"National
+          Institutes of Health","doi-asserted-by":"publisher","id":[{"id":"10.13039\/100000002","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":[],"crossmark-restriction":false},"published-print":{"date-parts":[[2024,1,4]]},"abstract":"<jats:title>Abstract<\/jats:title>\n               <jats:sec>\n                  <jats:title>Objective<\/jats:title>\n                  <jats:p>To
+          automate scientific claim verification using PubMed abstracts.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Materials
+          and Methods<\/jats:title>\n                  <jats:p>We developed CliVER,
+          an end-to-end scientific Claim VERification system that leverages retrieval-augmented
+          techniques to automatically retrieve relevant clinical trial abstracts, extract
+          pertinent sentences, and use the PICO framework to support or refute a scientific
+          claim. We also created an ensemble of three state-of-the-art deep learning
+          models to classify rationale of support, refute, and neutral. We then constructed
+          CoVERt, a new COVID VERification dataset comprising 15 PICO-encoded drug claims
+          accompanied by 96 manually selected and labeled clinical trial abstracts that
+          either support or refute each claim. We used CoVERt and SciFact (a public
+          scientific claim verification dataset) to assess CliVER\u2019s performance
+          in predicting labels. Finally, we compared CliVER to clinicians in the verification
+          of 19 claims from 6 disease domains, using 189\u00a0648 PubMed abstracts extracted
+          from January 2010 to October 2021.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Results<\/jats:title>\n                  <jats:p>In
+          the evaluation of label prediction accuracy on CoVERt, CliVER achieved a notable
+          F1 score of 0.92, highlighting the efficacy of the retrieval-augmented models.
+          The ensemble model outperforms each individual state-of-the-art model by an
+          absolute increase from 3% to 11% in the F1 score. Moreover, when compared
+          with four clinicians, CliVER achieved a precision of 79.0% for abstract retrieval,
+          67.4% for sentence selection, and 63.2% for label prediction, respectively.<\/jats:p>\n               <\/jats:sec>\n               <jats:sec>\n                  <jats:title>Conclusion<\/jats:title>\n                  <jats:p>CliVER
+          demonstrates its early potential to automate scientific claim verification
+          using retrieval-augmented strategies to harness the wealth of clinical trial
+          abstracts in PubMed. Future studies are warranted to further test its clinical
+          utility.<\/jats:p>\n               <\/jats:sec>","DOI":"10.1093\/jamiaopen\/ooae021","type":"journal-article","created":{"date-parts":[[2024,2,22]],"date-time":"2024-02-22T01:48:17Z","timestamp":1708566497000},"source":"Crossref","is-referenced-by-count":0,"title":["Retrieval
+          augmented scientific claim verification"],"prefix":"10.1093","volume":"7","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-1975-1272","authenticated-orcid":false,"given":"Hao","family":"Liu","sequence":"first","affiliation":[{"name":"School
+          of Computing, Montclair State University , Montclair, NJ 07043, United States"}]},{"given":"Ali","family":"Soroush","sequence":"additional","affiliation":[{"name":"Department
+          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0003-1418-3103","authenticated-orcid":false,"given":"Jordan
+          G","family":"Nestor","sequence":"additional","affiliation":[{"name":"Department
+          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"given":"Elizabeth","family":"Park","sequence":"additional","affiliation":[{"name":"Department
+          of Medicine, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0002-4318-5987","authenticated-orcid":false,"given":"Betina","family":"Idnay","sequence":"additional","affiliation":[{"name":"Department
+          of Biomedical Informatics, Columbia University , New York, NY 10027, United
+          States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0002-2681-1931","authenticated-orcid":false,"given":"Yilu","family":"Fang","sequence":"additional","affiliation":[{"name":"Department
+          of Biomedical Informatics, Columbia University , New York, NY 10027, United
+          States"}]},{"given":"Jane","family":"Pan","sequence":"additional","affiliation":[{"name":"Department
+          of Applied Physics and Applied Mathematics, Columbia University , New York,
+          NY 10027, United States"}]},{"given":"Stan","family":"Liao","sequence":"additional","affiliation":[{"name":"Department
+          of Applied Physics and Applied Mathematics, Columbia University , New York,
+          NY 10027, United States"}]},{"given":"Marguerite","family":"Bernard","sequence":"additional","affiliation":[{"name":"Institute
+          of Human Nutrition, Columbia University , New York, NY 10027, United States"}]},{"ORCID":"http:\/\/orcid.org\/0000-0001-9309-8331","authenticated-orcid":false,"given":"Yifan","family":"Peng","sequence":"additional","affiliation":[{"name":"Department
+          of Population Health Sciences, Weill Cornell Medicine , New York, NY 10065,
+          United States"}]},{"given":"Chunhua","family":"Weng","sequence":"additional","affiliation":[{"name":"Department
+          of Biomedical Informatics, Columbia University , New York, NY 10027, United
+          States"}]}],"member":"286","published-online":{"date-parts":[[2024,2,21]]},"reference":[{"issue":"6","key":"2024030720490192400_ooae021-B1","doi-asserted-by":"crossref","first-page":"1192","DOI":"10.1093\/jamia\/ocx050","article-title":"Evidence
+          appraisal: a scoping review, conceptual framework, and research agenda","volume":"24","author":"Goldstein","year":"2017","journal-title":"J
+          Am Med Inform Assoc"},{"issue":"D1","key":"2024030720490192400_ooae021-B2","doi-asserted-by":"crossref","first-page":"D1534","DOI":"10.1093\/nar\/gkaa952","article-title":"LitCovid:
+          an open database of COVID-19 literature","volume":"49","author":"Chen","year":"2021","journal-title":"Nucleic
+          Acids Res"},{"key":"2024030720490192400_ooae021-B3","author":"Medicine NLo"},{"issue":"1","key":"2024030720490192400_ooae021-B4","doi-asserted-by":"crossref","first-page":"6","DOI":"10.1038\/s41591-020-01203-7","article-title":"Automated
+          screening of COVID-19 preprints: can we help authors to improve transparency
+          and reproducibility?","volume":"27","author":"Weissgerber","year":"2021","journal-title":"Nat
+          Med"},{"issue":"2","key":"2024030720490192400_ooae021-B5","doi-asserted-by":"crossref","first-page":"218","DOI":"10.1001\/jama.294.2.218","article-title":"Contradicted
+          and initially stronger effects in highly cited clinical research","volume":"294","author":"Ioannidis","year":"2005","journal-title":"JAMA"},{"issue":"1","key":"2024030720490192400_ooae021-B6","doi-asserted-by":"crossref","first-page":"63","DOI":"10.1162\/coli.2007.33.1.63","article-title":"Answering
+          clinical questions with knowledge-based and statistical techniques","volume":"33","author":"Demner-Fushman","year":"2007","journal-title":"Comput
+          Linguist"},{"issue":"6","key":"2024030720490192400_ooae021-B7","doi-asserted-by":"crossref","first-page":"772","DOI":"10.1197\/jamia.M2407","article-title":"Knowledge-based
+          methods to help clinicians find answers in MEDLINE","volume":"14","author":"Sneiderman","year":"2007","journal-title":"J
+          Am Med Inform Assoc"},{"issue":"5","key":"2024030720490192400_ooae021-B8","doi-asserted-by":"crossref","first-page":"232","DOI":"10.1186\/cc5045","article-title":"Evidence-based
+          medicine: classifying the evidence from clinical trials\u2013the need to consider
+          other dimensions","volume":"10","author":"Bellomo","year":"2006","journal-title":"Crit
+          Care"},{"issue":"1","key":"2024030720490192400_ooae021-B9","doi-asserted-by":"crossref","first-page":"6","DOI":"10.1002\/clc.4960220106","article-title":"The
+          importance of randomized clinical trials and evidence-based medicine: a clinician''s
+          perspective","volume":"22","author":"Kennedy","year":"1999","journal-title":"Clin
+          Cardiol"},{"key":"2024030720490192400_ooae021-B10","first-page":"493","author":"Hanselowski","year":"2019"},{"key":"2024030720490192400_ooae021-B11","first-page":"809","author":"Thorne","year":"2018"},{"key":"2024030720490192400_ooae021-B12","first-page":"7534","author":"Wadden","year":"2020"},{"key":"2024030720490192400_ooae021-B13","first-page":"94","author":"Pradeep","year":"2021"},{"key":"2024030720490192400_ooae021-B14","first-page":"5485","article-title":"Exploring
+          the limits of transfer learning with a unified text-to-text transformer","volume":"140","author":"Raffel","year":"2020","journal-title":"J.
+          Mach. Learn. Res"},{"key":"2024030720490192400_ooae021-B15","author":"Li","year":"2021"},{"key":"2024030720490192400_ooae021-B16","first-page":"61","author":"Wadden","year":"2022"},{"key":"2024030720490192400_ooae021-B17","author":"Beltagy","year":"2020"},{"issue":"7256","key":"2024030720490192400_ooae021-B18","doi-asserted-by":"crossref","first-page":"255","DOI":"10.1136\/bmj.321.7256.255","article-title":"Which
+          clinical studies provide the best evidence?: the best RCT still trumps the
+          best observational study","volume":"321","author":"Barton","year":"2000","journal-title":"BMJ"},{"key":"2024030720490192400_ooae021-B19","doi-asserted-by":"crossref","first-page":"103717","DOI":"10.1016\/j.jbi.2021.103717","article-title":"Toward
+          assessing clinical trial publications for reporting transparency","volume":"116","author":"Kilicoglu","year":"2021","journal-title":"J
+          Biomed Inform"},{"key":"2024030720490192400_ooae021-B20","first-page":"1253","author":"Yang","year":"2017"},{"key":"2024030720490192400_ooae021-B21","first-page":"39","author":"Khattab","year":"2020"},{"key":"2024030720490192400_ooae021-B22","first-page":"19","author":"Yilmaz","year":"2019"},{"key":"2024030720490192400_ooae021-B23","author":"Kuzi","year":"2020"},{"key":"2024030720490192400_ooae021-B24","volume-title":"The
+          Probabilistic Relevance Framework: BM25 and Beyond","author":"Robertson","year":"2009"},{"key":"2024030720490192400_ooae021-B25","first-page":"105","author":"Wang","year":"2011"},{"key":"2024030720490192400_ooae021-B26","first-page":"7740","author":"Kotonya","year":"2020"},{"issue":"1","key":"2024030720490192400_ooae021-B27","doi-asserted-by":"crossref","first-page":"36","DOI":"10.1186\/s13326-016-0083-z","article-title":"A
+          corpus of potentially contradictory research claims from cardiovascular research
+          abstracts","volume":"7","author":"Alamri","year":"2016","journal-title":"J
+          Biomed Semantics"},{"key":"2024030720490192400_ooae021-B28","first-page":"3499","author":"Sarrouti","year":"2021"},{"issue":"9","key":"2024030720490192400_ooae021-B29","doi-asserted-by":"crossref","first-page":"1431","DOI":"10.1093\/jamia\/ocaa091","article-title":"TREC-COVID:
+          rationale and structure of an information retrieval shared task for COVID-19","volume":"27","author":"Roberts","year":"2020","journal-title":"J
+          Am Med Inform Assoc"},{"key":"2024030720490192400_ooae021-B30","author":"Wang","year":"2020"},{"key":"2024030720490192400_ooae021-B31","first-page":"2116","author":"Saakyan","year":"2021"},{"key":"2024030720490192400_ooae021-B32","first-page":"359","author":"Huang","year":"2006"},{"key":"2024030720490192400_ooae021-B33","first-page":"708","author":"Nogueira","year":"2020"},{"key":"2024030720490192400_ooae021-B34","doi-asserted-by":"crossref","first-page":"baw065","DOI":"10.1093\/database\/baw065","article-title":"Mining
+          chemical patents with an ensemble of open systems","volume":"2016","author":"Leaman","year":"2016","journal-title":"Database"},{"key":"2024030720490192400_ooae021-B35","doi-asserted-by":"crossref","first-page":"bay073","DOI":"10.1093\/database\/bay073","article-title":"Extracting
+          chemical\u2013protein relations with ensembles of SVM and deep learning models","volume":"2018","author":"Peng","year":"2018","journal-title":"Database"},{"key":"2024030720490192400_ooae021-B36","author":"Liu","year":"2019"},{"issue":"1","key":"2024030720490192400_ooae021-B37","doi-asserted-by":"crossref","first-page":"1","DOI":"10.1145\/3458754","article-title":"Domain-specific
+          language model pretraining for biomedical natural language processing","volume":"3","author":"Gu","year":"2021","journal-title":"ACM
+          Trans Comput Healthc"},{"issue":"3","key":"2024030720490192400_ooae021-B38","doi-asserted-by":"crossref","first-page":"A12","DOI":"10.7326\/ACPJC-1995-123-3-A12","article-title":"The
+          well-built clinical question: a key to evidence-based decisions","volume":"123","author":"Richardson","year":"1995","journal-title":"ACP
+          J Club"},{"key":"2024030720490192400_ooae021-B39","first-page":"1971","author":"Lee","year":"2021"},{"key":"2024030720490192400_ooae021-B40","author":"Loshchilov","year":"2019"},{"key":"2024030720490192400_ooae021-B41","first-page":"13","author":"Kingma","year":"2015"},{"key":"2024030720490192400_ooae021-B42","first-page":"38","author":"Wolf","year":"2020"},{"key":"2024030720490192400_ooae021-B43","first-page":"2356","author":"Lin","year":"2021"},{"key":"2024030720490192400_ooae021-B44","first-page":"243","author":"J\u00e4rvelin","year":"2017"},{"issue":"4","key":"2024030720490192400_ooae021-B45","doi-asserted-by":"crossref","first-page":"422","DOI":"10.1145\/582415.582418","article-title":"Cumulated
+          gain-based evaluation of IR techniques","volume":"20","author":"J\u00e4rvelin","year":"2002","journal-title":"ACM
+          Trans Inf Syst"},{"key":"2024030720490192400_ooae021-B46","volume-title":"Evidence-Based
+          Practice in Nursing & Healthcare: A Guide to Best Practice","author":"Melnyk","year":"2022"},{"key":"2024030720490192400_ooae021-B47","first-page":"206","author":"Gupta","year":"2017"},{"key":"2024030720490192400_ooae021-B48","first-page":"1","author":"Park","year":"2012"}],"container-title":["JAMIA
+          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":27.887123,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -821,11 +881,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "1208"
+          - "4502"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -849,59 +909,308 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=High-throughput+screening+of+human+genetic+variants+by+pooled+prime+editing&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=High-throughput+screening+of+human+genetic+variants+by+pooled+prime+editing&rows=1
     response:
       body:
         string:
-          '{"data": [{"paperId": "7e5d4466c8b85f93775fe183e1a318a3e65ac8e4", "externalIds":
-          {"DOI": "10.1101/2024.04.01.587366", "CorpusId": 268890006}, "url": "https://www.semanticscholar.org/paper/7e5d4466c8b85f93775fe183e1a318a3e65ac8e4",
-          "title": "High-throughput screening of human genetic variants by pooled prime
-          editing", "venue": "bioRxiv", "year": 2024, "citationCount": 1, "influentialCitationCount":
-          0, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf",
-          "status": "GREEN"}, "publicationTypes": null, "publicationDate": "2024-04-01",
-          "journal": {"name": "bioRxiv"}, "citationStyles": {"bibtex": "@Article{Herger2024HighthroughputSO,\n
-          author = {Michael Herger and Christina M. Kajba and Megan Buckley and Ana
-          Cunha and Molly Strom and Gregory M. Findlay},\n booktitle = {bioRxiv},\n
-          journal = {bioRxiv},\n title = {High-throughput screening of human genetic
-          variants by pooled prime editing},\n year = {2024}\n}\n"}, "authors": [{"authorId":
-          "2294884120", "name": "Michael Herger"}, {"authorId": "2163800172", "name":
-          "Christina M. Kajba"}, {"authorId": "2120283350", "name": "Megan Buckley"},
-          {"authorId": "2294861709", "name": "Ana Cunha"}, {"authorId": "2294881320",
-          "name": "Molly Strom"}, {"authorId": "145686550", "name": "Gregory M. Findlay"}],
-          "matchScore": 252.34943}]}
-
-          '
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5253170,"items":[{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:09:55Z","timestamp":1732043395754},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
+          Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"accepted":{"date-parts":[[2024,4,1]]},"abstract":"<jats:title>ABSTRACT<\/jats:title><jats:p>Understanding
+          the effects of rare genetic variants remains challenging, both in coding and
+          non-coding regions. While multiplexed assays of variant effect (MAVEs) have
+          enabled scalable functional assessment of variants, established MAVEs are
+          limited by either exogenous expression of variants or constraints of genome
+          editing. Here, we introduce a pooled prime editing (PE) platform in haploid
+          human cells to scalably assay variants in their endogenous context. We first
+          optimized delivery of variants to HAP1 cells, defining optimal pegRNA designs
+          and establishing a co-selection strategy for improved efficiency. We characterize
+          our platform in the context of negative selection by testing over 7,500 pegRNAs
+          targeting<jats:italic>SMARCB1<\/jats:italic>for editing activity and observing
+          depletion of highly active pegRNAs installing loss-of-function variants. We
+          next assess variants in<jats:italic>MLH1<\/jats:italic>via 6-thioguanine selection,
+          assaying 65.3% of all possible SNVs in a 200-bp region spanning exon 10 and
+          distinguishing LoF variants with high accuracy. Lastly, we assay 362 non-coding<jats:italic>MLH1<\/jats:italic>variants
+          across a 60 kb region in a single experiment, identifying pathogenic variants
+          acting via multiple mechanisms with high specificity. Our analyses detail
+          how filtering for highly active pegRNAs can facilitate both positive and negative
+          selection screens. Accordingly, our platform promises to enable highly scalable
+          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":1,"title":["High-throughput
+          screening of human genetic variants by pooled prime editing"],"prefix":"10.1101","author":[{"given":"Michael","family":"Herger","sequence":"first","affiliation":[]},{"given":"Christina
+          M.","family":"Kajba","sequence":"additional","affiliation":[]},{"given":"Megan","family":"Buckley","sequence":"additional","affiliation":[]},{"given":"Ana","family":"Cunha","sequence":"additional","affiliation":[]},{"given":"Molly","family":"Strom","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7767-8608","authenticated-orcid":false,"given":"Gregory
+          M.","family":"Findlay","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2024040415500652000_2024.04.01.587366v1.1","doi-asserted-by":"publisher","DOI":"10.1038\/gim.2015.30"},{"key":"2024040415500652000_2024.04.01.587366v1.2","doi-asserted-by":"crossref","first-page":"116","DOI":"10.1016\/j.cels.2017.11.003","article-title":"Quantitative
+          Missense Variant Effect Prediction Using Large-Scale Mutagenesis Data","volume":"6","year":"2018","journal-title":"Cell
+          Syst"},{"key":"2024040415500652000_2024.04.01.587366v1.3","doi-asserted-by":"publisher","DOI":"10.1126\/science.abi8207"},{"key":"2024040415500652000_2024.04.01.587366v1.4","doi-asserted-by":"publisher","DOI":"10.1016\/J.CELL.2018.12.015"},{"key":"2024040415500652000_2024.04.01.587366v1.5","doi-asserted-by":"crossref","first-page":"eabn8153","DOI":"10.1126\/science.abn8197","article-title":"The
+          landscape of tolerated genetic variation in humans and primates","volume":"380","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.6","doi-asserted-by":"crossref","first-page":"eadg7492","DOI":"10.1126\/science.adg7492","article-title":"Accurate
+          proteome-wide missense variant effect prediction with AlphaMissense","volume":"381","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.7","doi-asserted-by":"publisher","DOI":"10.1093\/nar\/gkv1222"},{"key":"2024040415500652000_2024.04.01.587366v1.8","doi-asserted-by":"crossref","first-page":"1381","DOI":"10.1038\/s41436-021-01172-3","article-title":"ACMG
+          SF v3.0 list for reporting of secondary findings in clinical exome and genome
+          sequencing: a policy statement of the American College of Medical Genetics
+          and Genomics (ACMG)","volume":"23","year":"2021","journal-title":"Genet. Med"},{"key":"2024040415500652000_2024.04.01.587366v1.9","doi-asserted-by":"publisher","DOI":"10.1038\/nprot.2016.135"},{"key":"2024040415500652000_2024.04.01.587366v1.10","doi-asserted-by":"publisher","DOI":"10.1093\/hmg\/ddab219"},{"key":"2024040415500652000_2024.04.01.587366v1.11","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-11526-w"},{"key":"2024040415500652000_2024.04.01.587366v1.12","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-022-02839-z"},{"key":"2024040415500652000_2024.04.01.587366v1.13","doi-asserted-by":"crossref","first-page":"2248","DOI":"10.1016\/j.ajhg.2021.11.001","article-title":"Closing
+          the gap: Systematic integration of multiplexed functional data resolves variants
+          of uncertain significance in BRCA1, TP53, and PTEN","volume":"108","year":"2021","journal-title":"Am.
+          J. Hum. Genet."},{"key":"2024040415500652000_2024.04.01.587366v1.14","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-018-0461-z"},{"key":"2024040415500652000_2024.04.01.587366v1.15","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.10.015"},{"key":"2024040415500652000_2024.04.01.587366v1.16","doi-asserted-by":"crossref","first-page":"7702","DOI":"10.1038\/s41467-023-43041-4","article-title":"Saturation
+          genome editing of DDX3X clarifies pathogenicity of germline and somatic variation","volume":"14","year":"2023","journal-title":"Nat.
+          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.17","doi-asserted-by":"publisher","DOI":"10.1038\/nature13695"},{"key":"2024040415500652000_2024.04.01.587366v1.18","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.012"},{"key":"2024040415500652000_2024.04.01.587366v1.19","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.041"},{"key":"2024040415500652000_2024.04.01.587366v1.20","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-019-1711-4"},{"key":"2024040415500652000_2024.04.01.587366v1.21","doi-asserted-by":"crossref","first-page":"288","DOI":"10.1016\/j.ccell.2022.12.009","article-title":"Base
+          editing screens map mutations affecting interferon-\u03b3 signaling in cancer","volume":"41","year":"2023","journal-title":"Cancer
+          Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.22","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.09.018"},{"key":"2024040415500652000_2024.04.01.587366v1.23","doi-asserted-by":"crossref","first-page":"402","DOI":"10.1038\/s41587-021-01039-7","article-title":"Engineered
+          pegRNAs improve prime editing efficiency","volume":"40","year":"2022","journal-title":"Nat.
+          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.24","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01201-1"},{"key":"2024040415500652000_2024.04.01.587366v1.25","doi-asserted-by":"publisher","DOI":"10.1016\/j.molcel.2023.11.021"},{"key":"2024040415500652000_2024.04.01.587366v1.26","doi-asserted-by":"publisher","DOI":"10.1038\/nature10348"},{"key":"2024040415500652000_2024.04.01.587366v1.27","doi-asserted-by":"publisher","DOI":"10.1126\/science.1247005"},{"key":"2024040415500652000_2024.04.01.587366v1.28","doi-asserted-by":"crossref","first-page":"1151","DOI":"10.1038\/s41587-022-01613-7","article-title":"Predicting
+          prime editing efficiency and product purity by deep learning","volume":"41","year":"2023","journal-title":"Nat.
+          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.29","doi-asserted-by":"crossref","first-page":"2256","DOI":"10.1016\/j.cell.2023.03.034","article-title":"Prediction
+          of efficiencies for diverse prime editing systems in multiple cell types","volume":"186","year":"2023","journal-title":"Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.30","doi-asserted-by":"publisher","DOI":"10.1101\/2022.10.26.513842"},{"key":"2024040415500652000_2024.04.01.587366v1.31","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01172-3"},{"key":"2024040415500652000_2024.04.01.587366v1.32","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-020-0677-y"},{"key":"2024040415500652000_2024.04.01.587366v1.33","doi-asserted-by":"publisher","DOI":"10.1016\/j.tibtech.2018.07.017"},{"key":"2024040415500652000_2024.04.01.587366v1.34","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-020-20810-z"},{"key":"2024040415500652000_2024.04.01.587366v1.35","doi-asserted-by":"crossref","first-page":"5909","DOI":"10.1038\/s41467-022-33669-z","article-title":"Marker-free
+          co-selection for successive rounds of prime editing in human cells","volume":"13","year":"2022","journal-title":"Nat.
+          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.36","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2013.12.001"},{"key":"2024040415500652000_2024.04.01.587366v1.37","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-018-02974-x"},{"key":"2024040415500652000_2024.04.01.587366v1.38","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-021-27838-9"},{"key":"2024040415500652000_2024.04.01.587366v1.39","doi-asserted-by":"publisher","DOI":"10.1126\/science.1225829"},{"key":"2024040415500652000_2024.04.01.587366v1.40","doi-asserted-by":"publisher","DOI":"10.3390\/cancers14153645"},{"key":"2024040415500652000_2024.04.01.587366v1.41","doi-asserted-by":"publisher","DOI":"10.1126\/science.aac7557"},{"key":"2024040415500652000_2024.04.01.587366v1.42","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-10849-y"},{"key":"2024040415500652000_2024.04.01.587366v1.43","doi-asserted-by":"publisher","DOI":"10.1038\/nbt.3437"},{"key":"2024040415500652000_2024.04.01.587366v1.44","doi-asserted-by":"publisher","DOI":"10.1136\/jmg.2007.056499"},{"key":"2024040415500652000_2024.04.01.587366v1.45","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.12.003"},{"key":"2024040415500652000_2024.04.01.587366v1.46","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-019-0032-3"},{"key":"2024040415500652000_2024.04.01.587366v1.47","doi-asserted-by":"publisher","DOI":"10.1038\/nmeth.3047"},{"key":"2024040415500652000_2024.04.01.587366v1.48","doi-asserted-by":"crossref","first-page":"96","DOI":"10.1089\/hgtb.2017.198","article-title":"Determination
+          of Lentiviral Infectious Titer by a Novel Droplet Digital PCR Method","volume":"29","year":"2018","journal-title":"Hum.
+          Gene Ther. Methods"},{"key":"2024040415500652000_2024.04.01.587366v1.49","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-020-02091-3"},{"key":"2024040415500652000_2024.04.01.587366v1.50","doi-asserted-by":"publisher","DOI":"10.1186\/s13073-021-00835-9"}],"link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1101\/2024.04.01.587366","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,4,4]],"date-time":"2024-04-04T22:50:19Z","timestamp":1712271019000},"score":61.355724,"resource":{"primary":{"URL":"http:\/\/biorxiv.org\/lookup\/doi\/10.1101\/2024.04.01.587366"}},"issued":{"date-parts":[[2024,4,1]]},"references-count":50,"URL":"http:\/\/dx.doi.org\/10.1101\/2024.04.01.587366","published":{"date-parts":[[2024,4,1]]},"subtype":"preprint"}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
         Access-Control-Allow-Origin:
           - "*"
+        Access-Control-Expose-Headers:
+          - Link
         Connection:
-          - keep-alive
+          - close
+        Content-Encoding:
+          - gzip
         Content-Length:
-          - "1362"
+          - "3258"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Via:
-          - 1.1 7dbcbf3457f77b741952e31c6826a8dc.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - buiSme2kqYH2y0xC8lWNUlTG5cRNJCXp1BdAHY8djTipgDc-gpIyDQ==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PwHfAvHcEsBQ=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1362"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - b18119d4-180d-46d0-aed5-ca252b08e260
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Vary:
+          - Accept-Encoding
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2/transform/application/x-bibtex
+    response:
+      body:
+        string:
+          " @article{2023, volume={1962}, ISSN={1179-2051}, url={http://dx.doi.org/10.1007/s40278-023-41815-2},
+          DOI={10.1007/s40278-023-41815-2}, number={1}, journal={Reactions Weekly},
+          publisher={Springer Science and Business Media LLC}, year={2023}, month=jun,
+          pages={145\u2013145} }\n"
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=An+essential+role+of+active+site+arginine+residue+in+iodide+binding+and+histidine+residue+in+electron+transfer+for+iodide+oxidation+by+horseradish+peroxidase&rows=1
+    response:
+      body:
+        string:
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4147440,"items":[{"indexed":{"date-parts":[[2024,6,24]],"date-time":"2024-06-24T23:08:06Z","timestamp":1719270486276},"reference-count":40,"publisher":"Elsevier
+          BV","issue":"14","license":[{"start":{"date-parts":[[1992,5,1]],"date-time":"1992-05-01T00:00:00Z","timestamp":704678400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.elsevier.com\/tdm\/userlicense\/1.0\/"},{"start":{"date-parts":[[2020,10,3]],"date-time":"2020-10-03T00:00:00Z","timestamp":1601683200000},"content-version":"vor","delay-in-days":10382,"URL":"http:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Journal
+          of Biological Chemistry"],"published-print":{"date-parts":[[1992,5]]},"DOI":"10.1016\/s0021-9258(19)50164-8","type":"journal-article","created":{"date-parts":[[2021,1,6]],"date-time":"2021-01-06T15:57:43Z","timestamp":1609948663000},"page":"9800-9804","source":"Crossref","is-referenced-by-count":23,"title":["Chemical
+          and kinetic evidence for an essential histidine in horseradish peroxidase
+          for iodide oxidation."],"prefix":"10.1016","volume":"267","author":[{"given":"D.K.","family":"Bhattacharyya","sequence":"first","affiliation":[]},{"given":"U","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"R.K.","family":"Banerjee","sequence":"additional","affiliation":[]}],"member":"78","reference":[{"key":"10.1016\/S0021-9258(19)50164-8_bib1","doi-asserted-by":"crossref","first-page":"531","DOI":"10.1093\/oxfordjournals.jbchem.a133961","volume":"92","author":"Aibara","year":"1982","journal-title":"J.
+          Biochem. (Tokyo)"},{"key":"10.1016\/S0021-9258(19)50164-8_bib2","doi-asserted-by":"crossref","first-page":"341","DOI":"10.1016\/0003-2697(62)90097-0","volume":"4","author":"Alexander","year":"1962","journal-title":"Anal.
+          Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib3","doi-asserted-by":"crossref","first-page":"10592","DOI":"10.1016\/S0021-9258(18)67426-5","volume":"261","author":"Banerjee","year":"1986","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib4","doi-asserted-by":"crossref","first-page":"396","DOI":"10.1016\/0005-2744(70)90245-7","volume":"212","author":"Bjorkstein","year":"1970","journal-title":"Biochim.
+          Biophys. Acta"},{"key":"10.1016\/S0021-9258(19)50164-8_bib5","doi-asserted-by":"crossref","first-page":"12454","DOI":"10.1016\/S0021-9258(19)38367-X","volume":"265","author":"Blanke","year":"1990","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib6","doi-asserted-by":"crossref","first-page":"205","DOI":"10.1021\/bi00698a030","volume":"13","author":"Burstein","year":"1974","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib7","doi-asserted-by":"crossref","first-page":"19666","DOI":"10.1016\/S0021-9258(19)47165-2","volume":"264","author":"Chang","year":"1989","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib8","doi-asserted-by":"crossref","first-page":"4936","DOI":"10.1016\/S0021-9258(18)89162-1","volume":"260","author":"Church","year":"1985","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib9","doi-asserted-by":"crossref","first-page":"4992","DOI":"10.1021\/bi00668a008","volume":"15","author":"Cousineau","year":"1976","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib10","doi-asserted-by":"crossref","first-page":"21498","DOI":"10.1016\/S0021-9258(18)45766-3","volume":"265","author":"Dumas","year":"1990","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib11","first-page":"410","volume":"4","author":"Dunford","year":"1982","journal-title":"Adv.
+          Inorg. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib12","doi-asserted-by":"crossref","first-page":"187","DOI":"10.1016\/S0010-8545(00)80316-1","volume":"19","author":"Dunford","year":"1976","journal-title":"Coord.
+          Chem. Rev."},{"key":"10.1016\/S0021-9258(19)50164-8_bib13","doi-asserted-by":"crossref","first-page":"21","DOI":"10.1016\/0022-2836(85)90180-9","volume":"185","author":"Fita","year":"1985","journal-title":"J.
+          Mol. Biol."},{"key":"10.1016\/S0021-9258(19)50164-8_bib14","doi-asserted-by":"crossref","first-page":"15054","DOI":"10.1016\/S0021-9258(18)33392-1","volume":"257","author":"Kaput","year":"1982","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib15","doi-asserted-by":"crossref","first-page":"409","DOI":"10.1016\/0003-9861(87)90118-4","volume":"254","author":"Kenigsberg","year":"1987","journal-title":"Arch.
+          Biochem. Biophys."},{"key":"10.1016\/S0021-9258(19)50164-8_bib16","doi-asserted-by":"crossref","first-page":"55","DOI":"10.1016\/0003-9861(88)90103-8","volume":"261","author":"Konpka","year":"1988","journal-title":"Arch.
+          Biochem. Biophys."},{"key":"10.1016\/S0021-9258(19)50164-8_bib17","doi-asserted-by":"crossref","first-page":"3654","DOI":"10.1016\/S0021-9258(19)75322-8","volume":"238","author":"Levy","year":"1963","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib18","volume":"1","author":"Lundblad","year":"1984"},{"key":"10.1016\/S0021-9258(19)50164-8_bib19","doi-asserted-by":"crossref","first-page":"197","DOI":"10.1016\/S0021-9258(17)43641-6","volume":"259","author":"Magnusson","year":"1984","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib20","doi-asserted-by":"crossref","first-page":"251","DOI":"10.1021\/bi00804a010","volume":"9","author":"Melchior","year":"1970","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib21","doi-asserted-by":"crossref","first-page":"431","DOI":"10.1016\/0076-6879(77)47043-5","volume":"47","author":"Miles","year":"1977","journal-title":"Methods
+          Enzymol."},{"key":"10.1016\/S0021-9258(19)50164-8_bib22","doi-asserted-by":"crossref","first-page":"861","DOI":"10.1146\/annurev.bi.45.070176.004241","volume":"45","author":"Morrison","year":"1976","journal-title":"Annu.
+          Rev. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib23","doi-asserted-by":"crossref","first-page":"13546","DOI":"10.1016\/S0021-9258(17)38757-4","volume":"260","author":"Nakamura","year":"1985","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib24","doi-asserted-by":"crossref","first-page":"805","DOI":"10.1016\/S0021-9258(19)70048-9","volume":"256","author":"Ohtaki","year":"1981","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib25","doi-asserted-by":"crossref","first-page":"761","DOI":"10.1016\/S0021-9258(19)68261-X","volume":"257","author":"Ohtaki","year":"1982","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib26","first-page":"445","volume":"2","author":"Ovadi","year":"1967","journal-title":"Acta
+          Biochim. Biophys. Acad. Sci. Hung."},{"key":"10.1016\/S0021-9258(19)50164-8_bib27","doi-asserted-by":"crossref","first-page":"395","DOI":"10.3891\/acta.chem.scand.32b-0395","volume":"B32","author":"Paul","year":"1978","journal-title":"Acta
+          Chem. Scand."},{"key":"10.1016\/S0021-9258(19)50164-8_bib28","doi-asserted-by":"crossref","first-page":"497","DOI":"10.1111\/j.1432-1033.1973.tb03085.x","volume":"38","author":"Pommier","year":"1973","journal-title":"Eur.
+          J. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib29","doi-asserted-by":"crossref","first-page":"8199","DOI":"10.1016\/S0021-9258(19)70630-9","volume":"255","author":"Poulos","year":"1980","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib30","doi-asserted-by":"crossref","first-page":"2076","DOI":"10.1021\/bi00761a013","volume":"11","author":"Roman","year":"1972","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib31","doi-asserted-by":"crossref","first-page":"211","DOI":"10.1246\/cl.1985.211","author":"Sakurada","year":"1985","journal-title":"Chem.
+          Lett."},{"key":"10.1016\/S0021-9258(19)50164-8_bib32","doi-asserted-by":"crossref","first-page":"9657","DOI":"10.1016\/S0021-9258(18)67564-7","volume":"261","author":"Sakurada","year":"1986","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib33","doi-asserted-by":"crossref","first-page":"4007","DOI":"10.1016\/S0021-9258(18)61303-1","volume":"262","author":"Sakurada","year":"1987","journal-title":"J.
+          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib34","doi-asserted-by":"crossref","first-page":"6478","DOI":"10.1021\/bi00394a028","volume":"26","author":"Sakurada","year":"1987","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib35","doi-asserted-by":"crossref","first-page":"2277","DOI":"10.1021\/bi00407a005","volume":"27","author":"Sams","year":"1988","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib36","doi-asserted-by":"crossref","first-page":"1571","DOI":"10.1093\/oxfordjournals.jbchem.a135630","volume":"99","author":"Takeuchi","year":"1986","journal-title":"J.
+          Biochem. (Tokyo)"},{"key":"10.1016\/S0021-9258(19)50164-8_bib37","doi-asserted-by":"crossref","first-page":"520","DOI":"10.1038\/326520a0","volume":"326","author":"Tien","year":"1987","journal-title":"Nature"},{"key":"10.1016\/S0021-9258(19)50164-8_bib38","doi-asserted-by":"crossref","first-page":"87","DOI":"10.1111\/j.1432-1033.1986.tb09461.x","volume":"155","author":"Topham","year":"1986","journal-title":"Eur.
+          J. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib39","doi-asserted-by":"crossref","first-page":"210","DOI":"10.1016\/0005-2744(81)90032-2","volume":"662","author":"Ugarova","year":"1981","journal-title":"Biochim.
+          Biophys. Acta"},{"key":"10.1016\/S0021-9258(19)50164-8_bib40","doi-asserted-by":"crossref","first-page":"483","DOI":"10.1111\/j.1432-1033.1979.tb13061.x","volume":"96","author":"Welinder","year":"1979","journal-title":"Eur.
+          J. Biochem."}],"container-title":["Journal of Biological Chemistry"],"language":"en","link":[{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0021925819501648?httpAccept=text\/xml","content-type":"text\/xml","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0021925819501648?httpAccept=text\/plain","content-type":"text\/plain","content-version":"vor","intended-application":"text-mining"}],"deposited":{"date-parts":[[2022,1,2]],"date-time":"2022-01-02T19:58:22Z","timestamp":1641153502000},"score":52.67746,"resource":{"primary":{"URL":"https:\/\/linkinghub.elsevier.com\/retrieve\/pii\/S0021925819501648"}},"issued":{"date-parts":[[1992,5]]},"references-count":40,"journal-issue":{"issue":"14","published-print":{"date-parts":[[1992,5]]}},"alternative-id":["S0021925819501648"],"URL":"http:\/\/dx.doi.org\/10.1016\/s0021-9258(19)50164-8","ISSN":["0021-9258"],"issn-type":[{"value":"0021-9258","type":"print"}],"published":{"date-parts":[[1992,5]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "2523"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Vary:
+          - Accept-Encoding
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1038%2Fs42256-024-00832-8/transform/application/x-bibtex
+    response:
+      body:
+        string:
+          " @article{M_Bran_2024, title={Augmenting large language models with
+          chemistry tools}, volume={6}, ISSN={2522-5839}, url={http://dx.doi.org/10.1038/s42256-024-00832-8},
+          DOI={10.1038/s42256-024-00832-8}, number={5}, journal={Nature Machine Intelligence},
+          publisher={Springer Science and Business Media LLC}, author={M. Bran, Andres
+          and Cox, Sam and Schilter, Oliver and Baldassari, Carlo and White, Andrew
+          D. and Schwaller, Philippe}, year={2024}, month=may, pages={525\u2013535}
+          }\n"
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.1101%2F2024.04.01.587366/transform/application/x-bibtex
+    response:
+      body:
+        string:
+          " @article{Herger_2024, title={High-throughput screening of human genetic
+          variants by pooled prime editing}, url={http://dx.doi.org/10.1101/2024.04.01.587366},
+          DOI={10.1101/2024.04.01.587366}, publisher={Cold Spring Harbor Laboratory},
+          author={Herger, Michael and Kajba, Christina M. and Buckley, Megan and Cunha,
+          Ana and Strom, Molly and Findlay, Gregory M.}, year={2024}, month=apr }
+
+          "
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Date:
+          - Mon, 02 Dec 2024 19:36:28 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
       status:
         code: 200
         message: OK
@@ -913,7 +1222,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":11962693,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":12022430,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
           Publishing","issue":"23","funder":[{"DOI":"10.13039\/100000006","name":"Office
           of Naval Research","doi-asserted-by":"publisher","award":["N00014-12-1-0542"],"id":[{"id":"10.13039\/100000006","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["pubs.aip.org"],"crossmark-restriction":true},"published-print":{"date-parts":[[2015,12,21]]},"abstract":"<jats:p>Metal-oxide
           layers are likely to be present on metallic nano-structures due to either
@@ -1007,7 +1316,7 @@ interactions:
           Sci. Eng. A"},{"key":"2023062402360541600_c55","doi-asserted-by":"publisher","first-page":"057129","DOI":"10.1063\/1.4880241","volume":"4","year":"2014","journal-title":"AIP
           Adv."},{"key":"2023062402360541600_c56","doi-asserted-by":"publisher","first-page":"94","DOI":"10.1016\/j.susc.2014.10.017","volume":"633","year":"2015","journal-title":"Surf.
           Sci."},{"key":"2023062402360541600_c57","doi-asserted-by":"publisher","first-page":"710","DOI":"10.1016\/j.pmatsci.2010.04.001","volume":"55","year":"2010","journal-title":"Prog.
-          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":63.98746,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":64.01677,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -1021,235 +1330,15 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3946"
+          - "3944"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
           - Accept-Encoding
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=High-throughput+screening+of+human+genetic+variants+by+pooled+prime+editing&rows=1
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5229968,"items":[{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,4,5]],"date-time":"2024-04-05T00:42:23Z","timestamp":1712277743507},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
-          Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"accepted":{"date-parts":[[2024,4,1]]},"abstract":"<jats:title>ABSTRACT<\/jats:title><jats:p>Understanding
-          the effects of rare genetic variants remains challenging, both in coding and
-          non-coding regions. While multiplexed assays of variant effect (MAVEs) have
-          enabled scalable functional assessment of variants, established MAVEs are
-          limited by either exogenous expression of variants or constraints of genome
-          editing. Here, we introduce a pooled prime editing (PE) platform in haploid
-          human cells to scalably assay variants in their endogenous context. We first
-          optimized delivery of variants to HAP1 cells, defining optimal pegRNA designs
-          and establishing a co-selection strategy for improved efficiency. We characterize
-          our platform in the context of negative selection by testing over 7,500 pegRNAs
-          targeting<jats:italic>SMARCB1<\/jats:italic>for editing activity and observing
-          depletion of highly active pegRNAs installing loss-of-function variants. We
-          next assess variants in<jats:italic>MLH1<\/jats:italic>via 6-thioguanine selection,
-          assaying 65.3% of all possible SNVs in a 200-bp region spanning exon 10 and
-          distinguishing LoF variants with high accuracy. Lastly, we assay 362 non-coding<jats:italic>MLH1<\/jats:italic>variants
-          across a 60 kb region in a single experiment, identifying pathogenic variants
-          acting via multiple mechanisms with high specificity. Our analyses detail
-          how filtering for highly active pegRNAs can facilitate both positive and negative
-          selection screens. Accordingly, our platform promises to enable highly scalable
-          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":0,"title":["High-throughput
-          screening of human genetic variants by pooled prime editing"],"prefix":"10.1101","author":[{"given":"Michael","family":"Herger","sequence":"first","affiliation":[]},{"given":"Christina
-          M.","family":"Kajba","sequence":"additional","affiliation":[]},{"given":"Megan","family":"Buckley","sequence":"additional","affiliation":[]},{"given":"Ana","family":"Cunha","sequence":"additional","affiliation":[]},{"given":"Molly","family":"Strom","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7767-8608","authenticated-orcid":false,"given":"Gregory
-          M.","family":"Findlay","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2024040415500652000_2024.04.01.587366v1.1","doi-asserted-by":"publisher","DOI":"10.1038\/gim.2015.30"},{"key":"2024040415500652000_2024.04.01.587366v1.2","doi-asserted-by":"crossref","first-page":"116","DOI":"10.1016\/j.cels.2017.11.003","article-title":"Quantitative
-          Missense Variant Effect Prediction Using Large-Scale Mutagenesis Data","volume":"6","year":"2018","journal-title":"Cell
-          Syst"},{"key":"2024040415500652000_2024.04.01.587366v1.3","doi-asserted-by":"publisher","DOI":"10.1126\/science.abi8207"},{"key":"2024040415500652000_2024.04.01.587366v1.4","doi-asserted-by":"publisher","DOI":"10.1016\/J.CELL.2018.12.015"},{"key":"2024040415500652000_2024.04.01.587366v1.5","doi-asserted-by":"crossref","first-page":"eabn8153","DOI":"10.1126\/science.abn8197","article-title":"The
-          landscape of tolerated genetic variation in humans and primates","volume":"380","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.6","doi-asserted-by":"crossref","first-page":"eadg7492","DOI":"10.1126\/science.adg7492","article-title":"Accurate
-          proteome-wide missense variant effect prediction with AlphaMissense","volume":"381","year":"2023","journal-title":"Science"},{"key":"2024040415500652000_2024.04.01.587366v1.7","doi-asserted-by":"publisher","DOI":"10.1093\/nar\/gkv1222"},{"key":"2024040415500652000_2024.04.01.587366v1.8","doi-asserted-by":"crossref","first-page":"1381","DOI":"10.1038\/s41436-021-01172-3","article-title":"ACMG
-          SF v3.0 list for reporting of secondary findings in clinical exome and genome
-          sequencing: a policy statement of the American College of Medical Genetics
-          and Genomics (ACMG)","volume":"23","year":"2021","journal-title":"Genet. Med"},{"key":"2024040415500652000_2024.04.01.587366v1.9","doi-asserted-by":"publisher","DOI":"10.1038\/nprot.2016.135"},{"key":"2024040415500652000_2024.04.01.587366v1.10","doi-asserted-by":"publisher","DOI":"10.1093\/hmg\/ddab219"},{"key":"2024040415500652000_2024.04.01.587366v1.11","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-11526-w"},{"key":"2024040415500652000_2024.04.01.587366v1.12","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-022-02839-z"},{"key":"2024040415500652000_2024.04.01.587366v1.13","doi-asserted-by":"crossref","first-page":"2248","DOI":"10.1016\/j.ajhg.2021.11.001","article-title":"Closing
-          the gap: Systematic integration of multiplexed functional data resolves variants
-          of uncertain significance in BRCA1, TP53, and PTEN","volume":"108","year":"2021","journal-title":"Am.
-          J. Hum. Genet."},{"key":"2024040415500652000_2024.04.01.587366v1.14","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-018-0461-z"},{"key":"2024040415500652000_2024.04.01.587366v1.15","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.10.015"},{"key":"2024040415500652000_2024.04.01.587366v1.16","doi-asserted-by":"crossref","first-page":"7702","DOI":"10.1038\/s41467-023-43041-4","article-title":"Saturation
-          genome editing of DDX3X clarifies pathogenicity of germline and somatic variation","volume":"14","year":"2023","journal-title":"Nat.
-          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.17","doi-asserted-by":"publisher","DOI":"10.1038\/nature13695"},{"key":"2024040415500652000_2024.04.01.587366v1.18","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.012"},{"key":"2024040415500652000_2024.04.01.587366v1.19","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.01.041"},{"key":"2024040415500652000_2024.04.01.587366v1.20","doi-asserted-by":"publisher","DOI":"10.1038\/s41586-019-1711-4"},{"key":"2024040415500652000_2024.04.01.587366v1.21","doi-asserted-by":"crossref","first-page":"288","DOI":"10.1016\/j.ccell.2022.12.009","article-title":"Base
-          editing screens map mutations affecting interferon-\u03b3 signaling in cancer","volume":"41","year":"2023","journal-title":"Cancer
-          Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.22","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2021.09.018"},{"key":"2024040415500652000_2024.04.01.587366v1.23","doi-asserted-by":"crossref","first-page":"402","DOI":"10.1038\/s41587-021-01039-7","article-title":"Engineered
-          pegRNAs improve prime editing efficiency","volume":"40","year":"2022","journal-title":"Nat.
-          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.24","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01201-1"},{"key":"2024040415500652000_2024.04.01.587366v1.25","doi-asserted-by":"publisher","DOI":"10.1016\/j.molcel.2023.11.021"},{"key":"2024040415500652000_2024.04.01.587366v1.26","doi-asserted-by":"publisher","DOI":"10.1038\/nature10348"},{"key":"2024040415500652000_2024.04.01.587366v1.27","doi-asserted-by":"publisher","DOI":"10.1126\/science.1247005"},{"key":"2024040415500652000_2024.04.01.587366v1.28","doi-asserted-by":"crossref","first-page":"1151","DOI":"10.1038\/s41587-022-01613-7","article-title":"Predicting
-          prime editing efficiency and product purity by deep learning","volume":"41","year":"2023","journal-title":"Nat.
-          Biotechnol"},{"key":"2024040415500652000_2024.04.01.587366v1.29","doi-asserted-by":"crossref","first-page":"2256","DOI":"10.1016\/j.cell.2023.03.034","article-title":"Prediction
-          of efficiencies for diverse prime editing systems in multiple cell types","volume":"186","year":"2023","journal-title":"Cell"},{"key":"2024040415500652000_2024.04.01.587366v1.30","doi-asserted-by":"publisher","DOI":"10.1101\/2022.10.26.513842"},{"key":"2024040415500652000_2024.04.01.587366v1.31","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-021-01172-3"},{"key":"2024040415500652000_2024.04.01.587366v1.32","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-020-0677-y"},{"key":"2024040415500652000_2024.04.01.587366v1.33","doi-asserted-by":"publisher","DOI":"10.1016\/j.tibtech.2018.07.017"},{"key":"2024040415500652000_2024.04.01.587366v1.34","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-020-20810-z"},{"key":"2024040415500652000_2024.04.01.587366v1.35","doi-asserted-by":"crossref","first-page":"5909","DOI":"10.1038\/s41467-022-33669-z","article-title":"Marker-free
-          co-selection for successive rounds of prime editing in human cells","volume":"13","year":"2022","journal-title":"Nat.
-          Commun"},{"key":"2024040415500652000_2024.04.01.587366v1.36","doi-asserted-by":"publisher","DOI":"10.1016\/j.cell.2013.12.001"},{"key":"2024040415500652000_2024.04.01.587366v1.37","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-018-02974-x"},{"key":"2024040415500652000_2024.04.01.587366v1.38","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-021-27838-9"},{"key":"2024040415500652000_2024.04.01.587366v1.39","doi-asserted-by":"publisher","DOI":"10.1126\/science.1225829"},{"key":"2024040415500652000_2024.04.01.587366v1.40","doi-asserted-by":"publisher","DOI":"10.3390\/cancers14153645"},{"key":"2024040415500652000_2024.04.01.587366v1.41","doi-asserted-by":"publisher","DOI":"10.1126\/science.aac7557"},{"key":"2024040415500652000_2024.04.01.587366v1.42","doi-asserted-by":"publisher","DOI":"10.1038\/s41467-019-10849-y"},{"key":"2024040415500652000_2024.04.01.587366v1.43","doi-asserted-by":"publisher","DOI":"10.1038\/nbt.3437"},{"key":"2024040415500652000_2024.04.01.587366v1.44","doi-asserted-by":"publisher","DOI":"10.1136\/jmg.2007.056499"},{"key":"2024040415500652000_2024.04.01.587366v1.45","doi-asserted-by":"publisher","DOI":"10.1016\/j.ajhg.2020.12.003"},{"key":"2024040415500652000_2024.04.01.587366v1.46","doi-asserted-by":"publisher","DOI":"10.1038\/s41587-019-0032-3"},{"key":"2024040415500652000_2024.04.01.587366v1.47","doi-asserted-by":"publisher","DOI":"10.1038\/nmeth.3047"},{"key":"2024040415500652000_2024.04.01.587366v1.48","doi-asserted-by":"crossref","first-page":"96","DOI":"10.1089\/hgtb.2017.198","article-title":"Determination
-          of Lentiviral Infectious Titer by a Novel Droplet Digital PCR Method","volume":"29","year":"2018","journal-title":"Hum.
-          Gene Ther. Methods"},{"key":"2024040415500652000_2024.04.01.587366v1.49","doi-asserted-by":"publisher","DOI":"10.1186\/s13059-020-02091-3"},{"key":"2024040415500652000_2024.04.01.587366v1.50","doi-asserted-by":"publisher","DOI":"10.1186\/s13073-021-00835-9"}],"link":[{"URL":"https:\/\/syndication.highwire.org\/content\/doi\/10.1101\/2024.04.01.587366","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,4,4]],"date-time":"2024-04-04T22:50:19Z","timestamp":1712271019000},"score":61.358017,"resource":{"primary":{"URL":"http:\/\/biorxiv.org\/lookup\/doi\/10.1101\/2024.04.01.587366"}},"issued":{"date-parts":[[2024,4,1]]},"references-count":50,"URL":"http:\/\/dx.doi.org\/10.1101\/2024.04.01.587366","published":{"date-parts":[[2024,4,1]]},"subtype":"preprint"}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "3247"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Vary:
-          - Accept-Encoding
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=An+essential+role+of+active+site+arginine+residue+in+iodide+binding+and+histidine+residue+in+electron+transfer+for+iodide+oxidation+by+horseradish+peroxidase&rows=1
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4129108,"items":[{"indexed":{"date-parts":[[2024,6,24]],"date-time":"2024-06-24T23:08:06Z","timestamp":1719270486276},"reference-count":40,"publisher":"Elsevier
-          BV","issue":"14","license":[{"start":{"date-parts":[[1992,5,1]],"date-time":"1992-05-01T00:00:00Z","timestamp":704678400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/www.elsevier.com\/tdm\/userlicense\/1.0\/"},{"start":{"date-parts":[[2020,10,3]],"date-time":"2020-10-03T00:00:00Z","timestamp":1601683200000},"content-version":"vor","delay-in-days":10382,"URL":"http:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":["Journal
-          of Biological Chemistry"],"published-print":{"date-parts":[[1992,5]]},"DOI":"10.1016\/s0021-9258(19)50164-8","type":"journal-article","created":{"date-parts":[[2021,1,6]],"date-time":"2021-01-06T15:57:43Z","timestamp":1609948663000},"page":"9800-9804","source":"Crossref","is-referenced-by-count":23,"title":["Chemical
-          and kinetic evidence for an essential histidine in horseradish peroxidase
-          for iodide oxidation."],"prefix":"10.1016","volume":"267","author":[{"given":"D.K.","family":"Bhattacharyya","sequence":"first","affiliation":[]},{"given":"U","family":"Bandyopadhyay","sequence":"additional","affiliation":[]},{"given":"R.K.","family":"Banerjee","sequence":"additional","affiliation":[]}],"member":"78","reference":[{"key":"10.1016\/S0021-9258(19)50164-8_bib1","doi-asserted-by":"crossref","first-page":"531","DOI":"10.1093\/oxfordjournals.jbchem.a133961","volume":"92","author":"Aibara","year":"1982","journal-title":"J.
-          Biochem. (Tokyo)"},{"key":"10.1016\/S0021-9258(19)50164-8_bib2","doi-asserted-by":"crossref","first-page":"341","DOI":"10.1016\/0003-2697(62)90097-0","volume":"4","author":"Alexander","year":"1962","journal-title":"Anal.
-          Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib3","doi-asserted-by":"crossref","first-page":"10592","DOI":"10.1016\/S0021-9258(18)67426-5","volume":"261","author":"Banerjee","year":"1986","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib4","doi-asserted-by":"crossref","first-page":"396","DOI":"10.1016\/0005-2744(70)90245-7","volume":"212","author":"Bjorkstein","year":"1970","journal-title":"Biochim.
-          Biophys. Acta"},{"key":"10.1016\/S0021-9258(19)50164-8_bib5","doi-asserted-by":"crossref","first-page":"12454","DOI":"10.1016\/S0021-9258(19)38367-X","volume":"265","author":"Blanke","year":"1990","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib6","doi-asserted-by":"crossref","first-page":"205","DOI":"10.1021\/bi00698a030","volume":"13","author":"Burstein","year":"1974","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib7","doi-asserted-by":"crossref","first-page":"19666","DOI":"10.1016\/S0021-9258(19)47165-2","volume":"264","author":"Chang","year":"1989","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib8","doi-asserted-by":"crossref","first-page":"4936","DOI":"10.1016\/S0021-9258(18)89162-1","volume":"260","author":"Church","year":"1985","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib9","doi-asserted-by":"crossref","first-page":"4992","DOI":"10.1021\/bi00668a008","volume":"15","author":"Cousineau","year":"1976","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib10","doi-asserted-by":"crossref","first-page":"21498","DOI":"10.1016\/S0021-9258(18)45766-3","volume":"265","author":"Dumas","year":"1990","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib11","first-page":"410","volume":"4","author":"Dunford","year":"1982","journal-title":"Adv.
-          Inorg. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib12","doi-asserted-by":"crossref","first-page":"187","DOI":"10.1016\/S0010-8545(00)80316-1","volume":"19","author":"Dunford","year":"1976","journal-title":"Coord.
-          Chem. Rev."},{"key":"10.1016\/S0021-9258(19)50164-8_bib13","doi-asserted-by":"crossref","first-page":"21","DOI":"10.1016\/0022-2836(85)90180-9","volume":"185","author":"Fita","year":"1985","journal-title":"J.
-          Mol. Biol."},{"key":"10.1016\/S0021-9258(19)50164-8_bib14","doi-asserted-by":"crossref","first-page":"15054","DOI":"10.1016\/S0021-9258(18)33392-1","volume":"257","author":"Kaput","year":"1982","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib15","doi-asserted-by":"crossref","first-page":"409","DOI":"10.1016\/0003-9861(87)90118-4","volume":"254","author":"Kenigsberg","year":"1987","journal-title":"Arch.
-          Biochem. Biophys."},{"key":"10.1016\/S0021-9258(19)50164-8_bib16","doi-asserted-by":"crossref","first-page":"55","DOI":"10.1016\/0003-9861(88)90103-8","volume":"261","author":"Konpka","year":"1988","journal-title":"Arch.
-          Biochem. Biophys."},{"key":"10.1016\/S0021-9258(19)50164-8_bib17","doi-asserted-by":"crossref","first-page":"3654","DOI":"10.1016\/S0021-9258(19)75322-8","volume":"238","author":"Levy","year":"1963","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib18","volume":"1","author":"Lundblad","year":"1984"},{"key":"10.1016\/S0021-9258(19)50164-8_bib19","doi-asserted-by":"crossref","first-page":"197","DOI":"10.1016\/S0021-9258(17)43641-6","volume":"259","author":"Magnusson","year":"1984","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib20","doi-asserted-by":"crossref","first-page":"251","DOI":"10.1021\/bi00804a010","volume":"9","author":"Melchior","year":"1970","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib21","doi-asserted-by":"crossref","first-page":"431","DOI":"10.1016\/0076-6879(77)47043-5","volume":"47","author":"Miles","year":"1977","journal-title":"Methods
-          Enzymol."},{"key":"10.1016\/S0021-9258(19)50164-8_bib22","doi-asserted-by":"crossref","first-page":"861","DOI":"10.1146\/annurev.bi.45.070176.004241","volume":"45","author":"Morrison","year":"1976","journal-title":"Annu.
-          Rev. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib23","doi-asserted-by":"crossref","first-page":"13546","DOI":"10.1016\/S0021-9258(17)38757-4","volume":"260","author":"Nakamura","year":"1985","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib24","doi-asserted-by":"crossref","first-page":"805","DOI":"10.1016\/S0021-9258(19)70048-9","volume":"256","author":"Ohtaki","year":"1981","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib25","doi-asserted-by":"crossref","first-page":"761","DOI":"10.1016\/S0021-9258(19)68261-X","volume":"257","author":"Ohtaki","year":"1982","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib26","first-page":"445","volume":"2","author":"Ovadi","year":"1967","journal-title":"Acta
-          Biochim. Biophys. Acad. Sci. Hung."},{"key":"10.1016\/S0021-9258(19)50164-8_bib27","doi-asserted-by":"crossref","first-page":"395","DOI":"10.3891\/acta.chem.scand.32b-0395","volume":"B32","author":"Paul","year":"1978","journal-title":"Acta
-          Chem. Scand."},{"key":"10.1016\/S0021-9258(19)50164-8_bib28","doi-asserted-by":"crossref","first-page":"497","DOI":"10.1111\/j.1432-1033.1973.tb03085.x","volume":"38","author":"Pommier","year":"1973","journal-title":"Eur.
-          J. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib29","doi-asserted-by":"crossref","first-page":"8199","DOI":"10.1016\/S0021-9258(19)70630-9","volume":"255","author":"Poulos","year":"1980","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib30","doi-asserted-by":"crossref","first-page":"2076","DOI":"10.1021\/bi00761a013","volume":"11","author":"Roman","year":"1972","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib31","doi-asserted-by":"crossref","first-page":"211","DOI":"10.1246\/cl.1985.211","author":"Sakurada","year":"1985","journal-title":"Chem.
-          Lett."},{"key":"10.1016\/S0021-9258(19)50164-8_bib32","doi-asserted-by":"crossref","first-page":"9657","DOI":"10.1016\/S0021-9258(18)67564-7","volume":"261","author":"Sakurada","year":"1986","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib33","doi-asserted-by":"crossref","first-page":"4007","DOI":"10.1016\/S0021-9258(18)61303-1","volume":"262","author":"Sakurada","year":"1987","journal-title":"J.
-          Biol. Chem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib34","doi-asserted-by":"crossref","first-page":"6478","DOI":"10.1021\/bi00394a028","volume":"26","author":"Sakurada","year":"1987","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib35","doi-asserted-by":"crossref","first-page":"2277","DOI":"10.1021\/bi00407a005","volume":"27","author":"Sams","year":"1988","journal-title":"Biochemistry"},{"key":"10.1016\/S0021-9258(19)50164-8_bib36","doi-asserted-by":"crossref","first-page":"1571","DOI":"10.1093\/oxfordjournals.jbchem.a135630","volume":"99","author":"Takeuchi","year":"1986","journal-title":"J.
-          Biochem. (Tokyo)"},{"key":"10.1016\/S0021-9258(19)50164-8_bib37","doi-asserted-by":"crossref","first-page":"520","DOI":"10.1038\/326520a0","volume":"326","author":"Tien","year":"1987","journal-title":"Nature"},{"key":"10.1016\/S0021-9258(19)50164-8_bib38","doi-asserted-by":"crossref","first-page":"87","DOI":"10.1111\/j.1432-1033.1986.tb09461.x","volume":"155","author":"Topham","year":"1986","journal-title":"Eur.
-          J. Biochem."},{"key":"10.1016\/S0021-9258(19)50164-8_bib39","doi-asserted-by":"crossref","first-page":"210","DOI":"10.1016\/0005-2744(81)90032-2","volume":"662","author":"Ugarova","year":"1981","journal-title":"Biochim.
-          Biophys. Acta"},{"key":"10.1016\/S0021-9258(19)50164-8_bib40","doi-asserted-by":"crossref","first-page":"483","DOI":"10.1111\/j.1432-1033.1979.tb13061.x","volume":"96","author":"Welinder","year":"1979","journal-title":"Eur.
-          J. Biochem."}],"container-title":["Journal of Biological Chemistry"],"language":"en","link":[{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0021925819501648?httpAccept=text\/xml","content-type":"text\/xml","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/api.elsevier.com\/content\/article\/PII:S0021925819501648?httpAccept=text\/plain","content-type":"text\/plain","content-version":"vor","intended-application":"text-mining"}],"deposited":{"date-parts":[[2022,1,2]],"date-time":"2022-01-02T19:58:22Z","timestamp":1641153502000},"score":52.630573,"resource":{"primary":{"URL":"https:\/\/linkinghub.elsevier.com\/retrieve\/pii\/S0021925819501648"}},"issued":{"date-parts":[[1992,5]]},"references-count":40,"journal-issue":{"issue":"14","published-print":{"date-parts":[[1992,5]]}},"alternative-id":["S0021925819501648"],"URL":"http:\/\/dx.doi.org\/10.1016\/s0021-9258(19)50164-8","ISSN":["0021-9258"],"issn-type":[{"value":"0021-9258","type":"print"}],"published":{"date-parts":[[1992,5]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "2524"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Vary:
-          - Accept-Encoding
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1038%2Fs42256-024-00832-8/transform/application/x-bibtex
-    response:
-      body:
-        string:
-          " @article{M_Bran_2024, title={Augmenting large language models with
-          chemistry tools}, volume={6}, ISSN={2522-5839}, url={http://dx.doi.org/10.1038/s42256-024-00832-8},
-          DOI={10.1038/s42256-024-00832-8}, number={5}, journal={Nature Machine Intelligence},
-          publisher={Springer Science and Business Media LLC}, author={M. Bran, Andres
-          and Cox, Sam and Schilter, Oliver and Baldassari, Carlo and White, Andrew
-          D. and Schwaller, Philippe}, year={2024}, month=may, pages={525\u2013535}
-          }\n"
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
         permissions-policy:
           - interest-cohort=()
         x-api-pool:
@@ -1292,96 +1381,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1007%2Fs40278-023-41815-2/transform/application/x-bibtex
-    response:
-      body:
-        string:
-          " @article{2023, volume={1962}, ISSN={1179-2051}, url={http://dx.doi.org/10.1007/s40278-023-41815-2},
-          DOI={10.1007/s40278-023-41815-2}, number={1}, journal={Reactions Weekly},
-          publisher={Springer Science and Business Media LLC}, year={2023}, month=jun,
-          pages={145\u2013145} }\n"
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.1101%2F2024.04.01.587366/transform/application/x-bibtex
-    response:
-      body:
-        string:
-          " @article{Herger_2024, title={High-throughput screening of human genetic
-          variants by pooled prime editing}, url={http://dx.doi.org/10.1101/2024.04.01.587366},
-          DOI={10.1101/2024.04.01.587366}, publisher={Cold Spring Harbor Laboratory},
-          author={Herger, Michael and Kajba, Christina M. and Buckley, Megan and Cunha,
-          Ana and Strom, Molly and Findlay, Gregory M.}, year={2024}, month=apr }
-
-          "
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_crossref_journalquality_fields_filtering.yaml
+++ b/tests/cassettes/test_crossref_journalquality_fields_filtering.yaml
@@ -7,7 +7,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"container-title":["Nature
           Machine Intelligence"],"title":["Augmenting large language models with chemistry
@@ -29,7 +29,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -57,7 +57,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":1799888,"items":[{"DOI":"10.1056\/nejmoa2404204","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-1901-2808","authenticated-orcid":false,"given":"Johanne","family":"Silvain","sequence":"first","affiliation":[{"name":"From
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":1806840,"items":[{"DOI":"10.1056\/nejmoa2404204","author":[{"ORCID":"http:\/\/orcid.org\/0000-0002-1901-2808","authenticated-orcid":false,"given":"Johanne","family":"Silvain","sequence":"first","affiliation":[{"name":"From
           Sorbonne Universit\u00e9, ACTION Group, INSERM Unit\u00e9 Mixte de Recherche
           (UMRS) 1166, H\u00f4pital Piti\u00e9\u2013Salp\u00eatri\u00e8re Assistance
           Publique\u2013H\u00f4pitaux de Paris (AP-HP) (J.S., P.G., N.P., K.A., G.M.),
@@ -363,11 +363,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "1357"
+          - "1356"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:

--- a/tests/cassettes/test_crossref_retraction_status.yaml
+++ b/tests/cassettes/test_crossref_retraction_status.yaml
@@ -7,7 +7,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4276707,"items":[{"DOI":"10.1155\/2022\/8341966","author":[{"ORCID":"http:\/\/orcid.org\/0000-0003-3902-2613","authenticated-orcid":true,"given":"Jiaye","family":"Han","sequence":"first","affiliation":[{"name":"Pingdingshan
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":4342705,"items":[{"DOI":"10.1155\/2022\/8341966","author":[{"ORCID":"http:\/\/orcid.org\/0000-0003-3902-2613","authenticated-orcid":true,"given":"Jiaye","family":"Han","sequence":"first","affiliation":[{"name":"Pingdingshan
           Polytechnic College, PingDingShan, Henan 467001, China"},{"name":"National
           University of Life and Environmental Sciences of Ukraine, Kyiv 03041, Ukraine"}]}],"container-title":["Wireless
           Communications and Mobile Computing"],"title":["The Dilemma and Countermeasures
@@ -25,7 +25,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 07 Oct 2024 01:01:33 GMT
+          - Mon, 02 Dec 2024 19:37:06 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_docs_lifecycle.yaml
+++ b/tests/cassettes/test_docs_lifecycle.yaml
@@ -1,11 +1,10 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Extract the title, authors,
-        and doi as a JSON from this MLA citation. If any field can not be found, return
+        '{"messages":[{"role":"user","content":"Extract the title, authors, and
+        doi as a JSON from this MLA citation. If any field can not be found, return
         it as null. Use title, authors, and doi as keys, author''s value should be a
-        list of authors. WikiMedia Foundation, 2023, Accessed now\n\nCitation JSON:"}],
-        "model": "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        list of authors. WikiMedia Foundation, 2023, Accessed now\n\nCitation JSON:"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -14,13 +13,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "373"
+          - "363"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -30,7 +29,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -44,19 +43,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSsW7bMBTc9RXEm61CdpXY1RYg8NSiQDNkiAKJIZ8kxhQfS1JAC8P/XlCWLBtp
-          gS4c7t4d7x55TBgDJaFgIDoeRG91+vDj6Xm333S7/PvjHn+qp6y7/zocdtSg47CKCnp7RxFm1SdB
-          vdUYFJkzLRzygNF1vf28XmfbXZ6NRE8SdZS1NqQ5pZtsk6fZLs3uJ2FHSqCHgr0kjDF2HM8Y0Uj8
-          BQUbbUakR+95i1BchhgDRzoiwL1XPnATYLWQgkxAM6au6/rdkynNsTSMlRBU0FhCwcyg9eqM8SF0
-          5HxEX0p4Vgf1DaXibE+DkTyWLeF1mpWkZnVpTqWp6/r6ZofN4LmeJib8dKmiqbWO3vx8/4w3yijf
-          VQ65JxNj+0AWRvaUMPY6rmy42QJYR70NVaADmmi4nTYGyxst5GY7kYEC1wv+ZcZv3CqJgSvtr1YO
-          gosO5aJc3ocPUtEVkVx1/hjmb97n3sq0/2O/EEKgDSgr61AqcVt4GXMYf/C/xi47HgOD/+0D9lWj
-          TIvOOnX+RI2t8jvR3OUSOUJySv4AAAD//wMAQPTb+E0DAAA=
+          H4sIAAAAAAAAA4xSwWrcMBS8+yvEO6+L17vZTXwLhV5KKWmhhcbBlqVnW4msJyQZEpb992Kvvd4l
+          LeSiw8yb0cyTDhFjoCRkDETLg+isju/57helD+ubz3++vr2q71u7IVv1N3c/fzy0sBoUVD2jCLPq
+          k6DOagyKzIkWDnnAwXW932zWu9s02Y5ERxL1IGtsiLcUp0m6jZPbONlNwpaUQA8Ze4wYY+wwnkNE
+          I/EVMpasZqRD73mDkJ2HGANHekCAe6984CbAaiEFmYBmTF2W5bMnk5tDbhjLIaigMYeMmV7r1Qnj
+          fWjJ+QF9zOG3elHfUCrOvlBvJB/K5vA0zUpSszo3x9yUZXl5s8O691xPExN+PFfR1FhHlZ/vn/Fa
+          GeXbwiH3ZIbYPpCFkT1GjD2NK+uvtgDWUWdDEegFzWC4nzYGyxstZLqfyECB6wW/m/Ert0Ji4Er7
+          i5WD4KJFuSiX9+G9VHRBRBed34f5l/eptzLNR+wXQgi0AWVhHUolrgsvYw6HH/y/sfOOx8Dg33zA
+          rqiVadBZp06fqLbFvt5VuMG6SiA6Rn8BAAD//wMAXV2y4U0DAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df9469f48affa52-SJC
+          - 8ebdc47dda0fed38-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -64,14 +63,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:59 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=_08X2kkIMas3XYFZGLhqeyHHTogb581t32N2y34nqK0-1731107840-1.0.1.1-H4M94sHLNcSlGJEdtIygK.jzlG0XlTwVJZ.wJvleSPbA324ExZSOZaaV5FwOsZJ_XZ52r43H7kUXsGBLFWETpA;
-            path=/; expires=Fri, 08-Nov-24 23:47:20 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=W.NFql5d8Z_.JFkOAd6m7nEQisArKoU9cNZeV1nfETo-1733168219-1.0.1.1-oQaRLrKRUfx8SJcnFKTibiLZShIrP7OyTAdF6ovBy656W9XkmGMrBoDPwg4VF4Y_kyQPFYvEzC.VpukZq6T4NQ;
+            path=/; expires=Mon, 02-Dec-24 20:06:59 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=xBJVl6tupRAygvceVjIpvq0vK4gwj1ii7pgCuolPvsU-1731107840462-0.0.1.1-604800000;
+          - _cfuvid=re2agnpLUwbLYSevB_Oe4ejPi5WIZro6fSI1XIvL990-1733168219473-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -84,7 +83,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "457"
+          - "14917"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -102,230 +101,234 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_f41e24a52cc2adba813ab583a1a78954
+          - req_1cdf93505147bdaab3b84829d17dfba2
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"input": ["Jump to content\n\nMain menu\n\nMain menu\n\nmove to sidebar  hide\n\nNavigation\n\n  *
-        [Main page](/wiki/Main_Page \"Visit the main page \\[z\\]\")\n  * [Contents](/wiki/Wikipedia:Contents
-        \"Guides to browsing Wikipedia\")\n  * [Current events](/wiki/Portal:Current_events
-        \"Articles related to current events\")\n  * [Random article](/wiki/Special:Random
-        \"Visit a randomly selected article \\[x\\]\")\n  * [About Wikipedia](/wiki/Wikipedia:About
-        \"Learn about Wikipedia and how it works\")\n  * [Contact us](//en.wikipedia.org/wiki/Wikipedia:Contact_us
-        \"How to contact Wikipedia\")\n  * [Donate](https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&utm_medium=sidebar&utm_campaign=C13_en.wikipedia.org&uselang=en
-        \"Support us by donating to the Wikimedia Foundation\")\n\nContribute\n\n  *
-        [Help](/wiki/Help:Contents \"Guidance on how to use and edit Wikipedia\")\n  *
-        [Learn to edit](/wiki/Help:Introduction \"Learn how to edit Wikipedia\")\n  *
-        [Community portal](/wiki/Wikipedia:Community_portal \"The hub for editors\")\n  *
-        [Recent changes](/wiki/Special:RecentChanges \"A list of recent changes to Wikipedia
-        \\[r\\]\")\n  * [Upload file](/wiki/Wikipedia:File_upload_wizard \"Add images
-        or other media for use on Wikipedia\")\n\n[ ![](/static/images/icons/wikipedia.png)\n![Wikipedia](/static/images/mobile/copyright/wikipedia-wordmark-en.svg)
-        ![The\nFree Encyclopedia](/static/images/mobile/copyright/wikipedia-tagline-en.svg)\n](/wiki/Main_Page)\n\n[
-        Search ](/wiki/Special:Search \"Search Wikipedia \\[f\\]\")\n\nSearch\n\nAppearance\n\n  *
-        [Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
-        \"You are encouraged to create an account and log in; however, it is not mandatory\")\n  *
-        [Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
-        \"You''re encouraged to log in; however, it''s not mandatory. \\[o\\]\")\n\nPersonal
-        tools\n\n  * [ Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
-        \"You are encouraged to create an account and log in; however, it is not mandatory\")\n  *
-        [ Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
-        \"You''re encouraged to log in; however, it''s not mandatory. \\[o\\]\")\n\nPages
-        for logged out editors [learn more](/wiki/Help:Introduction)\n\n  * [Contributions](/wiki/Special:MyContributions
-        \"A list of edits made from this IP address \\[y\\]\")\n  * [Talk](/wiki/Special:MyTalk
-        \"Discussion about edits from this IP address \\[n\\]\")\n\n## Contents\n\nmove
-        to sidebar  hide\n\n  * (Top)\n  * 1 History Toggle History subsection\n    *
-        1.1 Background\n    * 1.2 Flag Day\n  * 2 See also\n  * 3 Footnotes\n  * 4 External
-        links\n\nToggle the table of contents\n\n#  National Flag of Canada Day\n\n7
-        languages\n\n  * [\u0627\u0644\u0639\u0631\u0628\u064a\u0629](https://ar.wikipedia.org/wiki/%D9%8A%D9%88%D9%85_%D8%B9%D9%84%D9%85_%D9%83%D9%86%D8%AF%D8%A7_%D8%A7%D9%84%D9%88%D8%B7%D9%86%D9%8A
-        \"\u064a\u0648\u0645 \u0639\u0644\u0645 \u0643\u0646\u062f\u0627 \u0627\u0644\u0648\u0637\u0646\u064a
-        \u2013 Arabic\")\n  * [Espa\u00f1ol](https://es.wikipedia.org/wiki/D%C3%ADa_de_la_Bandera_Nacional_de_Canad%C3%A1
-        \"D\u00eda de la Bandera Nacional de Canad\u00e1 \u2013 Spanish\")\n  * [Fran\u00e7ais](https://fr.wikipedia.org/wiki/Jour_du_drapeau_national_du_Canada
-        \"Jour du drapeau national du Canada \u2013 French\")\n  * [\u0540\u0561\u0575\u0565\u0580\u0565\u0576](https://hy.wikipedia.org/wiki/%D4%BF%D5%A1%D5%B6%D5%A1%D5%A4%D5%A1%D5%B5%D5%AB_%D5%A1%D5%A6%D5%A3%D5%A1%D5%B5%D5%AB%D5%B6_%D5%A4%D6%80%D5%B8%D5%B7%D5%AB_%D6%85%D6%80
-        \"\u053f\u0561\u0576\u0561\u0564\u0561\u0575\u056b \u0561\u0566\u0563\u0561\u0575\u056b\u0576
-        \u0564\u0580\u0578\u0577\u056b \u0585\u0580 \u2013 Armenian\")\n  * [\u05e2\u05d1\u05e8\u05d9\u05ea](https://he.wikipedia.org/wiki/%D7%99%D7%95%D7%9D_%D7%94%D7%93%D7%92%D7%9C_%D7%94%D7%9C%D7%90%D7%95%D7%9E%D7%99_%D7%A9%D7%9C_%D7%A7%D7%A0%D7%93%D7%94
-        \"\u05d9\u05d5\u05dd \u05d4\u05d3\u05d2\u05dc \u05d4\u05dc\u05d0\u05d5\u05de\u05d9
-        \u05e9\u05dc \u05e7\u05e0\u05d3\u05d4 \u2013 Hebrew\")\n  * [Bahasa Melayu](https://ms.wikipedia.org/wiki/Hari_Bendera_Kebangsaan_Kanada
-        \"Hari Bendera Kebangsaan Kanada \u2013 Malay\")\n  * [Polski](https://pl.wikipedia.org/wiki/Narodowy_dzie%C5%84_flagi_Kanady
-        \"Narodowy dzie\u0144 flagi Kanady \u2013 Polish\")\n\n[Edit\nlinks](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703#sitelinks-\nwikipedia
-        \"Edit interlanguage links\")\n\n  * [Article](/wiki/National_Flag_of_Canada_Day
-        \"View the content page \\[c\\]\")\n  * [Talk](/wiki/Talk:National_Flag_of_Canada_Day
-        \"Discuss improvements to the content page \\[t\\]\")\n\nEnglish\n\n  * [Read](/wiki/National_Flag_of_Canada_Day)\n  *
-        [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \"Edit this
-        page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
-        \"Past revisions of this page \\[h\\]\")\n\nTools\n\nTools\n\nmove to sidebar  hide\n\nActions\n\n  *
-        [Read](/wiki/National_Flag_of_Canada_Day)\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
-        \"Edit this page \\[e\\]\")\n  * [View history](/w/index.php?title", "_Flag_of_Canada_Day)\n  *
-        [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \"Edit this
-        page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
-        \"Past revisions of this page \\[h\\]\")\n\nTools\n\nTools\n\nmove to sidebar  hide\n\nActions\n\n  *
-        [Read](/wiki/National_Flag_of_Canada_Day)\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
-        \"Edit this page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history)\n\nGeneral\n\n  *
-        [What links here](/wiki/Special:WhatLinksHere/National_Flag_of_Canada_Day \"List
-        of all English Wikipedia pages containing links to this page \\[j\\]\")\n  *
-        [Related changes](/wiki/Special:RecentChangesLinked/National_Flag_of_Canada_Day
-        \"Recent changes in pages linked from this page \\[k\\]\")\n  * [Upload file](/wiki/Wikipedia:File_Upload_Wizard
-        \"Upload files \\[u\\]\")\n  * [Special pages](/wiki/Special:SpecialPages \"A
-        list of all special pages \\[q\\]\")\n  * [Permanent link](/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994
-        \"Permanent link to this revision of this page\")\n  * [Page information](/w/index.php?title=National_Flag_of_Canada_Day&action=info
-        \"More information about this page\")\n  * [Cite this page](/w/index.php?title=Special:CiteThisPage&page=National_Flag_of_Canada_Day&id=1231946994&wpFormIdentifier=titleform
-        \"Information on how to cite this page\")\n  * [Get shortened URL](/w/index.php?title=Special:UrlShortener&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\n  *
-        [Download QR code](/w/index.php?title=Special:QrCode&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\n  *
-        [Wikidata item](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703 \"Structured
-        data on this page hosted by Wikidata \\[g\\]\")\n\nPrint/export\n\n  * [Download
-        as PDF](/w/index.php?title=Special:DownloadAsPdf&page=National_Flag_of_Canada_Day&action=show-download-screen
-        \"Download this page as a PDF file\")\n  * [Printable version](/w/index.php?title=National_Flag_of_Canada_Day&printable=yes
-        \"Printable version of this page \\[p\\]\")\n\nIn other projects\n\n  * [Wikimedia
-        Commons](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day)\n\nAppearance\n\nmove
-        to sidebar  hide\n\nFrom Wikipedia, the free encyclopedia\n\nCanadian holiday\n\nNational
-        Flag of Canada Day  \n---  \n[![](//upload.wikimedia.org/wikipedia/commons/thumb/6/68/Canada_flag_halifax_9_-04.JPG/250px-\nCanada_flag_halifax_9_-04.JPG)](/wiki/File:Canada_flag_halifax_9_-04.JPG)
-        The\nnational flag of Canada  \nObserved by  |  [Canada](/wiki/Canada \"Canada\")  \nDate
-        |  [February 15](/wiki/February_15 \"February 15\")  \nNext time  |  February
-        15, 2025 (2025-02-15)  \nFrequency | Annual  \n  \n**National Flag of Canada
-        Day** ([French](/wiki/French_language \"French\nlanguage\"): _Jour du drapeau
-        national du Canada_), commonly shortened to\n**Flag Day** , is observed annually
-        on February 15 to commemorate the\ninauguration of the [flag of Canada](/wiki/Flag_of_Canada
-        \"Flag of Canada\") on\nthat date in 1965.[1] The day is marked by flying the
-        flag, occasional public\nceremonies and educational programs in schools. It
-        is not a [public\nholiday](/wiki/Public_holidays_in_Canada \"Public holidays
-        in Canada\"),\nalthough there has been discussion about creating one.\n\n##
-        History\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=1\n\"Edit
-        section: History\")]\n\n### Background\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=2\n\"Edit
-        section: Background\")]\n\nAmid [much controversy](/wiki/Great_Canadian_flag_debate
-        \"Great Canadian flag\ndebate\"), the [Parliament of Canada](/wiki/Parliament_of_Canada
-        \"Parliament of\nCanada\") in 1964 voted to adopt a new design for the [Canadian\nflag](/wiki/Flag_of_Canada
-        \"Flag of Canada\") and issued a call for\nsubmissions.[2]\n\nThis flag would
-        replace the [Canadian Red Ensign](/wiki/Canadian_Red_Ensign\n\"Canadian Red
-        Ensign\"), which had been, with various successive alterations,\nin conventional
-        use as the national flag of [Canada](/wiki/Canada \"Canada\")\nsince 1868. Nearly
-        4,000 designs were submitted by Canadians.[2] On October\n22, 1964, the [Maple
-        Leaf flag](/wiki/Maple_Leaf_flag \"Maple Leaf\nflag\")\u2014designed by historian
-        [George Stanley](/wiki/George_Stanley \"George\nStanley\")\u2014won with a unanimous
-        vote.[3] Under the leadership of [Prime\nMinister](/wiki/Prime_Minister_of_Canada
-        \"Prime Minister of Canada\") [Lester\nPearson](/wiki/Lester_B._Pearson \"Lester
-        B. Pearson\"), resolutions\nrecommending the new design were passed by the [House
-        of\nCommons](/wiki/House_of_Commons_of_Canada \"House of Commons of Canada\")
-        on\nDecember 15, 1964, and by the [Senate](/wiki/Senate_of_Canada \"Senate of\nCanada\")
-        two days later.[4]\n\nThe flag was proclaimed by [Elizabeth II](/wiki/Elizabeth_II
-        \"Elizabeth II\"),\n[Queen of Canada](/wiki/Monarchy_of_Canada \"Monarchy of
-        Canada\"), on January\n28, 1965,[3][5] and took effect \"upon, from and after\"
-        February 15 that\nyear.[6]\n\n### Flag Day\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=3\n\"Edit
-        section: Flag Day\")]\n\nNational Flag of Canada Day was instituted in 1996
-        by an [Order in\nCouncil](/wiki/Order_in_Council \"Order in Council\") from
-        [Governor\nGeneral](/wiki/Governor_General_of_Canada \"Governor General of Canada\")
-        [Rom\u00e9o\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \"Rom\u00e9o LeBlanc\"), on the
-        initiative of Prime\nMinister [Jean Chr\u00e9tien](/wiki/Jean_Chr%C3%A9tien
-        \"Jean Chr\u00e9tien\").[7] At the\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
-        \"Hull, Quebec\"),\nChr\u00e9tien was confronted by demonstrators against proposed
-        cuts to the\n[un", " an [Order in\nCouncil](/wiki/Order_in_Council \"Order in
-        Council\") from [Governor\nGeneral](/wiki/Governor_General_of_Canada \"Governor
-        General of Canada\") [Rom\u00e9o\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \"Rom\u00e9o
-        LeBlanc\"), on the initiative of Prime\nMinister [Jean Chr\u00e9tien](/wiki/Jean_Chr%C3%A9tien
-        \"Jean Chr\u00e9tien\").[7] At the\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
-        \"Hull, Quebec\"),\nChr\u00e9tien was confronted by demonstrators against proposed
-        cuts to the\n[unemployment insurance](/wiki/Unemployment_insurance \"Unemployment\ninsurance\")
-        system, and while walking through the crowd he was [grabbed by the\nneck and
-        pushed aside](/wiki/Shawinigan_Handshake \"Shawinigan Handshake\") a\nprotester
-        who had approached him.\n\nIn 2010, on the flag''s 45th anniversary, federal
-        ceremonies were held to mark\nFlag Day at [Ottawa](/wiki/Ottawa \"Ottawa\"),
-        [Winnipeg](/wiki/Winnipeg\n\"Winnipeg\"), [St. John''s](/wiki/St._John%27s,_Newfoundland_and_Labrador
-        \"St.\nJohn''s, Newfoundland and Labrador\"), and at\n[Whistler](/wiki/Whistler,_British_Columbia
-        \"Whistler, British Columbia\") and\n[Vancouver](/wiki/Vancouver \"Vancouver\")
-        in conjunction with the [2010 Winter\nOlympics](/wiki/2010_Winter_Olympics \"2010
-        Winter Olympics\") in Vancouver.[8]\nIn 2011, Prime Minister [Stephen Harper](/wiki/Stephen_Harper
-        \"Stephen\nHarper\") observed Flag Day by presenting two citizens, whose work
-        honoured the\n[military](/wiki/Canadian_Armed_Forces \"Canadian Armed Forces\"),
-        with Canadian\nflags that had flown over the [Peace Tower](/wiki/Peace_Tower
-        \"Peace Tower\").\nIt was announced as inaugurating an annual recognition of
-        patriotism.[9]\n\n## See also\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=4\n\"Edit
-        section: See also\")]\n\n  * ![flag](//upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Maple_Leaf_%28from_roundel%29.svg/25px-Maple_Leaf_%28from_roundel%29.svg.png)[Canada
-        portal](/wiki/Portal:Canada \"Portal:Canada\")\n\n  * [Flag Day](/wiki/Flag_Day
-        \"Flag Day\")\n  * [List of Canadian flags](/wiki/List_of_Canadian_flags \"List
-        of Canadian flags\")\n  * [National flag](/wiki/National_flag \"National flag\")\n\n##
-        Footnotes\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=5\n\"Edit
-        section: Footnotes\")]\n\n  1. **^** [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage
-        \"Department of Canadian Heritage\"). [\"Ceremonial and Canadian Symbols Promotion
-        > The National Flag of Canada\"](https://web.archive.org/web/20100423114158/http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm).
-        Queen''s Printer for Canada. Archived from [the original](http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm)
-        on April 23, 2010. Retrieved March 21, 2010.\n  2. ^ _**a**_ _**b**_ Government
-        of Canada, Public Services and Procurement Canada (July 31, 2015). [\"Infographic:
-        National Flag of Canada Day \u2013 February 15 \u2013 Canada''s Parliamentary
-        Precinct \u2013 PWGSC\"](https://www.tpsgc-pwgsc.gc.ca/citeparlementaire-parliamentaryprecinct/decouvrez-discover/jour-drap-flag-day-eng.html).
-        _www.tpsgc-pwgsc.gc.ca_. Retrieved February 5, 2022.\n  3. ^ _**a**_ _**b**_
-        [\"What is the National Flag Day of Canada?\"](http://westernfinancialgroup.ca/What-is-the-National-Flag-of-Canada-Day).
-        _westernfinancialgroup.ca_. Retrieved February 5, 2022.\n  4. **^** [Department
-        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \"Department of
-        Canadian Heritage\"). [\"Ceremonial and Canadian Symbols Promotion > The National
-        Flag of Canada > Birth of the Canadian flag\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
-        Queen''s Printer for Canada. [Archived](https://web.archive.org/web/20100224005050/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
-        from the original on February 24, 2010. Retrieved March 21, 2010.\n  5. **^**
-        [\"Birth of the Canadian flag\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
-        [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \"Department
-        of Canadian Heritage\"). [Archived](https://web.archive.org/web/20081220170253/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
-        from the original on December 20, 2008. Retrieved December 16, 2008.\n  6. **^**
-        [Conserving the Proclamation of the Canadian Flag](http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
+        "{\"input\":[\"Jump to content\\n\\nMain menu\\n\\nMain menu\\n\\nmove to
+        sidebar  hide\\n\\nNavigation\\n\\n  * [Main page](/wiki/Main_Page \\\"Visit
+        the main page \\\\[z\\\\]\\\")\\n  * [Contents](/wiki/Wikipedia:Contents \\\"Guides
+        to browsing Wikipedia\\\")\\n  * [Current events](/wiki/Portal:Current_events
+        \\\"Articles related to current events\\\")\\n  * [Random article](/wiki/Special:Random
+        \\\"Visit a randomly selected article \\\\[x\\\\]\\\")\\n  * [About Wikipedia](/wiki/Wikipedia:About
+        \\\"Learn about Wikipedia and how it works\\\")\\n  * [Contact us](//en.wikipedia.org/wiki/Wikipedia:Contact_us
+        \\\"How to contact Wikipedia\\\")\\n  * [Donate](https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&utm_medium=sidebar&utm_campaign=C13_en.wikipedia.org&uselang=en
+        \\\"Support us by donating to the Wikimedia Foundation\\\")\\n\\nContribute\\n\\n
+        \ * [Help](/wiki/Help:Contents \\\"Guidance on how to use and edit Wikipedia\\\")\\n
+        \ * [Learn to edit](/wiki/Help:Introduction \\\"Learn how to edit Wikipedia\\\")\\n
+        \ * [Community portal](/wiki/Wikipedia:Community_portal \\\"The hub for editors\\\")\\n
+        \ * [Recent changes](/wiki/Special:RecentChanges \\\"A list of recent changes
+        to Wikipedia \\\\[r\\\\]\\\")\\n  * [Upload file](/wiki/Wikipedia:File_upload_wizard
+        \\\"Add images or other media for use on Wikipedia\\\")\\n\\n[ ![](/static/images/icons/wikipedia.png)\\n![Wikipedia](/static/images/mobile/copyright/wikipedia-wordmark-en.svg)
+        ![The\\nFree Encyclopedia](/static/images/mobile/copyright/wikipedia-tagline-en.svg)\\n](/wiki/Main_Page)\\n\\n[
+        Search ](/wiki/Special:Search \\\"Search Wikipedia \\\\[f\\\\]\\\")\\n\\nSearch\\n\\nAppearance\\n\\n
+        \ * [Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
+        \\\"You are encouraged to create an account and log in; however, it is not mandatory\\\")\\n
+        \ * [Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
+        \\\"You're encouraged to log in; however, it's not mandatory. \\\\[o\\\\]\\\")\\n\\nPersonal
+        tools\\n\\n  * [ Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
+        \\\"You are encouraged to create an account and log in; however, it is not mandatory\\\")\\n
+        \ * [ Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
+        \\\"You're encouraged to log in; however, it's not mandatory. \\\\[o\\\\]\\\")\\n\\nPages
+        for logged out editors [learn more](/wiki/Help:Introduction)\\n\\n  * [Contributions](/wiki/Special:MyContributions
+        \\\"A list of edits made from this IP address \\\\[y\\\\]\\\")\\n  * [Talk](/wiki/Special:MyTalk
+        \\\"Discussion about edits from this IP address \\\\[n\\\\]\\\")\\n\\n## Contents\\n\\nmove
+        to sidebar  hide\\n\\n  * (Top)\\n  * 1 History Toggle History subsection\\n
+        \   * 1.1 Background\\n    * 1.2 Flag Day\\n  * 2 See also\\n  * 3 Footnotes\\n
+        \ * 4 External links\\n\\nToggle the table of contents\\n\\n#  National Flag
+        of Canada Day\\n\\n7 languages\\n\\n  * [\u0627\u0644\u0639\u0631\u0628\u064A\u0629](https://ar.wikipedia.org/wiki/%D9%8A%D9%88%D9%85_%D8%B9%D9%84%D9%85_%D9%83%D9%86%D8%AF%D8%A7_%D8%A7%D9%84%D9%88%D8%B7%D9%86%D9%8A
+        \\\"\u064A\u0648\u0645 \u0639\u0644\u0645 \u0643\u0646\u062F\u0627 \u0627\u0644\u0648\u0637\u0646\u064A
+        \u2013 Arabic\\\")\\n  * [Espa\xF1ol](https://es.wikipedia.org/wiki/D%C3%ADa_de_la_Bandera_Nacional_de_Canad%C3%A1
+        \\\"D\xEDa de la Bandera Nacional de Canad\xE1 \u2013 Spanish\\\")\\n  * [Fran\xE7ais](https://fr.wikipedia.org/wiki/Jour_du_drapeau_national_du_Canada
+        \\\"Jour du drapeau national du Canada \u2013 French\\\")\\n  * [\u0540\u0561\u0575\u0565\u0580\u0565\u0576](https://hy.wikipedia.org/wiki/%D4%BF%D5%A1%D5%B6%D5%A1%D5%A4%D5%A1%D5%B5%D5%AB_%D5%A1%D5%A6%D5%A3%D5%A1%D5%B5%D5%AB%D5%B6_%D5%A4%D6%80%D5%B8%D5%B7%D5%AB_%D6%85%D6%80
+        \\\"\u053F\u0561\u0576\u0561\u0564\u0561\u0575\u056B \u0561\u0566\u0563\u0561\u0575\u056B\u0576
+        \u0564\u0580\u0578\u0577\u056B \u0585\u0580 \u2013 Armenian\\\")\\n  * [\u05E2\u05D1\u05E8\u05D9\u05EA](https://he.wikipedia.org/wiki/%D7%99%D7%95%D7%9D_%D7%94%D7%93%D7%92%D7%9C_%D7%94%D7%9C%D7%90%D7%95%D7%9E%D7%99_%D7%A9%D7%9C_%D7%A7%D7%A0%D7%93%D7%94
+        \\\"\u05D9\u05D5\u05DD \u05D4\u05D3\u05D2\u05DC \u05D4\u05DC\u05D0\u05D5\u05DE\u05D9
+        \u05E9\u05DC \u05E7\u05E0\u05D3\u05D4 \u2013 Hebrew\\\")\\n  * [Bahasa Melayu](https://ms.wikipedia.org/wiki/Hari_Bendera_Kebangsaan_Kanada
+        \\\"Hari Bendera Kebangsaan Kanada \u2013 Malay\\\")\\n  * [Polski](https://pl.wikipedia.org/wiki/Narodowy_dzie%C5%84_flagi_Kanady
+        \\\"Narodowy dzie\u0144 flagi Kanady \u2013 Polish\\\")\\n\\n[Edit\\nlinks](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703#sitelinks-\\nwikipedia
+        \\\"Edit interlanguage links\\\")\\n\\n  * [Article](/wiki/National_Flag_of_Canada_Day
+        \\\"View the content page \\\\[c\\\\]\\\")\\n  * [Talk](/wiki/Talk:National_Flag_of_Canada_Day
+        \\\"Discuss improvements to the content page \\\\[t\\\\]\\\")\\n\\nEnglish\\n\\n
+        \ * [Read](/wiki/National_Flag_of_Canada_Day)\\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
+        \\\"Edit this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
+        \\\"Past revisions of this page \\\\[h\\\\]\\\")\\n\\nTools\\n\\nTools\\n\\nmove
+        to sidebar  hide\\n\\nActions\\n\\n  * [Read](/wiki/National_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title\",\"_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
+        \\\"Past revisions of this page \\\\[h\\\\]\\\")\\n\\nTools\\n\\nTools\\n\\nmove
+        to sidebar  hide\\n\\nActions\\n\\n  * [Read](/wiki/National_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history)\\n\\nGeneral\\n\\n
+        \ * [What links here](/wiki/Special:WhatLinksHere/National_Flag_of_Canada_Day
+        \\\"List of all English Wikipedia pages containing links to this page \\\\[j\\\\]\\\")\\n
+        \ * [Related changes](/wiki/Special:RecentChangesLinked/National_Flag_of_Canada_Day
+        \\\"Recent changes in pages linked from this page \\\\[k\\\\]\\\")\\n  * [Upload
+        file](/wiki/Wikipedia:File_Upload_Wizard \\\"Upload files \\\\[u\\\\]\\\")\\n
+        \ * [Special pages](/wiki/Special:SpecialPages \\\"A list of all special pages
+        \\\\[q\\\\]\\\")\\n  * [Permanent link](/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994
+        \\\"Permanent link to this revision of this page\\\")\\n  * [Page information](/w/index.php?title=National_Flag_of_Canada_Day&action=info
+        \\\"More information about this page\\\")\\n  * [Cite this page](/w/index.php?title=Special:CiteThisPage&page=National_Flag_of_Canada_Day&id=1231946994&wpFormIdentifier=titleform
+        \\\"Information on how to cite this page\\\")\\n  * [Get shortened URL](/w/index.php?title=Special:UrlShortener&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\\n
+        \ * [Download QR code](/w/index.php?title=Special:QrCode&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\\n
+        \ * [Wikidata item](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703
+        \\\"Structured data on this page hosted by Wikidata \\\\[g\\\\]\\\")\\n\\nPrint/export\\n\\n
+        \ * [Download as PDF](/w/index.php?title=Special:DownloadAsPdf&page=National_Flag_of_Canada_Day&action=show-download-screen
+        \\\"Download this page as a PDF file\\\")\\n  * [Printable version](/w/index.php?title=National_Flag_of_Canada_Day&printable=yes
+        \\\"Printable version of this page \\\\[p\\\\]\\\")\\n\\nIn other projects\\n\\n
+        \ * [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day)\\n\\nAppearance\\n\\nmove
+        to sidebar  hide\\n\\nFrom Wikipedia, the free encyclopedia\\n\\nCanadian holiday\\n\\nNational
+        Flag of Canada Day  \\n---  \\n[![](//upload.wikimedia.org/wikipedia/commons/thumb/6/68/Canada_flag_halifax_9_-04.JPG/250px-\\nCanada_flag_halifax_9_-04.JPG)](/wiki/File:Canada_flag_halifax_9_-04.JPG)
+        The\\nnational flag of Canada  \\nObserved by  |  [Canada](/wiki/Canada \\\"Canada\\\")
+        \ \\nDate |  [February 15](/wiki/February_15 \\\"February 15\\\")  \\nNext time
+        \ |  February 15, 2025 (2025-02-15)  \\nFrequency | Annual  \\n  \\n**National
+        Flag of Canada Day** ([French](/wiki/French_language \\\"French\\nlanguage\\\"):
+        _Jour du drapeau national du Canada_), commonly shortened to\\n**Flag Day**
+        , is observed annually on February 15 to commemorate the\\ninauguration of the
+        [flag of Canada](/wiki/Flag_of_Canada \\\"Flag of Canada\\\") on\\nthat date
+        in 1965.[1] The day is marked by flying the flag, occasional public\\nceremonies
+        and educational programs in schools. It is not a [public\\nholiday](/wiki/Public_holidays_in_Canada
+        \\\"Public holidays in Canada\\\"),\\nalthough there has been discussion about
+        creating one.\\n\\n## History\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=1\\n\\\"Edit
+        section: History\\\")]\\n\\n### Background\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=2\\n\\\"Edit
+        section: Background\\\")]\\n\\nAmid [much controversy](/wiki/Great_Canadian_flag_debate
+        \\\"Great Canadian flag\\ndebate\\\"), the [Parliament of Canada](/wiki/Parliament_of_Canada
+        \\\"Parliament of\\nCanada\\\") in 1964 voted to adopt a new design for the
+        [Canadian\\nflag](/wiki/Flag_of_Canada \\\"Flag of Canada\\\") and issued a
+        call for\\nsubmissions.[2]\\n\\nThis flag would replace the [Canadian Red Ensign](/wiki/Canadian_Red_Ensign\\n\\\"Canadian
+        Red Ensign\\\"), which had been, with various successive alterations,\\nin conventional
+        use as the national flag of [Canada](/wiki/Canada \\\"Canada\\\")\\nsince 1868.
+        Nearly 4,000 designs were submitted by Canadians.[2] On October\\n22, 1964,
+        the [Maple Leaf flag](/wiki/Maple_Leaf_flag \\\"Maple Leaf\\nflag\\\")\u2014designed
+        by historian [George Stanley](/wiki/George_Stanley \\\"George\\nStanley\\\")\u2014won
+        with a unanimous vote.[3] Under the leadership of [Prime\\nMinister](/wiki/Prime_Minister_of_Canada
+        \\\"Prime Minister of Canada\\\") [Lester\\nPearson](/wiki/Lester_B._Pearson
+        \\\"Lester B. Pearson\\\"), resolutions\\nrecommending the new design were passed
+        by the [House of\\nCommons](/wiki/House_of_Commons_of_Canada \\\"House of Commons
+        of Canada\\\") on\\nDecember 15, 1964, and by the [Senate](/wiki/Senate_of_Canada
+        \\\"Senate of\\nCanada\\\") two days later.[4]\\n\\nThe flag was proclaimed
+        by [Elizabeth II](/wiki/Elizabeth_II \\\"Elizabeth II\\\"),\\n[Queen of Canada](/wiki/Monarchy_of_Canada
+        \\\"Monarchy of Canada\\\"), on January\\n28, 1965,[3][5] and took effect \\\"upon,
+        from and after\\\" February 15 that\\nyear.[6]\\n\\n### Flag Day\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=3\\n\\\"Edit
+        section: Flag Day\\\")]\\n\\nNational Flag of Canada Day was instituted in 1996
+        by an [Order in\\nCouncil](/wiki/Order_in_Council \\\"Order in Council\\\")
+        from [Governor\\nGeneral](/wiki/Governor_General_of_Canada \\\"Governor General
+        of Canada\\\") [Rom\xE9o\\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \\\"Rom\xE9o LeBlanc\\\"),
+        on the initiative of Prime\\nMinister [Jean Chr\xE9tien](/wiki/Jean_Chr%C3%A9tien
+        \\\"Jean Chr\xE9tien\\\").[7] At the\\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
+        \\\"Hull, Quebec\\\"),\\nChr\xE9tien was confronted by demonstrators against
+        proposed cuts to the\\n[un\",\" an [Order in\\nCouncil](/wiki/Order_in_Council
+        \\\"Order in Council\\\") from [Governor\\nGeneral](/wiki/Governor_General_of_Canada
+        \\\"Governor General of Canada\\\") [Rom\xE9o\\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc
+        \\\"Rom\xE9o LeBlanc\\\"), on the initiative of Prime\\nMinister [Jean Chr\xE9tien](/wiki/Jean_Chr%C3%A9tien
+        \\\"Jean Chr\xE9tien\\\").[7] At the\\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
+        \\\"Hull, Quebec\\\"),\\nChr\xE9tien was confronted by demonstrators against
+        proposed cuts to the\\n[unemployment insurance](/wiki/Unemployment_insurance
+        \\\"Unemployment\\ninsurance\\\") system, and while walking through the crowd
+        he was [grabbed by the\\nneck and pushed aside](/wiki/Shawinigan_Handshake \\\"Shawinigan
+        Handshake\\\") a\\nprotester who had approached him.\\n\\nIn 2010, on the flag's
+        45th anniversary, federal ceremonies were held to mark\\nFlag Day at [Ottawa](/wiki/Ottawa
+        \\\"Ottawa\\\"), [Winnipeg](/wiki/Winnipeg\\n\\\"Winnipeg\\\"), [St. John's](/wiki/St._John%27s,_Newfoundland_and_Labrador
+        \\\"St.\\nJohn's, Newfoundland and Labrador\\\"), and at\\n[Whistler](/wiki/Whistler,_British_Columbia
+        \\\"Whistler, British Columbia\\\") and\\n[Vancouver](/wiki/Vancouver \\\"Vancouver\\\")
+        in conjunction with the [2010 Winter\\nOlympics](/wiki/2010_Winter_Olympics
+        \\\"2010 Winter Olympics\\\") in Vancouver.[8]\\nIn 2011, Prime Minister [Stephen
+        Harper](/wiki/Stephen_Harper \\\"Stephen\\nHarper\\\") observed Flag Day by
+        presenting two citizens, whose work honoured the\\n[military](/wiki/Canadian_Armed_Forces
+        \\\"Canadian Armed Forces\\\"), with Canadian\\nflags that had flown over the
+        [Peace Tower](/wiki/Peace_Tower \\\"Peace Tower\\\").\\nIt was announced as
+        inaugurating an annual recognition of patriotism.[9]\\n\\n## See also\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=4\\n\\\"Edit
+        section: See also\\\")]\\n\\n  * ![flag](//upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Maple_Leaf_%28from_roundel%29.svg/25px-Maple_Leaf_%28from_roundel%29.svg.png)[Canada
+        portal](/wiki/Portal:Canada \\\"Portal:Canada\\\")\\n\\n  * [Flag Day](/wiki/Flag_Day
+        \\\"Flag Day\\\")\\n  * [List of Canadian flags](/wiki/List_of_Canadian_flags
+        \\\"List of Canadian flags\\\")\\n  * [National flag](/wiki/National_flag \\\"National
+        flag\\\")\\n\\n## Footnotes\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=5\\n\\\"Edit
+        section: Footnotes\\\")]\\n\\n  1. **^** [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage
+        \\\"Department of Canadian Heritage\\\"). [\\\"Ceremonial and Canadian Symbols
+        Promotion > The National Flag of Canada\\\"](https://web.archive.org/web/20100423114158/http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm).
+        Queen's Printer for Canada. Archived from [the original](http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm)
+        on April 23, 2010. Retrieved March 21, 2010.\\n  2. ^ _**a**_ _**b**_ Government
+        of Canada, Public Services and Procurement Canada (July 31, 2015). [\\\"Infographic:
+        National Flag of Canada Day \u2013 February 15 \u2013 Canada's Parliamentary
+        Precinct \u2013 PWGSC\\\"](https://www.tpsgc-pwgsc.gc.ca/citeparlementaire-parliamentaryprecinct/decouvrez-discover/jour-drap-flag-day-eng.html).
+        _www.tpsgc-pwgsc.gc.ca_. Retrieved February 5, 2022.\\n  3. ^ _**a**_ _**b**_
+        [\\\"What is the National Flag Day of Canada?\\\"](http://westernfinancialgroup.ca/What-is-the-National-Flag-of-Canada-Day).
+        _westernfinancialgroup.ca_. Retrieved February 5, 2022.\\n  4. **^** [Department
+        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department of
+        Canadian Heritage\\\"). [\\\"Ceremonial and Canadian Symbols Promotion > The
+        National Flag of Canada > Birth of the Canadian flag\\\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
+        Queen's Printer for Canada. [Archived](https://web.archive.org/web/20100224005050/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
+        from the original on February 24, 2010. Retrieved March 21, 2010.\\n  5. **^**
+        [\\\"Birth of the Canadian flag\\\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
+        [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department
+        of Canadian Heritage\\\"). [Archived](https://web.archive.org/web/20081220170253/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
+        from the original on December 20, 2008. Retrieved December 16, 2008.\\n  6.
+        **^** [Conserving the Proclamation of the Canadian Flag](http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
         [Archived](https://web.archive.org/web/20121021133944/http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
-        October 21, 2012, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        Library and Archives of Canada, from John Grace in The Archivist, National Archives,
-        Ottawa, 1990. Retrieved February 15, 2011.\n  7. **^** [Department of Canadian
-        Heritage](/wiki/Department_of_Canadian_Heritage \"Department of Canadian Heritage\").
-        [\"National Flag of Canada Day\"](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm).
-        Queen''s Printer for Canada. [Archived](https://web.archive.org/web/20100217042202/http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm)
-        from the original on February 17, 2010. Retrieved March 21, 2010.\n  8. **^**
+        October 21, 2012, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback
+        Machine\\\"), Library and Archives of Canada, from John Grace in The Archivist,
+        National Archives, Ottawa, 1990. Retrieved February 15, 2011.\\n  7. **^** [Department
+        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department of
+        Canadian Heritage\\\"). [\\\"National Flag of Canada Day\\\"](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm).
+        Queen's Printer for Canada. [Archived](https://web.archive.org/web/20100217042202/http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm)
+        from the original on February 17, 2010. Retrieved March 21, 2010.\\n  8. **^**
         [Dept. of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
         [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        February 15, 2010. Retrieved February 15, 2011.\n ", "2010.\n  8. **^** [Dept.
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        February 15, 2010. Retrieved February 15, 2011.\\n \",\"2010.\\n  8. **^** [Dept.
         of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
         [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        February 15, 2010. Retrieved February 15, 2011.\n  9. **^** [PM pays tribute
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        February 15, 2010. Retrieved February 15, 2011.\\n  9. **^** [PM pays tribute
         to outstanding Canadians on Flag Day](http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
         [Archived](https://web.archive.org/web/20110706181811/http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        Prime Minister''s Office news release. Retrieved February 16, 2011.\n\n## External
-        links\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=6\n\"Edit
-        section: External links\")]\n\n![](//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/30px-\nCommons-logo.svg.png)\n\nWikimedia
-        Commons has media related to [National Flag of Canada\nDay](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day\n\"commons:Category:National
-        Flag of Canada Day\").\n\n  * [Flag of Canada Song (1965) Freddie Grant](https://www.youtube.com/watch?v=2IkqmkTK46E)\n  *
-        [Flag Day](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm), Dept. of Canadian
-        Heritage \n  * [The famous Canadian Flag Collection, at Settlers, Rails & Trails
-        Inc, Argyle, Manitoba](http://argylemuseum.wixsite.com/argylemuseum/canadian-flag-collection)\n\n![](https://login.wikimedia.org/wiki/Special:CentralAutoLogin/start?type=1x1)\n\nRetrieved
-        from\n\"[https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994](https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994)\"\n\n[Categories](/wiki/Help:Category
-        \"Help:Category\"):\n\n  * [1996 establishments in Canada](/wiki/Category:1996_establishments_in_Canada
-        \"Category:1996 establishments in Canada\")\n  * [Public holidays in Canada](/wiki/Category:Public_holidays_in_Canada
-        \"Category:Public holidays in Canada\")\n  * [February observances](/wiki/Category:February_observances
-        \"Category:February observances\")\n  * [Flag days](/wiki/Category:Flag_days
-        \"Category:Flag days\")\n  * [Winter events in Canada](/wiki/Category:Winter_events_in_Canada
-        \"Category:Winter events in Canada\")\n\nHidden categories:\n\n  * [Webarchive
-        template wayback links](/wiki/Category:Webarchive_template_wayback_links \"Category:Webarchive
-        template wayback links\")\n  * [Articles with short description](/wiki/Category:Articles_with_short_description
-        \"Category:Articles with short description\")\n  * [Short description matches
-        Wikidata](/wiki/Category:Short_description_matches_Wikidata \"Category:Short
-        description matches Wikidata\")\n  * [Use mdy dates from February 2018](/wiki/Category:Use_mdy_dates_from_February_2018
-        \"Category:Use mdy dates from February 2018\")\n  * [Infobox holiday with missing
-        field](/wiki/Category:Infobox_holiday_with_missing_field \"Category:Infobox
-        holiday with missing field\")\n  * [Infobox holiday fixed day](/wiki/Category:Infobox_holiday_fixed_day
-        \"Category:Infobox holiday fixed day\")\n  * [Articles containing French-language
-        text](/wiki/Category:Articles_containing_French-language_text \"Category:Articles
-        containing French-language text\")\n  * [Commons category link is on Wikidata](/wiki/Category:Commons_category_link_is_on_Wikidata
-        \"Category:Commons category link is on Wikidata\")\n\n  * This page was last
-        edited on 1 July 2024, at 03:41 (UTC). \n  * Text is available under the [Creative
-        Commons Attribution-ShareAlike License 4.0](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License)[](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License);
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        Prime Minister's Office news release. Retrieved February 16, 2011.\\n\\n## External
+        links\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=6\\n\\\"Edit
+        section: External links\\\")]\\n\\n![](//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/30px-\\nCommons-logo.svg.png)\\n\\nWikimedia
+        Commons has media related to [National Flag of Canada\\nDay](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day\\n\\\"commons:Category:National
+        Flag of Canada Day\\\").\\n\\n  * [Flag of Canada Song (1965) Freddie Grant](https://www.youtube.com/watch?v=2IkqmkTK46E)\\n
+        \ * [Flag Day](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm), Dept. of
+        Canadian Heritage \\n  * [The famous Canadian Flag Collection, at Settlers,
+        Rails & Trails Inc, Argyle, Manitoba](http://argylemuseum.wixsite.com/argylemuseum/canadian-flag-collection)\\n\\n![](https://login.wikimedia.org/wiki/Special:CentralAutoLogin/start?type=1x1)\\n\\nRetrieved
+        from\\n\\\"[https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994](https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994)\\\"\\n\\n[Categories](/wiki/Help:Category
+        \\\"Help:Category\\\"):\\n\\n  * [1996 establishments in Canada](/wiki/Category:1996_establishments_in_Canada
+        \\\"Category:1996 establishments in Canada\\\")\\n  * [Public holidays in Canada](/wiki/Category:Public_holidays_in_Canada
+        \\\"Category:Public holidays in Canada\\\")\\n  * [February observances](/wiki/Category:February_observances
+        \\\"Category:February observances\\\")\\n  * [Flag days](/wiki/Category:Flag_days
+        \\\"Category:Flag days\\\")\\n  * [Winter events in Canada](/wiki/Category:Winter_events_in_Canada
+        \\\"Category:Winter events in Canada\\\")\\n\\nHidden categories:\\n\\n  * [Webarchive
+        template wayback links](/wiki/Category:Webarchive_template_wayback_links \\\"Category:Webarchive
+        template wayback links\\\")\\n  * [Articles with short description](/wiki/Category:Articles_with_short_description
+        \\\"Category:Articles with short description\\\")\\n  * [Short description matches
+        Wikidata](/wiki/Category:Short_description_matches_Wikidata \\\"Category:Short
+        description matches Wikidata\\\")\\n  * [Use mdy dates from February 2018](/wiki/Category:Use_mdy_dates_from_February_2018
+        \\\"Category:Use mdy dates from February 2018\\\")\\n  * [Infobox holiday with
+        missing field](/wiki/Category:Infobox_holiday_with_missing_field \\\"Category:Infobox
+        holiday with missing field\\\")\\n  * [Infobox holiday fixed day](/wiki/Category:Infobox_holiday_fixed_day
+        \\\"Category:Infobox holiday fixed day\\\")\\n  * [Articles containing French-language
+        text](/wiki/Category:Articles_containing_French-language_text \\\"Category:Articles
+        containing French-language text\\\")\\n  * [Commons category link is on Wikidata](/wiki/Category:Commons_category_link_is_on_Wikidata
+        \\\"Category:Commons category link is on Wikidata\\\")\\n\\n  * This page was
+        last edited on 1 July 2024, at 03:41 (UTC). \\n  * Text is available under the
+        [Creative Commons Attribution-ShareAlike License 4.0](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License)[](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License);
         additional terms may apply. By using this site, you agree to the [Terms of Use](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Terms_of_Use)
         and [Privacy Policy](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy).
-        Wikipedia\u00ae is a registered trademark of the [Wikimedia Foundation, Inc.](//wikimediafoundation.org/),
-        a non-profit organization. \n\n  * [Privacy policy](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy)\n  *
-        [About Wikipedia](/wiki/Wikipedia:About)\n  * [Disclaimers](/wiki/Wikipedia:General_disclaimer)\n  *
-        [Contact Wikipedia](//en.wikipedia.org/wiki/Wikipedia:Contact_us)\n  * [Code
-        of Conduct](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct)\n  *
-        [Developers](https://developer.wikimedia.org)\n  * [Statistics](https://stats.wikimedia.org/#/en.wikipedia.org)\n  *
-        [Cookie statement](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement)\n  *
-        [Mobile view](//en.m.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&mobileaction=toggle_view_mobile)\n\n  *
-        [![Wikimedia Foundation](/static/images/footer/wikimedia-button.svg)](https://wikimediafoundation.org/)\n  *
-        [![Powered by MediaWiki](/w/resources/assets/poweredby_mediawiki.svg)](https://www.mediawiki.org/)\n\n  *
-        \n\n"], "model": "text-embedding-3-small", "encoding_format": "base64"}'
+        Wikipedia\xAE is a registered trademark of the [Wikimedia Foundation, Inc.](//wikimediafoundation.org/),
+        a non-profit organization. \\n\\n  * [Privacy policy](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy)\\n
+        \ * [About Wikipedia](/wiki/Wikipedia:About)\\n  * [Disclaimers](/wiki/Wikipedia:General_disclaimer)\\n
+        \ * [Contact Wikipedia](//en.wikipedia.org/wiki/Wikipedia:Contact_us)\\n  *
+        [Code of Conduct](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct)\\n
+        \ * [Developers](https://developer.wikimedia.org)\\n  * [Statistics](https://stats.wikimedia.org/#/en.wikipedia.org)\\n
+        \ * [Cookie statement](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement)\\n
+        \ * [Mobile view](//en.m.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&mobileaction=toggle_view_mobile)\\n\\n
+        \ * [![Wikimedia Foundation](/static/images/footer/wikimedia-button.svg)](https://wikimediafoundation.org/)\\n
+        \ * [![Powered by MediaWiki](/w/resources/assets/poweredby_mediawiki.svg)](https://www.mediawiki.org/)\\n\\n
+        \ * \\n\\n\"],\"model\":\"text-embedding-3-small\",\"encoding_format\":\"base64\"}"
       headers:
         accept:
           - application/json
@@ -334,13 +337,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "22113"
+          - "21701"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -350,11 +353,11 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
-          - "0"
+          - "1"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
@@ -364,436 +367,436 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA5y6S9OCSrcmOK9fseObUhFyk8w8MwQEBCS5gz0CRBRE5JZAVvR/7/DdJ6qiI3rU
-          EweSKuZa+dwW/+t//PPPf/qiqcr5P//1z3/er2n+z//8vXfP5/w///XP//U//vnnn3/+19/r/2tl
-          1RXV/f761H/L/y6+Pvdq+89//cP+73f+z6L/+uc/WSTLuMrlmq7K6Z3Bx5mvXajaG90Wy2ThceIv
-          pMTMbO+4eneojZoDti+XsaH7lTHhtngF0VIqhESgW4Zevn/AeR/bTW8aUo+svhWI6jEcXS9LkUH7
-          oCCs7R0et9ZrIFq/nxlr57RttsOoJ4AjMMZZYzDqcq9eFfwE7BPfCWZGOuVKh36/hy+2FKp7MZo6
-          snKrxU6SngvhI+cuKI2GcQFAfbE9PVmBvP4w8ckzM7CTyeFBwfpvol+L0d4ed6KBw3PV8MmP83Cj
-          Vq6ALjgc3TeQG3vKF+gA/PLeJDoWiC79W5aQGMbx0kwMabYr/66gkesDkYswpDRwnjt01oFx74uC
-          7Ln7rhny6+VBcHQPwp06jgYW1YjIme8Dur2t2IR8ky7kquUJ2E072aGQGeaCDldzFG6PtUV7iJ/E
-          8PnLuKNzDeG63CjGu2oCtn5uOvBs/kz0+z2nUxRXHVj1OMLy/jAKynwmBjwQG5KHq+U2OT38BBk6
-          7xMbMV4oqIcmgIm3yiTLBjnkeAtBcEPTAyeIaymLCMejbQkKcrElam+9b4jIwxeLOMFaN6z2FBJg
-          ih+PuJPAgC3hfYthx/Dj7lOz2V/9m08wn3QdX/zH294q9eaCqw7PJLmwesipvKojY79YxNsWADb3
-          65sozDifOA/bbsiL8jrCXM0QW0UsXbZR0tHzKnYkeMdGw2cMgnAxjvkiefPLZslrGiDQIMTBPQlG
-          ejrwMqBd8iJRmj5DHg9riXj9bpLr6DSULxivRMFDO5M7zK1wfb+sAPKhqeJQbC/FOOq7K7WPWXRf
-          jBU0NO4mCRCnM0k4MXjkrhckQRbuPc67tCq2DNkSvApnDRdTuoDNaFQJunX/JgFHPuPujR8LYCX1
-          l9FKZntlynyB0ngrSPmwx3G/PQwG2mZtkxSco2Z3tkCGqVBsiyiFfrNqnLFA+xr5xD60sz0tPF6l
-          9fueySkMjZCL17sOM1PaiWH1ss3y5JBLrD8W2O7Xwd6PgZ+g0zUExL5bXkj9G6/B4JU8sM8axki/
-          lH0h2/Ib4lMiqPQc1AxKe1ThW3g07bXiSgcoa+ITGzdLs9VNY8HxljzJ1WKPYDKkTUG2/E3x4zOs
-          I/Uc+IJp6ui4mgoTsACPIoyz3cHy+pTCNYltFs7pXpAf/oAdp7WOuNHEOO2/J7DG2FjR6QZ5nK+R
-          3CyXdnShGWgVjm7ZJeRPjMrALI3PJD7mXcjyr0ZDd9atsbwtgM74Mpqgdy83dzZPYKSUTSSIWxUR
-          mTk/7f34/i7AatZtmVKkqEJLmwQxx9XDhbzU4/bi+x0w/PzCZj0De+UU30Tl8JKxE1sNFZ6SJkJL
-          0c8u0jMVCLEuuzAWkUDc2+c9UnCqGMBHoFjK7har9OpkHfTPH59olYNHYTiuHTLFt4evQyEW8wX3
-          OxRUX8EhoKgZb07vorULeld6XCJK6VOvURpkMs7bRQds9VJZaIdgJVgsn/YEL7EGe9e+Ldt+kYrx
-          734+nS4tHNvJ/42nUveOsfwYNVtgDDMA6yX79/fG/dKODtyfX5bY++bTLcZrhrjb1yVnjp4a7u98
-          wub+wrkA3vYmkyyBtjqdsbcYqc398Az98HdZk8e1EdTO0eBe3fLl0CsndcnFMoM3adxcb33mhTDN
-          AYQK/SYuDWyhoB85cADQX198ckGq8rcx4GEXoCNRIguq5CSuNZwqvyP47c3NWrm0hCfzwbkjZcJi
-          5VWDRQ5313AQPNti01RtgWth59iEcwToJI8Z7D+ThD1Tj5u1YNcAFeReYfWabup2Uuoduqmc4cos
-          c3t/TpiBa8rH5MwpvE3ec/mCaNvvxNk6Oq706wyQ9b8FqYhrqGwIzOHf8x88lxdYw2LOQFgfN5JZ
-          AbV3vCEIoWl+iV65XUFpuDuI0wSTXNjZLFjM9j0g9tkg0Wd7htv5Yq7QUrQzCUxzCvftqGeokRYD
-          uxZ9hbSQrfZvPT5z9DlSkDMWlJgvSxw3W4v5psoyTCEWXKZXs4ZOId2l334R2dWUZhO2agFPoTRw
-          9qhvhVDUxIO8d46J3rtqSMbrYQHVGYk4e5/HYrZV1UKirENXaqQ6FJbwqcCTvtyxVnc7nXIzLNHx
-          2Xv4Vi1JyHHDCP/ll0fGvcbtwFSLJCw5dvn882ymKE5aBJdvsTDfbxzufLaL8LsjgygRMJrtkyYT
-          HAYo4WtAXTC9uaCHwI4IPh/YS8gKZRkAe3AEdw3Enk6vuCjhhIWQXBfaj+va9xNqH0R0j7/72V73
-          U4vmAMYkeAGt4N6CM0Ej9lqMt+AeckctyuCPP11qEK3g8GCwqBG+N5yWQdls0V2b4KfTJHc1Aqz+
-          8dnfepxSwVZnm+wTYmtjWaC2NpT6+ntB2XUScckxDd3JedLgK0pmclpe8cjH/qv8O19Yfwh3sG9H
-          NwM6F3vkXlKbsprbQUQSJ8YR+0kb7tN8W+jFZUDKd9sAdiSxDLFhp8seWaW6qWUjIqzEPrat5KrO
-          F1zvCPnchQTCJhXkx2coS9Mzcc+dDPb93QTwvGb2H581a2jGCmg7Vcam7I/hyuN8Aa8omnG0yQHl
-          V7s3oZN1FXETbren67ORUfCx3ti+Ih/sutVrR1Md7GUNRBNwXBp2aCHoSPQbz9s7ZmQeDYt/IHa9
-          cfauM7GJLF20sd1mRzpS4xPBtGZDYiXLF2xEIBoQq6dLgvr5LHh+sgPofJQNY26Yx0EWsQg9b3Cw
-          6Q5qKAjGhQcy0j2iJV0MaHhrIjg+pghns1YXO7cHOriOB56cVihS0siHBW5ubODzPXdGjlqBgv7q
-          4zLFudkWXszgya4bIn/Dla7eafDAaEkuOZuOHi5yK7yQa7Zn7AvLpK6IIB5+c/FDXPzpm+F7qHZY
-          xxIlZnFkm32xJRGu7ASIf5redE7KjUE3zTyQq3kqmkkFVQ3Yh6jg/ALcZrqDRkHEWJWF/WzPYrNV
-          2wI/ffLT41eV9pIdwf05si54kZc93U0hQzfiOfgsXlu6fdG0wMZJamwxa1jsonP3YPHmAuJ+8K6S
-          V+jn0H89hCUWOLbYYBooyBJUy9Uz71bs8mbloH+JLNE49mZvO/JyVN6589IbIqEbbTYHblvNEb37
-          +oVwEsUXnKqww4672c3Sn+ceflwlJxcmZsGGLJhBjT8m2J09yd6f548DryPiscMxDRCYT8sgOXyt
-          WPOcACxRugWw+V51F57esc2dm2SAoqxBojDWPq6feOrBgPvTsun1ZA/wYZrwXjMGtj92Zm8B2UwY
-          vongcuI3B2v1sllo2ZNPHqnnNfQ1iS1M9mr64bEecn96nlWxSU6t9FX3z0Njj8stK5bXCp7hBMu5
-          hOoF3pfDUrYqnaWyhkM0Upc5dzXYNiGKQGhlDJGxr6ncvLIRfCNoLMMHAXUj6i6jZ/qixAKvL5gH
-          tefhAeTe8r7nTrP7Vc7DhRyO2PjpP+HkyAys0vKItZzRbSG/ViL4238Sfm3A6eT7ApVv6MTal6ZZ
-          HGvzEEOzOwl761vs392q4PebSFg+BMrItqXuwC7nZ5dfv27B6m7pQvE4lD8+UYp5aqQd9FH5dFd/
-          /IRsb3oRNIIr7zKrcm24nx8EH/Z5dUXTkwvBoY4GbXG0FuFeNsWO7bsDWfd2wt7v8z+98oJDIBZu
-          m1KhmNSIW+GcrsVyNEBlbzKcBuCLK4OLLukAsWjCQ9REFvnenxFdtechAn2Cj+QcXF17CLeshHfH
-          ncjpHFoj1SbZBGsoY1e83k+AWz3QwZ9/IbJ1pGBdeLxLZ7lpFmbIa0D5vGXgz88sQu6z4/eO7jqw
-          624kygu0xfuqrDnstGfnMnG/jhtqiw6c1dYn1vd1VQX/UJtwidoY/87ruCaxykJwnBJ8b09xQQM5
-          kSAnq4q7b6lQrCpIaiRdJkJselFs9u0e/71OFPFi0c/v/4IrPnvu4VdPng1MCwYP/bw0SfMZ90Uc
-          Sjh3zrJspa7Q/VXR4d/+SgR1+9OLK5wr011Yyx4oHfXdgfgh2/hx9IOQPurTimQOlwtCH5v+nSd0
-          sXSfuBVr2Av79mrpGsQDMQ+i+t/1CwAzLhK4LOMUKa4L9tsnwtipULhZ5StCfaXN5MZJX7CKLy9B
-          gEaNS9d3FE4E2iz0D+ZGzjM7NfSdOxYsb8oBq+9Vt4XA+e4ATqJKCjZRAe8zhxfkRZt1Nz+WioWc
-          Wx1CkCTklD9XQKrO61BUr7clud8lSrXJNEHY72/8wyN1j8ZT/1dvbJ3grVmZ70dBZiK2ODsYKV3d
-          ZWpB7aoMvrziwqbufkxgh+cHToAgjNsp3kz0OLzHxYuDyd605K5LP/xY6GWdCmo7YwJiEg/uFsGH
-          vSdVK0N38Db809vqFqvzC5YiDHFF3I9NDd1OYD5pOsZlaRTrAKQBrsfmtKw7uIcrwI10bJQpwtb2
-          VGz+s99dCFrJw/jaayq1H3SC/usuEAvXdbEJqclLJ2by8G3Tm2ZFqu7BZSsBPh3mp03wYZeg1gyI
-          mIaIwVbz9IUIYZ8//BPVz8/PAPZIJJf5frmCKsePA/2MG7D8u59pL1UdNovquOji3tW1XJ4VLNF6
-          IwZ6CHS7l2uOOt99EqW8bPYoGCcWPqY0IJpmNfYv71jRgIfTstEEUFJQYYAulRhi3xq74c4Q8dLP
-          z2OZTj1YnehZQbG3C2zOmlzQ9PiqUUtGB+vVAMNtH2QFRSMMiDedtYKUV82Exm5bLgxWuRne41DB
-          xfWvi3g5b03/O1+Q+BkmeZ3wzTSWWo9+/bqA9GL+tx+f0iPFXv2wxj9+hIOO64Wv3C7cuvv8gihz
-          4HLcw7O647TXoBPuGVG610Xd64ebg5N551xRCRn70xx3E0yXR/3Tk3yxhd9XAnA2ZNjpc6QShzo6
-          UMNuWFrx8KH7N/i4SPUaiA2hwpSOtZ8jjrrEZSr2o+5DNgbwdTMpviThGH7F0RChzqXeIp3qptn/
-          9M0XvkNcmqk50vP7GAGGZayF+uRUCL4+T1B/6cICjPY4bon30eDy4ReX6hejmYVKT6Cf6sGfHm5+
-          /dj/7T9xbSwW25LGJiqOxrjA5uBTKr97E4rrFZBLFdThv/1mi18L62m5g4nGrId+eITTX39MRXyX
-          YSNNBvbcOmsoZJUWdr7zJNrhZlH2xtkKDINHtTz/+uPnd+HX9wqcTp7ecMngenBTbZeY+UTtOV2t
-          CP7wGuMXPxSNpX8CqL4UhK8wtwrWilgHPFrXIDa/6mCN3Jsu/dUXP/C54WQ49QBBJsFyq5OQWJ1S
-          IwGyL3y33+eCKxofoi5RPvhigErdttZm/vU71tg+wL/79/PP5PKRJvrv9eWWFy4nYWH8yyeRXewt
-          Poc5GenF4XXwl4/pt1NLdzX1KtC1pUQck1bjtnqgBXu7vBYWUVfdLq/NRPeTTImWvy2wssSckIde
-          2yL+9CurFE4L/urfMMwULmb1MWHz6I7Yjsi72B7fI/zzG8Sdvdze9ZTNYSrcNmyziUrZ+nnU4cX7
-          rkQNN9aeArf5l59Idq4mQPXjaUHHpFGWPWkPNmGlnIGgepvESdFL3cjdd1A51DLBiyipdJAZC8j1
-          LSFmI35HwubCAtFSq9j/+Ze5v+c7tParhj3saza97LWJotR0SPXj2627v18wfuW3X361jWPeMdq/
-          +C4vhqCuC2+s0H6cv0TRgTUKyv6coEf0ilyuYl3wN/vQSWLLJi4rOZeC/vIKuFauuYiBb9qL0rYr
-          VJFpkfSkLuH2GYgOdUtOSRjvUF2bVywjkSlfOFhQZK/MxYrgY4oDLIs1CXfucZqQlF2U5a29Tw1/
-          t3MNvtjg9JcH2POOshy8b878y8N9uiUoGf49j+6GsTpXVrWA8i6cseuwVsgxqFaQP48rllnzoE48
-          EXLoP/B9YfVWt4WXfFJQLr1u7kDgau/5W5Ml6bIQctn0ZtyeninD1+ejEyVO0bj88EPqDdot1dHV
-          7E1MhReEHr4sRydQmz0TPxbcBQZgLFUh+OW9UCpv8uEPL5o1BkICJ8aV8J/eF9x9S/78O8aauofr
-          w5x6qCrnL7k8j2eVH4OolH778y/e02SqGRQPzxZbvtQ0Q8dILOiU3cVmF0x0Sce5g0xtaQuznM6N
-          IL9/+mhxn/hPj5JDng1w0K81UTzjVGyCRizw4zd8vRx++bYcR9A5J2dsB7Fic3GCJLj4zeeX14t0
-          +b4PHVyf5Qtfzx8x/PMf4CJXZ3cz5uu4c4/LBOFzsog6tFO4j++Jl9QsW/FP34/rXGwSFGvZI8He
-          ZnRtS9eFPoUiOdPTom5JeYTSKbZWcnKerE2W2XTgjpFBdMf9NtuhlXk4KZLi8g8BgV1uhRotuqmQ
-          MD+gkQ5d78A8/5x/+fx3nH98CeXxjRd4fJvN3/wBKeKjXHbGCsbd9VsZOSMvYDk7rmB24fOFTnIy
-          LMd6Upu9FucWglqzlmMDBDD/8lzpL3+RA7EHK//rY6OSVpfROK7YH4HGS/yqfPFFjo7jvCAkHXtd
-          dnH540vW6p0WaLvh4VOxBL95iKnAobNY4vZsa5OCHnrYF6cDPpP8G87F3Tbh7//hWOCiggr1U4Hj
-          KVCIdYdhsU5f1wFdSg8uPW4W3dc3LwPtCDWcHu4t/eVT+b/fr5f9ZVyFiypKf36+ODMl3UvxMsD7
-          a34QGc+5/S3X8PXnT8klm5dmeye9Ao+nBRLFNKdiVSO0Ais3W3xOnEZdMVsP0B5cgZyX64duj/tH
-          gy8kXomlXoC9mOn39/3k4e7+KoJ2hlULDJ31F/peO5UGciUdx8X6uHTbObDxwvyCTCzzxK+OJ3s5
-          HO0ASo3nuVzkJur37Oke7C02Ig9TyJrFuIsllO8mJPqhKkMqPR0IrWbfyGkAK5hDKE1gDpjY/bT+
-          1qxO9C1hCq8C/psf/eV38EFymWhcptr8Ig4VJN9qwXLymJvNVT+a5NfTA+vRl21mIZV5lL77GynD
-          90a/LQpr+JpuDnG6W2zzc3CZII4/w0JP8TP85eU7PPXFBVtvC4Jf/rXAcDKGBbBJQ79iq+SQsbMv
-          VgKUh9vxTtt/9aDTpq9wY7bYAgxo+mUPkBRu10TekabvKVZ98ixIWtsR+Cqs+a8+HLg91+Ff/qMO
-          rRPOCy/m8PAF2EWMbNjk/D4m0LD7FBdGexs3ycoqqRi+mbvWj6GZ11TJ4eFsc+5QALugn/m0o4Pn
-          q/gEX3szJSdQAdVdG3JmPh/6dfHGoEJpj1gTco5S/XhZADv6HxxnXVcsfhWwUDGTu4veLk93w587
-          mAa5/MNrYu89U2vSL38muFee6pqe+gUeHYnDp86wmp1kbAW12B1cHmJT5X1bqY5M87i463tyVHrI
-          vQEJ2dkkmn+LQnI68ArEIR8QI767xRzjNYcmuiWkeF/e4Zv4bgSfQmW49U8fLdm7WsFzoA7+5ccN
-          SaaeOWrMapG/vGat3XqB/rt+L2zUNvZkPn0W3YXmjRUHBo3wt//5ewqXGHqHkYDFfYGfvnbfbCfb
-          m2g1DvzliS73O8/btbnr0DlHZxyMxBrZw7f0JCSa3r/zA3o6MApklygmnmiw6tpw7xzwRegu690/
-          qbyxyTzEQNxcaDSK+sv3fvyqpNj+wKahIBQHqL5khHW5J3T/HqoVvhFjLL98d1yvbt5DDZASO7/5
-          cffMhA5KTeD98v60oCdHhkgc3QvWpYG3t788JL72DH4UvUzZon9n0PN6h6iBnYZ7nzEKuLzMjcQ+
-          u4P9Y8MSXtPLSpQ0tsY/fQ1rrdj/9GO4J3bRw8fe5/i0X6RwP1sSD375MjYeZwmM8g4rWEvDdVnj
-          wFFZ+tX6f+erodTBX3/UE/jVH5+vstPwHbPzMOOm6edXynDM9MkEDHj25Prnn2zONeE+cbN7iO5B
-          wZYArbBZTg52HbWiM6+uJfQjtXX722NrfvPwHOSOueOqPJlg1fKNhRbgPGycVLfYt+w7AZNBKtay
-          D6K0kJUOxh/3gV3hG9i/emXw53eI9cvjKem2HP34Csu/eYwwS+VL2tvpRU5RfVF5r/32ME8DeYG/
-          +cBeZeGA/vP3VMD//T//fzxRwP1/P1FwyVkdR3nypPSyfUvY6ZKN5c4d6V7Y0QQrM7JIdSougHvW
-          EY+Q9/RwkviPcE+egwfDcbWJsvKlTc95w8Lb7YxwdlJOIWuXhon6YNKJkaQPuvHXUw+vxkFw4eHp
-          FGy4pC1Kx+2L5bc5hPvCBTxIUuBg82GDZvU8TYb7jVuxT4cj2HdJ1BGiOVr8Y5VQWrB3Bl4HrnXh
-          56uPwuWTKvB5tjisyA0B+1OeGci38hU/gly2t7N/q6AsODHxqi5QvwlZd9SvwoXo8iqEu1DsCVgW
-          ScG45EmxpqPWQzJPhCTh/Qv2Xa0TSE/UdZn0ETTbTPIE3LWdYlMxX5R2xKmg/3hP7qEMl2Z1pL5F
-          q7LX2F4Tak/NdoPQo/2Mi+6ujVtsnTJ0ARfnp/zLcY33ugT3G9vg4u1L9s4NrYbujBiSq4YNQB5H
-          4MJMVe9EIcpDJZdPKsObwJjkvNZjsfgXz0PkmHzxGShNSPPn00GXh+uQi7JpKm/sjATTuo4IjsxI
-          pRo+K4CvmJLYcbtQOgdchMCVPxOsaKO6utTZYfZ8aiR27qNKnwC3UFusmmhTblGB5RcTMvxndYHD
-          h+NM6r5Dhym2cKK3rL3v67tH89Hssc5Hh+Z7itocdbpoExfnJ5XjtVv1V19SDd+7za/ycYHq8xIu
-          N/rZVDrkvoXcQfkxDjfS3a13Fy23+0ISPno06yXfVxQtkHEjW3cLgQvnHFqei4h+jAx7EnikQwu+
-          avJ4ny5USI+2CdGll7GCzx/K0i1lUR8sOrbKexXyC2Mr4L09BCwXlx2MQb2Z8L2xBTm/Gaou5RF6
-          MHEfMbGKwLZ5eG531JTdF3vnfgBba0qSJI9tgdPHGdjrHu8iVPNAJY+RO9iD5y0OXIRDjO13qqrb
-          2IAX5N/cREJDnsF0uJxbeP3KZ1LNukpZvsgsWL98kyTqwDUrfrY5vHaPyl3l1AXbzdVyZGqFsmxf
-          dwCDgU4RzF0uJY/IZNXdzRQZhVGdYTxmRkihKFbQ49gVy1evbUjpxy404e+JArP/0p17Agnyb2Ei
-          jtp1IQ2SZQGW5yCco0tfbIv6zIFYbccFTXdl3PPlXkFrFT9YKz/JuCeZpEPP22SXOcxzse5Vo8GR
-          1Cs2H+y5YKfrR4Fil/k43N56KKx7Y4LWs07k7ivRyJ1s6EixHbywBeuq2e6BkaGhTmtsqzkEO3hw
-          CbpadYVvqOvHPSvqCSlgL0kimrChX3ePQCFsb2I8Fo2yjnORoaXcZKKS7VJs97ciQ9ug/CJRywP7
-          QLgOKoW+E9l8XUJBVnwWYPMi4qv3CMGWOqsCNiSu2MXoBDalVh1kn2GK7fkQh0Jz8Cqgg00iPkN2
-          sGPu5KJJdgpcxgMJF1VodXRwZI1kMLqPmz4xOZx55k2u30azOaUHOeRaFuLyHOXFmitWAm/Cu8Uu
-          pFhdoBsxcKqfTxzzUa+u1+TcordzlvFj4PSRf2RYBIJJbsT2wp2u+l5O0FDzgMj2wQx3eJ5WYL2D
-          eZFY5grIqVsgWEolXkhznQC1zuILnuTewVXgJiPLcfUE7btjufvtmapUGoUMmpJVElm37WZVzCEB
-          fLnfcOAlrb1/7bpCcpT07kDnbVxrk0L4meBInPXAhuv9uZpI+Fxlch2+75EO+c2EJaoPuKyyYVyl
-          FbygS8uJJJl9LvintWZoh+S+DGp+Dvl7AmrYp5pD0sfS0nVpvABeKq5fgGmKITWWnUX+g/Gwvf4m
-          CHZ3a38cXrr7Iw7B9FKkHP7wdQG//unVItWg+fEIDh3fUtkZ6h1QxUJ3OY3bCuofPyXUtJOMM32N
-          VWoIjQxPcZrh0ye/At70vRzlme8SrBU92FdyC6B6Aw/iQs8NV/YhVAh/FBXfv/fCpmzXK8D8BIQo
-          /HoC7FcGLPrO1oSNY/4Z1+IYaOhy3hPiWtObUl0OAwguRkHkEmHAabsAoa0WKz6Z/YWyrvZ2kCJk
-          CT5tt3ex80YTQdUN3/iimHlIfvUCCi5Fcj6DHWx2pup/eIDTjO2ajRP3Fn434UjMg1tQmqfVLvjz
-          esWBECojf0LvHpkv6UuMY26M9NxEMpBHLGDHu9FiPuw6j67qe8PF2T3SzdcmCzAOS0mapAe66UUi
-          o4zEMvavxzPldgaaUFcUBmtxr4+sMgklXN/D1T1O8w5WZq5bpL1eH2KH100l3X3SJI/jV2J8tb2Z
-          04/coQrNMjk91TWkl/qiQ1NxDi6gNFBXTawCcIfpRBT3ZaiUC+cMwoFy5PrDk7V9bC364R3Jrzzb
-          TNMDZ7B6GQax6+8HbOShJ8j1uoN7mL5Nw32zcgFFLSXYqA8nmxu5UET8xlo4555uQx8/hapKn4sL
-          5e6hcu/3rqMfn2KVfbTgDQ6TAwslI9iqnG/D8jdOhIM9hK6Q2SV4ERP3kB+65F8+31PvJKKEzygJ
-          BahSbnFuLVw1piFpZpd0h6wTwXtNKFa9YxnyL3KtwXy0emJ4ul2wgTgo4Kp+NvLHXyTyfjmlstYY
-          j9xBpdPSW/BWTzExMrYbp9NLkuB+E1biauJXpfHcJvB2K5/kbqnauCUn3wXvofsslFPeDXkcqYuA
-          PSi4MrDecLdHu0MmCQZipM1Q7CvxPTSfsO1Cnvr2OjjBAK/WqyIaN+pgQ6tUgt95JidvBsXOQqeC
-          ZtFz2Ohmls5HiFp4q9PNhT++2YRB5qGRVYorKspP7zleDUPOUUg2fYKCD09sBb9817j05Gw2Ybay
-          h6mwGjityzqkhjAqUOr3GFvzMQL7jJsKXh6Og6vDfA0pXOUAbkhasVUEo72TINfB04hEHO0mM1KV
-          1goM97EgrnV529P+CT2YsO6KZS7jw1VZbhPkhzYhSlbEYw/OSofinSuJLm5dOH0atoOvjsNEfz93
-          sI67oqBB+ITEhBFqNhsHIhwu54lE6bFQF9PPMvjrL1K8pQasVfqeJOtTrrignh9Spp8q+Ncft5TY
-          Besc9eRfPLS7ezuuwSnwgDzv1YJ8JWrW7ibKCD+KETvEr0O66ZIL4mi6uevMvxsava41fG7ljRiP
-          c6HuWqcukD/XHf7pi5FeRCGD740vML50Bdjja+gB//GZiBVl099+lrC49S98J74AlqA8y3AV7WRZ
-          fvptE7ZkRzE5LH98SSkITxoyzl381w90fUX5Civ1XePLcOTAfozFFSZ8TvFFU+qCxUPUoSwkBlau
-          x3u4u7XkAml3HJzlzaUQUHSvoFQdJOKihICd4SUG7E+jxYoQvpqJ8FcZcF+suNBV4nG3xdKEKddq
-          xHzYRbN1p4f2x/9E6dB13H94Dv0Q0T+8aLh3IJRQLGFOTlnMqVt2RBHMct8j5tei9hYHW4f46iMu
-          s96dQ34gqIU/Pbo0hnwFO0sjD6lxcyP6Qcnprlyc13/rNYve6Vrp5whBf2mIs5xjuhWvMEcmU78w
-          drrm33rBW9G32CdvMxR+9Qe3Ymjx6SR7Nmt3fgsK+FseD7jglvBTg0XBgJilfy8oiRsIBRisC4Kz
-          22wRtycwFLIzvk/pcdwOgyj+u/5cUtneg7DkYZod4QL4eW1W4/8BAAD//6ScS5d7wNrFP5BBhESV
-          oSDiWiWIMENEEMStUJ/+Xfp/1js6szPs1d1ZUZf97P17qvzqUkyACeazfbvT9Yp5BMPHZODrl/GV
-          ff2UwvklmjN7lEVrz0OBaDSZROLqDq3tMjou3K56veeXxJrRr4+AtHEYmwkxfZqVYiMcxqeJlXgq
-          hpnjTAEuJyPEqet7YPMyR4adlXvEzZU13RS+Vv/8PQkLyg+dfUYBFPzxi7anW6Z0zgNzb+e2WIF1
-          6E85QfWffyeywQ6ARtaBAX44psTRgzhdDXt0Yedab6wfApUuR8Y9wXGeL8ThD76ynlAow6UAFd7z
-          lL99C3+Dbm9z5KI8nerouK0L1pejYZTEq7Vp6LPBdx71OCoOp2EclD6D1jtyiGEsO6EmbCFyK2cS
-          /X1XB944HRLIW660+zWPbkl2VP/tZ3/X93XRXFmUwnLA9nII/K5/mCyUHfdI1DRT/O2rWQg8hrab
-          u309bgIodBHRfMSGvNbKXAtjAF78ocHKOw38jkVvVcgv2wUbVF38Om3XWawgIETb9/vKPG792Xpf
-          fkR7ZZ+UAt9Q4SNW3zhrK3Ggw72AYALBQKSey5XjXR11GMMAEe/H2xb3ZD4Z/N1LisDL1oc9X2Rw
-          vXwd7LR24w+tUHni3TMDLOcbtRZYtCUYIlckj5OcWUtTdjawc1sgWkH5iiTRWYJtv3XY/niGsr3j
-          3hSzSyPNkFi8T2PhXQBbpeoMmNOgzHzdF/BvPNYJasr4OymNuL6whk6lVSnrzRB7oTJmiOVw+lTr
-          7ifg7kdxvOsNSVydBe9vn8/EVuSBzTUn/Mvn82Jlt4HCRXehycwVNvtD6L/2z4OtXxwJLm+Wv9c/
-          D34O7gOrNDCsNTofwz+92Y9m6APZxk8jrnzYEiuNhmoWywr+q2d73gZUKaYEvGE1EalZx2px2i+E
-          JTgdEO2LKV2ON0OHWTJ4+GIdDn96qkFsC+VckkGnay4RGS5EU8g9ehyt0TSSRPxkSTfzXPGzVic5
-          z1Di+BWjTSiG2dm8GqIRndD4e1XV9nBSF35vo4B3fqMsVPVKsdSfHVob3lHGH0kTmCD+udfbu8Up
-          UhBAt5MoAtYgpdtJP4ywf3rOzFranFLzwfSwro8OsfJjT+cpSjuBCd0exy/pNrA+OXNgz2PYbrUr
-          2M5BWMDTPfxgByO+or54CuHs8CyxrkFJNzdZesAmyQOBomLo3PFxAtKU+6LT7s/rrfU9MbhbMnFa
-          0lqkIXYGFdQbBBlFmm7FV4f/6r+669XMqnCEWlF+54NjqNYItpsAI/KUsKUUX0rKwcghfFtgXjpZ
-          p+yWDyro+NQjzu7npz8/7q55v/Mc3zriTNPACz5GrM0YWceMKyMYjhAS7/3wadcZtSzi7R7jpJC0
-          iusvoSzu/gFfws/J+u3+EdaufiH+7h/7EQQRfJ4ZEzvFsQPbdS0LcbS44D/53WjfkqAC5kVw5s/D
-          Oho9AzvDxViyWwFs2zJ1cJiCiXhxK1n85aE1sNRHG8tNMtLNzpUaPpzsS5KX1lkbRBmEwlXo8N6L
-          odNej/70DlWHnK0WcpsyOD87jF2/LZUpjSsbsNfgi2N5ra1VuKsdFJraI7GsCykVmE2GUXRz5lMi
-          6dWeJ2fQBdUXsb0y/fnzRLArb8Dy05X99bAh9o/PoGbnb83diDxI090ck9RVaNT2C4x5qGN1FIdh
-          S+W6gB9R81CLvNkf1fNSiFWHqnnkwzs9PuoYwhcj+HPgXXN/U2Z6Ek+iX+y8Qx0462JHsH9oJlon
-          7qWMH94vxeXbOQgcW2LRyPEQxD7d5p/hUH9RDGaGNiPU6CyMpsXiz5jAEL0eWJM4KeWJDTZgvZXf
-          fBrVtVpfWcyB01t/YfT71cM+fyWEvtCgydNDZWWU1oXVeucwOkyTv9TXnwRTaA1EsvfhMezaA8S5
-          XIl8+a3+4vx0BPw3nfA1OQvK4hSuJH7W23GGLmStcjkZOXwJpUOunsXQJTG3Ev75k3VfX+PmyCPk
-          v5JIwuiapYutuNzfeiQGTHJr+YK8hHi47DxCqtK/8QYUCDOabyPjb+29l6H4O2hEm/GsrIUwJfBd
-          ABaj53sbNkxnCFEeAewy2n1YO/DK4P0oXYguy/Gub98EHi8HjKA0dtZ6z+EIfmi4EnNxt4qO9WME
-          HxluRBaci8VqQD3Bx3kxSPg6ny268ymA9SJD/O7vd57awOtjStDjMd8sSo2Chc1bfBG7sNtqK443
-          TWRvZUduhHEpP9z2E32TnuK/v+fmseyh99hPEB/1V7XrfQA/7kKIKQcKXd12FABNsYqd/net1g+C
-          OXwf1IBIRYIVftfz0/AZWVRqT7saWfTWwIKiGLu0Pvt0O8YbHE6wxeFp1Xz2Ftk6vIdlQpQx6NOl
-          tjkGOg0nYx0mzbD8JMDBIfJEdNieT58u26CDw5Fe0LL0qbKocrGJu99DpM5/yjqMwwx3nkxU52Vb
-          SxbeQ1Ao9IPV5CxX016fBV2NZRzLepKuCRwYeL3IaD7sPJf3xSWEV/Ru8AVlWrVO39sJftY8xrbO
-          y9VRz+0O/j2PDVUnPb5D1xM58fpGq+sq1XI8diPUYfDGqaRodIH9mYHz+EyxbLAWPTpGHEDXExVs
-          XVFMRy4+ClBT8YUYJVuny+dLzfMY3yd80VgbHMmmQ7h9Xz3RXWIPXHfkdeBstwhbnRVV5H4mOdi+
-          HJpFFbf0X357DvQ3M3XUVWOX2gmEbOPOwteKq2315/wvb2I5bKNhYTLdhiNN0Xz2crJf+YtlqNWn
-          gSAPhRUFOtP/8TfyoIkx/H5RMIq9cRsRtyiDNTN3q4Gk1DhsgM0a1vYpBeKPjQqCF00GRxwsJrjY
-          7nXPz/Ww87IEWk1/IbfifFJo37/df/Ol8UVvLVM/2zD5TFeMe+8L5iF/ILhJS77nOXXYnrf7KO68
-          CKtTMabDH397Ol2D98+z6HNJGHhA6EaQo1TD33qHVirf8FWpjwr1IomBT1macOBbBzDueQqWWmHg
-          t91U6TaCIBHbfulIPlaVQk59JYnPogywZJ3f6Si6n0iEofojVvMEwyjP8QzvQfgk2BxfKS3jjwYl
-          R2WxfK55f8mcjwmvAjUROxhz1VsGrMH8uHbEfu434Jh6ieAbnu7kIee0WkZ88WAcTDxBO9/mnswv
-          F7jb+MNO7ekKJ2GkguvnEfzTp21mLAmeWITmv/mc/voFu59EXV0WlPYRI4A4vonz8nhwynKaVeEf
-          73XO1FXWMxQb6KGrPy9FQpR1ep0heATPI2q4RB/YF43Kv3xEcjHEdOf1grjvd4zs5ExHZ10iEeSG
-          RVwu5+k3LdMEKlmmIXgNEn/745U+r3zIjVd+tGvH/YRTDN6ISzvVP872vRaj08Zja8/z6+P+DICS
-          5RpRRe6TLrsfBy0xZ8SMUumv3GPlhA5zEdYOQ13Nnyza4PvrC8TRiixdHl0oATbfUmyIxWGY/vpH
-          T1mesAreSsXZudLApcpMtFjnQ7oYo68LO48mWfcsrQkcRgTRtyPYWJmZrtkhaVhlpDa+ZhOvrCqb
-          oL/+FZGUu6Nw41Yj8c8vMjs/IQ8uK4XbF6Q7bxTS1XdNCNewF8kfj+y2fNDgKWMSVAlc6S8TRA1M
-          kvcdHZODYm3GKIZA2JCNhJFSv5uTTgM8k9O/7+tP/i3Z4M7/sC40RrV1db7AJhh1tLXF7E8H+tHE
-          983kZ6gVKt15ZQ+tprvgez5u1V6/bQjar4yNJ7H8Y3iJ7fNvPZ7J7YDU9M/P/fOHjh6c/c30xu0f
-          7zWyVwN+jzpmwEsoHJzs9eAIvn4HgsdHJ/h4P4I9X4XQaK4ZwUYDwHI+DzN8PtUXAsvZp0v/kDnx
-          1XYFsZnUpEuVPwMwcFs9A1n8WpPxCHJQ17xDZEkiyghLYxHu0+bMVPa2YXyzowAu6FqjZtefJf4q
-          qvjHdzWtDpQj6ysIEIx1vPOmdM3NNQNyOI8zxVaX0uz+sqHysfyZNaupovt8wbMOEnwJ24/FPinL
-          wj9+e1l8BbCfeQghtLuN3He/0DFT0YiXxyPCejlXdNQU0YRMf+D+/Dpd/vT8JSUT2vb8MRW2w4Le
-          eW/YOrZY4T/03EE5HMe/fgSg8FLM4NtFNdYYufTJc9nxdvIq543Ib4tWBzcTpaPk4QvvyBbva10t
-          9A4XzgeVMSpuU7oA1u81I9gTJcoTValFPChfIhO9sxb5sKnwr7/83nk8/QG+h/Fc3Imiarja3Kpg
-          RZ0pS3zR7ray+BmP/vwfvrhTmk7SK6hBotQyqnmY+ot6PhWw0UmP//zJuve7/43f1WO7aimtvgav
-          +H3Y80+RbiW5lvC3oRexdXSiq1qeOThcFPMfX6R6ULriYL6lPX9J1USndPnjwVhNwgvYVr/J//rL
-          cw37EKzf76bCpsV3jHc/sO/PGhZaoGM5MSXKB+5Xh7vfRBvRdeXPP4O7TQ5EO+gK5Sola2Cz8da8
-          MD8v5WPhXf7T32znTfTofyNoiZVLTHAareWvP/o/nCjg/vuJgmSw7zj5bj9lw9DNRM0TP4inXlDx
-          onRjzvTRquQa3jXAEbbSxGwtZpy14rNaq15axOzyPCP2ur4Brd6MDu6lE2AvVmp/VW/bIj7jw2em
-          HDNR+jWhCu0FjVivvhpgey/KRPe+8uiYtnLFsiEfCAV1bvNxIFxF0YVnoUj0E/YLU06P5W8LRVG1
-          YyLpmlTRQGE1eJq0H3LDUzRwnv9sQEAzlaDm9hsI87h4orrpMvbyWLKWg2Yz8KO4M/GPPwvQbC09
-          8ZJWJXGW7KpwRYx68Au3GV8/l24gP14WhN9458mdZL9hqxI9gR90O6BzCitlTaFXwr/xi5Pfs6Le
-          9JHFSU8LJHxW4k9bqkJRGZMMK4Up+8vnXLvwfbJijHq98ukzqaC4PRyE7f5H0lV/56OwBCnAjmqO
-          wwaq0ygmIPXIdTXgMA1R1sPsgt7EEuUAkNfL4cD3GIrk2ifsMPVTOMLTlsVYuQaVQorXqot/3//2
-          vFF/CdmuhOKPXbBptC3dfF9P4PYGV4KCwfXp77NF4q85EOIErqmw8XHNRcS9PuQpM99q2aQxgMJr
-          mYmTwEvFzcaEzuXc91jrae2vCRB78ZjyZ6x1hpQexWPbiW4WBNjv7llFy3c7i5lWtIhxe65aQBzl
-          QnZ3NfI4W651vOoXBHm4JOhQsZeKT7Q6AY+5rRFwl8xfYsvNRSbgeBInP75a2LDQxRcfT4g1tnjg
-          6OfZwAoBj2gWHPxJ3XoEu9V8En9ff+vNsEa41O+SqF0/+sfqELui7hMHq18mqLjT6SGA3KYZlsJT
-          VG1iTW1QGVVFpDrYlK3fDBsy72Im2UVBAyvEbS+iEJ2xrzCtNUlamgA9j1UcTVIzLF4euhCiH0vC
-          WtcGogdzBuNresWXNs7Smf3MMnyXvUvSET7TZT2cELzbfUUkIv2qH2N+ZEgl50HeKOr8Jfm8JKEd
-          khVfGrkCCyBaI2Lto2PpcJPomJ/8AP4akZBXJVnVaKdSIEZH84WxMD7T5VOnG3xPwQ0H8Xmh2+Uj
-          53DyrxFOeCT7R4ONZNg12Ztk/Q/728KupchnPxunLNODv/8/57JhY2Wfz/FvPVU5PM+EmVZrqeql
-          F63gFGKjvrTW0jStDX8auWHloKzDJgqJCR3rVmPLlJFCl2+4wUwrWxIrrGfxxeusg6dghviatuUw
-          0jAexdicHPzkw3xYM1FrxO19zPELWDZY/bMTwO6jLcQvnK1af3LrAefaycTwvlO1yhlkgVE/BnKz
-          o2HYVF4I/tbTDNwFpoS6lQnj4xQQ7M+qwsm2FEH/lIQY1WxurVXfJMCf+BMSz8e7tT7QtogO8GJE
-          0fL2uX67IBHkyCLYi0trfQrjDK/i08Cm6m7+RNShhCo/WORWlNTavteBgSsLG5LdzSvgjYA9CRg6
-          GvZ4ENN1Uc8MHOXig6ir1pRI7n6QKmIz/DDtSlkNM+hEulQ1vnDmE/Bmn7IQj9KVKN0dVkv6GTJY
-          B92JOC5e/PXupBG43uZtZvX0oizXyJWB9SbtXN+uX2sm7KCCYFYDnJPiMRzVVzyDJYgBUb8MO8z2
-          t6hhJJQ2MVXX8xdAUHPWz8jE76NvpZtQYwGqbW4iHOumxU7+J4LOkbnPG/dllOXr9h3sW9siWHwe
-          U/JzcAEesZri5/VXDes5t+YzC753koyfu8VLYFBhQHN1nmlpKCw7hi78VLVI7jU5+dPldsuFwUMe
-          mmxbUviWkyKxWZIBy0cXWlv8OI3i3/wK++etH4ZNoBlzHeLVMLJmEfcjfG/HO457clToBT51+L7x
-          5jzVMQ8o16YSfMTOEUv0oqTzSBMdQv9kYuP4DgFbVHdP9Fp4Jlp/FMC4PVgOHnrCEcUjZbXO6kMT
-          iX8acLQqIVirA3cCh+P7QW5qeLI2tfyxokBTDZuVdk9XjdajWHjMm9gon5VFjVpb+EFbJcFlxgMP
-          gzGCf3oiGalc7fVXFd17/0KRZ95Sqh9wJgg01vB7X3+ksVwGWqbJz+zjxFsLe5k54VDcGoycQ1Tt
-          9dCFXzPgiMd0g7+20mmGV/mh4OC6HsDq8mwkDi+lIhZSWjqmHID/5utuIWDtv0/E5LoAHLR3SVlz
-          ccihRlVCXrrV+Ctkv7r4+OkyzpJqpX/PA4vIa/f9LA98Zb5teOI5HRuf6DAsloYl6FjXmiiFWfpk
-          rKwAsEPiEvNSJwORGq/ZT8hdiB4cv/7minuHToonbI6fu7LT6w12q/4kbgmudGkaYoPXdvsStf5t
-          w2qwkSRq0xCRy/uxpVsRfSTxB585uZAUAxatn02sVPVCblnxrtjU9hiYhQ1CvDPfUnYb/N2/iJ/d
-          7/DDXChuIf74S4hEydjoNrNBLx6+XoDOSftRaMfBDJ4784nOn+hd8ay71rCTDiWa2dNVafn2l8Ea
-          +zpBzP1ubRdrheJ2tVri5IeVbh6DJXCWS4kklbb62/U0RzAShgarcK2qI00/LNj3H3HW9Wax1iJH
-          whK4H2KhK5N+EiB2YD3UHBp/weQvp2gyIR3khEgNE1rrAxsIljEOyMXgy2p9CJiDCswU8jK52lqv
-          r8IUrd67ok2oLynl218ukorx8F16+/4xu5+L82s91eS6ZZ21fL9UF/mnqfyrZ5vTBD0oTjVH8tmi
-          w9xnpxF+v/eQROtFSjkL5DOw+vi914N7tXG8H4lZdntiXSUtXblNceFlaA2st00xUEu6eOchOxnE
-          k91Hevw+tg2eZNPEWGXkit4nr4ZGnG3YC59jRQX/J8Bdv7BegBKse/0EWnT/4UzLhGoOAlOA55LF
-          WO+DGezPzwru83bAknfUU34VjjOcHNKRS9YHFbkxaQT9LiCIApmn6yV7Q9hxhUaMsGnTkQSDAFsp
-          98jNV3c/eB80mHwFg5iSI1tUYOIQMiy8kns2zP7WpBwU9npJ/vziXn8zyHKqTiLrdQQ/0UwakKZF
-          gUPUVdZ4mwcZbu9RJS/blqxjDC4NmJypm4eCpwOJrn4GxcPzPP/yfvXX8iCz4nIWTlifH101dzcr
-          hEGVvBDd6/UcDzMLqIQfs0Csh7JVSSND6107+FmZxUDmc73A1lJLbN3CMN3uXlWCfX0Tk9ozWKRh
-          m+HQTil+35XGX9TIqCF3CXiib2GZ0nyjSPx+/RCjRL6Cba+nok9xh9Yh4SxiPzobmr/Tfr+rPaV0
-          c7MRyimI0DbQL2APmsqIVvI4Yas7t9aYfc4CdIAbY0P8mCnLjrkH1e2eEeWeFMO2mLIGmu9gY/Mx
-          WtVUBR8W5nxn4IxZi3Qjb1uHui7OiPEfrN8th98Cq5w5E/kuPa1RTBIGJEVzQef6clO45BK4MCmm
-          lJgHb/Q3Q3AWGPXfA8FKL1p0ODkJ/GnTDauHnKdLC4pCtIVTRQz5vShTOzoL5O7tmxjMOasWYU5K
-          GNBvjg2F9RSSrNdI9MXtSuzp0SrLHDxyUTygNzrXskRXg3Ul6N4pvz//TTkCelahEh40bF1EM2Wf
-          Jm1Af9mOWLkdCsCOjBlBxcbt7l9qi3Ycm0HxfbsTuxJue/4SFoDvbosDO7+n/CenHSheffj/42dq
-          8MHKAONzcFXY+SeF4vvlFvgivak/anPQgB5OAVa4Q1tt9fVVgDG63WeYniigqSaw0HnwCpG8/R1l
-          zXAfxXs2mjjf/dPkcFUGN9y/MEaR7i/4Jm3Q6t0rDm43UM3f1BTgfQtKHO9+cb2sjACztZzJ++tM
-          YHFWPxDD83gmyWfF6cpvfABFQVnnT9TW6fruftG//X079bUyL+y5gOFB7UjK+SNY9vGC+34iN/25
-          Amoc6gDWvdPNh+n+pL+C+UKYWUJIVEa7VosiZwjs9QbfzgdNYdNPlcPaOEizmDAnhVZHrT8Xp4b7
-          V8/Y/JSGwlksNPye8CXdWI4pgDfdL8TJAtairy0MxF+zv+NIKDaLyHe3FB/+OM6nPkB0nINXBs4e
-          uRDDcHKf+ooki5bKEqzMQgUmbHMFvEXlFfF1ZVO6CEYHnljHRE5JDla3rE7w+9AeWJ/kl5Xd5kGC
-          NYlCHLXdU/nJmb6A8fQ4I+tPL/7yMG/nFpHuJQRbt44BqH79SpTyWFi7f3bhWS4k/KCskG4jPSxg
-          M8MHkXT9qbAF0hfIYFcjryK8DUfmyGlwil63GYyCRL973oPtsn2w9c5v/ippfiIOt4z+5ZnhL6/A
-          JjlPxNv3O00zJYAbXnli380rXYbuJYEjONyw8efPTuIsi4mbUXx9SYhulnvpoOrJ7Lwgdh6m7cpm
-          0D9FIRJPBVGm6Fv2orx+FiwhFlXLg000qLaViODpdvBX9PEYmDZxvOd1fpjW5bHnMVud2dNiANbL
-          bxw8fN0AIwVzYEx5M4L9TRMRNK6yQurjS4OOlE7zmTUDOjLJLxLKc1hiPXT46h1d/RzufALj9zH3
-          e9yspdhppkvMQVcBrU1JBsa5kcjux4bVLqIckrwpyV5//OO2DAKY0S2fa4PSdP0ENoQMTgtsXmqh
-          on3Z5OD7UB9EViqJrr9nYsKLexxIeHGqYXmffpv4OTHjfOoONlgdi5XhqT0DrO77f/FyzAJavESC
-          3K5QRpFUGfytvxbLTGf5tC/nfL8zpqGzgyJl+SCWg+ZbX4iClkO6NIAf4RPff4hbyzGlfrT7IYhU
-          cpP8FqxWIcvipCgryq1772/nyufg4Nkedl2zH2j7eZTw8EATdl49BvR7HIq/PI0vNYl8OiHDg8gK
-          pN2PqArJX5kHri/1g5U9D03B2V9AkMsT1kVNtVbrWDBiiOaNoPR5o9OauCfx/UqF+Wx+lGHiX4YN
-          //KjrsQW/ef/PTkysMqpnjL5ZyeEn6oKMWozaxhhYpdAMuFAVDtf//GS84OVAMm+Pq1Imu3vBHpg
-          hPV37VjH9apHkLejGiveGltccxUSUJNqIYZZCdZQ0EgTj803wvEnOlSr81H3/b/5WL1drxZhG7cU
-          jx8Vk5DZr7wKVe8KMxNPWJJJD6j9KGzRdm85Rvt4roa5n6A8ZPkM17AAC/nBBD7OTwUtztseaHab
-          T3A8Pc9EyxfeWpLPQwbP98Od4W2F1ZxeyhEQVAJiHk/NsH4Hy4U7L8NefE3o+mFgAqDCVvPxc+mq
-          lbFQB91WsnH8uH/9qR/P6p++4tjivsMXmrYO56rOyFs6HNJpub6bv/nDRjlYyvG0FabowhriXV+U
-          De53yk8tABhzneOvzHstRNkan+Sqczd/Om2dCe8XZsS6dq2qhb1cbJi3dYmWdfyky3lWVQiNx4il
-          I7kPv9NLdKHw2uZZpLeSHq+vQhdl7nja9WKma9XPETy4ygFLDcNZ21YMBRTrssP7/Cgzy7mCuORM
-          NM/dkQc0SaEAPDHBRDrcCrp1mc/9Jz+eD5p1xLwUiqlmrgiKL2CtOkvQefJv0b/xWv704/S6yNi8
-          lLVFo+tPgIy6unMYyYay5VPQQdR4Bf7jjX/5QOw/gkLMt3JR2MiSJUivkUKMq/nHR/INyAM8YHsN
-          C7o2Qzz+y/vOnn+3WOoQfMzfmuhKPNBl8n8JDGYtIH986I8/CHayPnZ+dx0WvJ4Q9OVzjDV8SIfN
-          898N/PaZig7nMB0oC34SVMfFw8aaNRV96wn627/kXk8f+uvGDMGSlRNsC5tojRnvslCSXBZnZZuC
-          H3/rXbjr9QzL7zfd3oqswetL+2Dd1ClYd75w/vPXzvU9V6vLwwi0nPYj6u0GBspIeQQyaH/JIwl4
-          a43dooE7T5z5SSj99aJ9ODG31wyBDojDyCxSCLK7pxHbuJ2q5TZXsrj/PEOoyRVn1EdX3PkNto/x
-          ai2kNzmoUY1gm1kL/zgoqi4+D3lOUDSa1lIJFxNaiZ1jaxHv1thCZEI91iDZ/SzlTCFDwj5eGAnu
-          01/lrEng8uPvWK3cxu9FwTNh/Q4IzgUkUQ6cDRvyWfslkm0sYBETj4Fl7ARY/YA6pZfmI4uaOB/m
-          5Uju1bpepUh8T+/PDPRx8/++jyh/QoKvZDWV+Zf1Hlze142Y53ORLqGxqvC3Du2+3wZrasfrBh0T
-          mth7acHwt37gKBYtMbOUVpwDaAMV2L6woo1Hf4vDMIAvSI7z1eYvCqedIAv3PIxgXlsD27cFI+ro
-          8cKmhE9VV2LFhTdFD7H/eqs+lduHBk/2IcVWeLvTo3IbA2jhspnrQ/bx59dYNHDnNeSPn8xXJw6B
-          rvwabPussfMU7gSXOtCR+CN0WEMh9KAR3BTs7H6rv6HSE/a8Nhc7f12z+1pC7zbeyS37xCmNEiGB
-          g82V6FSAkm7q6Q2BL4I3NlO5TTdqpRJwvkI/H5nyWi0x99YAQ5oHucV0UOjz6sh/40Xewsj73XpY
-          bPGv3ji8EfsLUKcG7vkA/9PLfspHeN88gESj0FPWe536P95O3HvRpJuA7hsYN24hinp5VlupptKf
-          fySa2f72E1dxAB/+eSKXWJSszRLOGtz95tzv/pbK7UuFER7e6M9fEIKVBbJut+Fr81RTlvzYRDw7
-          j/u8Ltt14Cb9bELjPCVoey+nnaczGpC1COOISTVrqnvIwfj6zLFpQoNOhHiMaCDiE6OZQdrFxzUT
-          8SdEc3Xur8NiXj0o7vydKLp8T8kFnEuojmD821/DBlBhgxvNv6ibnwdlNd6TDpR7z6BPfOCGztJu
-          Mtjz3kzl31dZTnJXQ3uxR/LUnyvd2uXkwSVee2KX36vPtvevDnO7l7H8uSGfPSwwAa+VsYjGotpa
-          dr4herf5jtr7ylfTzivA7x4d/un3SIcSQZOlOjL2/MTV11cJP7PjEF2aZ2VdE1cQX3A6zmWfK/QY
-          A6MGe74h8kM2B17/xSF0UsMirxC0YK6vj1IM8yXGEpGMiqIB2LBmN42830cmHZPPSwZ7v4HYUCur
-          vR8UwSXuXXLb9XW7fMzsr58yi+3l6h+F3NPFoYx9fNlubUXd54SAMbOfvX/yGSgajf4v385L4CR0
-          TRvagD99MNubpez1sRS7YWlJvGbNsGnI5/7l85TzbbCUZ2GExBcGxFTpSrci+slQOE0I7/x72O+Q
-          hzCcWYk8ZJPs/QA9hHu9wVoyaZRvjisE92eV4Ytlq9WRLkIIjfo5kMsd2BUPDtdEVEJRm7eXFuz5
-          +scC78YP+GZH1rBifoJQ5uacWPZkK0T1UhkAZNYIoCvj0+5TMeLO4+aOSRtruzoMAybd1bAxpSP4
-          7v4D1L2GUBOOjkL/8slezzG+q4UyJcCVxBZk0V9/ZhiL84v7V1+4+jbSFX9+CUy5l4TtnXetAi07
-          0HFDgUrkyxWn14YN8Chf9zwWWP/6N3teILffuav2epPAzQwec4m7upr8CnICewX+nz5RXnJpBysi
-          F0RjxAGMVX3q4e730RZfBUCz7SaAEgUpQXxV0u15YDlRubRPojrspIwx91QFz2tNdNE/DaAcrApI
-          e4YSPRN+Vm99D9v5/kzk+cyc4TDF4FLDykgMJDjdZ6CuHIzibzRfWNvH5/iXdz60q7Gzrq218fyH
-          g2wjf+YtviaAiofehX9+BBymrVqiItn1kh8w0ht74J+EzWDA3B8YCUgC7POYNZAh9YM8z4dGIX/r
-          MRZOMtqSBNLpKdQz2P002rxwo3seLf/4GKrWblPG7xfof3qFNbF1FX7BBxZmEH2JwfCaxduSGIL1
-          0HDYHqWvQvEzX8BrLFh0EAZxmMcXsCFbzDES71/7X/8ErOSD54W/Tj7NskME52riiEnxQaE7vxCP
-          H/wjVu8ehm3KLx08FNeGuIXbWVT1fjlca+FA9NKtwa97WiP8PwAAAP//pH1Lz4LM1uX8/Iov75Sc
-          iIBU1TdD7gJS3ERMOh1ARFBEbgVU0v+9g89JJ530rIemYqSofVlr7V3b4Sp6WN7qEYvrWAVMZypj
-          s/JUMHX5PAGqPe8uJ7/3dPnVT9dZivCluaohh3A1wa0ejlVGf9ezluw7+KiWzuWCPszIiZk94Hha
-          QeQt/q5j8Qmglz8mLBvNpu8+PQEZSam58zJdwTAyTA7hRGVXbIsSrKK7S4D22aXuVeheNn3cqwFc
-          1SLBduc96o0/sXAlzOCSp8Mqy/sizvConyjWb4kKZnUMVMjnvUOOkD+FlA+Y5qevT/sdb/T8VJcu
-          +tVXI8aEyvRdxPmvfuyWyxlQZidM/z8dBfz/u6NArm4cNpmnFC5V2b3gqx6eRF56XeEXwZTgLVQ5
-          kiLRy7gHd5HRcn3bODeQXc/Ho+tARryeXNRLTj/fHKlEIVvccGH0MV1fl5hF2sob7mJnR4VP1ryE
-          QUMWF5hRkrHqqs3I1qcE25PVKSuoqkrc2XqJTUubKX1x281SD8o4UI1dRol4SxEDYe2u1XxW5uIN
-          Cqh+7Nrd1U7Ss9nbSOG+niSXIhj29MUFDHJnacVXqYzD6Xx3UxC0x4Jc1KjLSPJhRNjtxJe7q/j7
-          dgeiXaGrrAI2XJGxl/5rz9CyJZYE42MOB2IvFpQT5orNLnvQefftKkhlS8Enb5tKzQZfC1qn0SBO
-          a11CclWDBL0ij8e4foZ0xUnfwgP73rvfyVDqJRiRADM+OE+wtfbZHJJEhfD9yV20EALoJ7hGyGK/
-          EQlnR872KuN2cHj6T2JH8jnj/UGYgQ/oiyiM79JufXgmtGqAXKEnA50K+njBbie8SBZdzZq+D16K
-          9kauT3SQnJoeyVRA6SmJxPb235BeoKvCxdFbl9/1JmUztYwRejsGCWsEFYKebIIYnEByH4VLyA2C
-          pQN8UMHEhvUjG7wZpUjywhqrnXTtabMIDlpS543jz9CETcUfdWR6dzQtxuFI+csxZyB6nAF5yJek
-          34NMyOFtd9AI3s6Deyd5ANv0Vk5gs48ZWOWKbmtVklsUyQrb32UBnfDFc4U+9XuuOD8npJ3cD5Gn
-          orIHBrSR2IX6hdy+4EzZIV3K3/o0hMdO4Q7kViIvqd4uBapF+WU9OGKTxj62cpWph0vAdn/+cPJM
-          J1zPdz2B8n7+kCDqy56zieqiMAoTHC2TU8/s+6WDPFLv+LqLx56aOIpAjm8MyY7eAXx2d79FQasU
-          WIVm1M/C7Wkh9XOqiU/arl8/HqtCg/MNEnserKedn6zgpHgJKQKtAMP1sqrweXWuBOsOtamj+Cn6
-          tqZJNNHc9f2ZDgJYn0gmt1rR7DnrCgeGVXbBxz5nQZt1hQu3553QNbsrVKCuBQ0cHLEn7JWai2Rb
-          h2p790gaRGeFnq5lg8ymMPFlGL/9qlVmAPH4Slze0zS63q1XAFMcE6IfwjWbo9daoN3VvmHjLRgZ
-          t/kztP37C19HcgRcjEoPXtJ4xUdxOCmLcEEN2OyBpHSv9FzydDjoEMfGng1Cm36T1EHxPpdwynEL
-          WALqTLCQ9zuceC0TjgBeSzDsECWJD+2QH043FjZmeJ72u9BQ5rc1m5B/65BoCj3Ya8fHEnxaiTHx
-          u/jcE/doSqAW9SNx1MBQOPHx1iH/GWJ8u15me2iY7U70E0fYEdTSnhlQRgg8tzuxQvFW+OIludBW
-          dYZYhjf1iz22DLT4YMKGWTf93H/aCh6KSJ8OoDr046pUHNrvZoHcff7Z76+f0wofs+TjuJcJmC5i
-          xUFC+hErL9rW004HFnQe6xNv9qysHz3OkfdSTGyWvJqxdn7zYNG4M3HSVKEzkGwTqlkvEadES0i1
-          6Wj9fT6S1urnvvInwICOc2lbjNlg3TIWquOg4uLqNRmrHsVAZHhCpnk0pppc9HoF2YU+JtarlnBW
-          +fwFf/6R6bpuL8UwVsD57q4uNx2sjG+7RIJvRr1i+/jeK5StZxZ+WXwk5qGPbAqHVIInh3D41LzV
-          jI+SbwNJZNsEl6UG2LZh899+sHmXTpS9VE8dGtg7EhtpirJY5VkU7bpsp7Ia9Xov2FcIXWh0LvDK
-          yV6eFYWoHfIXPoXUA8tKmRjuqyTEsmo8svWT3Qb4Wy+MOKsXtMsZOCrRGztMsNrEv6ISYGk+4Wtz
-          rnq694EMt3zkkvoZAu583TVQjNWapHoj2NS/OzF0Mj4lxlPOlNZYFw712c3A9y6O7ZnoXQSfF6Ej
-          ia3KPTuFtwgJ92xyV12rAF1LmiC7BC7R9b2eTdq16/7OyzBrveeCU+/BoBkXd4ay0a+R4QuI6PN7
-          mqukz6iMTiXwcd1hVQBevwA/5SD/lRVim1/azy3XiuA6ziv2wvsakrnEEZSK3Z6cc/9U028SbN3W
-          o4UvhWGDPbu8ILohv5/24hrb67uVJnBJoxUnga/X09dvLcSutMUnmOgKb+IohkLQ1qSYRblexU4e
-          0AQ8GV9MW6U86QYIbf/xmlZt/vTzG9gtpEjFv/ejDFdda9ENIMYVLGKEG17g4GrMDnF5MNdDzh8C
-          eNO9xkWHxgpXmFkxfGp2iHHONPWohico6qFkkrszpMpqAeBAU92lRKkRtMfn/W0iNnMdon4itZ6L
-          7M5CRolUknRzZu8Dqk5w+/7EHsQq5IpgLqH3gdjlDu3YL+/jfkbw/c5xPGFKFzqREj6U+eqCx8vJ
-          xmBEIkSaouNz1/vZ+LFkCYGR22GX91OFdc+eKPZ8f8RSwTnKfPV6D/jySdtmyKTZPgNvAW3xiFzK
-          C6MsXynJxXNqJeSx7W9W1/MM7+cJYkf9VOEeHKdtal5wIA4ZoowVbk8Ttr3JT4qi5/Z8qpccSTGr
-          uvOYn+gSD0kDATEHctdPQz0Ow9FFpG72xNazDZBkQwNvl8EjkX5/9TQLyQR3Qmu4LEtEMA0rDRDD
-          jwSnzKFSeCbNHfBWTJsYFwb2i9NIM+Kpc8CaW+XZcn2KDGz2LEuCltllq/ryW7gyi08eQrez6TJ2
-          KYz3heTCEvnZPCkvAaHLfMf6KaGUakU+ia5IkRv7r1O/vE4XCHXxUxNj/lj9frxqDCys4Yy9amzq
-          me1WAQl+xOHf+1pZGU7QuZ8MbOYxzWgin6Q/f/cN3GftumY6fMmYTgtX0uw7LJ6MPujjYfNSbBWP
-          4BHDe8YdiBWXFZ20a9XCa3E13WbLx4t5FBy4srJOdP/wosOXSBMCKPi69WG+U9opBQMf/WXFcqXH
-          /WydSApP6ksjBbgTOp+KroX4+/XJdde3lApnLwDlEFhECaWGjsx4tcDnNZg4Rg/THsfrmYHrrO+I
-          Re2zzXnmzgV+gSKi8R5HieG/Bzgzg0y057dXpoQzVdRnmYGNGLkhxwZPC3JF57gA7yCtzdsCoRbe
-          7kQyxbey+r5dwC0eYa0Kn/08KYPIeaG/YEXJ+Gy2nRcHNnsmFi3bbLFSXodX5OT4On+6ejpfdy/w
-          md3eHX3+2LPH+Figr3YdsTvclnq00p0KL0JBplvjbf8iYL896IxigTWlQIC2nSeh87eR8fkA3j37
-          BkqH5iA/4aiitCaM9ZkBJ1oEy6yMAB3ZooJnR8qIpCVvQMHUp+D3vMbzGmf9XnZfcAT91QXe/pst
-          rN56kBukFevWUILZSD4zLNhoJKkOaNYS+2CBXfWFRFF9hXLnz0sCYqzXWwUQ0jnrYgf24GW6czU2
-          /R8fWXh571L75IR8H0ssNOxIdFeP1e0ZTWcPVrg+EafQ2noVnlwBQv/LuHx2UpXhDZQWIaMtSW60
-          XrjylA0Q20o5ObqoDKdCmBLRV+cH9q3FqnkZHUt44W0ZH/vFs/nffrf16RDHRcaBzzaN/cFjchpo
-          XE8wsyJY7AyB6Gv27SfzfNChgp4KDg5nLeOswZ1BrKDA5eOQB9NHjwtoNfUVu5t9Lok1xZABLUes
-          V24p/HkqdPH8fcnufryWytw9cg+clCCZmCAVbRqkIoTZHpbEGkK151/gOaNvvP3rV9dagC7rwQXi
-          dqV7y2/hkCNTh7oq2tjgEQXE9qQUXK5jgq/DPNvzcKkmtGOJRELSLzZV36yAIt/7Eu+X/76GVUKX
-          GVVslOMOzPnaFeJyTi8Yk5dqL+P1DMWNDxLtAjh7/kzRpqmup+kXz9ZxfOVQ1K7OBITDOVxUc4hA
-          ezPoz3/s1qciB41vzuNAy4aQHqSvB2L0WYgRhzyln8qewY6TRmwM+qFf5VxL4Y/f3D2BgG5qVA8s
-          WRW44ISk/o//pg65TEyozv1g3JnmF6+JQZZCWTb8Cjd7IjjASjjsHo4IU083iJkfBXvjawkk5S6b
-          kF4YlDKd2YLRLyqipUuVzW/tGQGerRqs3fxHTXu7d4DzmJ8428sBWIpPMUDk72N8rk+B/ec/Rqqc
-          iXPPVnvdOUcIKdLxhl/d7U6fkcODK+T47FwZMF/OIwvecO6mWkdxzV06JoHVl+wInjzenqektUB6
-          ZCy3JY0RTkUglHDvt3CaZ+ak0IxKDdKu8QtLtXwE3BzpxZ+ekOjCANbWrSa4s9USO/3+APpKkWVo
-          744WNvfsrZ6NsZeR74Uy1sQ1Vmj7WBN4ZcoTcd9Pkw7H+JRDpRxY93DdNfUsylGF7kURYqtfaUjb
-          tG/gUdwqFJdbSZfbPXFA2p4FfN3w1dqeQgFl9KJj9bRTALvFa/C1Xk+y4e9+cSMLwg8jIHc2xbf9
-          3rNdCoEc36fL5g/Dh/Y5GKKH/8P79Sh40wpuKnPAGu/FYH29lQDhrI6m93Y+y75T5x8/cDkxeNk/
-          fAmYgm3IcQie4SxEQQQ/5BFOS2yp2R4cmwT++EbwbfeUWijOAWR9Mg1kYLPhLaUV9BfpRor7CWX0
-          2F27X/x3Wa/ywzYT5e7Hr/HpSQSb6E0JIc0PLnHV3UtZMjAKQDNEEavaaauAbPx8v6gNNr22CBfh
-          sm/gKwp44mZGCbb4r/7hCTNiWXt9kVaAwmRrE7dfQnsVPufgL36cvZqtVyasTCBFToeLKnoB2iyz
-          C7IPW2PHPB37ZXWlHImrSLHl7xY65oroQpF1SuJVyqwMj1YQwMaX8DF6QqUnu9YFck1qbBLfUab8
-          chQhOEoz8Wbmaw+JAj0o09OZnP1zb4+Z93Rg2vEBPr5m2V5JMaiQvYaaKyJxDtd+VwUo1MUVO0+o
-          2FMhNCm4gR1DTgVPwtVm5hamR2iRqNmdwnWO3ByqORyxAqZjtn+28ipu+gqOu5HtFx+3Lvgunw85
-          UrYM50NgMqhT2h5H2omvqVbXFXJ8HWPde18p5aK5QLWoHjc8YILRPb0jKC5vHSuMPwF68Y8J+tRJ
-          hq/gESrvz9YRZXCh4bYl/8rW28sKwIbPXOGlmtmWP9tD7VQpMeKW2kvYEh3uvSuexh8+PrBlBO5F
-          HpI8X7Kto2WBqDk14oZXRWVeDjQAc/oWiRRQQMeXO8zQEfoOWxzn0zWCrAPuGXvAvnF4bnqE+Kvw
-          V8StvpK9dkc6wYPkWBs+1+u9Lw4iHPRLNB1syIW0OHEm9KJPgfW6nGtaCUMEH+XrQzRgLNm4Pyzu
-          NrOC286rUmh3Zl/wnY4NVlJVy9jkULxEx8nmie48qabvbw+h+bayqSF1SfeLbUvwcnpn7t5+Tsqc
-          sHiGr7fk4kxbLMAv6+Kgp7GO2Kh6JRzO4sTAI0hndzDCiz0bd64BGx6axNg26j1jfAMQVxrGagEP
-          9rz5E6p7qGLLEN825SKhAF+Oy4gxpk29zIiIwBh03602freyMjvAo1PnEw0vlbJ8CC/AMquoW475
-          ly7T6ymhj/6yidKeVmXeu9cc7r7Ofdr574Gu+5lhRcY1MLYbpCtLawgtHDTlMwl57/akjyUO7lVu
-          mNZwzyqL8d0V4GxqEVEnTgErqUUB+oGQkxyQVz9teBCNEKnYMVDfb3jWhY/h+/jpBRmxpQxCV37Y
-          0468VGVfvrUYNpb4IepYcWA4BBKDGiF3cd4+5p5orRgDp8hZfIPjM+yvappAriMakbTxaNP2IaZQ
-          dy9fLN15MZtgebNAyOY3Epw+m35X3QbIOEtFcLk/2rw6ByXcVT0ksvewAJvtbjng6wWTzT+VYZQ+
-          BawklsfKs1F76qW6CIVizIjDu7Te8mGMNn2BYPki1LOLXgmSyOjgjf/0P70L9KmRYu2Pn4p+gjb9
-          w2ULeFNoRS8VUNuHhzWbO2U/veaHD92qTrc7wIPIQbPJTfLTN6evIVdwLuojdp+7bz2/1l0KhyRJ
-          sH9IcmU22twBl5xxiFvcu4y+ntcJzulHdOmljrJ5XwcT+umz2BdNhfJWwMJKNl/Efq5MTR+BlUJ2
-          uQN38Rm3JlnCVD9/+um12cA8i0BMBEHCFzLxdfc8BAXUiSFhbdfK4fD5njkYfroTljb+z//4nayD
-          ECvgpivzEfARrMRHPB3mnRPugY4cKO7LM5GujJLxw8nnkPRijtiuFi9ck5hs/M+ysWNbpF5vX19H
-          /m7qsVMiP+SFc+L98hE+Vbepn7Z1uKNZONEa5TaVx7sOfnhWEkoz48zzooLAxi4xVHnfU206WUCz
-          yginQP7Uq5B/Orjpp+5r4hS6DigRQJuRs/suL4VNi5fkgMCpwMRu+uv6078XnWex9H3jbGQ5sIp1
-          KyPy48+0fZ9cmKTSQPAlN0Lu+Z1k2IXqhdwv6rsesjdO4CVrH+S06cVL9T6ksELqjLUhmbI1LWiO
-          QLYAYn+CY8a+0EUWf3rrQ2zlvtW6dwN9XXemVddkOo8aFwD0wGASwVUGi3HoBQjANtdB/xY9sQxo
-          wTkDn4kTA9Xe7FlANA1Z9+kiKRufSRGL0aQLP/ycsSucJ5Rk8Y384tECsrmAZw627kc7fsLX93sQ
-          gKIIL/ywkpYuLJQb+JyNEjv3+Rx+h2ZN0aGIdfLj60O+VjnKKyd1GXWn2kvXuBHMmopzu8tzsb/x
-          4DUolvs30R9RCjY9ZAU/vQKjvV5zJuO8YP+tf3rDly7ZRZBB9GDAHz5bwecQwUrJfRLvjbze8GXx
-          439EMr2p/quv6Dvu6q5bvWnfNXoEnlf3Spxn4PTrD2/6YHm5h3Ftw0nFRQq0pPNdsMXDH74DZVZS
-          9z6dvZo8rr6LXIaoE6ubp3DToyYk83rk7oxSUthHOwtQiyWe2NrSAYqeMIVHYYlJ6u8WMKqJt6Lf
-          +ztNRl2vajQ6MFzYHQlW6ZnNDOdX8JAmOyKbyK43feUFNz2OnJNGBYs9lhDxX0mZmKunh/zpWr5Q
-          o/UUO+IcbHTobIJ5ZPpNf/v2M4FqB0+iv934Cz/hyh9sHQSiWmFVaC7h+NMv0W4XEGnMv2B5kA4C
-          +8VesHZf534VX1SACrnp2AqiUVl++PRK9AeW+A6AubIcHZY5W7r9qX2Hg2qcdBivXINtmA01HRnW
-          hH6xi7BJgFzzfWyyYPcRZiJrmRPym/6LLPOWTldxD+vOZkMJHE7fFuPT7Wp3SZO14By+eXJ2rgUd
-          /O/Fhbwl6FhjmJ4ux+Au/vG1XzyfT18zgE+Gri6z6WPE8McJXN4G46JTb9OF1csAPZNSxVrLYWW2
-          XMaB9dVv3M9z8OsVfJYYDcoouodr14fL2eYGcLgZwRbPX3SxSk2AYyk67kegUrjvhdmB+eQHxFWl
-          IKN600LIN+mX6OVDrtnn05tQpwcadpRlT8dHl5vCrz5SDxeDcgVCLtAPPkeMXTzWv/of2vbn7s5q
-          Bij82C6UCrQnp6HIQlrcqubnT1t9SKrH51omUDwF4ZYv+J7AIZDAkTtBYswBzsbNXuDNeIVb/o7s
-          bq+Jpmibsuay8E7AoAtSi354yIa6H7JnsWHgG64d1p5Mk9E93KY1IAdhJej7frWW+wvy1aOaQuux
-          p/PveTf/w3GX3LL9nq0S+HlNJtYtucvmLmI6uOtKi8QTDil9s8cGRiR5u4fm/QppfHq68KnfpXE5
-          3+81DS6DBZ/KvsHHWrzUn5tYztDV0wBb+XRR+E/wiP7eh6TeWHtpcMKBDZ/gY8Rdw9k1ZV0UZ/9G
-          8OE70+Gnh5U5V2J9w89UkNcOEFMPpp3OnbZ2M7P8D54fa1GZVVgnMIVCTLJat3v+yCIPdsi3SNxf
-          e3vZ4j3c+MTGt7162vAu2viZC4C4zSBYtRWiqJixpn61fhHK0AHfVLJdYc8e6tVk1BfY6nE4D2Mt
-          5Cc+gwB/e99lmB1R6NrILvxe02VaPbaxB3Y+TjCaVIGoB6+n9BJ7LniMOwc7w5GA2bgzL+hXsb7l
-          IxIOjyLzYEPPqbuLTDEcjlniQfW7ImzltwNYjsFFPCi+b2ElvMjKoibJDKCp7N3FMlhlNSzQiQ5/
-          RS5HXK1f1YfMwrsUXUkAtUmh1tli4EquHxfA2QCszMAV4o5hiAVko6bprJggeT/xtG765PDTQ//T
-          UfCv//qv/7E1CPzTtPfivTUGjMUy/vv/tAr8m//30KTv96+v4J9pSMvin//+TwfCP9++bb7j/xzb
-          V/EZ/vnv/xK5w+Gv2+CfsR3T9/+98q/t5/7Xv/43AAAA//8DAK1nVZXagQAA
+          H4sIAAAAAAAAA5y6S++CTPclOu9P8eSd0olclKr6z7jJXQoBEXsEqAioKFAFVZ3+7h1/T+ecnOSM
+          emIillx27b32WmvzP//bP//8Z6i6Wz3/57/++c+zneb//PffsWs5l//5r3/+x3/7559//vmff5//
+          n5W3V3W7Xtt387f878f2fb2t//mvf8T/58j/u+i//vmPmFkazlu54et52Gcw2QtNtFEOK+cAFQus
+          qtyj9aDNFVeS/QtdjvcN9i/B2K0wIi68B25Fw+mjdGQQjwWq+nmDq0j0zVGKvgOKikmh3k6T+JIT
+          UMD00CLsYAOPzDuaEF2v5oyjU9F3nCqvBDxiK8d5zISUOJNxgyWDD1zSRBj5ITNeqHsMNT74JDWX
+          4OnaaFO8euzc+L6SPy/VB8mbCtEuvAwjv3eLAW17dHGwZwXg0n2SgfGen3TvXceA7xSsgXvXWNg3
+          aWkuTLkIYH8CSjQvmy6Y3QGGwDaKJ00qG/FZfzYqSl/riTz7F+3Y8t3foLZ9femenlLO0oPOYOJj
+          MzqDDwR0+GoF0ufXjZqTmqQ83oUasNM0o37+TTjbIsmCj64j1CquOVieG5tAx01dAgLsjlLfxD3K
+          zOpB997WG1d70rbwTp4cH+y9C8SyP0ZgCdQ9NbZLZZKPK7yA+3pk+GA3TrUmQy0A/wBTWpq0DGb+
+          OuaI5uqRRkSLUwXbXQ5ZLGr03o9aKmrFDIFf9nd8vCg9l3fLSUZtY9T04BMerMZR2aJ22QXUvBVN
+          p5zhOQf16R7T8EIEwIH88IVrRN8RL8ACBv5RJwivzMbm7vEMlm69RIC4w54er7WdSrrc2ahgR59W
+          8wIA55+Hiz4DOtIguQTd/Hi/bHR5xwI1vEEyiTGVNjrD4kXveu50YhcSDQbuviRsom0g7T7TFxon
+          F+Iz0JJx8Z5PCIb81tL6XDxSMe6XGtn2x6XOPeq4eFmXGq3XZk/rXvZTvqvUBJ76rYlrzfCrQVGM
+          XFX3Tzl66yzp1n0GBZCQ3KUnScOjEvhXFU4gGfC5LG/VCtGowlI5WPgaXwhYx65T4V5bnvTe+u9x
+          UZKzD9hzk5DxVczB8q1VAovqWdE600ewkkQRILFhQK/Uybr1vU8s6BFnJfAIjh0/S28COSqONND7
+          OZgsebOolbfO9PDOnFSmC7Lh2SkZPQhYC+Q4uyfq8aFU2BPZN1hfyZojCVWAhtyPzfUrvixoNvId
+          31zXGZev2LeIfC8dvVSrYq5NqglIuexvOJ+oW60nWIdgTr9HGtIn6dbnt/Ph1Y4e1BHvakA68WGg
+          Z7yecfKel3FJs7CFihLbuNauLpDafNxCtZBD7Pedmi7SaRTh1VErmid1Axaj0GxUfQaM75Wsj/yD
+          3wuySkvG6UHQOnIcxwjumHvDyUn0UnneWwZ8Kte/fHqlotiZFjpaeYNDpQB8JsroAleUyugtWmBk
+          D8lW4T7DiLrEfgQssj8MhI67kv4cGKZCRDNHr882xkmxNCOX5S0Dj3zXYmO7gIAXxsNFahhp2D69
+          Oi4qegbhM/hakfzSTCAd7CaCzsVTqHf5PEf2NSIBLEezIAmpT+baXLYv+DTuR/qHf5Ksxi/UABTj
+          /fO7rWiTFwxa8mzgbN8K5udgDxH6vMohWnvxZLLoITeIJ7WG82KxgWR+TBEqorlQZ7g9ApJ5kgU3
+          Cr+QreqowUfjmg/nPFIJ2uuaOe+K9gZPqn7C/n2yAtnIhgQcdo2BYyyjkR2eQQgfqyRS/OJHzs+x
+          ViB/vEb0gES9U/7q825+Wnzq0DPgGh1y+O2WPT7Pp3Og6L7kori/C2SRnUOniHNoQSPYX8hOIbpJ
+          b3tYQ3X/lqM/PFKqhkH47vVzBIyDUnHrwEIgDckHuzI6m3LMEhleP58dPRQhNGd9ihuYRNcX1bTd
+          3C2dkdZwLd5S1Ex6Oi6hqYjor/5qAvuKYd8i8BCcSxyJNANc0YMCznmo4vO8nDr2MLQcAfq8YXvm
+          q8nPXswg3E4FLi5pGazKfSPA6i2c6OGwlYPpScIWzk1ypfoT83H9w5vjQ6poqcSOKbeg+P5b/5Xs
+          tWBl+FAA7bFfaS1nPFgSNkMoDfGH6kL8qribJSGyJNOl9q++5NN7OwChOji0frNHymu8XeCndff0
+          uPWndHV3coH2pexgp/q0KfcO3x7sxNnBByQ+RnaWiA+/RBLpoS+WinpmrEHnEiiRPCZFuj6uaavy
+          UZGoB1KjWzaviAHT6R18pN2l+uFFDH/9g0by2zQJiigBce5tca7sxmC2kWmjjRbBaFVgk0ob7WFA
+          ZrMrtmuBddPb5TW6L26M7wjmqVyNAfy3vxSPYzsu6TMi6kNncYSQ+OgIO8k9+uEfkW7NKWXiK9lC
+          YJ8cegDESRc9sCdIP7WKg1MXjVMssQHCJluwSWUvlcYaJsBjoRIJtfMxp7cLamhpZkaDAA8j14ft
+          hPIN2Ear88zTpbo+elSk1onWm9yqZKJME0SnrMfBerqmMrPEAvq7NYtQuliV+P4qItoo6wUn21Pd
+          see3n+CwmXbRSlRscmXx/L944dwYA3PaLsmEKo/PRFpYx1fbORFUI3GL8x9e8IsdWvDW32bqRv1p
+          lKTEqJGlzxE2NuoVLJtJKEB9usa03koBlxm2ISpf2QnX0+fcicPq9VB9uwn9nQ/IJpU02B26nECl
+          qPj6uprbv/6JPQBDTmu8MBTxj0ev2VsdqeYkEXoq9z3dC4YG2Jh0CfwsdUBPJsMpC6FkAPIKNOxY
+          6ZguLVYJuPX1jC9HI+HiYz+4UHC/f3yGVVM4dBryzskTY31zBHxehmI3chIQtEldIHtn/kKt5qn/
+          1s/yFhoZtdF1Q3VNkwLeC5KLaNEHeK9VO/7l7jmDAhoS6t6WD1he27sFQmGOaFm0j0qxd2MCQ8df
+          sVF3M/ik42YLxYWEWP9OZiqrzkcG77GNaWAMJ8Dr0sxgjsUM33f7pmI2YzYQJkemfiNsORlF+oUa
+          eTh4f63DUdz4zED/7o8o7bu/54FbQeyoOZ8Wzu+iGoLjaEQ0KpBtzv7z3aIfn8F/9cl2y1WGD6C9
+          qVYKH/NTHiIZPmyD0ygFYsfasNxCJRMBrQ/zk091vgqofzcbah+GKiVnIjQgiTUT1/4addNJ6gwU
+          KluDwHPxqFYbBTbIutik10d0SDlTxwz2e0eMGPLagN69c4FAWYdYi3HPGRdCAk+l3GCssrRaLodD
+          DO30mFH9EDOTaLs1h1tthKTcmGK1umdmoF9/inCTXKr1vn5L8KYLp+ESXQIuo6ZE8vGhk2+nUr7k
+          1zWEKylE6hvjsZL2bNvCJLq/sHfugnQ67q49PN9ZSbUuFAEDR1jAm6Ln+I8vrJV9DuGPX2H7pXVA
+          SoZMQEL3WrAblMk4CcUx+cODiHnDKVBuufyF27wG1MlDNq6dFw5gHzY6EStxqgZycV24ab8ONkFU
+          BFxZdBeaxqhEizWVYFHrQITL0BxpkqZxt85z0cMkeU0/PLZT+Y/PGyt3KdbAx1wuh328i2WtJJ9E
+          fZjkfT3UcG7iK9mVVm8uBIQNzMiZRdI8NIB9FDEDzVHb0F9/NeXfdxhXlkuelgbSBViJhlrny6ln
+          9h9AN+ZWhr98Jc9rHXbrpihl2JuViqMUZJ3041+wPcEdxmxjB5IkRuIf3hPyPgZAgXTXgu91s6eW
+          nXfdJAXHGFHeXGm8YZ+ABex7gyskKvaD2RjltX6FcOhsEm21MarEWYcR/FZljc1jZwRzci4ZqK3+
+          EcFD8k7lbdtkkI+SFG2C7yEVjzdXBD+8ijb9qFXKlk8WvBbcJ+t+21VcLlAIN7eHjuvH9E6Znckt
+          9MP4Ek2BpFQzc08LfNyKikjYvwXrUk9fUG63Ai6c8AVmpNsqbHjtU3rpMs737T0DVV7tqN+conG4
+          rNsaXsJ8ojhT/XEhF80FZ9PF0bLudCBbx+oFD7S+030JOOCspkz9mqAj8o9frlqUCbDnSU0k/8HB
+          d4uQDZwkH6k9+y/wjkythLZweEbrbb+MrBPAC8zp8Me3D6bkaVoI//DYEa1qXHrQLfAT1DlORetU
+          MTuyVahuTT3awadSsQbIDUIPuFDrHBiBItaeCoUQ6NSlvsef09uWwQ+vI+G3n+IrdH34af09aezN
+          e2Txzq/h7PWEqLVjcCY8+b/xouV5v1b0jx889CUm7HL58j8+AcVlCnH605usaR4LKolSkd/5+Wzc
+          1gQtQ3ukwXBzKiqjplCl5Pqlxl01Kz4HKIRRaI8EqGcykgGTCPg7nv36I0qXR95m6HkLZ1r4+Qew
+          bdvkaMjrNoKfe9bNDh1FiGttpftVnrolymofPnf+BkdotQO5f3sMVAfNpKemMIFUbWgLv0QRo90N
+          qAFtU8uG752cU6vtFjCvfHmh587dkPjTqHzh98EFB8Se+HAyLuYaj4/hb7+xKfBLx5evYyAhhz2O
+          9fbMV7cNe3COsIDNa18FK39dcmhvdnd8q/bKyJ+57qIhQgOJD2QKuO4jXzWdl0O4zqaK12WQA44P
+          nwjd8xtgcmJp8OAuK/7xbZPr1qGF9sdKcanE74Bje8zhzt3aOIBbp1oyWH7/9pvA3Lumv/6s7qKs
+          zrCBPCNQNk8Uwe5kxNjbfy2TK2o6QdP4KFTv2qbiESyIOmrFEaca6Tp+il8xlM0Q4OCwPCqapkyA
+          YcoQ9TsVg5UraYteZtjiaJvJ6ZupXf5XP5G4m6RqleZzCGF4+OLDfb2m0xt3NlysKox2+vFqcuex
+          3v7qlWp6q3B+v2oluqz5g/q/fPuqzkOEMrwn9BAGXfDzOxbkdYZB0I+fk1F8f+E5MwTqo03QyTm8
+          MvV9mo84wvMAmJCtN5i75wprXqNVTOFtg5QND7F+3MGUd9/YQAhqCb3sv1YwRVnmwpyaXiTxbtM9
+          hbt/g7pwPRAhXFf+/ekhmOsNpgnT5W5e6n5Av3wl283G/T96vHL3HMeR549//RHiCTRkFeJXytPb
+          oYUAZICIt9Pe5MKxsKD6vBVU83vPXOS7UIKJ7aVoM+pofB8fSQgCu2qiDYJytQSykQDBzwvs5BLk
+          lL4mG7Tw+yaPtXrztU/PEfr1V+yLWWyyqllLJG8jGqkv+W2ydxgksLvEHFsZHs1POipb+PNTCH+2
+          XbfW280WGuGa4kvD3XFVpl0GXtXLJ+Cw6JVkO9cJustLIWL33o1LcDxbcPZeJFq2B4dP/k3O4TZV
+          E+qr0tD98nH4iz+1x2Rbcf8such4mSNZguHIFzgNLpy1C6CaQJr033y7FquPfXBjYL55WYw+/UTw
+          vZ4VPq8npEHLCx18XtSi4wMwengmVkNNXvlcPEmjAUntXMn8p99UbfnC4lFUOB0mu1NeXxLDvXmO
+          aPjTRxNfvhn84TXWHvM8to5zTqCvtQiHWe1XIjhlIdAlwaHOj8mt5DUI6sWSOPb5uO/kwJwmMMX5
+          GZufhaaEvtoGjWPW4sJ87yvx2a0Q3XL/jfdUuJksuQUCxPHxRN3ufQf/xs9+vEvqAThxdu5H4c+f
+          iJB8VMYlGeUcGajtsS0MdFy5/vLB41ZWVPeuPefDVyvBV89U6j2/t5FZx6oH/fpqiZzjyOSk0110
+          Ywunxof7gPvSdkKZ6DOy5omZiiCaetBhHJNOZ1M6e9PZha/ptsP2JXhWS3O9wH/1mfvTp0wOshIa
+          4mnF+6YwuYyqjw2lZl2oy7kYTCs2RfjeiTktjs0E2H73IEg/KgbZeGwT0FlVBRiQ1aUW2LTmUvbH
+          EP38YOqqjvrzh4gN6m7N/+Xj1K7eBNa3wcS5mZ2quepLBs/tycLlYlvVqnHNRbtzGNKfnwx4etu3
+          0GzbC9kWeK0+jzex/sV3N/EUk4PPe4E/fKUaQf4o61yfoEGjG9WualNJKaOtSrr+HDF18KpV0t0E
+          /vw3ItmpG9DD01rgq+p9Wkg7kv70gg3XbX2mt4cIzVVtJQ3NQt/igvMsWDLTz+AOzwk2Gpemq3h/
+          TGjw5z2Zr5reSWOgWlBIiI7353UBVLXcG0iSfoo2+ubI+Q7J33/rUd9k2Jz8IiJ//AuHP/9QWdBi
+          IOh3Cw7VVuB07c4lZOx9I5v2aQd/ehnRZ3SO5rOwBNx89pq69WRKzaPbjTzPtxpk3tmm+Ic35AvO
+          iUq29EOKRraCVS/eLXQvwCUMN2a6etPZh9v8BrClOin4+ZNQ7Z7bDS7Gp5vyu/e7vpCr2BgTZkrK
+          tOYIgBxg07VZ+sef4a//UcsDe1Nxn1mhyvCa0P0QrMHKZk1Au++nx/ufnv3e9uoWHKw2wq6cTXxy
+          p+sL9r5hkd3ls+9Efm9c2JL8gX/P05H4UXxhYF8a6g9QrxYluftgf9op2M91dxSRvs/gKJV7bLKz
+          ESjZ+arCTKdv/KfP5g2nL9ht4APvNXmbLs55uYHf9aJ1PB3GdUw+07980VS0KWWKNTHVcJsF//j9
+          yJfTQ4U3ocG0+r4KztaaRDC3rC21vx9i/v1f3UjR8vPvOZiHeQihyS8uteLvp1tOfSPDX3+L2EZF
+          YPWf7wYFr9ig99/+rH/rB5/u/9aPP7+/hKVxiIn6qtyOH7zFQA/3XRMlD5ORrUGvoaggCrYibwGT
+          Lj9atDv4H8Luqpkuf3rpSnqPrFRQAP3jI8nnssWH724AS4sZQVbFlkjMtlLFp6SX1UXzP9i8bHYj
+          ucWH2y7K3QinjGmddBim/s+fx3bYJyM/xoUBJzsRqQONPvjp3wHewWGD9VX7pPP5HLjQ7wcD19aY
+          jezn50LnznSKv0VaMfVDQnBVNpuId7rPF+n10kC7LSyc8F3Pf/5UCb/iV/zFwxt5ZqeTqmswpTnT
+          a75etp8vREy609+8JfiQhbcwn24N9RdKul/+G1BPW0j1cz4F7ECvC9gUfY+j16EzWQviL/zFj+q/
+          /rpkt7MFnak4UFMoQDCbhfeFxqW6R4zp8vg2qdCD3alJiIDWl7mKqnDbvfR2iIAxSICT/eEFzaKW
+          f/6zBugff2vNIo7gz28Zr9dXDBMVZjQFUWFO4a2ooYNiSHV5rtM1ekAIfald6R9ezHtTXYCG8yQa
+          3XTtmJDtauhNFwUfTzf0F58CQnzTaKRfzEB2Jv8GPz0hWLcfc7cmu7Ormo14x6E1it0UnhsZ7aXl
+          QrMjYekvXg2UpkdIDVKfAukVehNUnvRLVJQ/Us7qN4NHG3jYZjoE3KYFgcL9/iVSU3T8k9yMEqrR
+          8sFhtClTdrilPVSe8xf/4T/fPKUIfBP8ITDaqClv8pihv37qD/BR0UczZiAQe5eaebk1vzZTbfjn
+          //z8k46uilvCHJ1xtLtGTjAr0y6HTLXOOOvel3G5boubyvpjEW0y9dvN3tEoId2fpehjekHFPvOD
+          ISwjE++rnKXTHYAS/Pkvhi69+ZB6q4Cum3qLg3ct8X/9+xJc3/g4y69qnoVkgdwtr5FYXGXON/fD
+          C/LkpmFNu9FgCZ6apTqlslLH+Tac/fm1alVKWLt1fsenS3aDQCu/EZ+OrinWD6vdpWXgRZthF5rM
+          zeLvv/Mjf2Nm6RwfXjZUjCShPgZRRau8KWGjHnN6Pgov3utHIYM/PRF9oF/w+ahFIhC/IMSGbfKO
+          0GhLdu859KnWf3rOaLQQGEL3SVD97ALqVrqIjDd9/vzVpFOIGGTAhVlKUvO+qYidCS1Ar0MazXtd
+          C9bNsQuh95GiiN/rT8peHbLhKBV7fExXf5TED4zVPh9inKPeBqujERv+5q00jz3RXKNqnwNLpxHZ
+          Els3xXLUZOhLzRqJYGOYfOdvbchU+4yt0e865mbFF/pag7CbfSlfy0Mkwh8/I0I7PEb+m//CrlJq
+          7Eo7Uj3l1/sF74sf//z+c7XWYQNRXQsePrBJDhb36MrwjgsBn52vxmXzsy+gxLKQBsbhnC7ThRjA
+          aYaVXiSZAT5d6hoqor7Q3/6N7P4+ljB2FIYPpfVN2ZpUA4zapcQBCdR0XS1VBlu+d7DOXRWM4qu+
+          QW/zPZDlQEJT2n364d/56t0YoMne+jKBsKk8vD8YYSeftkyG2VOc8AFptTnsndoFTzAP1K2vV/Pn
+          v7vw0T1IxOsmqeQffkFls4Y4vJAbp6ql1bD7Bm00osfaLaVUlaCsY4ar+8cd2SbSRfg3D3Kf96ha
+          6cWbwOm+N7G2fBHn3qF9QdfJ79gAUxKwUN7//GqeUcPKm+7v+f/0GHYT7xyIv/mb+r1MLY2Wh2dK
+          4dMb4FZ9aWSTiEvFpIJ/0X/+3gr4X//9/+KNAun//42C/STaOLPlB+f1fVfDxVUDrJ/akbNrZk1w
+          dSyfFpB6QJ5rS0a2dYnxXR/uKZe6MobJQwtpqIt1wFwvFeFyWRE+P1w9Vd63t4vIWts0eOd3zp7g
+          2MPLCcuRCs1wlIzV6ZH+OXxwUEjflIHRUEEz3ENsv1rQsemn4Hv/seDCFHeAWbCwkdkZW5JoYs4Z
+          NwUDFsGxi1TLt4FCY8eAasMkHGgjBRx9Dircy9YBn02iBUsXfm5wZ2UnWq1D3H37NWboc6w8ajWq
+          kvLLauSgTFoTRzdEgyXl4gBn2FN6e/cfwOnaJPBbKFG0Ypx0axyrOUiLlmPPMVq+KOfpBqP5QiI5
+          M0i3tMYwIJrfGuw9Zx7M3fSBUM/cGee+b418m+gFel2f++hxcepxnd9LA15z0+FkX6vBuntlFpKM
+          LKWWQJ2Rno0qgYk5Xulhfd7N+aE4GvSI7FJdHMaKmkocoji4fXB0y7p0lbtjiLqrEFKNbC1T+gxE
+          haLlZjR67DKTD7eTATz1VVPTSwlfwemUofBT7qlDtdFcgFQzGDdXiyZWMJqrseIeHoVXQw9b4HPx
+          uru50GhGGu38dzqSonVfyAcnH1evWQzWWNtPiDyaAYd2vUmHLhdL5LR1QKONrZtSsvmUsLiuC63M
+          4RrIvucRmJifK8nBsprrrtZ9dKx9KfpsupHzR9tGqCw9QtNwe+94mRsLqtZHEl3SKKpkwTuUcNAI
+          ovur5AT0MB1seIZCQ89Xz+MKE0cXzqqmYYuGb64spSOij2nb+KANt1Tmu9EAXyP4Mb6KjZ9drbtQ
+          vBYltb8PbpIrDWPoBMqJ2mkZBErjiOzfeF9u3hfw/FrK6t4vKnwMYhAs+pltofExTHqqHGEciR2F
+          8Ns6Jxyw0TTZ8gQtHMzjRC/tSgLqF6cehp9iT9Pd2+QiwlsfJq+9S2NHlDpef60S8rm7RdxLI7Am
+          nlgilacGkZj2DcameBRwj69nmtWJaPJTmmjIsPsC76PESTnQti20znDBodb23dQ3UgQTyO64gPTD
+          F6EPVBhf+ESd4vHqFrsXXoBgC+Ls/hmC5Z6uLRCMHSBoPhvjai3oBg/O8MKauOYj/2S+DaOvuInE
+          szFXXJ5TC1ZmvGIbOPvq3/pMh/qIj/Nkp+KVmiGIE1+nOSyyUVpFGKqVILRYx9tbyk6OUqBGxA0O
+          2QrBGrSnHF122Q0fY3UY+fmqTegvf8/nO0xZarUFmLeXJ8Uw2pvyxfE0uBo7jXph4o3s1SQahOAu
+          EWmcY7CO7PSCxvhi1IHYSyWSrws4D9IWa0czBWurY1V96MOK9eCrg7WvuhApDjxji3inVK7LpQWn
+          6arSU3ljYL191ggN8VDhpPzSbmI70UaSoFk0P6XXkVX0VkLXuT2p/YmtQFq+oITndIE4LtOyYkRW
+          EzhsDz12shabkxWLAkTzrsGnDR5MvgtOPUpHXcNXJ7dHkUd4C16f84XqGLNuiUE4QRipR7qnk5ty
+          L6oXoGf+TBDqooBM9Q2CpSoLMtfeHPybD2E7hPgq9fkoD19tgou7DaLlNJ5NXoB3AfFWqKmP7aDj
+          9lImgF6jC84/cf9zUJsbquVyiD5neR1ZcUwhHGU4UrxCMeVyp7l/90sDO3+O7Hj6uNCd6g0uIvs7
+          rscNaKGRZBM9hsm+kvswLtC0bBryrB77VJGTqoGqUof0DqOnuT6PcQIXeBgILJJtyt7fREQQ2THW
+          lw8HS1V5PfrMQR1BeckqaijfHGZgDsmOPyH49l/FgvvcpfgaCB6XMyS34H40nYjVwlqxQ35u4Gg9
+          NBy36snk7dRp8LELCmwr7gH87q9Eh413oEaDBrCy7yeBVtndqWsGkbn67fuGohMzcWbXVcB20lsA
+          +9yn1LENHciNAUTUq+WEw2x+j2sFDAuZTMhpmF+enG1cnkCY3ysaNkcM5J30hnBx0gU7P/yS2U5y
+          ETsvOdbD5Fnx1Osy6CfBC0ejV3ZT+3AykN3hlprCloEFlab9hwf4tAWvbhnEpIf1x9xRR35WfHH6
+          qZZ2u/iAz/LGGKU/vOYP8qEHMXVGXoSZBZJhVLC2eLyaT29ZRqJyXXEqPnecwTL0gVMtnN7adsPX
+          7CprSN/sNHxdN3suEj0MIccJwnrr2aPkt+8a5p0RRVCsGVg/VOvR55G/acjc1Zx3r9pSc9Ne6H7X
+          s5QUrfb6N38Ozbqk66u62H/5Ey0RTcx1rwoJ+MMr3TQdk0X5oYDNkUvURGE2Ltbj0SM/zxZ6Ab2Y
+          zs9sU8BLOzrUMLv3yJTHK0fK5iZE2zfsUsWLagZOxD5hLz7qgYhXc4vcZvDx9XaNuvXgBAPcg8CL
+          OBVuXPaJYaNfP8UGoq/x+cMv2AoaweZR/XRSjU9b+Dm90kh5Lv3YSufNANmZ5TTc+w5g5Lhu0cXe
+          clpphmWKv/yFvil39HZV6467nzqD+bHiWDtYdSo7/dyAs2sM1MyioBIXTbVB+DBX6vjxLaWHaW+D
+          BC537IDDxuT3z+DD+dyfqHU9vcZJP6sqBL83kIxj+TG5Umc5JEP8oGkkWOPC6cMHHRPeZBv4z478
+          8hGt0DBwbHR2J6+ZyOBLZl+6b6/famXfR4wsuPGj3ftyrJj5aL/wsstv1B16G7A2/DbAzsGVBrEC
+          qlUN6hYO0iDh8PwV+XQIrwP83X+03TqvjjXbRobmOzKiZXfZAR4clgaa79Cg17RNAglZ1g3++kMk
+          HMkaTONcD7C1GwdnVtukPOCBAR+lfMJGYmaAd8fuBrsrDPGt+Bw6thGaBDLIFmyn5RisXPzaYFXE
+          LS7yVBiZMmjGv/Xn7+VnMBmQxzDOyILDz0NOl7HzJthMQ06Dyy0PxqeWvFAPUUWtaftK6bDLXlA6
+          XzD1pJiB9c6ZgVBVpdQ+pahbVp9toTXrEy2WteQE7LcFNFjs06TUO7C60VNUhU+z4MreHFO+fOEN
+          /uVHbipBJbvklUNN2obU+vb9uL79JANyatzJamhZx1+VqyG+mBP2+LlJ+bMqfXDupjIS9PbZsV/+
+          QGRnZxqFZpXycTAJTG3thX/8YmSD+6tPqa2wNvgV4GcjjYE1mxN11mwCq67wAs5fq8U1KJSRDreT
+          BoVEuZBZEK/Bkog2Qz8+iMNJMcw1eqwWms+vE/1NxDk36u8CT861wVZqSmApj+4C//izY5ImUH7x
+          QwcJONjwrWu6xCc1An/96W5/vUo5euinAKlK7eeOAi7cVAGI/abHFuBtR3bjVQMfNzAiZL1PYLXV
+          yYWHc29R70Gqbn0oWIM6oDI13rvDyH54Dtubx/7wopN2p3f9L9/ziptkMsE7FJCUUkzDfseDhWeP
+          F9ps0i15AWefKn5x7aHMJUo+LDsAtpf6GP3iQUOoVSY7WrCFZ1O5RWB53kz2dU8Z+qtvJ8Inztw+
+          LZFvih02dk6XrpqrRnCdrB6fceKmSrHWN6CUtx77qxsHSvHWG7ANVYz3zwuu/vAUMDsA1LXqa7UE
+          2xT+5StZd3HU/fhQ+ccn8f1z2o3LqykgOE13lVrZXgu46E4yvE8SJGL1XbrlfwMAAP//pF1Lt7Iw
+          EvxBLkRAkiyRl7wkCIi4AwUEROSRAPn1c7jfLGc3y3u8RyVJV1dVd9rsE1XIaHlA5jy4srkPvh58
+          NT8L6x4I1bWKUS69259D2PGCnC2efHRsZ5mGpg+z2SSTDy29a3C6lx9gqq99At7XFmNXzOyQfeyp
+          kja8wEbTlYA4oi3B+vOOcfLoA8C6/KVAA1UBLV7Lks3rkdOQsH/uaME3wvBLAIlgpLkfj29hla0w
+          1WzIUemLL4cmrul9Ic0ff6f4CAYwaxmWACvcjJ6i4pHNoQd9+J1Zgc/pRWOsHn0RZjJRqHuLw3DL
+          XwoMnXOF1cgbQrbv2Ar9F+Sp/tUvNdcHXxdAezpjpXsvzppbywozW+7x42WIGcGO9ITELS/UHN6c
+          M2afqEQeVSwq41UbuDPZp7C6+DI1H33A2GXUtX/85qF0T3XRT76CPmI7YJefo7DT/Z6D+xLy9Hw/
+          quoCb44HHgr9ESIXzFlltXSREsQjNn5+o9ItX4BV/LbYtM+h2kkHIkpPT5KxnMUja4b6RFCR3imV
+          t3hffl0rHXPl2FPtA9/ZgqKjBhNgFvhVEzTM0vskA9MfR6rsT7nKZfLThCLQPHrV967D39j1CQs9
+          YN5RAuaw8ckSPobjBV/OcVt3CmQB2s9StJ0f5sx0vlfA/7qI5kh+OivlOxPkfgTo+SQLbOojS4ZX
+          q++wfOAslaFIspFetzIRR0uo10tclMAvC43szd2gEie0S2jeWEfm989QScTqFv3xud0k1CpTWkQk
+          veshViT2rtn5JrfwE1syLo5B6UwvTeTAxm/J5xwrGd+brxjSDk5EOILzwOjS+bCdqhqrZq+q5cV9
+          9X/5i5p71QmXdDkFEO/HGzaePytbd5aewkcUadiUMtMhiFta5Fr5d+PPQz398hDCN9ZO1NAKApai
+          vqTAmvBEFaMY6/na6xCm92bvrcJzyphs/kwoZjjAW7yqhza7Gn/fh4x9Y7I5VwsFDjhX6SPJD84E
+          HDtFGz8g6zX9OXP0+xHICcWC3UIuB3o8KR3kReXoNdbmCH5x5sPDkZOwtzlkq2QoFfrgovMArC/q
+          9KdPNv7rLS64OgcCNR8CApkHPCRn83e37+DBMlwisI5ki5WQHi63x4XaiPZszCOnk0ox6fEzms4D
+          v9g/HsB9t8fW/aKD5WobJTRO/Bu7IBHqFehiCgUQcvTy4io2V0rZg6MW3zz4rnaMPEYrBaGhtN4u
+          6mP1Iz7DABnzWaHm4/R1xo3PwuiVWhvfyLJ59xDhP//H1J4oI6/IHaHyMD5k2QEtIx9OkCCvnk8Y
+          Xz8fRqbxmEPBuENyeFom41DqaEAz1eAvX2bkj4+PH7vHbnMMHX4IYhuI82XCjnL3HGFa1gQeAQfp
+          9W1Eaj8GmoJ2weGB0/tkhDxTeQWJhhnjS3cTh776VgZ8eqJMH9GxyX5I057wY8c21uS6Awwd1xLF
+          YxDhjY/XLMM5lDxpfVE14cmwaE6/gwj4GDsUScOyZ5cOJvg50efOkJ1DY/MtpPboYo03RzbbYdjA
+          eRI/NOdY58xMhRBW3Nrhyy8ZVIp9lsL8rHFeZ2YcY1cLPSFunxgXz7IK6aY3gHl+frBPxMZZ1gfX
+          wfwuB9RPQymbk3NgwBDVFwLSt1nzYzX3oHKGj8crzqQu32gKJBQYA1aHWQnnlttxsBqqt1dXxkH9
+          qkLiwffroWEP3v1wDX/9DFf2NPHpow/DYidRCRc5vnp18yDh2AK/RFhTGkKV4coODrMgDLv8SlL9
+          mYdz29ciQhMosaXH2sCfIIz+1tcDavdSibyyCvlN53lLalNnkc3Vg8QGK5lmyELWr3kPh4k03l74
+          2o7A1WMKQXG64ZMVyxkXV8MKLrf9jxzM71LPrmjxQLi6OTZsuxnmG6sqGJz5r9flQazOu/Duw8Wb
+          DthLflO9/vkT+5EN1OCYygQ/5TxQFhedeoqzhGztEw8sbCDYxaqkbvxURlt8kF3U884bG8cKEre6
+          UHeLj7Vyqwr+8ZPDVRAdatyCEca3BtH4/Hw6y0ubebS2+oM68yd3mDrvKvjnl2jJVGd//AzQbjd5
+          byzuQnYLUwV6zdmgVrUQdZ7nSwqz65fDm98wLOiXQ/jzRICDS3Yd5gih5z98u0juA/zDQ3feGspu
+          l87550eUBdap0zzW+s8fBKmurVS9HU8Ox1QOwtYsLZp66tFZ4/MnANlnfHqLFZfhuvmLf/ji3TZ/
+          j+3zkoN39ZDTTU/Xy0EQjD/8o/ow+Yx7340S7R2Y4b//59eo6uHiWga2ouJVCw/w8mEHE0I91VPZ
+          4qCnBN6vTMO6s9Prxbu6//WLdQ5ildeHRyy0s7x4dau7NQ1fewPQl/vAQVMdayYK1gqDM/fFsZkb
+          oTBcXBM6/C6lrpj1GctwvIM43ClYF0E7rCLMVngEPPR27fsezjbJTOCS4uRxxjNTF1uTV2R1Bvba
+          0f2pbOgcAk+nvqSa7rjO+mqWGHy47I3lsVFqIr6friSxq4Jjf0g3Ppjt4O6Ye0Qi7qAK4d6PYQuE
+          FnsVNGoWfQURJm/pgbGLlPqQls8OHrLmgWWHXRzukPsB8s/XwgO1qYZr15sjzH9lgbPvbNSL1Fo7
+          eFGLJ/bSm8O4YWf58Ep+Ct72nxFHuUlw1uiJysWtydiml45vY5rwiYcuEEzJhFAaPz01ZcEdDg/9
+          64JjMCTYTYIkHOlcVMBveo+sav2t2V2UA5groCeg17pwrGOYQvMo+WT/uz3qlc5eDqT0/MLnBSXD
+          XL06F/K3r0c4i9Fwlt6WAoV6HOgfX1y/O9L++W/02Tcm6Ld6x59+8li99ICyx9DCY9XyePO/huWd
+          lBECoVtSNbkogNegbwBjkHUa/8X7mQgptMP1RB0XiyorJuzDzf+nWpD2zlJOnvsP37Z8A/75rwg3
+          L3r+zNrArod3hza/CGu6MzrdmQgJPBCtxeZFFR3WftId1Eh/pppl1wP75l8b+ll6xpfvdFBX3fB3
+          8OKLE86+8R5MRtG0cDn4Fo62+F42/YyuVtfRtOoqRqVWlf/xM3zqioz+1SOmOvrRy4gAoJAeCTSZ
+          faebHss2PWdAqZwP+PQhQsgS5WTDo+w4HvRSEv7yh9uAKHh31Bae13o5PPwEnlB0pffhxGrW2acA
+          9oolUP1xUdmf/y99OfjDp1k2Ve44EA08DlZET2T3AqtmDBq8BbFClHhInBEYVg6rhxJ5H10p2bLV
+          M8CZ3RER84BX1+DHSX/+Hd30kjrD/auF2/sRIaqoyk7BDwKzCw8euU3mwO04sYJJbOo0/hwx2/x6
+          CfmTGGGLoGNNd8cyQRayHJoMb05tzSZLIbfndI/dijRc3WBOkJeCNz3dvV799V00Q/8cFt5eJVp4
+          cLxTg75WIGBPca4hY5MQgT1JDXp+m++MJd9TBaqdQrw1myr1zy+Q8jJ44E3f1zRqkhW+H1iidjA8
+          s9kSWw2wwsuwfB33w7/9Ah8yYZc5ai2wR93CwRxtjze1/TCnfOhLVeVntBjVyhl78xnA4y+iWLbP
+          hLFNXwoRoC5WfUFQ15S3vX/+xBb/6mHhOA951/boQaReavrs3VQy1TDDl8KQsvmW9BD6Xw9Rmyua
+          rPuUgwERbl9e28Iq/BdfXxJePeF+VJ3FqV4xkITc9fZ+xcL+eRAN8Kcf4FYfoivu139+i3qVrHo5
+          fb35z9/xWMKTejwfrgbyXzueiAemscOe6T0Uu+aEc19Z2ezfVhf+TEvBf/z88Lkm/pFT3keKVaJl
+          nPd1tH/80HsEx3BdIrjC4r7IWAmNb9b3D2sHNv2G/V2mMiEr1QYYx9vW/50dADlBGMNTPD2pvSwA
+          LC/srNByk5c3X9WQzS9b4dELRCXV1bvNGCjuLij3dk2Wza+dWrvJwXLLLvRv/Yly/3GSzhsXsqs/
+          azb95Z8gtnpv+iWDM3/KWkN//q45vCOVj7zaA1u9Ehtm3mYzdpYE5FAZiYCDLpubErlwJEVApJMw
+          1WxctxudcZhiOZ3eDmdajfhXb8OWsFeHw6t3YqgMzUqTnSyC/tSVLfrzi02Nb9R/9bPNL8FGcjLU
+          5YlvEtw+z5s3fTaZ3sSBKndWrN1irPJHaHUQ1uL4V48YmFyXBKCEaza+V4XTrDMZFOdDRQRwKbb6
+          w1yiPpwDrIJQcQS57kZpp1Ux4S+GVR/EwIzga368KLZ/MuMqlzVoErMP1bZ61J9/Dn+qZtBo48vz
+          dyf0//DGmjtcs+9H5tBtbmt80veuytzx7sHBJDY+OX7mTHzQNED7JCePPo2snluQlDCInR579Wfd
+          bvRpPCwgS7HLn7uafeS0Aa+y2HtHdi+z9dx8Ktg2wYt6YiKyJWx+POTw3vrnL85NXPnoMg4y1rRK
+          Dse4GmZ4HY0Qm+/uBGYvjnOIhmghlczFYJYvqwb3Z3bF3sYHWHXuOzjpmonl3pcZ55e6CQ8w+3mH
+          PTZVJpyICHR+v//HX3i0dyuYdaFDZtUNMmGPcAUvvXal9z+/aWfpCYyX+5U6uB2dhRoXG/4fHQX8
+          /+4okMXkil/noGOz0JUN+t1+N48Ht6gWXstpd8xvQKOK/D07vM+HBuLYSPCjDe4he5xmDjW6wHmS
+          9igdNjw8E7DHJ8SvbmlCNt2rGY2S+iDcaZ4Ya3RXg48mHbByUM8OdzonTzTUsezN+llh/FwlpXSY
+          DypZdie+XoT8PsND6ou48G9KJuTymqI54h5UN+ZTuPgoMqComaOX3bkk4zJb9IB9m3Vq6r8+m87W
+          EqAuEBX88AN5mMXoosDvc5zoMyqcYVnNNUbzem+owqjG+J++q8By3RHspGkHRk7+SpKVvgT6mIRf
+          tmgfM4YpEE/YMVitzjWpekj3jY9fHEtUdtGvBpqK8O0thC4h/f64vx6cJ5bF44nNl6Jx4ZyxB7a9
+          e60uvqhCZL+Rh89lQYf1k6GnlEa1hC1wGLMZJ+KIbo4TUTwjlI2naSTw5Ac5NSf+ntHLMMXgnueI
+          Kgs7DKNp8BB6dZRgh/ffNc2ubxe9GiTSM1mZypw52e6EPCd8Ubovm/ncjKF83u4scle/Zuq6RmhJ
+          8UwvZ2gx7ipec8QpS0UTan7q1chHH8Yfn1KH9081F14CRXpy/A9ftv1ezMOrR+FblbAzpnuweNq5
+          Q8XjGWH/oz/ZclLuK3rmfu6heetRDrS0l47EN2hy832Hy+nbgEo6E2/WXid2eGmRDRZt33l8wT1D
+          xmQ5R+4hEOhd3gnhGmmlifY/HXlzcX4MHOPPLUSv+kqdMhnVscqlAPKCcqfZbyTqKpVZB4UQl/RU
+          vEZV+L2OEVKR42Dde0W14DuGDdAhy7Fz55JwdvSwATfuXlPNT1Z1qe5HH1qeT2jiX72Bl+C5R4Zq
+          HHGMwMchgZP14LBaOn4ef23Grrc2gaJ/O1A/TI1s+rxIBNUH1vH5gXNnDH+eAj3PwDR2LzFY8kn0
+          IJD7hjqlOtT9fndVYLb7RTTQ265ezj1KJI6PV2x+uHpYM83oEfV+GpZRrTAyWLUPuf5HaLEe3Xoq
+          mByhNvBe2IXKfVie3ECgWjdnHGEyMzYFQQ8T+k5wmFdKyMlQtGExywX1x95ja6tfW1S5RxcXkzQ4
+          a3kf1qOKLAd7QpXVo9B1LZSxq5Cq4mewBHzZIvk4htjw8naY4/CsQdlkZ+wI+2VYu6L3oDNnH6xJ
+          by+cKzsmsP4qX/q4y4HDJ0crAbNa3bHyWd6AnpLfiLr5ccFJIOfDfNsZFUKHR45fl487sGydItjv
+          V0pvyF9VJknxCqiRKNSCHFHXHR45sCOfkdrDd8iWVe1dED8xJTCuoUPDSFVglk4e9d4XLTzk0+zC
+          n6/c8enFv7J5eZ8NgMGdeQfu6g8M5NWMrgcj8fbStQiF7Pr2EFJ6hyqtUWXrzn4SSK+hhd1xXsOp
+          G0AMV+7uUN3KmbPqHpAglz8/NHOfOuBWu3YlXn2d8e1NH2wGL+vf697ujt8qefzQTrz9nk985aM6
+          ZOytbR1YQoVdeE8cntRAhPZdO1PTHGG9ZL3zhC8iC1TJ33O4vLSnCXTEz2SPh5PK9oKvgJufvchb
+          udRgNMu+AydHvuEnUG/gUH9/PRAPH0QdzzmA8XeXI/j5Epd6DxQwlsVLLNGht3E6BDZY+ieVoCxX
+          OslnznYE2Vwi+HCrnEjrfqfOt2/fQTl6OtRQGs4ZW64YARPEDD9nuQbbfnjHz/t6peE98IHwLjMT
+          dp61I/XKLJWDauzCThchTVZHYON54VOJ7lvfo85JVvmzKSeoz/gf1r8qAIyzuxFJwf1Jdv7PB8uY
+          aRWsu/jnzVcrHogA+hGO0XLFed0ewn/n89jWFpk4Jjrz/mxDyKHruuGZlo3hJZVhdfc9bL1RDAQP
+          LzGCWJPoBUdwoI9Xw8O9ut35v7VVve5T3UD1sRvwE0wx2M7jDJIniOjJa0SHKa8jhz42NfD5w64D
+          49poRG1dFfQSN0Rdn14rSscn1Ogrq/HAXRoYwVz7KFjf80ooGEFoIp/vTl6a9AZg6fRypeiKDBxz
+          QTXQByx7aDX8kUjpgwfLQEsD6C5osJYPt3qq7osP97nL01A8D+F8uooE2s5DxYVh78GK9lzyd76o
+          /FJ/KgGfYQaTlmT4tVuAs1KRS5GyduAvn9artndy+BBkStPk1obLm9xM9DmZCo42vJyb4u7C2440
+          WNbPChDCAzbhRbItbAu/vcP0bi/DNn0V1GDdO6T6WRIBitsrNSF7OjTQgh5111amm9NaL9eLW8Gv
+          +iPYusuB+oPwZsOfL9+3/KTXbHt/0O6yD7Xut3Vg65zICL2LhJ7YY82YK8sQmTbNqa6WGBwWtqzo
+          ENSAoEdQMM6aQwVeKY89uAvPGR/49YyC6/WN01TjMzJXfomq4u17u0e3hovmRD2K5sDzwJZvmW3A
+          J9Ry4+7xv7WoBS+9NhA4de+9Nz7zvsVWAqEYWtR8fPyBvZYTRFt+o2oGt5lQ2l4Da8zLNHLVpV7Y
+          b/eEwAQtNkRY14dbdi1BIhOX4iIwgKCfV1FyWq6k8rynWT3WJAECEWtvfLGpZu77YsCRGQ+Kk3vs
+          MNk8xjDJvgFVc6FizDQLHt6Hp0qvGx4s13b20DHrFQ/V5jYjprZyVP2kAPtnJwz5l6hA6VGYFfVo
+          +QXsXYYmkrGnYOvQPIf5WB9SUO6eBxrv+4NDnUPXQXlBMY0uvZwdPp3XAra8SqxbVlAvXq0+//YH
+          e4PzDdfACTt4/AoOVh91Cbb9U0S1ES365MktE8hzleCRtiZ2pI+izjtYdXDvNCsu1uNYz6FpSfCu
+          6RB7iVcBlj1POXDY6Yez1wrqcZHtHeT95wVf4iMZVtucIgkmwx7b75+ZccXns0K9qDtqZfuwnrza
+          ecIw4hYPwruoruTiy+jyLXV6gkE7TOIZSPCmSAF12VCrLHxkNjwbvUXN8qA4szZaMbzDWaf34kBC
+          duJuo5S+miONmigJZ7OsOlipkUmvs8qG/lT0BJg3rcQ3J62y6RJmBuQdV6PZcpUdnm8rD+BYH0jL
+          n9aBop1aQlcfJjKwflFZ6K0i+nKthE9Xu6tHW3ZyOGlp9seP6onb7SC4dueAzG5xq5f92zDg+eFf
+          sC+b74y6ccPBXTi22PGcG1iLi1oB9PNu1D5I1GGBVa1wBLcMB/OjVZlAH80/PMH+rcrm/bX2ULbf
+          x/isSMaw/uEzloXa2/j8QO2yM2F+KL0tf4nOejs8O8hScPPmUP8AfhdxOxS+TxI26doO499+3mIu
+          wd5ffjl+8gA6j0NKtUtfZmxAgQEua+biU/FyVer3JwjzSrSxr7JyYOv16cLYQF9P+OSLOuDmyP3h
+          I5Xd4jZQkPcrWBUdeVCvDMalbePCorllVIXLGC6762uEB7GV6enFo4zx8pTCjz0ZeMNzlXG636An
+          K7/U6FRaj9p9muEP4oKeo89rc+DTCtbmVGAlEi9sPNaHBGVepVPt3bb1yqpDjn5s9/J2sSTXc6qX
+          Ggzz7IC1NzirnN/9NPgW9wZW7I/tHHpDU4AVeAdssLAEQmHYJeyvRUd199E4rE21BuaI+fTklud6
+          uUuSDx7X+YuvhF6zg48iDbReEFPtsi/B0gipAklnSFhtHF0VklVO0ZM2JTYUzGqysyMCpIseYnN+
+          fhnrjlME6Adjssu/DKx4kDh4VL4qVbLrDrBT8h4RX5g2zkX3CcaNP0PnU+WbnjLZUqCy/YsHHB7e
+          EhvjUVphMHQVvoPh66zCc+t4ZoTQ6DRPYD3e2DYLRDvSGws8sB6XbwKdM45JRdMm2+IrAmb1GbBs
+          PetwHI1HCXcfuaMF8yZnduyawIdb5tQKhmVgSag10NV/ExH6V1APvfcR4d966LdEr2f5BWPg8/0J
+          47TTmXB+shReLA8R/uqK4fwsRCKKPeGxS2NlOHBJTyTeLQ18279PW77PZ7CWD53a/sxlbKzbrUMy
+          v/37/PHkli3CTFvI0VKwOt3gqwMwVE8Un8qcrTDyFdRP5oC15/fjkJ/OlzC72rZ3VB9uOEuXRwnY
+          NbpSZ5jzYVEWFcLzrrptw5jKoYA/R4at58c4090o/JWmKYKIQMeTzw7LpshfAvTH5/RhgoA9XiMH
+          4rZdqHrzymz+04+qi/dYLhZpYLum4ADPpSG100fMhK8pclC+cmeaPvfn7GDphgFV43Mia8dFzrPl
+          7iPsjfaNrU48s23/UvTKEkblV/IbZpTE5C9/0yLtPmC2DrUJl/HAUVcWdca+PwjBvaYGvvQHjjEx
+          3SmoBNyC3WrF6rI7vDu4dyWOABJTh1QLl8CCbBWnj0HYaJZVj5bzZ8SXuPFUdtRSG2586Y9vqKto
+          qAr8ddcHDpRBGMax0ks4mo1JjsS1gGCadx7+8jHCan/kh5EOdgL3RSV6UjCqNdmnFwMGR2ciXL2/
+          1+PmX0i61lfYXVIW5ldDreAfv73YfVb/btm1Qn98Rpk1fZgrOydSyH47avKHBCySkVRw+vU13fJP
+          ePjxWQvOjROR3jVYNj9lKP7hCbZGX6rZE+ktkO7PG3VO3Kn+93xbPqDRvauzZScdV7Rr454wuLjZ
+          5i/sYBq9JSzz4TX7y1+wGXRIbSt51+QqswSaFLX4YraOunrCLocEqrIn6OGdMW5oePjNZUr15bR3
+          lv75FaGbXBdPiN9jtt4iv0QGp+jUfkVfMBtGoKClaVfvZV77+l/8/V5JgJ/hoc/Yb3fIoWLlI/7j
+          X2txcUqoPLUZWz1Mwvk6HT2oFp1MY+6rqjTeuQq4Qa3E9n34qKMtMR+Iek6wQnUVzMPi79Cmh6l+
+          mwyV7I+yiC6ysyPSdj4nWP5MaJc/F18uH7f+x/8vInfGxkkK1T//BI7f7IZPcW4PYzbAGLiXpKfy
+          SVjCPz5x9B8doDfvxdWTHIMIqrvigr3denEOBTMjiJ9liy/H18M5rKYUg5rhmdq/ATr92+ls9Hfe
+          krjf1yvStRbdNC/CVuqr/8UDdPMxTWcw1f1LtKGknCaKtdHrwSzD2fzjq9ha3304e/TZwFLpasJt
+          +D1fGhhDerkrHjN79x/+QLHaH6keGULG5OYTg8vLUgnMLkglKg01cDlLgDpXowVLWgwuXH9PDceZ
+          nYWLZrgVOC9mSkS57xi7ll4Hu+PTxU/u1oTjdTq68FFrP3x1+DZrDvSpwecTPumzEHbOxIf7Ch4+
+          zt7bnRRH5eGjtFFaujuslGsZbueJg4SqEjb9q1cvaL6WqEjnmJ5BbNQk0job7oR+xN6zrsM1OZ4S
+          yNll4R327jtbxCAyYR/pIzajFjudb00+3PCLHBxaMcEuS/O//MG/kpptfBj+8bszN/PZWmx31vSk
+          7bBePSRGv568QzeUVqQvVAEsxePZA69Ir3TLr2wFn3r90y/ePu10wFfxNrPjQCZPFC3gLJJT9tLp
+          jnNyKOKuZn/4kXKWhnWfNMP6MI88lIrpTi6AmGydd9rWAWWU2EDbnfBNH6DoQVR6muRTyKdhoEHV
+          hyrVV+SFS9LmBAz9VcbY2e6gOfDXwU84G9T9TLI6b34nBOaxpZ4+jirjm2MMWb27UbO1GofokatI
+          qLRiGtuW4cx8InpQup5SbGpKNqxaiXtIdU321kuYgdWqHjLkuSTEl1Vvw9lwehtmfBLQ4H0u2WDB
+          pw1Z2z7+6e2xH2UOksjkcIqKt9Nfrr0Lu8zSCJqyT/aHBxBbUoWdY8jArIja7lhP+y9VrzvC1tvs
+          lgBEbU9NTQEDO35yH/SW+6GPNhCyRev9HDZJIRJeQG+2cvHCo80P8472sndoHRe89AlXg6rzRWTz
+          pt/+1pOIb1upedv8RGhw9iI2H9LiMPKUJPhKVooNsitD/v2NTHTr15wqu7vl/Pm3sFiiN1YelQem
+          +zX3IPRTRN1jpDOBvd1W+ihPDW/+a8iKN1/Ba8x8bCd9y/qNn0PuIM/Y57DMBL74uZC7ZS112G0e
+          2D+/afeLsIHaZmCpezUQOaaQANZf1UX7yNGf/iaz8V5DxhdvD31zhWKnIDajOeg9+NhfF6pLVZkt
+          xt6HEIfFF9vjdRzoU7mt8L5PLJx8xciZbybh4S5IGqo+AasPPz5sYfEZXvjMZQfGVCv24fZ500ES
+          ZMabIhT/8r/X2aGTCX/xYdpTjhVoHMPh/al9uMUrDuu3yhajvNlwBNvMGcW9ssPxCRPY4jYhH0ko
+          GZm/ZQ/RVwqpRdtHNvrdzwC7x63B5nG2AC88WxFu/q83OyUDLL/HAewegoJPjKxs2PxeaVsv0uXN
+          qi63+JTCK+UwtespAXPV2CmckvjtAUmqto50KoI/vFTk79dh0iPtgOUFhMA/fqF3ewX8chJRBeNB
+          nV/GRfnnT+X1lWO/I5hdJO3kAl8MOa2XarfNIHr+EN74+rB6Sj7DWKoET9r0Ir8jXQ+Lp5bQ6O/1
+          Zr4q4CEolBpudQ9X0XBkGOH7iaqC+RuYh48RDI7WRG212g/k/nso8HzeOWQgMXbWfXrR/vK9B0L7
+          Ho7fF+NgqJYUKzTVMr5auBShdUnJsW704fAOfjYsxOvbm9OXWC9rkXuAyTLG/p0agCwXuIPCCeRY
+          bkenpu9MVRAVhJBqK4RZV+yvT/QSPpCM+sXI5uaoiMg7wCdVJisa6PP9aGEfnUeqgKforAYqNfDH
+          h8jlsQ+XqYciWMtM90YD8tkANMEAsbH/knXWPvW6+yUlVKznSFPnvNQsGcUA6sW7o66418MDPH0i
+          eDhKClYvP2+Lx6cNumPuUvfPH2Se8kS7q1F5701vEQniHhjd7YQvenys6ab//vibl2pErvlPhnKI
+          rI9Dja82sXVZZenPzyBNhlTGu6cjBzZ9Q/HvYw9cIVnxv/8Pp+Lr0Ew45GjLf9jFjhUul2Rw4R++
+          REKLMvp4jTzQA2uiupNW4fy7mxGsktb/e55s5Rf7Cdc3PZM5mPWQo2VlIn64hfgM5S9bpvLZ//t8
+          58S9hzlAvxYG5/FJVjin4Rr49Qp4+LthPEmO+s9/n0b/S5/6pc1YLDIJYkuscIgMF7Dp3s9wQu3P
+          Y3/+Ueo+jL/nwZcATwOzP2IA94iTafCoCBt/dzOGw2GnYRftDCaoXaABxJ2f2HFWreZlLMV/fhV1
+          H5a7rech/8vfZLE+cT2Z+XEGU1P3WAkbZ1iWCEF4erclPV8FJyRHfwhAsG87j/+Yu3r+1uoO4fg8
+          kPf5/QH/4i/zSh1v/HNoVW5wATROwPupxGVLdV8CBL4ewZs+ZdTKfBmNTHtgRRnuw2RK0wpVFSLC
+          zH5ks2RaKbwX8x6b+DuFi+spEMx2cfdI4ilsiw8T2LdVp+5CQ7Cy0zH600fUPBgdW7d6H/Tc+UKm
+          yWgY3ZkDLxX4HOALTGxVqHqWwBs0Siq34zBMBepayOX5x0ObH/rnTwEncp/0Xz0QHzkeaSGNqeJ7
+          IxuVZwKlzQ+bBEVqh3V6hB3c+DF1Mu0HuuE+Bcc836lkP4YwmzZ/D1Zab//5iQNri2j8Vz/c+KZ6
+          ON4b/w/PMS6CFixWc5IgZ1cFWe5i6rAr17swITgm8z5YGZMiu4J1+R23eqL7hx8JPDdWtK2vDLif
+          6ObQq+SY3hWprUlr/whM5NH15h9FbPrzG17CF3pwq2dQLeQruPnJ3mert4x7N9PgH97aUuOrwqYX
+          4QzJZ7sba2T8J55isAgej08gbNiMknwEWz3Xk8gNOeNqDy7c/CXvT6/MXu/mQN1mkInbfq55TRNY
+          Hh48PX3tfbgWQdghh6k/6l0e+2zWwTJC7vZoaVHDL1g/spXDS1rtqWFxn6Gf8mGGP3v1sL3VI9au
+          kWJ4v54VbG34SVA+B+AaL77HFTKvztQ1Guh4MMRpeNJUQVeqFQYY5Xh7v3pBxiGHT+n19QS2RAPZ
+          9NSfn0ld93NU2ft0jyHIHYJtY706a9xseiQST97CTdEwUtdrYHf2dt7RD8ph/quHxNZn8LZ6ecZ0
+          pZrBX/3J2PxjVkv1DOsb+Xi9P3ObX9h3sD/eOGzVWHcW6xfIkL9nF2r9Lma4bP4qzDnPJUjpzuCg
+          FrOH/vjic+P/tPT7GdantaCXAF+GuW9F8v90FAj/u6MgvyEe24Ihq7P1thv4Ps8lteDBUHl+n8iQ
+          JBFPH4T5GTehg4LWwXLw/b536kXGuQvHIDO99ei6gHW6XyIWVQ/si5+7ylDdcoh8BNM7BJ+TKhTe
+          s4GVW8/ePtWSjOvXz4x6Y02wvnP77Q5ulUqKVZXY6M8zW2I/0wCPmhNOdXmfsfH0y9Gvho3Hp/FF
+          XY/vLIWWVVfeCnAyHFp4j+G+few9EeEwW2utVlC+cCt+KfDGCOXyGLxMK6ep2/7AOGx39kOWfzzh
+          U7zquS26FRarLeJLrO+cFW09JfsrPNB7dp/VUfstBtwLwR1jnxZsKWq7gtbPVrEWhqM6l6Flw8A5
+          mdTt85tKj06VoEiGAjZeaciWCxoaiA4L89pir4bLjrxEuO8qj+yQdMiYlYoafARC5gFZomCxw3OE
+          sLZE9GFelIy/uzmBk38pKQ67i8MntjiD3Cwaevb6UO09RXYhO+Cdx3J1ZKPWFg0M2VbBtLEZrss6
+          p+jxdnUyf2a3ntU5zyHPlRJVBeunsj3ZaTBnxs9btcZSDy9BDlCgR2ea1CZU6VBFCbqd/O2OiXQL
+          D9I1VcBt5SQy53kBxu/ySpEz7it8DpT7MNM1cdFBNz84ep8atbnrVxvxyW9H+FA6MeFxgjuYOAjQ
+          q9knw8G8JU94D18G1XnpFfI4gQHk0ndJDtv5mKOtZzdv4pLG3KKoQv4KRBSCX+TtgXAduLd3Isi9
+          t1/qLvMbjIejmEjn0LvR1/F9YVwTXUvUOFVLiJD3KsfTY4kgzj8ev3/b7HDNLVn6qkqAlc9hV5PP
+          oekhgcmb6kh0Q+a82gROD/9L42Ysh0P/5jwEjHOCE8lx66WMNA8UN/GFbz9jAuubi3wg7d87mubR
+          aeit4d2hRikKLEdKBNbPY7FRJE01jTq9B6x7azI0foczfREB1rQSRR44SZnQa3LOh9FsFRmikLtT
+          b+dtv0KhLik6OaNJLREg0Be/iwzc+qDQawh1Z3mKxIXHBt8wrpZD1gkn4sHpWtwJq/OXOv/9neD4
+          hO8yr9aH3wAM+JWuPo2GxWVzmcgterWViWP6/GXLSzADGB/Hh3eQOH0bIRh5sEkDSvUxX7NZGpUc
+          1YHzwKewO2eHdVdV8HH9NPhmuCcg7L5yBLU+X7EGBStci+bSgi46IZqwTB345D3yUD/JLo41GDrr
+          KZFcpNecjB/xaQHsaborRAra42Dbn1Fr7w04qx+OpsnghJyS/zhYc/sL2WXRWWXCNoWN7StIzeFw
+          dNad18qwMBOHrGXqZePl1MlgjcmJakl0Vrm0uimQM7QYP72OAvJ0LRu6yz3ClvYundUFc4Qu+dPA
+          OSw+6sHJygBWB2lHz05Ahnmv/BQIPY/g80tuh2X/FSu4/806QaA5DqS1Vx6141Okj+PrPRyS8rfC
+          h5f4+IUus/P3OlT3woRNnnUq0W+ODQlM3/i8KyqV5UcjQb23P2M8US3jjf7hw6lTZnrZ25q66jfH
+          hK+pkKlmB0vIbH/x4G7vyFRfmA1mni4VgM+d4C2KN2VTpDscvNmRhvPv1GZ8LPWKlCl4JpzAk3Ac
+          z2wHiuGbE+Dvl3DhZ9jA0iRXnL5Hw1nj+NWCckcT71jEdnbQInP71QX/jl39e1DnI5Bn2HzZiZ4H
+          MwRzwCQZfuRQwHLw1bJD1h5bOJ+pQ89apQP+VkbPv+fBtttajN/iAz55V6GXdlTDbVp+Kr2N8kfK
+          ODRqwTifRfhh58E7Gj5x5sOthsgM/GbLHz5Y25bEEGMtwPZPKLJVnB8jJDbX4Oh1ztjqXiblDx+x
+          83utDh2TVwmKIzS3KURVNnfOoMA680rvq1xDINzeRQVPd1jT11CIzopeYwwXg6XUUPY563124pGJ
+          rmccXfobWOmr9+H4HXt6y3tl4L7pL0LJjlFP3HMVmA9pnSD3pHpUr5SzM5LE7qH+q08Um40xCIkP
+          fPgzDos3W9I5Wx/yIiJW+xVh/GHI1qU7lqCmQ4/VifOHebhKPOx7XqWatWPD6vKiBM4XccXXXFvr
+          6UVoBG8mPlAzP1k1K7vKhqfTw8YPo3EAr+45iJboOpJlOsTZSsayBcpdXnFyhaY6/RzTRiquv/jU
+          pYbKD4q2Dbada5p8Y0Vl/RKMaNsvHLJFq4WduN2BoveGAFB8h+XXgg4Gmubj7OjdGAGXW4f0mpf/
+          ni/c+AIP/cq90AtGc00e+jGG53L8etJHs2v2qtIYnnwnxO7BbENyGSVZerXbBMvOSUP2t15BUqdU
+          bw8ATCTXTUT9/EJdzdXYgn8TB/3wqdH8/MscjtkRgdftbshx0qpQ2PgL/HIN9qANp2E9cZ8RqdVt
+          mzVQM8YKisu/873lVxeQM7xIED1VAzv+/ppR3g5klPBfGavnKFWFxywHkhqfT/hiftyQ6YfMBc56
+          1Wl0VdKMP0NdRDNrzjT7loitktw9JSepElqYTVvP/TrNMJh4iE/JrwoFBe8SuL76I9WqZ5Txwe6q
+          wV6Mb8S+Ts+M7V+nJwp4UfNgqdjqDE9JD41LM9LX9BzD6c2uHtJM6UCx9HyHrPCe7d9+0KBVm2G5
+          V5jA74czvF1XgmyiLAzQlXtR7AegUjlquRHYGZ1DL0SAwzq0/ozUeyRim2+e2Xr92Tt4v0GOJvtg
+          77ByejdQVG4BvS/N3ll9YqfQTons7azgOsyzpoko3ctP7Lk7xlZ1D3dStta851utNSyVroswkmhN
+          lehnD7xvHXbwZmkX/MCftmZ/+d9mLo/vL7mtZ7Z1dF0iy8Rn4c0cdrlb8r94f47nYRgEObOhNjsc
+          WbHMOV3xkhXUX6iPHQv0w/IiNIa3lZeodmRVPZJE6WC8AMsbPxas1wSLLtRkYlBrnpuaGNQnSBrj
+          wRuU34vNf3yS604rVpM0HpbjfZ/Cp9bpdMN3dYVj38Foulypv+M7tpTIN0CSGzZVvbZlZPqdDSCd
+          IhMXyc90yOM+7eB3XHfUSOOLwz29IgBJ8L5R1T0JIf0F+giPV1mh5rXrw+lOO+1fftCCvRcKJ/Xk
+          wfRdOd6xuevhp+hOENL6V1Jvy19Leh1yeLl8CVbv3/fAqkfN802BZmyYkTCwUIoIOFwzmSoHrsvW
+          7fvB4+Q/cWaBvqZbPID72Ru8fuM3wv51ypGYf0d8abKlJtMPa5DnKomkiP+pLDzcfOjvSY4d5YfA
+          /OtnGaXBquDL6f0ZDlAJCVIL08SpjVg4Fi9TBm+ep9ikFzTMy8GroN3CjOIIfQDrxywAbf1YsDE5
+          9+Gn+aSB6FcnHguCn7NyR9OFI/9k+LRkJVj1Vth+RWbrKO7zgzPY/tEDafEA1GSZWh/4AycDuCg1
+          Pc1HpC4fI/Yh9Z8XT2xJO8wFkiD42O3B2wWhGx6ixudgITfAk7Z8yOzv5MMqPNtUt/yuXsQ3H4DC
+          uEJv//4PAAAA//9UXdsOskqWvu+n6Oxb05GTVNF3HBQQsIqTislkAooIiiBQBVTS7z6Bf88kc22C
+          Rtf6TrWs9dMZJUPVKFtBLWh86fxqfAzvcK1/arhlYdAxJnc5MuwnDneFU/HhTXtDJEY6xnT2Xc6v
+          ugvQwf5BRtHPM94LXgm88R2m2ut+NWgc/2K4qa0ddbduCwbxfDThHewMnB7RIRNRvhlBgW4hUhb+
+          6r2NmcNJul6x206UzY9kc4E2HXl6uJ0dg8tvpJTTcNSRHOLCmDkMY7D4OzKXD9kdz6MDIcD2k658
+          Lta8Nir6+7XH50VvTD/tGIJkM1GsB4FpDIWSmHBj/lxs6QEDJAvUGtyvfILPzTy6U4R1olwqV6Vh
+          NkzuvEnekqK84pYGi55c/FYBrWz5DyuVtt2cAjmV0aM840X/uHP1eUD5ityKWgdFcMcV3xf9SmSt
+          kcHshe875DZfl/BeczJmnEAfKDxj1K1vXdYoQypAeIciftifPpqxdPRBa4oTddBZZKPlAwl8XK7H
+          7tvedbOP+BReLtIHh+OTgi7axjYYlEuIBINXM8adBU55HLMzEbPr6A57n9RQrPci1RIrr9jkfN+w
+          qAhPXVM0GLXquwyZpVvUlWTJHfteTSCvdCnhN4XFpp9p94BVYUmdAJTZzFEtBi/JrFd98ze/LH4F
+          p9IpBDPjSQ8v+BDjg/UN3T/9Y6Xuie7LcXanFQ9OA8LU0yuUzbFm3eFSX3i/CzZgVNCJA7lW9ORD
+          hUslxl2ewP3puqV654guM5etWfIsH9Dn3FqMNoekgHur2RDoLrfGz6yoFeIIb3zoDA1w+a0u4YLX
+          NDblHkyfX0lglXkFPoXDruu2ia5D53l0sLMNbtEof11daVGnYeugXIyJ288J5CTJoftEPUZDPhwT
+          yLAnoLmlNRt7nSuVh0FibKg+q2Yhc2u4OX0NrHnvgs2/LvEA2+8knG4cEzBFZ5JyE3YmXr5/wMfF
+          9gLMMXlRpJdNN21OPwhfsQrQ5q29s3qpN3jbkAuJln4d0qC7g8k2Amxshdog7XdDwOigHdY75+pO
+          jysLlQh0MemT+7OafnduhMFmHhDk7293TgV5A9Q6qSlyxZfBHmUYQ0m/hmRc+kl4JEIM8UuycPRm
+          PFv9J3jdBkgao+Y6wn+cHIYhd6Px/qxkI5DEn+Kq1EZQx37VIVsn8D7zECP+JGX9Vn+pcNp9EN0v
+          fny6iQ8OLHoCH9XvlY2rP39oXo3X+pyf70MNE1EQqZ6GBZjf2XUPtbrvqY23DMxGa0vwDoBBRPEV
+          uSziHyFMRE5c9AkXjcND34Nj+P7hWHm+wXzgfAcUF6/C6jPWssk++3flV+kML/4xGkTXQXDFx9sR
+          jhFZng9aLEkYWS0wOlwmIQivUYXtxW+TRW/DeugpvY1261LS9B5Un7xH7QPuXEqtyYdG9Y3+1N8c
+          Pr095FB0QLvl+aMyh6FSNWTG+xjqHd2VlxxIvbWh1nekEYuqoln1Ib3Q+zFiCz7D79PvsfbRtU6w
+          PoEgj8R/4yd1uG4WtokOeEes6YneimhM3Waj8Py9w5fBFas5eBulYpYyXvORihnIz5WouWs0qAYb
+          0JUfhWAwsdreCZgWfFfsqMhwHEWe8flm7wQeibhHw9Z5u6MypyHAL42iqTftTLRBpe7KVE6puYfM
+          nd/Z04RZwo5kAO/bsubRj0Fy5yIaHrusm85pAJXEDGVsNMutsA6MELDYTqbWOYXG8LvDEf5u2w6r
+          dxqw2Q7iPRgdb4efxCjdVX/DfdmWC3+p7px0FYGjrjqL/zUr/nvpN7D5fS6EJalQjaJWezDlaI69
+          rzlW7GYuJ5AE1hRXtxEM+DohuPDrH7+79HMBRRLUWH/8Dhm/8LtcV9lExDlVK2b8XAgXvUyqQn0Z
+          3HTLVOjmpxuSXjdizJijIwRag3BuIgeItax5SluSASOJ6Wy4DfkG6ld9RvW+OWcs7i7pspWUEHBp
+          rIrH1x0CEtthbJXWzp1UVv7W/AzbaftxJ/uc5OAwmhnFU7asQXS3G7B8HvSdzRLM2ZdrII6qBxkX
+          /cw4V4TwTtIJ/aZHy6Yg11Rl9xwdquN4YrPLrgm8+1JBJpb31WhOhJMlBvAf/mRR1TQQFbQl4nfE
+          2aDbowBPu/xHwD7kosWflIBTzvHKJ4Dlj1SC47PI6H3vvUG/9nfzOOyxyeyuG6OjjWDnTU964MSp
+          I18VQAh/zyMRonpvCKZ2SKG/yb/U5koh61O32CjLSAxOudfYDWWbXoCCCg6fO+PFWm4vJ3D6iQfq
+          bY6aO1tFmsI02P3W+sp6JLYmYHFx+5PfCbRse+j2Skm9W6i5/LPSC3ifRUi9a+t0XCDt7kDwH3jh
+          Oz0isWblK778yQ/GrqlluHVvGd0TnlXjw5suSglFgephIlWMH/eJorPgtORzfbfmXWDhU7z6Qf4r
+          T4niwreBpI6/GWzL+BLsz66P1cV/9F0wCwBNtYaaRR9yqz5Y9Dld8BLQdzuX0Pa2GrZ2TlvN+oem
+          cMnr8AX3GZuK2POACy4etYXnL5tQfCXQYkBGcpXFLntVJVnzCqr7ih2NuClHuOTbdM0fJ24vp9C5
+          nmU0oQixvvnmJWzvx4haftR2NPghXXbSXsWXeBDYbzvPOSz3Vw17aqFXQ3k4ybC1yBHbhjxH/N6k
+          BNrOM8JIF8xoepBvDJOwOhNluHuRoO4G+4//Np9bIxN3/ktQgoOuYW/hk1H9YA8sfgLrbkOrccnD
+          FbidO+zyQhAJq96etP0NH0tCAF39R0e/EdlZ27s7vf2HA0Z7q2NtwSvhOL724JwzRI8q4LtpsG4m
+          UBMpxjEG32ram18Cs/kloA+he2O0RlsC+mxcVr8FGC59H/Q8gmQjOl608Iu9+jt8GmzU9R81m+Wt
+          TzZUFefSYIveh4ueoZb/tSKxOhATWpF3pr6JPgaJNXyH58v7SVGZnBi71ccUUnAfsRNtiDtVz+iu
+          LHxKV/4S55ar5TVvXfOd5t0daiik84nsiuUO2sg1L8C5XmUiH0rDnXPmSrAGWCOV0+ddf6k9Ey58
+          sfabO95OpqTIGEuIxL7a9Ue4MeW6z6X198q4Nf+GZZhS29zs3Pn7UVOYtHuCqOc37Ju+jhAs9YP9
+          83K/VhvoPzj4uMDqkvf/UjCnCikcixqSnwGynee7sj30KYL+Z+/OOx0l8KyFCurZk4JmzX+X/IY6
+          9TMF08c9k9Wf0hXfxbmFb+jO0QFN17itRmAmJqi+OaD2L7XZzNFjDB+8H9BbI9yjOUdiDumwyelp
+          sEk1OWI2QiUSrmi3njdFrhkD3Zmva96esTXvMPDri7ZJ2xhkyfMArMoAQT8wo3k4ZTU4FA8ZnZvZ
+          N1b+UAZjeyCwz47RRKWQKEteiZhbqga/y3wJysdCpAcP/sA0tvcUHg6PC30k+pyRV1LMCr6/39j6
+          DFU1IvTwoE2KDQ1U99VN4U2rIW64LdUHy43mLLD/Pl/xWmMPxv6rQmVAvkGEKDQjrv2Mb2WHwIy1
+          fB9WrL2ebFDEm54ueNGNLXz/YFArD6we5W/EwmNmgvijltjcN+eI7HSUrnkXdaZH+wfPgQ7jGLuP
+          ZOymkUQcXPXrgX8OxuqH4PlSP7GJewCmrdGb8GLbd9Sk7ccY3rtWh+myNczqH33FPinnQdFnZ4yu
+          UK9499JwYGjUkZ4WPOA+ajQrVno8kXzVX4u+AM6Rb/DJbBK3y0K3Ab3zEekht3NGtRsfwk+YmNjx
+          wn7ZKqLIsBJOe4wW/p3crAnhMNAJicRLq/71VuZVbyHpMbhs0k5juOZX2BUcvJ5PeDDYH1tUP0hQ
+          jWMTXBQRTBJiwaaLRm9j3sEGdiE+neQ3m27imYPDSfdQr3JqxGun0YfZ9xVSD8WhOwqcBNfzLeo+
+          Wz3i4asgimJeDhh5S2r6budid3mID9LfLxYTJO8UgrN94hc8GNgf/uR/dwvxNZ+BxW8hWEJeoMhq
+          M2Pep3qtZMU7pX6eb9lvmscEzm8UUUveiR3p74EE/uDHw8BdL3AjhF9DDYkQnMPsVx1/d7kqSgOJ
+          EI0Z/WzVRrHpzGM9GwKD5y9ffeX7Nf/MpoKKBG79foNNJ+i6cZCUNzQFqyTx/OLZfPc0R1n6D6dp
+          ess47xsmMItMG6v1frlj9Jz//vip4BDGxnhVAwIhvn/Qzt29o+mnaeHqR4kJm0fF1Ao6sFMOH3zQ
+          Nhn7mrjgYHvJQ2x457PBSSL14TVreaoWGefOiiYJINfKHhuedo0mz3tt5Co83la9x8iah5lj+sJ4
+          1c9XvqwBxmZIJsk9Mn77lQq48DfVy4dssDyJ7lCC8EIvzHY7Hi93IraPm0OD6tat57XzqueIyHif
+          9RavxoquUR/Nxy6rRqaehT/nCy5gh2y+jpUNknzvIGhvd9UsBvse+AZf4SyEh0hc9CW4jF2IgOBQ
+          Y9aSGcGrWE5EfvW1S+6WRuDiT6j9GDrGOre4gGduedg4XyiYLj16w+9HMLGXadSgnOz6sKe7G5p2
+          tWxQM258eGscBeP6uANTSYJ5t1F2R2yMB71ixJN64MpPDk2/I2cwEWQ/eXCAgjYYH7qpfC9bgtXk
+          SpNF7y5+dbPqQ8SfWwsIpukJsB3RlnpLPc8PyYjBcficyOi254wOc2f+70TBP/75z/9aBgT+qptH
+          /lkGA4Z8Gv71f6MC/xL/1dfp57POFfxF+rTI//r33xMIf7VdU7fDfw/NO//2f/37n7Kw2/2ZNvhr
+          aIb08/9f+cfydv/5x/8AAAD//wMAzAgK1tqBAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a358ab67d7-SJC
+          - 8ebdc4deceaa251d-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -801,15 +804,9 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:37:04 GMT
         Server:
           - cloudflare
-        Set-Cookie:
-          - __cf_bm=Oh7.nNtLfOJl6oOCqmqI_JtlCUWEGCPEFLizf94qapo-1731107840-1.0.1.1-LA0o235D4aXqT8wLmyKQXpDO5XL5Z5.so3fszsKRgQIcu1FG8foa7093HGvqffWomHFePnzADUAJDgrLhmw7QA;
-            path=/; expires=Fri, 08-Nov-24 23:47:20 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=g2cQru67hGOvz6LXId5Rf8tL96khKSEFyqkicDXKBj8-1731107840773-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -825,7 +822,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "139"
+          - "4264"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -843,14 +840,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 31ms
         x-request-id:
-          - req_1053113c5f6bc525149c037e59c9caeb
+          - req_64668dc591e8e227f304a134552a64a5
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["What is the national flag of Canada?"], "model": "text-embedding-3-small",
-        "encoding_format": "base64"}'
+      body: '{"input":["What is the national flag of Canada?"],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -859,13 +854,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "115"
+          - "110"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -875,7 +870,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -889,120 +884,120 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA1SaSRO6SrPm9++nOHG29BsySVWdHbPIVCio0NHRAYoIiMhQxXDjfvcO/N+43b1x
-          gYRSRWY+T/6y/uNff/31d5tV+X38+5+//n6Xw/j3/9iuPdIx/fufv/7nv/7666+//uP3+f/dmTdZ
-          /niUn+J3++/L8vPI57//+Yv97yv/96Z//vr7tZYW9lmJ9KsnvmuoqFaMk1NngjVynwWoMcbU893O
-          mRwimfD71C84WB+vcLKbkEWHU3uh+sJ9QVsa+gKGsO+xhpZwZWutrBELbz7FObyuU5hEHSyVhCGo
-          fbs9Z+LCQqIjAvws32bI2k3GQ2ZxSnqo1F4bo2WGaFdQCWsrp/TsrhOuKGz5gixVw6zr+C0adH+9
-          cio/Lg3483xIY0JsZ3O2Lp7aF3CJ3BEnApIzLjTiAfJltNC73bXrMsv3KxRYw/O5WFgyMjZAlPqr
-          FeOsTNd+7E+duI9Tq6Wn2wmCoSoOV5g07h4flkiuuDxbrsA7fyJ/rZJTSLO2VFFlcUdsOPIz5PuL
-          EKOJ4CNWwtJ3luVZuagvHi1WYJqBCQMqwqdarPTQpcdsJs0coarNG3wYboYjHHS7A0GW3qhTmIe+
-          W0bUwG+0FBRzTVdN235Av75Qevxy94xeX0WEDgthqfvc7bU5sXwddpf87jd9qmj8GH9LdNSfmHon
-          lYbTTviK8HwwDfzbv7kxIxEpssoSxur22SzbZoCuY8JRvDwjTYAfTkaXm0apZg/lugjd7CJbyhfs
-          tVEWLkddNlHiJzYOH/cLmIZbdEf5fI+wn5jffl7f0YJ+z+tM8iUU5tZVYVYik2b6uexXMi4FUPwd
-          8cG0Z8Cwuw8M5MniUOfyWdb5cWtTVJdJSO9+cutJDrQJpdUVY0scDo7g9FwM3wCq1O5eYjY97fUM
-          A6ZO6Yl+6nB2drMFm4f6Il4w5xpL2hhCHzoPjM35FQ7DLcrReGJNfEOo6eeuVhpkzBEk4PWynQWN
-          TQO9l32m/nDwALd7njrUnU8rDi36APx1fjJwzY8JfoyHdz8Zz9SG6CIvNP30q0Pb/FxDXyhjH/Lf
-          YZ1+/8e/TiO1c3EJ6Zl7ufBUiSq+7vdDuOykfAHhXtr53/RxqDjci8Hvffssk2OwZjybIhC2EoFL
-          /HZm5nvWURvpNQ2UYKrWoK4HxHz4M35Ijq99ktu7RE+BTf1pdSdt4Vpsgt1r2WHTXk+A8muqQqtV
-          M2ow+7Ra8mGfwpGTj9hTrFc10NObgdEcOfTuVOdwFWybQJ1UmS9WDw4sKlvoMIGopM+Q+4J1uh0K
-          9Pjsa6w4Lb9SwLQqqqTaxucalCEfjnIK3182x4f3Z+fMoGMD2OZxgp/BTgdrWsc6XIR4wsGZPztz
-          Y399pL+IgZ9M0odUNwYeDKRV6dnJjtmEx0cJ+4sRUo3vm3XVQ8GFbUu/f+rDmNmTCwlIMeEPyO2n
-          bD+b8BVEBg3G4r2y41MaYGrdBOyV7QQIONcq/DpgIPtzFYT8jVELpNzYkiqElZyxeSU81Pf7CR+h
-          32ZT+GgZOCuJhy/TkcnIseYncJi/lMajpjgc7qczsqn+wHrsXDOBM8QF+vEuJYKagXX6xLMMeyDA
-          Lb5GMC/n6Y708HjACR4dbR1edgS/LpxxEMij1sVBIyKF+Tj0mF1Pzjp5yh2VQ3zBKrmCcJmzUwDu
-          B9+n2vfqaav0vblS7loD1ljzWC1egETgDJ8JO7tv5rDho4AoWoWBHp4g6hflkriQf4Uj9bT72Hf1
-          CkwosAcPR+dnv35Jai5oRJil1rY+wQu7WooE9UKNb91lc/t65uCgGTds636+LnStTbjvzAl7CTc5
-          64UxTNC245fq7mnn0CWZW6SKLxEfQYZW4gWcCLtzuNJj7l7DwbSoBbnPTfZnBboVGxd5BIWjkdFf
-          fC5FKUJU6s0H+5b60ui9vgzgsAwsdc/qwRnR+XVHmnz5UOVt4VWov5wPs+9woXK8emBmLVGFr49J
-          MD5euWxsYlDDKvJynHw5GI4v791A0WVkH5rJyxGe+ceFanH18MHxYU9/+UVvgoaPxkSrodl3JlTB
-          8PIve2/Ktvo3oS0eyU50mH7p8liGt+Q+0McJxIAm2cyjfM4jemTKKONCfF3g/S7G+Bonaz905hP+
-          id81baZ+eb+iFEjJ4JFpf3QAfyJdDUxxOtDkfH46i2V8RBgNCsK/9W96zUMS+y6V3T1freveKuGY
-          6Tw+CFRz+Jo2EwJSUhHp0JjZ6nWZL+Uk7HwhxXa2HOq9Ddf58sAnm3ohn1BukX71ID4JbNbV/qSj
-          oJkGH40Ho1oaeGXAURa/VL1div6nN+Bz3fkE7JQStEbmsVDQn5MvOuciW/djVcBZyTxfQDbMSCZL
-          V/i4V5gI43KoONDBAEpQCrC6Ho1qHCWBB6d949JNX7X1k8odosxnoMeXCvp1tG8RLHr1QXbuowdk
-          zpIASs/0hi3Ei+Hmb0r4mcQXDV4NqbhVPi1I/gY2Dlfu1bNxXbaoTPDgT+nzVa0pkAc0p4FMOB3p
-          FVellwUlCppxpjiuthDTZmE16iccavC+suvLOsPHetrjsErmcBancoLP2XCwqfN8NiKhvkMkuhxV
-          pvmyCpOFLFB4ZU3TNdpr09NsIFS4KMPRqSlDNkspC72Dv/MFzn6DuVmnEp6icEegPo7h1+NE8ttP
-          8inn/brsFVpAHekJzj9a1n/HYbyDm6ecaWBrp5AHYwGh4VsiTSIsrUP3/vpoCAyDXoYUV2NE3i3U
-          +CEkJA/SldM/EoSeyMiksx0pXK25l6RvNBVYG9wlG3fPU4sGK7xu8XXt2U9wXlA5pBeqiW3Zz1V6
-          mUCSzE8c3qshXD5PyZfGh59i9+aKYfu6VXc4SPLN3w2l2NcMuqpQqpUH9izs93/8Y2ebBwIJvVTD
-          uQcRgBbzwmrbzVrvOm4EmO6yEuFmhWDm5FsKHy384muhVtq0KPtYepttRs38U4TT8eBCIMW9hX/1
-          fKnMhJW+x9ih92mYsykKixI2+pFg7Wl9q/mWzzpkxzQkSD0v63xiIxsxu07292CgzthLi4+Y5VhS
-          xXsv/RIKZg7Xp5vT8GuAdT1roAXjiyvobYvnNdh9Wxj4DKLKK1G06eTWd7RDTrj5KRAuDcwZ4D+H
-          L30UkQ62+D/D+7muqKdWtbMyB42Bm95jH404ZJPREn/xRSY7UithmbozXEKnJVV+2YXztZ0LeDDP
-          Mta80tImzX+0sH7v9li5X7A2h/djBNXRqbAZNks1VbuggR633qhvjo+eZz7SHS7hscW5wUZa+95d
-          XSi99dIHu2+mTb1olOjouDl+ylXUz6zeD/DZXV/0GGEJkC7Vhv1hZ3tY+15HZ7ooCg8f71TDODZn
-          MLX94wrPrV1ju3wpYEp3ow9fVxlj4+gP2VrBTJJeh+cJ61yPHeHCeOafeqQQNtXW0D2JaLnNIbUO
-          kurM7tPSUWLYKTUPyK1YnM4uStroQW9PEFVUfiwyKE+yQs9sKGgrF2kWjMk6YtO/KyFJsTuArFYd
-          eoBl7czsmTfROgw3uuVvOFAtrKGWizVVnPa6TrciJjDxM9tH01NbZ9UVU6DVNaWapq3ZcFEUFuUl
-          uPrv6ciEwy8/djIpsDaLsJrPpFDBT+/Nza/P5SwvUCy/b2qCd+GssaG40L19SmxhhTpLJi8Rai2C
-          qftp23497JgA7s+hSh3eV51JOuUMpPc7oY/sVYFuXo4iHE6WTRP2La5T8UY8mLq2ommsjuFULUSF
-          14tv4yMeHWfVViuHn3fpYuV2uq+rkrwHeD1rL+w4XdEvsRoVEHlYo4a0r7VWLq8FJOxXxlfvK2ij
-          XXRn+CEL9EMattWk+LEK1dxtcYx82WE/iFXRK8cSNvsjXpvNL0HFRwQbtiQ7S6TtdWTfzpQe7EbP
-          +s1PgvjJL1jhyZxN60sOgDCccqx/WKjNKfe5QkZ72zQr07CfHd9pwIdM0J8+VaetltuKsLqlhy2e
-          Ud/bSWKC3GpMar4e72p57b8NBIEeUb3+NNUkl9cShuPzTS1hf6+WHVOZwA6HI76+HkbPSSiFEq28
-          GD/FO12HslAGxJxtix5OjFrxy4hqOPGySJ+55mVUDecG3Uco4FPix9UisMIZWntTIgzlYbgy6q6D
-          xDRbrMeMXLF3xlHBN713WN4fnXVASpmC3LWHTa8rZ30fXQsw+S4nXbN8KxrOdxFu8YUVENjhsnpu
-          AbqFufj8CqdqCZxDiuTWMwh7yBmNss2LhaxemNgW4z6b3x+PgUrlCti7iWxGGphD4PJ2Qd1pmMNJ
-          xjsW3o+UksWKQoeTqNygPfcwMD5+mn7+hp4O6yqPfTJ9zXU5e3OJ6K6bsTxitp++D5sBZviUqEHM
-          Klt3TcpC4XjIsNE9wnUJRyuGOB0yfN8/F43c6GSjfU4yfKhUx5mqpZHhO78f8RF9u3UY+f4KouD7
-          pTi6Vc7yIW4t/XiFfmrUkMNJ0oCaYQecHi6cNh2k+wC2/MT2xW2daS7LHFmiwlGDv/XOFDrqGbXK
-          TvYn5fVat/WY4LU8NezvEs0hN0Yt4RJ0B2ruW6AtlWoUQAiAjR1buIbLrBctes4HB6tScO7HTiYp
-          2J8woq6f3CpKs5CFp9FaaJgKLzCqV+YOlnlo6BW8ZU0Y7rz8q8f+HOmfbOSfJICn6LTDh9WztcX5
-          tBJ8D5cdlW2Ygu5D9AZx+7ymydfTnemDoAoP2uFGvSNQQxI4OIUW7AtsXKyqn2UAWLjFC5aDsnHm
-          26jdwdbf+0V1LrPuovEErccywkZ1bcBy2U8NOpnp0R9ubhwuO6Y3oXg7BdRNjqxDjFiG4B3sel9i
-          LiYQbOmwIElwTew8az+bNz2E9j4ZsbP190sCi+sf/7vxn2rYCS8JcfwJ4IeFSTVh8JGgW8sQ//qN
-          uT910h8+4PiFsXKBuUjQSOszTo7PPFuEvdPAR8t8qdyfxXXUeCOCsmkeqDshtXp9VsaCuyMKqI+Y
-          ol+o/zLhmQEeWR6K4ywnUjZoe7/+HGQ3QPVw54I//Kiu4TolZwfCzc9u/EAPp82fACxRzmdxzGUr
-          vAQD2slDsfGpV798JTjBWzVDij/01i+4CzqkXOcHfrxzXvv1Oygezi7ZNztBW8zufYaSIj7padOP
-          H88A8RC4+Km7urP56wklZRviGCtY4wVWCMDzeFax0+6tbCp56QrZ6FVgWQmCXihoNSDbkVKCDCt2
-          1lqXfBjl9gGbe1ldWf47WDB0og+9pyrqyRh/C7jxFHy6X6g2nT7f9NffEY6/9doyvYz4jx/+8YvG
-          UIII3rv0hBV+p/Z8bBY89Kf5SMPsKTlLTckCb7Cj/mzTMeumM1DhUy1X7GFj7QcnRBbceNZWn7pw
-          /nxFE2w8EDuvV6dt/TMEG88h0nhD/a//hVl2vGGbO7FrKyxqDMO9uMP43nbrumNHHwz6MJGakjDk
-          N734o3faxuMmOdIt6Lqeh42cHcHAC0wBbem+YH2p436OuRdBnGaI9OdHqGcEPrzmuUTl6dpry3W+
-          MfB0uenYickx46aGhzDW85w6Gx+cnaMQwMoSjlQzTnK4FuukSo813PuzO3yd+YRPNvzp/5Z/1Tr6
-          VYu+4Zj532Z30xpwFSPI37sPlXe7YF2t8dbs69jUsJXMfTU4ZDGRe9EVrFFVCIfrTbrDHy/1Y092
-          fvwP/PQll4ROG3b3moFS/LXoFV9ssCSvKoVNNTs005U5+/lt2GToTrXBPWcT678atOZOQkAXdWBq
-          BqEEhmg61LiNxTr71kUHmz7Rw/uzGZpWV9FCP4rf163cc4dSv8NFs3ysqq3Vr/4y35EGLjE+lEel
-          WtC8SJDJUU5eChx6ErWsDkCaHqlcjIbG6Z+FAQPp1G09hUPeoS1DY75CemTfMZhNtrIBsM5vf0mk
-          qFrJTZFQmyyE/ta/brwPcZ+LTGUC2vB3P/S4+eZHSqaFHHFg/IeX6JSEGf+rn4qTWT4ykmPIF1c/
-          hpsfJ8yHN8BsXO7nH6/DWRf99q9PIWF7meyG9biyh8uJwPWNLH/c+PXkn88Q9Psow1v8a0MWvBa0
-          /R7+8bfNv0M43Iuc+lE99YvDgfP+xWvf/9KzZ3gqkaTLGsa6W2sE42z4k194888LK40LrBl+8Pf4
-          vl/7qxgw0H59dhT38cdZtvgB4/Xh4MCOymrmFhdCUS4/+PS2MJhDRU+h4dsitR87a+WTVx9DW2ne
-          WFuOHlgulqZCayRv6iEJrksI0gnuiB//6h+YyT5QUSLdFRoNIglX/27xQNYQwjFrE21xmVP547FY
-          azBfbfWSAfF+MXyoCK0z5KzdgI1n+PP9gh3+VMQuIEEiUizeMfjxP7TV5z9+Y9aTtv7pF7aYb9mv
-          qsjWmw88YdPRNWcVzwUDN96Bz/6JVOMc1/WPB1En72uwLpd3BOrqHm/1DDv8LQK+xHWgwf6WHytn
-          TAvc/KbPGCyrzYKHG5gKKKJK3MghZ0yJizrtKvpw6/+okozkjx9z+/0UTkEwTWiUhpDeN/2bhEpU
-          odAOIj1vfmh5f6UOvHjlS9qKHDT+x6c3nknNo9Rmaz4bInwOd4OItyqv5lcaWGh35nWsntdPP5sq
-          V6MvNSiVPfsDOrMbA9DNIKB++hq0Aad7H/KSVdDHEagZzzKLDt0SCVgHtyScNx4JjOTl4V/8L3tj
-          5WHyevs4Koyxan96u9WnP++7TtPShacjpH/6yU1vRXghwsMvPPsAljF6+KD+2iXFxf7cL3vlU0BD
-          1B26+XNtNqbEh2bTVdQllKv+8Me6zEIyMRyvbfvRAnTsHgSdVJq9j6vMoH3By9R0hiykeQkKWABF
-          oNiclWyITARhKAoSmeTdMyQjPVuoUVoPe2/6CTee64P1WEQ+Us/nrb9/pvDAsvGP91TrrjnzkMc2
-          8efecEIBXfIrVCpfINL7dtB45qSwiGlWzyeFx/dzZvbSXnESiz43PjQq34cNeURNitcYVbT+IheM
-          1+emDFb8xy+DqO9kf5wPd215tm8dzjpasXZa6TqJfHQFh53lYZUzlZCzizJATVekOPDfdjhdGpcF
-          YXk4/fhAVVts0cCNx+Nsrx/COYmmFroXU8HuftJC7scXBMx31OpNI1ugnnSQam/w8zMVHf2+hfVN
-          ZbCr36G2zbtKSOQ0p6r00gC3O1MTXEAg0OjJvvtffw42XrHN4/h1uXL1Gdrs1OIkM3YrqVSjhNv8
-          iET421QzyUMTpVlR4HAO6mxNli6H7IccsdKwVT/O9tlFJzM+0mtqHMKlUr0SuLskwN62P6N2sq8w
-          UXYz2VsNC76ZPfnIOl9PpDLt70pR0nXgVNCEcIfTVPXFKqqgNuDTn3a7CYw/3rQ/n1QfOQxy6Kav
-          cEfcmIb2oK5TU845DK8DxHLXFdW88SfQe2Htcw+gh0Ipt2fweZAHmU9+6SzxI7nDWc3Pm95O6+xz
-          /PXHc6gy14U22ErMw7s9sdgiuVYJ18ddhnN75LFGw7afVjTKMFiOCpmUYOrHjedC4AgOdoOPXnH8
-          KZN+PNrfb7z+x1uQM/F7eqh35m/eGIGtPlOv3Jca2fwhPA2HESvu8NUGwVpNFDyASJYhlHuhgpkI
-          mYMzYdXIvXX2uGmAGV5VbCqHT78cv44OpF02E26CVs9htYVw41dYPniD9mfepNz40l9suQG8wO4C
-          4Nxgj4/5Tu756WWk0IfHB/WzlKuG7v3y0caXyC8/huCpWUCrqg6bgnZwNr9LYFo4DTVPZ7Na+MNV
-          hgrzdrB6Q/H653m5bt9grSk+P/4Ww/jF3PyJWIy2xp3rg40Pkl4/qz1/sRwZSrX28EVhD/ulfhcE
-          kSAT/dXXFY3FgErA9zubsAv3XSfhZtyRqHYOlbd5zcbXdWjyPaLuPeiqwSvGK8yvD0hiTrtVowMG
-          Fm68wP9+PV2bkcGL0tX8utiMk7D/CNQg0NPahKZcaWrso6+v8KsNCk4vbqsNrpLnv36EHsbl02/z
-          Ex9u9cKf/fzuLBv/hlv/QvH6JeuCH8SUmLG44/v8TsGU5dCCvuIM2Hr35ToHFy8ArXD+YPcN2XXI
-          E6OVihvH+pwj77LJK97Rj1fh37zjxxug12Wqz228iAZ1TYAeOoc/ejsjYcjBiMmLbv1WOP3Wv80H
-          yW6bv3FiGaeQiLghe46G1TzdRRFycn2jipm/+6nJRxv+/TsV8J//+uuv//U7YdC0j/y9HQwY83n8
-          938fFfi38O+hSd/vP8cQyJAW+d///NcJhL+/fdt8x/89tnX+Gf7+5y/456jB32M7pu//5/K/tj/6
-          z3/9HwAAAP//AwD6seOu3iAAAA==
+          H4sIAAAAAAAAA1SaTROyOrul5++v2LWn9ikRkNzZM74EBCQIqNjV1QWICIIiHwFy6vz3Ln3eOt09
+          cYApTUKy7rWu5D//9ddff7/TKs+Gv//56++67Ie//8f32S0Zkr//+et//uuvv/766z9/n/9fy7xJ
+          89utfBW/5r8vy9ctn//+5y/uv5/830b//PX3ZdWYRK2DsWP9bfMG/z5dSJSmBmIE0QLlU+VTYtQf
+          Z1Zr24CgtM7kJmwfIYseGoetG0RUiey267DN8ajnWEfkfg6ZIBP1iWdp7VGrqc+MXVfcByzzhEY8
+          BW4nxEZhYcF+IxLYnRHy+JzyoBlmST3l2mn0zGbA9pVuiQdHBXHe83LG2ZovRuH9WGvM6fwGw+ma
+          U2tLGzS9Th8bHo4REu+spGzaWV0B9zgbSOZQOeX7i9WDoFgLvbpJqy3JlAXwULeeB5RfnN4THZDS
+          2opJllPWjdUWrO097d/00uyhG476K4H3E7ZEPs1yxa3CIEeFdw89jkuO1WC0i4ojWu+JaaJ7uDnq
+          rxgTF+2JXlaew0KkuXi+Pl7Eoqe0mzz7DnDoYKE7Pt+nk/E+Rnhrqw1xdHPnbG7J54N2dnKhdjMY
+          3afFQwPykhR0t/l8quk7H7CSZkr3Kpd1Y5LLEZZ1j6P27r0Np64fZXi+7cTr6UPRNmPUlhjLF0LN
+          LqYaS8RWhN72dkTvxqZbdOcp4vhxZqO0e2/TSfN4H++deUMdaR9pwmnYyXgbm5TK8b7SJjLP7q89
+          UbpVGrKb4xu4s082CfrkhFh35DKsQRYS52a33VLduQWTZTtRoq5O2mY1gArP62DQ3InLdKZF2aO3
+          r1Fvq7hrp39c3BXwqe1QD5qFTXZkJViblZD6uXrpBonXJhy9FkLI1jAdLkKbGNw+U6n7uovpQhLm
+          QTCKCU1c9Vkx93h0QbYYG61hyDUOohiguKxvxF78R9UrGZfjRAaDHPm46abyMzdY9XUYN0ptO6xd
+          jAbk3j5S484dOu7WKB9M5ZaRWxHd0Oa9ua+ALruEXG5i3bF9/bEBKm6hxxkvqN/slyeUV/XiYdL3
+          7Ds/Oa7J0FPj+VyqvoGHC3ndqyREda9NUrhaEBKR4rW3h1ltZGb5cNwcR29CBUHLCqLkT//w9lY7
+          i3AvdWxW8pNGTzRV857jepy1TUBuYmuEL+u4KfEn4RJPkIRJm+7C3UCvolwTeceOiL63kgpVs0qp
+          ftgk1fJkbQKn3t0Tgysf4eDImxXUoe7Q4FwFIfP8ZIT3QUu9LZ03aOL5QgdLnEsam16L5vtOKLC7
+          3z2Jeg8FbTgaloGTW2+TO3cuQ0EdpwS8xMqJfRPWzqLVTx+6TL6SSJ90NNkPS4cV704kfmwCZ1bc
+          vYdFf9mR8G104TDIICF6m1Qad9w+nUp8KIFZ24A6dNewaRBfLlDTaakdJA0aX71vwUlceeO8itxu
+          5jvFANGfdvS+lWrGG13Sg9ubAvGu7wkNxzhS4Spd+nE6S37I5Wu1wCd7KqmlX7aof5UtD8UHT8Qk
+          +O0wjlor2E7KgSR2vHLo/sb3aFQHSvP4rjiCI/oBToo+J1pxP6f80Xwv4JJXMq7OCmLLUXrIkJcm
+          0J25H7rlGBUZpnRnkHuiO9rMliSCDk0zybV5CFvzZIjYNAWHOlp/dObMe2T4p8/2u0Ehw93DQsxs
+          PKpcx4O2sNDopUjTB6JE9r5ahs2NQ7ZMJrIPUeoI5rUA/B0vlcGPEHOPVxdqQnvqGsWAut0WGbAO
+          6IEcr+OgtX7eLPghIo6S2VYcPtPsTLqe1RNVuvaTzi9yT5A9txci13bOpt34NICM54loPT85E1xr
+          D+Vk96a/9z8GxeON2WorEtuOV9p4+dQcSGeNUbVPTmxw3bUFg+atvalu3Yp/JF4EmdCm1ATpUbH8
+          GQMuMulFbDsv2MDyukfO9cnRw3pjpvS4VzJcHG8v6viMMP6s1wF8PP1EPcQfEHv4lgob5o3E9i+b
+          bixD9IRvfSHRxKDqRXPTwN61ZW9pHg+HbwTBgsofD+TgbgDRPKtLvG0qjZjGQqshppIBD17WvcwS
+          p3SRPs8Jc63QjuLBXHXz2RZlwG+/p4Hnxl3vX2YeCzUf0d0iRCknhfwCJH/GJPZH1vX1iQDUlCej
+          uMDUzQfjmaCwefqjOLoO2nB18kamUZg0EpwcLXl0EWHHYUwcujPQdFEqCST4uFT2Kr5ijSSW0G/7
+          DbE4R0v5aMVPWDN25bhWFKObt77jSb5w+XhC+bbTOUtbG5L6eCNZZxxCPlg2jWRFmUOjV7ig7ub4
+          Oh7muPN45bCrprXzUtFzFb/pwTcLxPpVC+iEq8M4vbMStZ/TgYNEDCcPHFqks/VmBbyFtetJsIO0
+          T8zkDF//MbKmNCt+Qq4PynD2iaV8jLDfB68RbfYrl1r90wsnePgf/CnTgWp6i7rlNl58WFXebeQy
+          p0M9mFcfXmi8EOuUi+G88WkJkpcVNMR4rDYGP4+YWJFNziE8OmH9Kd9Yu786D2z0qNi1L3o8mGw1
+          du9Br4QqOi24m04zOUW+G86vi82B3FtHEghlxrjw9g5AfylbEmj6HDL+oU5Qv1qbuA+Td/pxiTIQ
+          ib6h+m53YptswDqKU+NJT8Jrqy3O5iyCXL9Tct1eypBT9oSDr157qxup0TQWcgn7U7gekZcOYeu9
+          4hF23Z2N/Tnesvm+Wxd/9PRaJZnTHdNbjFb5MaD+53oMuYc+y3DpRZGeFAlpo95fPSxE+x2NeJVo
+          v/0DNtYvY18LCeNF8QMQEFsdPydTClmTuJ7kmlPxrR8z+rN/1z0508PVPXfcyggWrHyME9XVuEyZ
+          dN9NKN/V93/Xty5JDCk+NinR1ONWa1cmy37+0+PUgaXPrm9UmGUl//pTr5vXIfcB0yjNcQ7pqaL2
+          3EXo7KwexDju5qozdxChc/XgRlaaIZpf5JJA/OJa4n/9yvIWr5F0cN2E7s/XImSckgEqzYtF9DGV
+          HHZmW5Cmd+bQ+3GY03lPixzcoB6JYgpttUjO0QK7OIfjPOOFzfwzsrFlrxRveirUoTMfePhx2j6o
+          vdRLxxbU5HC9FzlNiw6x5WqnPeKKU0GzQDCrpe2ub5API6bOay8zFpl6hqOtGf5bv73TuELtXWxp
+          Nu90tBkSCKBeuIoaQfR0mHOpVjCZ8pM4mysJeX0bi0DftT9CnqjVxnl8gp9+j+VWWodse50L0Mp6
+          TbzqZWnL2rq9QX9pW6LKPdHYdLtG8IlRRQ4vtFTLlE4feGTphdrj6tbxCvtkoCrtm5ycbRB28nh2
+          AedT6fF5nWpTiXcl/tXzK4hRt6jr7g3f90Odgyuh4YW1eLvt8gORFW1w5hjmBeSTpJGDn81oFqbb
+          GT7R+Un2u0BBy1kfAujDnpBd5Pfp4suIlwwtPRKdV4nD372DDbXU3ohZzYm2yIeHiJN0DqnaDmq6
+          nJpYx9dgSahZyy7bXM6zi/fi+0Zvu+FUjW1+BOStOJlmXCNobLdlOqDPfSDyR5fDoVj3PapDw6H7
+          FFdojlXDwGc1i6lx2vDh8NMrVy9q6nLNRWPX/j1CcCOOJ4a1Vs1nLAbonWaUWl/9ppWqcHi7rc7e
+          51vfaHEOFhzn5zsxDjlUTEgmFcmXg0nU5qFoy0GdeGDptqZurBYpKzPFBWHqSmJ4A3UWT1min/+l
+          8hS/0TQ9cx8ufKpS+/BRnSngvRUYXTTSqLEr5zNUexGap2/T66ES2XL5DDyC27Oip44O2hyrngH7
+          08cmMj85znyX4hxMLXCJ7h5u2pyFmx5SRh7EEbKim1OTK0BHa41aal5rrQjnAjx2lclvPodHnwQw
+          mp+tdwr6dzV5tajCN0+R+62THf4kPlWsRh0ietudwtrPm+nnb4nx0OR0ee+uOn6nOaWHZlFRF+/M
+          DB261ULkz3VO52ArRygOtnfiRhOETLheznDnsE1jfwy7OWddiQ51Bp7Ao482hdpb/OkHVcYzRm9q
+          7G10kBKDHiKhrpZzfW0gfcchNaK+qf7s3633qqlXFxmbZJ8FyG64PcnnctfxYCdvqX/MMQl7ftJG
+          L517XGkri2rLTq029e32BIPjxO/8HpxRTh4NVgJLJNdDFbOF25oBdJsAjSy2oJrPcG8gMs5vYriT
+          XAmelqqIqs8PUQzianQtlGekpWpPzLSoHEarXkfrmhbjWLI2pF89gxuYJ2KtQzucl6Av0NePeQB4
+          YvMqMZOfvo/rWV+FY3pTOLDM3iA7ee5SFii5Cl4r8kTFDy7tA94DlCtqQfedMmvTmFMOWJ3SUYjb
+          0Nmcp6nB83zbEeWXl1QV6/DVe2+cRoOxiiglnvN8Ju7icR2rPUdFBXeXqOkcqpRdXEmETOhSYlxu
+          IWPx9h0Dd5dTcurvizZiQbYxd1dTQhLdcaaub2RIc3FP1Gr8sP6ZoeSPf9zreeX8xiuFnUPofntR
+          Q2Fz2jfIK+KB+PfPRlsOJ3dCaEkdIrvN21kUVubYG28bKvNT50yWEgQ4Opuyx+zwwZa9drPReHQ0
+          4s5bres1WjaAZsOkWkvQT+8KVL86mxinzTlcNMN/49/va947QPS89TwkByGmDk0ubPRlxv3J+6d1
+          +0A0nVYZeivQ0JAOssb9xtfvBcnj386r63/7eX86rgkxaltjWyZKQCZVpuqtu3ZtsIoavGnHJ71J
+          Rw0x1XMNOJvahe5STQ2Ho04T8AehIHuoqm6SecRBMJE70U2oERNMLUbr9aH13u617D6ZdR5xsZci
+          oq6mBv3hKyUpD1677OOQZXpn/+oLdX98RN/6IrKWsPemfWIg4bMyF/xbT+6q9tLZeZQBoM9tIPtW
+          Lzt2W/ln/FLNbkRV6bCBsKOEDx8FkTtDYzihu7ACS52AGHdu6Nhw+UhguccdVYJmx4ThUkqQtc+A
+          xMOQOwxWqIH4xbf05x8GYTpF0Aq8+c0fdlhsh5UFn93Wp8ry1Sv79DDgy6NG9jacdPq+T8yYoHng
+          y5eOhoe7i06bMSTOZANbOBfBH39+U2K9muZcK9BSrDeecFc26SRkRY+rqi+ILhwfHfM32QRPfQZq
+          Pq4XNAe9/MHFBd/I/XzjtXkRawN/9XRcvnl4MqU6AH60cnpv4aINVRdOKHYil/j0rSHO/+wm7Idy
+          SM7eQDROrkwX5fWo/uq3s9jYPsO6HgqiP5HfCcad9di8lsm43qaxM382kg30U5pE3Zkq2/DPzAJB
+          5F70l097/7ktYF8NIbmT08gmtWoT4A4Xd1wneqexY3qKsZBFNjl5Rw7Vg1VEsDmPR3IQdmrHKbhY
+          QCx3e3p2DMmZ/Xxc4DiN1INfXvzud/jxoX17Zd24124WDGNyIc7UfqoFC5aNsvuAv+v7o7HrvZVR
+          H45kZN0Lp9PynDLYefhM3MN7o7XXcolh2Yhr4h37D1sGcgtQwvp5fKpDGPIrf6//qXfanR7D+X59
+          WrDb3Q5EjsrRGYnpPX/7j6jfvDX//P7oHkTqMKVHvXIpPCioJFFNvHbaVJ/MFfjKRSd2tOxTAXUG
+          gJfYOT2ghHUsPFxc0IRqT83tKIdzqhaB9PVT3ixOrTMvzdGGUpwotSqxChms2BNLGPteMT/i6onG
+          OALNC150d5WPGrs5sbGtTE8jxi3rwlG4lwaeC0shO78VwnE5SBn8eKl6itZo+Oo5+tWXaAg+Ye+4
+          0QpeH8WicTLYaDoEWgJouTr02imzM23Tjwer15xR5+IEDsvtY4PvtnYdN/Xlg6a0fuWo2y0OVSWu
+          YKwTNjLSy1z65vO7Nq8GTsWfSVC8xp3kbrPDegavxfWIs++sbrmPc4YX/RaTQ9Uo1ZQMgQTXYlON
+          j1XUdyPnMkCn3tvT3cHaaXzYlzy6zLxGdnFXOIOo2zKEsQ3UbrwYLTCFHnK0c+OhaxVVX38nYaM7
+          j9Qzg3VHX80uxnt/kOmuXL/DiafMBlRhwQu2rhZuDkYfw+koz8TgtLATytaSYMio5aHhtg+5o+/F
+          kLLDY+RM2KFFq/sA1PNzIaf6YqNJenUJrJxgPS5ZuWccN80f+Poz7/HlRwzFTEZGHKUkGlNJG5h7
+          XLCkKQX58bev/wK4q+6dapY/ddPQpME27tP3n3o2x/u5xBs504iWrZ7a+PPLsWUciemUUTr5n8MC
+          180yeGtn3LLPee2vYEWEFdVN6+UsWhhHSKn3Drm2elnNXt8DvOTlRfwvH5yKWT/DpZdEqu41i3GH
+          wInBePA1+fGO5TEsK8igqamsusCmipcm6G9eTLy6ADR59aRi2BQKTfZkDOdiiBckB0dMwp04asxa
+          P0r8zZPEmwW+mo9xpqJurxreMrTvlKb5p0R+qIYeu16Iw+el6KNbtBfpXrQI4oS2SPCzOvhEP7tc
+          OsuN9QR77i5kZ0/lH38pSdvkSOzbXnMmiPwVcNZ0IPnFH8Nxs3AFJBaT6Z5mT8S0ZOejrz8n/lMh
+          zuaFnUQ6uWZD9qT5aJOh+gsIdyJ50iPnNAZH0gA424geuEEOeb2/ulgJbNHbGuncDVmIR7i26vur
+          r1M1scs0YfElhzR55JwzIRSrENiuSC9fP7QwWVp+9XRsxNwM+W+9x/wjTqhzW73T2ZE3AFkY6SMW
+          WF7N0nmy8Pax0olxEV/dJJqbJz6d6onax+btvDn/EKHPDvnUi8T+Tz4HLp0Ket1e1FSoNqoOynkQ
+          iMuvruGEhyuPfHtzIDm1NW3B55CHE34cyPnODVWXiA8Jf/WJetF1FdakCdw/+kTU9un88WNxgO7e
+          p96aaCL6wUN9M5Z052yD9Mdz//BfNVTlL//fetDVZUUJ0jbVvFyPGf6eh4yLw/Eaa+/SGw2dnY0T
+          Kiiq11yxwqdylKkp+KnWz7lTQODNAlXmt4J6jj+IMPeVNIpZc6/ofQos/Gbxgai5/Qq/PCdA2Coi
+          b7oGAZqk7fr84wVUv0WoWr568uN3ntTdnJC3SX6GWv8Io1hnpsZ//S7m79T2hqvLd/PZd4Ptsr5a
+          NPryIepWgw2UmgbVqx6zHq6Di/7w1a9/691QEdG3/15ZaJm23L2dBRw7MbIXLcrmHdZzNDb6gZBC
+          UMKN8yh9/HxbCbmUbzucohNw6JtfqbHpZq3ZFEUDv+/P3/Uyn6fpCeo7UIjTPrSQd6lu492QfKih
+          HHbdXDv7D8C8RVSvlqLq26h7gxMaK2KMOmhsxF0OJD3fqNG8NMRT5W6gKZEFmoRe3bEvn0RCwCvf
+          vCpo85BwAXSl/yYn+7Nm42LuSujQMo9n/dqwJX6GBv6uNxK152fK+NHOYYjtPdHmY4XoBqkWHmJr
+          T3/9Z9YRl+hb34g+sawaa/dzhi9fHqd+Zqj7uIWH79gmYzu5LRvBTj4IX4V4XL58rK1cy0bRSr55
+          qy9/Hx+DBMAbB8Vb6RJOqSEXxo+H0uDrZ9grnHP45rvveVxRzcJR6dERsafHtWc9FBpTDFChJfko
+          Tuvyy8fbDAyPP1LFW09sEZ78GRq8hPR3Xjd89Q188Dmyy4lWcbUKMnzQlieHtfLuWCdgGdyHoo7w
+          5bnU30TTL+8T/aTp1Ua/OBKIm13mff1lOPnPucC3eyN+zyMMNtlNFqH9Yr+oIYxl2NumPMJGYAPR
+          jmmrDSddM/BaD7cjLhK543PVASALmogp3g9sRjD18Msjlsy/uq8ft1CokWXczrLV8bMnAtyn2CHW
+          vulDerkuT0hXn4c3N7sGCQ+PRigVre6b3+VOOKanBPhyyOlhu/AaLTPFw8ZJL8bXUvBpv09CC63X
+          pCWucDOd6ddfPdIa6qxjo2Jv15AhJluHeBy5asKjTAGS1dyQQ0peaOnoK4bWlc6e9OUd8/3a22jn
+          rc9jAVTtvvlWhlnWcg9/+fn8XOQRb4+v7ZevKxrP3YmErCh3RtH0WjYrx1OGfzxmN0k1G6j00eGX
+          r6xO/lQ95x/O0B9yeUzO9MIGucs4gIpfvOe21bV5W14s6VbW7tcPes5Luu8WwCf/Su/1y9A2z2OU
+          QKK7CjmvP+9w6JCXQCxxQG3efXWsjU0PvnrhiTbNnOnFbRZQoxZRnVep9j1vVSU/KzISuM/U+Y7X
+          Au+57sk+mks2/fR8OdsvsvOOHBu+45Gi4573uKBep/OjrqMfryL2iz+HC6WaAbfWVD1UaSutZx99
+          RBJ3N//UWyaGboNW9MvXHpIXzo96OEOJT+NvvhDfP60EiuP9NUJOw4qVrSVC1kQXKtte3S18jG34
+          +3cr4L/+9ddf/+t3w6B53/L6ezFgyOfhP/77qsB/CP/RN0ld/7mGMPZJkf/9z79vIPzddu+mHf73
+          8H7mr/7vf/6CP1cN/h7eQ1L/P4//9f2j//rX/wEAAP//AwD62oOQ3iAAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a54ab067d7-SJC
+          - 8ebdc4fadeb3251d-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1010,7 +1005,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:37:05 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -1028,7 +1023,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "74"
+          - "821"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1040,75 +1035,77 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9937222"
+          - "9999991"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 376ms
+          - 0s
         x-request-id:
-          - req_e681983616bb5d2606b1a21d0b15d030
+          - req_bcc7ffbf51879ae261c3ac0dd9610cc2
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from Wiki2023 chunk 4:
-        WikiMedia Foundation, 2023, Accessed now\n\n----\n\n2010.\n  8. **^** [Dept.
-        of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        February 15, 2010. Retrieved February 15, 2011.\n  9. **^** [PM pays tribute
-        to outstanding Canadians on Flag Day](http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
-        [Archived](https://web.archive.org/web/20110706181811/http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        Prime Minister''s Office news release. Retrieved February 16, 2011.\n\n## External
-        links\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=6\n\"Edit
-        section: External links\")]\n\n![](//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/30px-\nCommons-logo.svg.png)\n\nWikimedia
-        Commons has media related to [National Flag of Canada\nDay](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day\n\"commons:Category:National
-        Flag of Canada Day\").\n\n  * [Flag of Canada Song (1965) Freddie Grant](https://www.youtube.com/watch?v=2IkqmkTK46E)\n  *
-        [Flag Day](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm), Dept. of Canadian
-        Heritage \n  * [The famous Canadian Flag Collection, at Settlers, Rails & Trails
-        Inc, Argyle, Manitoba](http://argylemuseum.wixsite.com/argylemuseum/canadian-flag-collection)\n\n![](https://login.wikimedia.org/wiki/Special:CentralAutoLogin/start?type=1x1)\n\nRetrieved
-        from\n\"[https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994](https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994)\"\n\n[Categories](/wiki/Help:Category
-        \"Help:Category\"):\n\n  * [1996 establishments in Canada](/wiki/Category:1996_establishments_in_Canada
-        \"Category:1996 establishments in Canada\")\n  * [Public holidays in Canada](/wiki/Category:Public_holidays_in_Canada
-        \"Category:Public holidays in Canada\")\n  * [February observances](/wiki/Category:February_observances
-        \"Category:February observances\")\n  * [Flag days](/wiki/Category:Flag_days
-        \"Category:Flag days\")\n  * [Winter events in Canada](/wiki/Category:Winter_events_in_Canada
-        \"Category:Winter events in Canada\")\n\nHidden categories:\n\n  * [Webarchive
-        template wayback links](/wiki/Category:Webarchive_template_wayback_links \"Category:Webarchive
-        template wayback links\")\n  * [Articles with short description](/wiki/Category:Articles_with_short_description
-        \"Category:Articles with short description\")\n  * [Short description matches
-        Wikidata](/wiki/Category:Short_description_matches_Wikidata \"Category:Short
-        description matches Wikidata\")\n  * [Use mdy dates from February 2018](/wiki/Category:Use_mdy_dates_from_February_2018
-        \"Category:Use mdy dates from February 2018\")\n  * [Infobox holiday with missing
-        field](/wiki/Category:Infobox_holiday_with_missing_field \"Category:Infobox
-        holiday with missing field\")\n  * [Infobox holiday fixed day](/wiki/Category:Infobox_holiday_fixed_day
-        \"Category:Infobox holiday fixed day\")\n  * [Articles containing French-language
-        text](/wiki/Category:Articles_containing_French-language_text \"Category:Articles
-        containing French-language text\")\n  * [Commons category link is on Wikidata](/wiki/Category:Commons_category_link_is_on_Wikidata
-        \"Category:Commons category link is on Wikidata\")\n\n  * This page was last
-        edited on 1 July 2024, at 03:41 (UTC). \n  * Text is available under the [Creative
-        Commons Attribution-ShareAlike License 4.0](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License)[](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License);
-        additional terms may apply. By using this site, you agree to the [Terms of Use](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Terms_of_Use)
-        and [Privacy Policy](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy).
-        Wikipedia\u00ae is a registered trademark of the [Wikimedia Foundation, Inc.](//wikimediafoundation.org/),
-        a non-profit organization. \n\n  * [Privacy policy](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy)\n  *
-        [About Wikipedia](/wiki/Wikipedia:About)\n  * [Disclaimers](/wiki/Wikipedia:General_disclaimer)\n  *
-        [Contact Wikipedia](//en.wikipedia.org/wiki/Wikipedia:Contact_us)\n  * [Code
-        of Conduct](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct)\n  *
-        [Developers](https://developer.wikimedia.org)\n  * [Statistics](https://stats.wikimedia.org/#/en.wikipedia.org)\n  *
-        [Cookie statement](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement)\n  *
-        [Mobile view](//en.m.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&mobileaction=toggle_view_mobile)\n\n  *
-        [![Wikimedia Foundation](/static/images/footer/wikimedia-button.svg)](https://wikimediafoundation.org/)\n  *
-        [![Powered by MediaWiki](/w/resources/assets/poweredby_mediawiki.svg)](https://www.mediawiki.org/)\n\n  *
-        \n\n\n\n----\n\nQuestion: What is the national flag of Canada?\n\n"}], "model":
-        "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from Wiki2023 chunk 1: WikiMedia Foundation, 2023, Accessed now\\n\\n----\\n\\nJump
+        to content\\n\\nMain menu\\n\\nMain menu\\n\\nmove to sidebar  hide\\n\\nNavigation\\n\\n
+        \ * [Main page](/wiki/Main_Page \\\"Visit the main page \\\\[z\\\\]\\\")\\n
+        \ * [Contents](/wiki/Wikipedia:Contents \\\"Guides to browsing Wikipedia\\\")\\n
+        \ * [Current events](/wiki/Portal:Current_events \\\"Articles related to current
+        events\\\")\\n  * [Random article](/wiki/Special:Random \\\"Visit a randomly
+        selected article \\\\[x\\\\]\\\")\\n  * [About Wikipedia](/wiki/Wikipedia:About
+        \\\"Learn about Wikipedia and how it works\\\")\\n  * [Contact us](//en.wikipedia.org/wiki/Wikipedia:Contact_us
+        \\\"How to contact Wikipedia\\\")\\n  * [Donate](https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&utm_medium=sidebar&utm_campaign=C13_en.wikipedia.org&uselang=en
+        \\\"Support us by donating to the Wikimedia Foundation\\\")\\n\\nContribute\\n\\n
+        \ * [Help](/wiki/Help:Contents \\\"Guidance on how to use and edit Wikipedia\\\")\\n
+        \ * [Learn to edit](/wiki/Help:Introduction \\\"Learn how to edit Wikipedia\\\")\\n
+        \ * [Community portal](/wiki/Wikipedia:Community_portal \\\"The hub for editors\\\")\\n
+        \ * [Recent changes](/wiki/Special:RecentChanges \\\"A list of recent changes
+        to Wikipedia \\\\[r\\\\]\\\")\\n  * [Upload file](/wiki/Wikipedia:File_upload_wizard
+        \\\"Add images or other media for use on Wikipedia\\\")\\n\\n[ ![](/static/images/icons/wikipedia.png)\\n![Wikipedia](/static/images/mobile/copyright/wikipedia-wordmark-en.svg)
+        ![The\\nFree Encyclopedia](/static/images/mobile/copyright/wikipedia-tagline-en.svg)\\n](/wiki/Main_Page)\\n\\n[
+        Search ](/wiki/Special:Search \\\"Search Wikipedia \\\\[f\\\\]\\\")\\n\\nSearch\\n\\nAppearance\\n\\n
+        \ * [Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
+        \\\"You are encouraged to create an account and log in; however, it is not mandatory\\\")\\n
+        \ * [Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
+        \\\"You're encouraged to log in; however, it's not mandatory. \\\\[o\\\\]\\\")\\n\\nPersonal
+        tools\\n\\n  * [ Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
+        \\\"You are encouraged to create an account and log in; however, it is not mandatory\\\")\\n
+        \ * [ Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
+        \\\"You're encouraged to log in; however, it's not mandatory. \\\\[o\\\\]\\\")\\n\\nPages
+        for logged out editors [learn more](/wiki/Help:Introduction)\\n\\n  * [Contributions](/wiki/Special:MyContributions
+        \\\"A list of edits made from this IP address \\\\[y\\\\]\\\")\\n  * [Talk](/wiki/Special:MyTalk
+        \\\"Discussion about edits from this IP address \\\\[n\\\\]\\\")\\n\\n## Contents\\n\\nmove
+        to sidebar  hide\\n\\n  * (Top)\\n  * 1 History Toggle History subsection\\n
+        \   * 1.1 Background\\n    * 1.2 Flag Day\\n  * 2 See also\\n  * 3 Footnotes\\n
+        \ * 4 External links\\n\\nToggle the table of contents\\n\\n#  National Flag
+        of Canada Day\\n\\n7 languages\\n\\n  * [\u0627\u0644\u0639\u0631\u0628\u064A\u0629](https://ar.wikipedia.org/wiki/%D9%8A%D9%88%D9%85_%D8%B9%D9%84%D9%85_%D9%83%D9%86%D8%AF%D8%A7_%D8%A7%D9%84%D9%88%D8%B7%D9%86%D9%8A
+        \\\"\u064A\u0648\u0645 \u0639\u0644\u0645 \u0643\u0646\u062F\u0627 \u0627\u0644\u0648\u0637\u0646\u064A
+        \u2013 Arabic\\\")\\n  * [Espa\xF1ol](https://es.wikipedia.org/wiki/D%C3%ADa_de_la_Bandera_Nacional_de_Canad%C3%A1
+        \\\"D\xEDa de la Bandera Nacional de Canad\xE1 \u2013 Spanish\\\")\\n  * [Fran\xE7ais](https://fr.wikipedia.org/wiki/Jour_du_drapeau_national_du_Canada
+        \\\"Jour du drapeau national du Canada \u2013 French\\\")\\n  * [\u0540\u0561\u0575\u0565\u0580\u0565\u0576](https://hy.wikipedia.org/wiki/%D4%BF%D5%A1%D5%B6%D5%A1%D5%A4%D5%A1%D5%B5%D5%AB_%D5%A1%D5%A6%D5%A3%D5%A1%D5%B5%D5%AB%D5%B6_%D5%A4%D6%80%D5%B8%D5%B7%D5%AB_%D6%85%D6%80
+        \\\"\u053F\u0561\u0576\u0561\u0564\u0561\u0575\u056B \u0561\u0566\u0563\u0561\u0575\u056B\u0576
+        \u0564\u0580\u0578\u0577\u056B \u0585\u0580 \u2013 Armenian\\\")\\n  * [\u05E2\u05D1\u05E8\u05D9\u05EA](https://he.wikipedia.org/wiki/%D7%99%D7%95%D7%9D_%D7%94%D7%93%D7%92%D7%9C_%D7%94%D7%9C%D7%90%D7%95%D7%9E%D7%99_%D7%A9%D7%9C_%D7%A7%D7%A0%D7%93%D7%94
+        \\\"\u05D9\u05D5\u05DD \u05D4\u05D3\u05D2\u05DC \u05D4\u05DC\u05D0\u05D5\u05DE\u05D9
+        \u05E9\u05DC \u05E7\u05E0\u05D3\u05D4 \u2013 Hebrew\\\")\\n  * [Bahasa Melayu](https://ms.wikipedia.org/wiki/Hari_Bendera_Kebangsaan_Kanada
+        \\\"Hari Bendera Kebangsaan Kanada \u2013 Malay\\\")\\n  * [Polski](https://pl.wikipedia.org/wiki/Narodowy_dzie%C5%84_flagi_Kanady
+        \\\"Narodowy dzie\u0144 flagi Kanady \u2013 Polish\\\")\\n\\n[Edit\\nlinks](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703#sitelinks-\\nwikipedia
+        \\\"Edit interlanguage links\\\")\\n\\n  * [Article](/wiki/National_Flag_of_Canada_Day
+        \\\"View the content page \\\\[c\\\\]\\\")\\n  * [Talk](/wiki/Talk:National_Flag_of_Canada_Day
+        \\\"Discuss improvements to the content page \\\\[t\\\\]\\\")\\n\\nEnglish\\n\\n
+        \ * [Read](/wiki/National_Flag_of_Canada_Day)\\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
+        \\\"Edit this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
+        \\\"Past revisions of this page \\\\[h\\\\]\\\")\\n\\nTools\\n\\nTools\\n\\nmove
+        to sidebar  hide\\n\\nActions\\n\\n  * [Read](/wiki/National_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title\\n\\n----\\n\\nQuestion:
+        What is the national flag of Canada?\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -1117,13 +1114,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6006"
+          - "5537"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1133,7 +1130,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1147,24 +1144,22 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA3xUS2/bMAy+51cQuuziBHGTtmluRbuih23YugIdMA+JKtE2E1k0JLlpWuS/D7Lz
-          Ktbu4gO/h0j6k157AIK0mIJQpQyqqk3/8u7nw8WXz5cjd/ryi9fff1ynXxeLe/2yfOA7kUQFPy5Q
-          hZ1qoLiqDQZi28HKoQwYXdPzUZoOzyfjtAUq1miirKhDf8z9k+HJuD+c9IdnW2HJpNCLKfzuAQC8
-          tt/YotX4LKYwTHaVCr2XBYrpngQgHJtYEdJ78kHaIJIDqNgGtG3X8/l84dlm9jWzAJnwTVVJt87E
-          FDJxXyLgs0JXB9CMHiwH0ORQBbMGjV45ekQIJYKVcWhpIDeyAM7hSlqp5QBueYVP6BKgAA5zdGgV
-          +lbzbae5eaOBa7lOYFWSKsE3RYE+dPxo/cmDp8JSTkpahUC2U5G0oBoTGocDuN+SgTwYWqJZt3qH
-          GqTV0TpsCSsKJUioZG0QDMo8ARkPIx+1UbRCY/pLyyv78Yw37KBih6AxSDKogWzOrmr5CbBFqKgo
-          twuAwK0zPgd00c6QXXqoHT+RRp2Ab1TZtYFwjbV0oUIb9gfGUW/RUZAFAruW9kBLqlCThCuuKrYe
-          lAxYsFuDQxMjuDv1P0sfZCLpUuDQ4FPc78wrdtil4TwTmd1kdj6fH4fJYd54GbNsG2O29c0+nYaL
-          2vGj3+L7ek6WfDlzKD3bmEQfuBYtuukB/GlvQfMm2KJ2XNVhFniJNhqmp+NJZygOF+8ITkdbNHCQ
-          5gg4O0uTdyxn3f/zR1dJKKlK1Efa8XCyH0I2mviADXtHs//b0nv23fxkiyOXD+0PgFJYB9Sz2qEm
-          9XbsA81hfJw+ou133TYs/NoHrGY52QJd7ah7H/J6lp5e6MlonColepveXwAAAP//AwDhIH2iKAUA
-          AA==
+          H4sIAAAAAAAAA3SUTW8aMRCG7/yKkS+5LIhAQgi3tlHUVE1OkXLoVjDYs8sEf8k2BBTx3yvv8hU1
+          uexhXr/Pzjue3fcOgGAlJiDkApM0Xne/4ejl9nttfs4f7K/Hu82NMWnL8d48Lc2LKLLDzV9JpoOr
+          J53xmhI728oyECbK1Mub4fByNB4MrhvBOEU622qfuleuO+gPrrr9cbc/2hsXjiVFMYE/HQCA9+aZ
+          W7SKNmIC/eJQMRQj1iQmx0MAIjidKwJj5JjQJlGcROlsItt0PZvNXqOzpX0vLUAp4soYDNtSTKAU
+          zwsC2kgKPoFyFMG6BD64NSsCBMWBZAJFUQb2OTS4AGywJnAVpAWBxVxGDZXGOhd/oEWFPXjIIDYY
+          WG+hcnIVKYKzYHHNdWMCtAr2nUIgnecIyTXYi6cD9/4DF+5wewEYEktNGffCS/akGAtgK/VKsa1B
+          s13GjAqEqgBSnIrmbWumt4a/4Jhc2B5SeKypB89f5ylAOmOc1VtYWvdmAWNjfESvCX4TVgVwO752
+          WnNSwBbSgiMk2qReKYr2AgJpWqOVNI3SBWovYliK0u5KO5vNzu8xULWKmNfIrrTe13fHxdCu9sHN
+          414/1iu2HBfTQBidzUsQk/OiUXcdgL/NAq4+7JTwwRmfpsktyWbg5fXtoAWK086f5NvhXkwuoT6z
+          jcbXxSfEqaKErOPZEguJckHqzHvVHx8z4EqxO2n9zln0/zv6DN/GZ1ufUb7EnwQpySdSUx9IsfyY
+          +nQsUP4tfHXsOOqmYRG3MZGZVmxrCj5w+2VWfnpTjeY0pGreF51d5x8AAAD//wMAidhaLqIEAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a6795efaca-SJC
+          - 8ebdc5011ff3270a-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1172,14 +1167,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:22 GMT
+          - Mon, 02 Dec 2024 19:37:06 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=ZHQN2KoJsWeskd47J89zr24vGkCtJjLGFZ46mgzAeI4-1731107842-1.0.1.1-BBtTxquHzsQqJEO_pit0dJHK9Tnw7e4iaWfJ6SxJKcQMn81voomoSSteq5wA2OPW5XzhqzCwXazDdUyuWS4YIg;
-            path=/; expires=Fri, 08-Nov-24 23:47:22 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=e9X7mhCkdDhu32.9Suxb5XofKk5L6MTtDCDfF_p_GS4-1733168226-1.0.1.1-8BiWjOrrbZy0V1_rLGEi60FcqtMFXGNEnlObZpqVOBx89b4Hm.1UKjizShSmeg5zVLL5K1IxiIzisaUESmPxow;
+            path=/; expires=Mon, 02-Dec-24 20:07:06 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=W7QcVIpEIRJ033ZrV_LGGZAx2zlE8fhIat.phonj5kc-1731107842721-0.0.1.1-604800000;
+          - _cfuvid=sb85mIcSFJYHbiA4Tykap8ETCMwcXteAP6V5mUoiduA-1733168226892-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1192,346 +1187,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "1510"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9991"
-        x-ratelimit-remaining-tokens:
-          - "29980719"
-        x-ratelimit-reset-requests:
-          - 48ms
-        x-ratelimit-reset-tokens:
-          - 38ms
-        x-request-id:
-          - req_9ecc953dad7cc10a2a5ce5b8048df281
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from Wiki2023 chunk 1:
-        WikiMedia Foundation, 2023, Accessed now\n\n----\n\nJump to content\n\nMain
-        menu\n\nMain menu\n\nmove to sidebar  hide\n\nNavigation\n\n  * [Main page](/wiki/Main_Page
-        \"Visit the main page \\[z\\]\")\n  * [Contents](/wiki/Wikipedia:Contents \"Guides
-        to browsing Wikipedia\")\n  * [Current events](/wiki/Portal:Current_events \"Articles
-        related to current events\")\n  * [Random article](/wiki/Special:Random \"Visit
-        a randomly selected article \\[x\\]\")\n  * [About Wikipedia](/wiki/Wikipedia:About
-        \"Learn about Wikipedia and how it works\")\n  * [Contact us](//en.wikipedia.org/wiki/Wikipedia:Contact_us
-        \"How to contact Wikipedia\")\n  * [Donate](https://donate.wikimedia.org/wiki/Special:FundraiserRedirector?utm_source=donate&utm_medium=sidebar&utm_campaign=C13_en.wikipedia.org&uselang=en
-        \"Support us by donating to the Wikimedia Foundation\")\n\nContribute\n\n  *
-        [Help](/wiki/Help:Contents \"Guidance on how to use and edit Wikipedia\")\n  *
-        [Learn to edit](/wiki/Help:Introduction \"Learn how to edit Wikipedia\")\n  *
-        [Community portal](/wiki/Wikipedia:Community_portal \"The hub for editors\")\n  *
-        [Recent changes](/wiki/Special:RecentChanges \"A list of recent changes to Wikipedia
-        \\[r\\]\")\n  * [Upload file](/wiki/Wikipedia:File_upload_wizard \"Add images
-        or other media for use on Wikipedia\")\n\n[ ![](/static/images/icons/wikipedia.png)\n![Wikipedia](/static/images/mobile/copyright/wikipedia-wordmark-en.svg)
-        ![The\nFree Encyclopedia](/static/images/mobile/copyright/wikipedia-tagline-en.svg)\n](/wiki/Main_Page)\n\n[
-        Search ](/wiki/Special:Search \"Search Wikipedia \\[f\\]\")\n\nSearch\n\nAppearance\n\n  *
-        [Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
-        \"You are encouraged to create an account and log in; however, it is not mandatory\")\n  *
-        [Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
-        \"You''re encouraged to log in; however, it''s not mandatory. \\[o\\]\")\n\nPersonal
-        tools\n\n  * [ Create account](/w/index.php?title=Special:CreateAccount&returnto=National+Flag+of+Canada+Day
-        \"You are encouraged to create an account and log in; however, it is not mandatory\")\n  *
-        [ Log in](/w/index.php?title=Special:UserLogin&returnto=National+Flag+of+Canada+Day
-        \"You''re encouraged to log in; however, it''s not mandatory. \\[o\\]\")\n\nPages
-        for logged out editors [learn more](/wiki/Help:Introduction)\n\n  * [Contributions](/wiki/Special:MyContributions
-        \"A list of edits made from this IP address \\[y\\]\")\n  * [Talk](/wiki/Special:MyTalk
-        \"Discussion about edits from this IP address \\[n\\]\")\n\n## Contents\n\nmove
-        to sidebar  hide\n\n  * (Top)\n  * 1 History Toggle History subsection\n    *
-        1.1 Background\n    * 1.2 Flag Day\n  * 2 See also\n  * 3 Footnotes\n  * 4 External
-        links\n\nToggle the table of contents\n\n#  National Flag of Canada Day\n\n7
-        languages\n\n  * [\u0627\u0644\u0639\u0631\u0628\u064a\u0629](https://ar.wikipedia.org/wiki/%D9%8A%D9%88%D9%85_%D8%B9%D9%84%D9%85_%D9%83%D9%86%D8%AF%D8%A7_%D8%A7%D9%84%D9%88%D8%B7%D9%86%D9%8A
-        \"\u064a\u0648\u0645 \u0639\u0644\u0645 \u0643\u0646\u062f\u0627 \u0627\u0644\u0648\u0637\u0646\u064a
-        \u2013 Arabic\")\n  * [Espa\u00f1ol](https://es.wikipedia.org/wiki/D%C3%ADa_de_la_Bandera_Nacional_de_Canad%C3%A1
-        \"D\u00eda de la Bandera Nacional de Canad\u00e1 \u2013 Spanish\")\n  * [Fran\u00e7ais](https://fr.wikipedia.org/wiki/Jour_du_drapeau_national_du_Canada
-        \"Jour du drapeau national du Canada \u2013 French\")\n  * [\u0540\u0561\u0575\u0565\u0580\u0565\u0576](https://hy.wikipedia.org/wiki/%D4%BF%D5%A1%D5%B6%D5%A1%D5%A4%D5%A1%D5%B5%D5%AB_%D5%A1%D5%A6%D5%A3%D5%A1%D5%B5%D5%AB%D5%B6_%D5%A4%D6%80%D5%B8%D5%B7%D5%AB_%D6%85%D6%80
-        \"\u053f\u0561\u0576\u0561\u0564\u0561\u0575\u056b \u0561\u0566\u0563\u0561\u0575\u056b\u0576
-        \u0564\u0580\u0578\u0577\u056b \u0585\u0580 \u2013 Armenian\")\n  * [\u05e2\u05d1\u05e8\u05d9\u05ea](https://he.wikipedia.org/wiki/%D7%99%D7%95%D7%9D_%D7%94%D7%93%D7%92%D7%9C_%D7%94%D7%9C%D7%90%D7%95%D7%9E%D7%99_%D7%A9%D7%9C_%D7%A7%D7%A0%D7%93%D7%94
-        \"\u05d9\u05d5\u05dd \u05d4\u05d3\u05d2\u05dc \u05d4\u05dc\u05d0\u05d5\u05de\u05d9
-        \u05e9\u05dc \u05e7\u05e0\u05d3\u05d4 \u2013 Hebrew\")\n  * [Bahasa Melayu](https://ms.wikipedia.org/wiki/Hari_Bendera_Kebangsaan_Kanada
-        \"Hari Bendera Kebangsaan Kanada \u2013 Malay\")\n  * [Polski](https://pl.wikipedia.org/wiki/Narodowy_dzie%C5%84_flagi_Kanady
-        \"Narodowy dzie\u0144 flagi Kanady \u2013 Polish\")\n\n[Edit\nlinks](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703#sitelinks-\nwikipedia
-        \"Edit interlanguage links\")\n\n  * [Article](/wiki/National_Flag_of_Canada_Day
-        \"View the content page \\[c\\]\")\n  * [Talk](/wiki/Talk:National_Flag_of_Canada_Day
-        \"Discuss improvements to the content page \\[t\\]\")\n\nEnglish\n\n  * [Read](/wiki/National_Flag_of_Canada_Day)\n  *
-        [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \"Edit this
-        page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
-        \"Past revisions of this page \\[h\\]\")\n\nTools\n\nTools\n\nmove to sidebar  hide\n\nActions\n\n  *
-        [Read](/wiki/National_Flag_of_Canada_Day)\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
-        \"Edit this page \\[e\\]\")\n  * [View history](/w/index.php?title\n\n----\n\nQuestion:
-        What is the national flag of Canada?\n\n"}], "model": "gpt-4o-2024-08-06", "stream":
-        false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "5896"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.54.3
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.54.3
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA3xUS0/bQBC+51eM9sLFQUkIj+SGiipV0B4oBVV1lUx2x/aS9a67MyYElP9e2Xmi
-          Qi+WPN9jv/HM+rUDoKxRY1C6QNFl5bqXt98fRiXfXF6/zO9/LB6y+9vHwc8rW1y/xBOVNIoweyQt
-          W9WxDmXlSGzwa1hHQqHGtX9+0u/3zi+G/RYogyHXyPJKusPQHfQGw27vots72wiLYDWxGsOvDgDA
-          a/tsInpDz2oMvWRbKYkZc1LjHQlAxeCaikJmy4JeVLIHdfBCvk09nU4fOfjUv6YeIFVclyXGZarG
-          kKq7goCeNcVKwARi8EGgiuHJGgIEYyNpAUOso62apiFkIAWBx+YNHWQO86b4CT0aPIYvAiX5BmQ4
-          +rZlfX7DgitcHgF6sz2KwVk/Z5AAGMVqRwzWwxNGG2oGhz6vMScGnIVaQArLYHCZwKwWsAfR10ln
-          1GZso1lhctkx3C0rq9G5ZfK//GAZ5j4sPCC3vK9YOYIbwiyBjFDqaH0OCJEMZJacgYWVAhAWhRUC
-          /lNjJMAmFYMmLxQTmBFuZCxLZ1/ItPqy9XaE2XGqkvV0Ijl6Qq9pwjpEWk/pLFWpX6V+Op0eDjlS
-          VjM2O+Zr5zb11W5rXMirGGa8wXf1zHrLxSQScvDNhrCESrXoqgPwu93O+s3CqSqGspKJhDn5xrB/
-          OhqsDdX+Quzh0WgDShB0B7KzUT95x3FiSNA6PthwpVEXZA60w97FrgesjQ17rNc5aP3fRO/Zr9u3
-          Pj9w+dB+D2hNlZCZVJGM1W+73tMiNf+Mj2i7T90GVrxkoXKSWZ9TrKJdX9usmgxPdXY6NISkOqvO
-          XwAAAP//AwDul1F5vwQAAA==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8df946a67e307adc-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:22 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=N8.KiYTAKYt9TGosII0DBHDWOwagsBMs2b_yoxBfJGI-1731107842-1.0.1.1-Q5lribozOebpLDBEV_Pi5qEynoVKqTbNDKyUioCyam0PY0xhe7oZRyzI72BDuWZIVeT3BFYpF9dQM_zk6umKDA;
-            path=/; expires=Fri, 08-Nov-24 23:47:22 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=N7U52tCEIehL.G2CEoqqak03p8xzEMJnpnKdzUluBZg-1731107842985-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "1838"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998684"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_4b59c8c075775da2365ad93f18775920
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from Wiki2023 chunk 3:
-        WikiMedia Foundation, 2023, Accessed now\n\n----\n\n an [Order in\nCouncil](/wiki/Order_in_Council
-        \"Order in Council\") from [Governor\nGeneral](/wiki/Governor_General_of_Canada
-        \"Governor General of Canada\") [Rom\u00e9o\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc
-        \"Rom\u00e9o LeBlanc\"), on the initiative of Prime\nMinister [Jean Chr\u00e9tien](/wiki/Jean_Chr%C3%A9tien
-        \"Jean Chr\u00e9tien\").[7] At the\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
-        \"Hull, Quebec\"),\nChr\u00e9tien was confronted by demonstrators against proposed
-        cuts to the\n[unemployment insurance](/wiki/Unemployment_insurance \"Unemployment\ninsurance\")
-        system, and while walking through the crowd he was [grabbed by the\nneck and
-        pushed aside](/wiki/Shawinigan_Handshake \"Shawinigan Handshake\") a\nprotester
-        who had approached him.\n\nIn 2010, on the flag''s 45th anniversary, federal
-        ceremonies were held to mark\nFlag Day at [Ottawa](/wiki/Ottawa \"Ottawa\"),
-        [Winnipeg](/wiki/Winnipeg\n\"Winnipeg\"), [St. John''s](/wiki/St._John%27s,_Newfoundland_and_Labrador
-        \"St.\nJohn''s, Newfoundland and Labrador\"), and at\n[Whistler](/wiki/Whistler,_British_Columbia
-        \"Whistler, British Columbia\") and\n[Vancouver](/wiki/Vancouver \"Vancouver\")
-        in conjunction with the [2010 Winter\nOlympics](/wiki/2010_Winter_Olympics \"2010
-        Winter Olympics\") in Vancouver.[8]\nIn 2011, Prime Minister [Stephen Harper](/wiki/Stephen_Harper
-        \"Stephen\nHarper\") observed Flag Day by presenting two citizens, whose work
-        honoured the\n[military](/wiki/Canadian_Armed_Forces \"Canadian Armed Forces\"),
-        with Canadian\nflags that had flown over the [Peace Tower](/wiki/Peace_Tower
-        \"Peace Tower\").\nIt was announced as inaugurating an annual recognition of
-        patriotism.[9]\n\n## See also\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=4\n\"Edit
-        section: See also\")]\n\n  * ![flag](//upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Maple_Leaf_%28from_roundel%29.svg/25px-Maple_Leaf_%28from_roundel%29.svg.png)[Canada
-        portal](/wiki/Portal:Canada \"Portal:Canada\")\n\n  * [Flag Day](/wiki/Flag_Day
-        \"Flag Day\")\n  * [List of Canadian flags](/wiki/List_of_Canadian_flags \"List
-        of Canadian flags\")\n  * [National flag](/wiki/National_flag \"National flag\")\n\n##
-        Footnotes\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=5\n\"Edit
-        section: Footnotes\")]\n\n  1. **^** [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage
-        \"Department of Canadian Heritage\"). [\"Ceremonial and Canadian Symbols Promotion
-        > The National Flag of Canada\"](https://web.archive.org/web/20100423114158/http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm).
-        Queen''s Printer for Canada. Archived from [the original](http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm)
-        on April 23, 2010. Retrieved March 21, 2010.\n  2. ^ _**a**_ _**b**_ Government
-        of Canada, Public Services and Procurement Canada (July 31, 2015). [\"Infographic:
-        National Flag of Canada Day \u2013 February 15 \u2013 Canada''s Parliamentary
-        Precinct \u2013 PWGSC\"](https://www.tpsgc-pwgsc.gc.ca/citeparlementaire-parliamentaryprecinct/decouvrez-discover/jour-drap-flag-day-eng.html).
-        _www.tpsgc-pwgsc.gc.ca_. Retrieved February 5, 2022.\n  3. ^ _**a**_ _**b**_
-        [\"What is the National Flag Day of Canada?\"](http://westernfinancialgroup.ca/What-is-the-National-Flag-of-Canada-Day).
-        _westernfinancialgroup.ca_. Retrieved February 5, 2022.\n  4. **^** [Department
-        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \"Department of
-        Canadian Heritage\"). [\"Ceremonial and Canadian Symbols Promotion > The National
-        Flag of Canada > Birth of the Canadian flag\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
-        Queen''s Printer for Canada. [Archived](https://web.archive.org/web/20100224005050/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
-        from the original on February 24, 2010. Retrieved March 21, 2010.\n  5. **^**
-        [\"Birth of the Canadian flag\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
-        [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \"Department
-        of Canadian Heritage\"). [Archived](https://web.archive.org/web/20081220170253/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
-        from the original on December 20, 2008. Retrieved December 16, 2008.\n  6. **^**
-        [Conserving the Proclamation of the Canadian Flag](http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
-        [Archived](https://web.archive.org/web/20121021133944/http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
-        October 21, 2012, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        Library and Archives of Canada, from John Grace in The Archivist, National Archives,
-        Ottawa, 1990. Retrieved February 15, 2011.\n  7. **^** [Department of Canadian
-        Heritage](/wiki/Department_of_Canadian_Heritage \"Department of Canadian Heritage\").
-        [\"National Flag of Canada Day\"](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm).
-        Queen''s Printer for Canada. [Archived](https://web.archive.org/web/20100217042202/http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm)
-        from the original on February 17, 2010. Retrieved March 21, 2010.\n  8. **^**
-        [Dept. of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
-        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \"Wayback Machine\"),
-        February 15, 2010. Retrieved February 15, 2011.\n \n\n----\n\nQuestion: What
-        is the national flag of Canada?\n\n"}], "model": "gpt-4o-2024-08-06", "stream":
-        false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6275"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.54.3
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.54.3
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA3RUwW4bRwy96yuIufSyMrS2JFu6tW4dtIjbIG2QAFUhUbNcLeNZzmY4K2dr+IPy
-          HfmxYnZtSUaTyxz4yDd8b8h5GAEYLswSjK0w2rpx4x/f/vl+8e7SfWrsh/m7i/bm9s35L22803aa
-          fzZZqvDbj2Tjc9WZ9XXjKLKXAbaBMFJizS8v8nxyeTXNe6D2BblUtmvieOrH55Pz6XhyNZ7Mnwor
-          z5bULOHvEQDAQ3+mFqWgz2YJk+w5UpMq7sgsD0kAJniXIgZVWSNKNNkRtF4iSd/1ZrP5qF5W8rAS
-          gJXRtq4xdCuzhJX5qyIQTGrQQelwB76EaxQsMAN06uFO/L0AKsSK4BYbR/CasMzgHhVYsN21IRkA
-          XuCGtqHF0EE+yyBfzGdn8GuEkjC2gRQQAhVQMrkC7jlWgHBfcSTQTy0GAozAUcGSRAoZsCTYpjSN
-          neN/qegJ6r4JR1gOLHkOjWeJCqxQsDYOOyrOIGnrJaVOSSNuHWtFBWw7QIE/QkEhXXLtW7HsoAy+
-          hld+T0F8gFckFNDBW19//eLhNf3kUGxSmYxg4cgYeU/JsDeBa4JbFtZIAX4jFLiuwtcvkUmOjfyg
-          gCK8p6DJJE5SHW0H+1CkRee6dMPvzy9y8+JF4GfsskHzHgP7NhEEqr0wKVTJVrTB6/BW1rcSQwfR
-          Q+WTouSt8k64ZIti6WxlsmEkAjnap9BarQ80jMZiZVbyuJLNZnM6WYHKVjENtrTOPcUfD6Pq/K4J
-          fqtP+CFeJnOqdSBUL2ksNfrG9OjjCOCffiXaF1NumuDrJq6jvyPRfsGmi4HQHLfwBD6fP6HRR3Qn
-          wNXlLPsG5bqgiOz0ZK+MRVtRcVI7u5gfRGBbsD9ik9GJ9v+39C36QT/L7oTlu/RHwFpqIhXrJlDB
-          9qXsY1qg9FN9L+3gdd+w0U4j1euSZUehCTx8FmWzzmeL4upimltrRo+j/wAAAP//AwB8qUCcNQUA
-          AA==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8df946a67c767ae5-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:23 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=cFKA86NlavL6C7gv6dqmJUjotBAXZH6dNk81k9_gUY8-1731107843-1.0.1.1-Watl4Fw4T1dv1Egq68zZ5diH8HZaLbVtvKbx_D3.gfWNSHcEtKa0LI95BaThb.IF35hvb95qpC1TEWAiswXIEA;
-            path=/; expires=Fri, 08-Nov-24 23:47:23 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=btxY0UCgqMI.rTAKyiXQFquv58pb4WL2Jz0YCzgcH5w-1731107843101-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "1945"
+          - "1306"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1543,88 +1199,85 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9998"
         x-ratelimit-remaining-tokens:
-          - "29998493"
+          - "29997430"
         x-ratelimit-reset-requests:
-          - 6ms
+          - 11ms
         x-ratelimit-reset-tokens:
-          - 3ms
+          - 5ms
         x-request-id:
-          - req_07da763baaeff58c78453f7cbd8fd7db
+          - req_c63d692b5e63318af718667ab4a5883b
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from Wiki2023 chunk 2:
-        WikiMedia Foundation, 2023, Accessed now\n\n----\n\n_Flag_of_Canada_Day)\n  *
-        [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \"Edit this
-        page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
-        \"Past revisions of this page \\[h\\]\")\n\nTools\n\nTools\n\nmove to sidebar  hide\n\nActions\n\n  *
-        [Read](/wiki/National_Flag_of_Canada_Day)\n  * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit
-        \"Edit this page \\[e\\]\")\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history)\n\nGeneral\n\n  *
-        [What links here](/wiki/Special:WhatLinksHere/National_Flag_of_Canada_Day \"List
-        of all English Wikipedia pages containing links to this page \\[j\\]\")\n  *
-        [Related changes](/wiki/Special:RecentChangesLinked/National_Flag_of_Canada_Day
-        \"Recent changes in pages linked from this page \\[k\\]\")\n  * [Upload file](/wiki/Wikipedia:File_Upload_Wizard
-        \"Upload files \\[u\\]\")\n  * [Special pages](/wiki/Special:SpecialPages \"A
-        list of all special pages \\[q\\]\")\n  * [Permanent link](/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994
-        \"Permanent link to this revision of this page\")\n  * [Page information](/w/index.php?title=National_Flag_of_Canada_Day&action=info
-        \"More information about this page\")\n  * [Cite this page](/w/index.php?title=Special:CiteThisPage&page=National_Flag_of_Canada_Day&id=1231946994&wpFormIdentifier=titleform
-        \"Information on how to cite this page\")\n  * [Get shortened URL](/w/index.php?title=Special:UrlShortener&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\n  *
-        [Download QR code](/w/index.php?title=Special:QrCode&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\n  *
-        [Wikidata item](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703 \"Structured
-        data on this page hosted by Wikidata \\[g\\]\")\n\nPrint/export\n\n  * [Download
-        as PDF](/w/index.php?title=Special:DownloadAsPdf&page=National_Flag_of_Canada_Day&action=show-download-screen
-        \"Download this page as a PDF file\")\n  * [Printable version](/w/index.php?title=National_Flag_of_Canada_Day&printable=yes
-        \"Printable version of this page \\[p\\]\")\n\nIn other projects\n\n  * [Wikimedia
-        Commons](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day)\n\nAppearance\n\nmove
-        to sidebar  hide\n\nFrom Wikipedia, the free encyclopedia\n\nCanadian holiday\n\nNational
-        Flag of Canada Day  \n---  \n[![](//upload.wikimedia.org/wikipedia/commons/thumb/6/68/Canada_flag_halifax_9_-04.JPG/250px-\nCanada_flag_halifax_9_-04.JPG)](/wiki/File:Canada_flag_halifax_9_-04.JPG)
-        The\nnational flag of Canada  \nObserved by  |  [Canada](/wiki/Canada \"Canada\")  \nDate
-        |  [February 15](/wiki/February_15 \"February 15\")  \nNext time  |  February
-        15, 2025 (2025-02-15)  \nFrequency | Annual  \n  \n**National Flag of Canada
-        Day** ([French](/wiki/French_language \"French\nlanguage\"): _Jour du drapeau
-        national du Canada_), commonly shortened to\n**Flag Day** , is observed annually
-        on February 15 to commemorate the\ninauguration of the [flag of Canada](/wiki/Flag_of_Canada
-        \"Flag of Canada\") on\nthat date in 1965.[1] The day is marked by flying the
-        flag, occasional public\nceremonies and educational programs in schools. It
-        is not a [public\nholiday](/wiki/Public_holidays_in_Canada \"Public holidays
-        in Canada\"),\nalthough there has been discussion about creating one.\n\n##
-        History\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=1\n\"Edit
-        section: History\")]\n\n### Background\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=2\n\"Edit
-        section: Background\")]\n\nAmid [much controversy](/wiki/Great_Canadian_flag_debate
-        \"Great Canadian flag\ndebate\"), the [Parliament of Canada](/wiki/Parliament_of_Canada
-        \"Parliament of\nCanada\") in 1964 voted to adopt a new design for the [Canadian\nflag](/wiki/Flag_of_Canada
-        \"Flag of Canada\") and issued a call for\nsubmissions.[2]\n\nThis flag would
-        replace the [Canadian Red Ensign](/wiki/Canadian_Red_Ensign\n\"Canadian Red
-        Ensign\"), which had been, with various successive alterations,\nin conventional
-        use as the national flag of [Canada](/wiki/Canada \"Canada\")\nsince 1868. Nearly
-        4,000 designs were submitted by Canadians.[2] On October\n22, 1964, the [Maple
-        Leaf flag](/wiki/Maple_Leaf_flag \"Maple Leaf\nflag\")\u2014designed by historian
-        [George Stanley](/wiki/George_Stanley \"George\nStanley\")\u2014won with a unanimous
-        vote.[3] Under the leadership of [Prime\nMinister](/wiki/Prime_Minister_of_Canada
-        \"Prime Minister of Canada\") [Lester\nPearson](/wiki/Lester_B._Pearson \"Lester
-        B. Pearson\"), resolutions\nrecommending the new design were passed by the [House
-        of\nCommons](/wiki/House_of_Commons_of_Canada \"House of Commons of Canada\")
-        on\nDecember 15, 1964, and by the [Senate](/wiki/Senate_of_Canada \"Senate of\nCanada\")
-        two days later.[4]\n\nThe flag was proclaimed by [Elizabeth II](/wiki/Elizabeth_II
-        \"Elizabeth II\"),\n[Queen of Canada](/wiki/Monarchy_of_Canada \"Monarchy of
-        Canada\"), on January\n28, 1965,[3][5] and took effect \"upon, from and after\"
-        February 15 that\nyear.[6]\n\n### Flag Day\n\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=3\n\"Edit
-        section: Flag Day\")]\n\nNational Flag of Canada Day was instituted in 1996
-        by an [Order in\nCouncil](/wiki/Order_in_Council \"Order in Council\") from
-        [Governor\nGeneral](/wiki/Governor_General_of_Canada \"Governor General of Canada\")
-        [Rom\u00e9o\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \"Rom\u00e9o LeBlanc\"), on the
-        initiative of Prime\nMinister [Jean Chr\u00e9tien](/wiki/Jean_Chr%C3%A9tien
-        \"Jean Chr\u00e9tien\").[7] At the\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
-        \"Hull, Quebec\"),\nChr\u00e9tien was confronted by demonstrators against proposed
-        cuts to the\n[un\n\n----\n\nQuestion: What is the national flag of Canada?\n\n"}],
-        "model": "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from Wiki2023 chunk 3: WikiMedia Foundation, 2023, Accessed now\\n\\n----\\n\\n
+        an [Order in\\nCouncil](/wiki/Order_in_Council \\\"Order in Council\\\") from
+        [Governor\\nGeneral](/wiki/Governor_General_of_Canada \\\"Governor General of
+        Canada\\\") [Rom\xE9o\\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \\\"Rom\xE9o LeBlanc\\\"),
+        on the initiative of Prime\\nMinister [Jean Chr\xE9tien](/wiki/Jean_Chr%C3%A9tien
+        \\\"Jean Chr\xE9tien\\\").[7] At the\\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
+        \\\"Hull, Quebec\\\"),\\nChr\xE9tien was confronted by demonstrators against
+        proposed cuts to the\\n[unemployment insurance](/wiki/Unemployment_insurance
+        \\\"Unemployment\\ninsurance\\\") system, and while walking through the crowd
+        he was [grabbed by the\\nneck and pushed aside](/wiki/Shawinigan_Handshake \\\"Shawinigan
+        Handshake\\\") a\\nprotester who had approached him.\\n\\nIn 2010, on the flag's
+        45th anniversary, federal ceremonies were held to mark\\nFlag Day at [Ottawa](/wiki/Ottawa
+        \\\"Ottawa\\\"), [Winnipeg](/wiki/Winnipeg\\n\\\"Winnipeg\\\"), [St. John's](/wiki/St._John%27s,_Newfoundland_and_Labrador
+        \\\"St.\\nJohn's, Newfoundland and Labrador\\\"), and at\\n[Whistler](/wiki/Whistler,_British_Columbia
+        \\\"Whistler, British Columbia\\\") and\\n[Vancouver](/wiki/Vancouver \\\"Vancouver\\\")
+        in conjunction with the [2010 Winter\\nOlympics](/wiki/2010_Winter_Olympics
+        \\\"2010 Winter Olympics\\\") in Vancouver.[8]\\nIn 2011, Prime Minister [Stephen
+        Harper](/wiki/Stephen_Harper \\\"Stephen\\nHarper\\\") observed Flag Day by
+        presenting two citizens, whose work honoured the\\n[military](/wiki/Canadian_Armed_Forces
+        \\\"Canadian Armed Forces\\\"), with Canadian\\nflags that had flown over the
+        [Peace Tower](/wiki/Peace_Tower \\\"Peace Tower\\\").\\nIt was announced as
+        inaugurating an annual recognition of patriotism.[9]\\n\\n## See also\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=4\\n\\\"Edit
+        section: See also\\\")]\\n\\n  * ![flag](//upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Maple_Leaf_%28from_roundel%29.svg/25px-Maple_Leaf_%28from_roundel%29.svg.png)[Canada
+        portal](/wiki/Portal:Canada \\\"Portal:Canada\\\")\\n\\n  * [Flag Day](/wiki/Flag_Day
+        \\\"Flag Day\\\")\\n  * [List of Canadian flags](/wiki/List_of_Canadian_flags
+        \\\"List of Canadian flags\\\")\\n  * [National flag](/wiki/National_flag \\\"National
+        flag\\\")\\n\\n## Footnotes\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=5\\n\\\"Edit
+        section: Footnotes\\\")]\\n\\n  1. **^** [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage
+        \\\"Department of Canadian Heritage\\\"). [\\\"Ceremonial and Canadian Symbols
+        Promotion > The National Flag of Canada\\\"](https://web.archive.org/web/20100423114158/http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm).
+        Queen's Printer for Canada. Archived from [the original](http://www.canadianheritage.gc.ca/progs/cpsc-ccsp/sc-cs/df1_e.cfm)
+        on April 23, 2010. Retrieved March 21, 2010.\\n  2. ^ _**a**_ _**b**_ Government
+        of Canada, Public Services and Procurement Canada (July 31, 2015). [\\\"Infographic:
+        National Flag of Canada Day \u2013 February 15 \u2013 Canada's Parliamentary
+        Precinct \u2013 PWGSC\\\"](https://www.tpsgc-pwgsc.gc.ca/citeparlementaire-parliamentaryprecinct/decouvrez-discover/jour-drap-flag-day-eng.html).
+        _www.tpsgc-pwgsc.gc.ca_. Retrieved February 5, 2022.\\n  3. ^ _**a**_ _**b**_
+        [\\\"What is the National Flag Day of Canada?\\\"](http://westernfinancialgroup.ca/What-is-the-National-Flag-of-Canada-Day).
+        _westernfinancialgroup.ca_. Retrieved February 5, 2022.\\n  4. **^** [Department
+        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department of
+        Canadian Heritage\\\"). [\\\"Ceremonial and Canadian Symbols Promotion > The
+        National Flag of Canada > Birth of the Canadian flag\\\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
+        Queen's Printer for Canada. [Archived](https://web.archive.org/web/20100224005050/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
+        from the original on February 24, 2010. Retrieved March 21, 2010.\\n  5. **^**
+        [\\\"Birth of the Canadian flag\\\"](http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm).
+        [Department of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department
+        of Canadian Heritage\\\"). [Archived](https://web.archive.org/web/20081220170253/http://www.pch.gc.ca/pgm/ceem-cced/symbl/df3-eng.cfm)
+        from the original on December 20, 2008. Retrieved December 16, 2008.\\n  6.
+        **^** [Conserving the Proclamation of the Canadian Flag](http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
+        [Archived](https://web.archive.org/web/20121021133944/http://www.collectionscanada.gc.ca/publications/archivist-magazine/015002-2021-e.html)
+        October 21, 2012, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback
+        Machine\\\"), Library and Archives of Canada, from John Grace in The Archivist,
+        National Archives, Ottawa, 1990. Retrieved February 15, 2011.\\n  7. **^** [Department
+        of Canadian Heritage](/wiki/Department_of_Canadian_Heritage \\\"Department of
+        Canadian Heritage\\\"). [\\\"National Flag of Canada Day\\\"](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm).
+        Queen's Printer for Canada. [Archived](https://web.archive.org/web/20100217042202/http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm)
+        from the original on February 17, 2010. Retrieved March 21, 2010.\\n  8. **^**
+        [Dept. of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
+        [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        February 15, 2010. Retrieved February 15, 2011.\\n \\n\\n----\\n\\nQuestion:
+        What is the national flag of Canada?\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -1633,13 +1286,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6505"
+          - "6232"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1649,7 +1302,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1663,24 +1316,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA3RUy47bOBC8+ysavORiG1bicTy+BdlMMPtIsEmQxSJa2G2yJTFDdWtJarzOYP49
-          IOXxA5tcdOjqLlb1Qw8jAGWNWoHSDUbddm7y6sPHv66vq7uO3/3273tTfX71680y/k13719/jmqc
-          KmT7lXR8qppqaTtH0QoPsPaEkRJr8fJFUcxeLudFBlox5FJZ3cXJXCbPZ8/nk9lyMlscChuxmoJa
-          wZcRAMBD/iaJbOg/tYLZ+CnSUghYk1odkwCUF5ciCkOwISIPcg+gFo7EWfVms/kahEt+KBmgVKFv
-          W/T7Uq2gVJ8aAsbkBh1UDmuQCl4jo8ExaGlbYbeHO5YdAwaIDcEf2DmC3wmrXDCGHQZAI10kA8Jw
-          Q1vfo99DcTWG4npxNYXbmJMMBVszGdjuobEhirfI8JbE1wQfI7KjPSAb8NQ51GTye1lNSvxABt5w
-          ohjDrrG6gQYNbIkYLEMfCIJlTVAsF8spJGfZUEUYe08BEELcO/uN0gMG2uzDJR+W80uaOJIfSrMh
-          K5z6kTCm3UA3mIBKnJMdGUDoyFsxKTF13cs9+TD4MLTFSOPL/r1NC3NydSAdElNR6pRUldUWndtD
-          50U7tO3Qtj/7ZPeNs99wS7GB29spvHua383F/OAX3IMNINtA/j4pZe4z5eWQIEqeNLXiMVLWmEQ9
-          C2AZ+7r3mX9aqvGwQJ4c3SNrWgctnoZFKmalKvmx5M1mc76Inqo+YLoD7p07xB+Pm+2k7rxswwE/
-          xivLNjRrTxiE0xaHKJ3K6OMI4J98Qf3FUajOS9vFdZQ74pDvcTkfCNXpaM/gF09olIjuDLguluMf
-          UK4NRbQunJ2h0qgbMme1i8X8aAJ7Y+WEzUZn3v8v6Uf0g3/L9RnLT+lPgNaUrnHdeTJWX9o+pXlK
-          P7afpR17nQWrsA+R2nVluSbfeTv8W6puPb/S1dXcEJIaPY6+AwAA//8DAC1ZqXpkBQAA
+          H4sIAAAAAAAAA3RUTW/bOBC9+1cMeNmLHNhO4ji+bb92L82p2w/UC2NMjqRpqaFKjpJVgvz3glJi
+          K9j2IoB8bx7fGw71MAMw7MwWjK1RbdP6+Z+4/nR988+rv+/ff//YNTeLz/2Xqw9vP366ffNXY4pc
+          EQ7fyOpz1ZkNTetJOcgI20iolFWXV+fny/VmtbocgCY48rmsanV+EearxepivtjMF+unwjqwpWS2
+          8HUGAPAwfLNFcfSf2cKieN5pKCWsyGyPJAATg887BlPipChqihNogyjJ4PphJwA7k7qmwdjvzBZ2
+          5kNNIJhDoIfSYwWhhNco6LCAUCoJJG5a30OkkmIkBxoAE2hNI49RhsICSkLtIiVAyLySyTu4Y60B
+          4a5mJUg/OowEqMCawJIoxQJYMmwzLWnv+Z7cINBg6wk8YTmqLJfQBhZNwAkcp9ZjT+4McobB+h0m
+          YMGu6mK+CQgC7+gQO4w9LC8LWF6vLwtAcaB1lkClLCXhDix5OoxVKNKh931OefPcmncvWgNvsD+d
+          +0cCR4krGQzYOiSS3KVIbaREokOzOmHth8PZkWheTFo9BMy0SegDsVSA4INU83yxLq9T3xyCz7WZ
+          bkMnGl+aGQaRw2inxaiZjHCIAR1FYGFlVL6lbJKS4sFzqnNHlcXq6VrHo9LZzhTj6ETydItiaZ9s
+          iDSO0PXO7ORxOnORyi5hHnnpvH/afzwOsQ9VG8MhPeHH/ZKFU72PhClIHtikoTUD+jgD+Hd4LN2L
+          +TdtDE2rew3fSdLw9C6uR0Fzep8TePWMalD0E2BztSl+Ibl3pMg+TV6csWhrcpPay/P1MQR2jsMJ
+          W8wm2f9v6VfyY36WaqLyW/kTYC21Sm7fRnJsX8Y+0SLlf9jvaMdeD4ZN6pNSsy9ZKopt5PE3Urb7
+          zfmSFusrt1mZ2ePsJwAAAP//AwC7H1t9TwUAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a67a93250c-SJC
+          - 8ebdc5011e30cef1-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1688,14 +1341,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:23 GMT
+          - Mon, 02 Dec 2024 19:37:07 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=ypaRrVuN3tJXpO4RegjW3zvJPCUlUgDoujw_NXaKYUs-1731107843-1.0.1.1-LsOtPZEj9fw36d39.z0GP1hTYWUEPVa1Oo4C2cDMX2H8DVp7sbBhL.kazdjVU7NBxpx.1QPPpsOKB2eiNTsc8Q;
-            path=/; expires=Fri, 08-Nov-24 23:47:23 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=1q.JFqh.shT7YDA2emI53BRjFblheoV0BxeWs_YvDZU-1733168227-1.0.1.1-aY78e4HB5QM0EOUdmGtqTaisXx5KDaFiAnmd8kNduTJMr7sATmFJPePqNV2xTi_uqcV6DxvH5NKBzNPPAuIbFw;
+            path=/; expires=Mon, 02-Dec-24 20:07:07 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=FU8PoJepF68WTfxmJaPa.YMN_FY5Wyfkf.r5inOVw2E-1731107843485-0.0.1.1-604800000;
+          - _cfuvid=eax08E99zTYwoyffztg5tM69bxX5TRDBJzaZhd0anvs-1733168227057-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1708,7 +1361,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "2345"
+          - "1466"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1718,15 +1371,356 @@ interactions:
         x-ratelimit-limit-tokens:
           - "30000000"
         x-ratelimit-remaining-requests:
-          - "9997"
+          - "9999"
         x-ratelimit-remaining-tokens:
-          - "29996614"
+          - "29998493"
         x-ratelimit-reset-requests:
-          - 13ms
-        x-ratelimit-reset-tokens:
           - 6ms
+        x-ratelimit-reset-tokens:
+          - 3ms
         x-request-id:
-          - req_f6da51dc452f4f138ee10ca9fd082ab8
+          - req_5ad29d4070517faf59497a1bebc962e8
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from Wiki2023 chunk 4: WikiMedia Foundation, 2023, Accessed now\\n\\n----\\n\\n2010.\\n
+        \ 8. **^** [Dept. of Canadian Heritage news release](http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
+        [Archived](https://web.archive.org/web/20110706182436/http://www.pch.gc.ca/pc-ch/infoCntr/cdm-mc/index-eng.cfm?action=doc&DocIDCd=CJM092444)
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        February 15, 2010. Retrieved February 15, 2011.\\n  9. **^** [PM pays tribute
+        to outstanding Canadians on Flag Day](http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
+        [Archived](https://web.archive.org/web/20110706181811/http://www.pm.gc.ca/eng/media.asp?category=1&id=3958&featureId=6&pageId=26)
+        July 6, 2011, at the [Wayback Machine](/wiki/Wayback_Machine \\\"Wayback Machine\\\"),
+        Prime Minister's Office news release. Retrieved February 16, 2011.\\n\\n## External
+        links\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=6\\n\\\"Edit
+        section: External links\\\")]\\n\\n![](//upload.wikimedia.org/wikipedia/en/thumb/4/4a/Commons-logo.svg/30px-\\nCommons-logo.svg.png)\\n\\nWikimedia
+        Commons has media related to [National Flag of Canada\\nDay](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day\\n\\\"commons:Category:National
+        Flag of Canada Day\\\").\\n\\n  * [Flag of Canada Song (1965) Freddie Grant](https://www.youtube.com/watch?v=2IkqmkTK46E)\\n
+        \ * [Flag Day](http://www.pch.gc.ca/special/jdn-nfd/index-eng.cfm), Dept. of
+        Canadian Heritage \\n  * [The famous Canadian Flag Collection, at Settlers,
+        Rails & Trails Inc, Argyle, Manitoba](http://argylemuseum.wixsite.com/argylemuseum/canadian-flag-collection)\\n\\n![](https://login.wikimedia.org/wiki/Special:CentralAutoLogin/start?type=1x1)\\n\\nRetrieved
+        from\\n\\\"[https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994](https://en.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994)\\\"\\n\\n[Categories](/wiki/Help:Category
+        \\\"Help:Category\\\"):\\n\\n  * [1996 establishments in Canada](/wiki/Category:1996_establishments_in_Canada
+        \\\"Category:1996 establishments in Canada\\\")\\n  * [Public holidays in Canada](/wiki/Category:Public_holidays_in_Canada
+        \\\"Category:Public holidays in Canada\\\")\\n  * [February observances](/wiki/Category:February_observances
+        \\\"Category:February observances\\\")\\n  * [Flag days](/wiki/Category:Flag_days
+        \\\"Category:Flag days\\\")\\n  * [Winter events in Canada](/wiki/Category:Winter_events_in_Canada
+        \\\"Category:Winter events in Canada\\\")\\n\\nHidden categories:\\n\\n  * [Webarchive
+        template wayback links](/wiki/Category:Webarchive_template_wayback_links \\\"Category:Webarchive
+        template wayback links\\\")\\n  * [Articles with short description](/wiki/Category:Articles_with_short_description
+        \\\"Category:Articles with short description\\\")\\n  * [Short description matches
+        Wikidata](/wiki/Category:Short_description_matches_Wikidata \\\"Category:Short
+        description matches Wikidata\\\")\\n  * [Use mdy dates from February 2018](/wiki/Category:Use_mdy_dates_from_February_2018
+        \\\"Category:Use mdy dates from February 2018\\\")\\n  * [Infobox holiday with
+        missing field](/wiki/Category:Infobox_holiday_with_missing_field \\\"Category:Infobox
+        holiday with missing field\\\")\\n  * [Infobox holiday fixed day](/wiki/Category:Infobox_holiday_fixed_day
+        \\\"Category:Infobox holiday fixed day\\\")\\n  * [Articles containing French-language
+        text](/wiki/Category:Articles_containing_French-language_text \\\"Category:Articles
+        containing French-language text\\\")\\n  * [Commons category link is on Wikidata](/wiki/Category:Commons_category_link_is_on_Wikidata
+        \\\"Category:Commons category link is on Wikidata\\\")\\n\\n  * This page was
+        last edited on 1 July 2024, at 03:41 (UTC). \\n  * Text is available under the
+        [Creative Commons Attribution-ShareAlike License 4.0](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License)[](//en.wikipedia.org/wiki/Wikipedia:Text_of_the_Creative_Commons_Attribution-ShareAlike_4.0_International_License);
+        additional terms may apply. By using this site, you agree to the [Terms of Use](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Terms_of_Use)
+        and [Privacy Policy](//foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy).
+        Wikipedia\xAE is a registered trademark of the [Wikimedia Foundation, Inc.](//wikimediafoundation.org/),
+        a non-profit organization. \\n\\n  * [Privacy policy](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Privacy_policy)\\n
+        \ * [About Wikipedia](/wiki/Wikipedia:About)\\n  * [Disclaimers](/wiki/Wikipedia:General_disclaimer)\\n
+        \ * [Contact Wikipedia](//en.wikipedia.org/wiki/Wikipedia:Contact_us)\\n  *
+        [Code of Conduct](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Universal_Code_of_Conduct)\\n
+        \ * [Developers](https://developer.wikimedia.org)\\n  * [Statistics](https://stats.wikimedia.org/#/en.wikipedia.org)\\n
+        \ * [Cookie statement](https://foundation.wikimedia.org/wiki/Special:MyLanguage/Policy:Cookie_statement)\\n
+        \ * [Mobile view](//en.m.wikipedia.org/w/index.php?title=National_Flag_of_Canada_Day&mobileaction=toggle_view_mobile)\\n\\n
+        \ * [![Wikimedia Foundation](/static/images/footer/wikimedia-button.svg)](https://wikimediafoundation.org/)\\n
+        \ * [![Powered by MediaWiki](/w/resources/assets/poweredby_mediawiki.svg)](https://www.mediawiki.org/)\\n\\n
+        \ * \\n\\n\\n\\n----\\n\\nQuestion: What is the national flag of Canada?\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "5988"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3xUy27bMBC8+ysWPNuG7diO7VvRoCiKPlA06ANVYa/JlcSEWrIkFccJ/O8FJT/R
+          phcB2tkZzSyXeu4ACK3EAoQsMcrKmd4rnH6bq0/047Ocf//q8Ys045t5iI/v1ESJbmLY9R3JeGD1
+          pa2coagtt7D0hJGS6vD66mo4nY1GkwaorCKTaIWLvbHtjQajcW8w6w2me2JptaQgFvCzAwDw3DyT
+          RVb0KBYw6B4qFYWABYnFsQlAeGtSRWAIOkTkKLonUFqOxI3r1Wp1Fyxn/JwxQCZCXVXot5lYQCZu
+          SwJ6lORdBGUpANsIztsHrQgQlPYkIygK0muXQoPNIZYEjOkNDeQGi1R8jYwK+/DWbuiBfBd0BE85
+          eWJJoeF8PHDeXHDgBreArECzNLWiAEbzfYBowZNJw4WKlMamx1OwtZcU+nD7so0uSFtVls0W7tlu
+          GLB18AGdIXhPmHchJ4y1pwAInhTkmoyCjY4lIGxKHQnC7xo9AUbQMYAkjinXmtBrLgAhxK3RT6Qa
+          ftVIG8K8FRkOwVnNsTGqQ5qhLhg2GACVdSmVZhjOp5M2e/qAobVv8iJzjcZswfL/ptbPRLc9VE+G
+          HpAlLYO0ntrDvc5ExruMV6vV+W54yuuAaTW5NmZf3x2XzdjCebsOe/xYzzXrUC49YbCcFitE60SD
+          7joAv5qlri/2VDhvKxeX0d4TJ8HhZDxrBcXpHp3Bw/3Oi2gjmjNgOjnwLiSXiiJqE85uhpAoS1Jn
+          3PFgdgyBtdL2hA06Z9n/tvQv+Ta/5uJM5UX5EyAlpTNfOk9Ky8vYpzZP6V/zUttx1o1hEbYhUrXM
+          NRfkndftdc/d8jqfrumK8vVAdHadPwAAAP//AwAdJ+839wQAAA==
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdc5011e012349-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:37:07 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=HAQzMsHvwNSWkBdkNVGF8eYCmrjdHZ3qP37r1_Z83ac-1733168227-1.0.1.1-262.pQuwBqYseiMMKXZ8AM0kj7OBRg4k7clCpzvcJvDeBJ0SnFYz_IStaLeTPpOQHWY5vSvmx3ZKlwrZUvD1mQ;
+            path=/; expires=Mon, 02-Dec-24 20:07:07 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=Qi6sB5GE1848ZcJpExFyRyBp8DuVvGKEf3nkn6H3eVM-1733168227136-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "1566"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998550"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_4feabb9e8372ae1dd93073d22a370754
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from Wiki2023 chunk 2: WikiMedia Foundation, 2023, Accessed now\\n\\n----\\n\\n_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history
+        \\\"Past revisions of this page \\\\[h\\\\]\\\")\\n\\nTools\\n\\nTools\\n\\nmove
+        to sidebar  hide\\n\\nActions\\n\\n  * [Read](/wiki/National_Flag_of_Canada_Day)\\n
+        \ * [Edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit \\\"Edit
+        this page \\\\[e\\\\]\\\")\\n  * [View history](/w/index.php?title=National_Flag_of_Canada_Day&action=history)\\n\\nGeneral\\n\\n
+        \ * [What links here](/wiki/Special:WhatLinksHere/National_Flag_of_Canada_Day
+        \\\"List of all English Wikipedia pages containing links to this page \\\\[j\\\\]\\\")\\n
+        \ * [Related changes](/wiki/Special:RecentChangesLinked/National_Flag_of_Canada_Day
+        \\\"Recent changes in pages linked from this page \\\\[k\\\\]\\\")\\n  * [Upload
+        file](/wiki/Wikipedia:File_Upload_Wizard \\\"Upload files \\\\[u\\\\]\\\")\\n
+        \ * [Special pages](/wiki/Special:SpecialPages \\\"A list of all special pages
+        \\\\[q\\\\]\\\")\\n  * [Permanent link](/w/index.php?title=National_Flag_of_Canada_Day&oldid=1231946994
+        \\\"Permanent link to this revision of this page\\\")\\n  * [Page information](/w/index.php?title=National_Flag_of_Canada_Day&action=info
+        \\\"More information about this page\\\")\\n  * [Cite this page](/w/index.php?title=Special:CiteThisPage&page=National_Flag_of_Canada_Day&id=1231946994&wpFormIdentifier=titleform
+        \\\"Information on how to cite this page\\\")\\n  * [Get shortened URL](/w/index.php?title=Special:UrlShortener&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\\n
+        \ * [Download QR code](/w/index.php?title=Special:QrCode&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FNational_Flag_of_Canada_Day)\\n
+        \ * [Wikidata item](https://www.wikidata.org/wiki/Special:EntityPage/Q6972703
+        \\\"Structured data on this page hosted by Wikidata \\\\[g\\\\]\\\")\\n\\nPrint/export\\n\\n
+        \ * [Download as PDF](/w/index.php?title=Special:DownloadAsPdf&page=National_Flag_of_Canada_Day&action=show-download-screen
+        \\\"Download this page as a PDF file\\\")\\n  * [Printable version](/w/index.php?title=National_Flag_of_Canada_Day&printable=yes
+        \\\"Printable version of this page \\\\[p\\\\]\\\")\\n\\nIn other projects\\n\\n
+        \ * [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:National_Flag_of_Canada_Day)\\n\\nAppearance\\n\\nmove
+        to sidebar  hide\\n\\nFrom Wikipedia, the free encyclopedia\\n\\nCanadian holiday\\n\\nNational
+        Flag of Canada Day  \\n---  \\n[![](//upload.wikimedia.org/wikipedia/commons/thumb/6/68/Canada_flag_halifax_9_-04.JPG/250px-\\nCanada_flag_halifax_9_-04.JPG)](/wiki/File:Canada_flag_halifax_9_-04.JPG)
+        The\\nnational flag of Canada  \\nObserved by  |  [Canada](/wiki/Canada \\\"Canada\\\")
+        \ \\nDate |  [February 15](/wiki/February_15 \\\"February 15\\\")  \\nNext time
+        \ |  February 15, 2025 (2025-02-15)  \\nFrequency | Annual  \\n  \\n**National
+        Flag of Canada Day** ([French](/wiki/French_language \\\"French\\nlanguage\\\"):
+        _Jour du drapeau national du Canada_), commonly shortened to\\n**Flag Day**
+        , is observed annually on February 15 to commemorate the\\ninauguration of the
+        [flag of Canada](/wiki/Flag_of_Canada \\\"Flag of Canada\\\") on\\nthat date
+        in 1965.[1] The day is marked by flying the flag, occasional public\\nceremonies
+        and educational programs in schools. It is not a [public\\nholiday](/wiki/Public_holidays_in_Canada
+        \\\"Public holidays in Canada\\\"),\\nalthough there has been discussion about
+        creating one.\\n\\n## History\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=1\\n\\\"Edit
+        section: History\\\")]\\n\\n### Background\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=2\\n\\\"Edit
+        section: Background\\\")]\\n\\nAmid [much controversy](/wiki/Great_Canadian_flag_debate
+        \\\"Great Canadian flag\\ndebate\\\"), the [Parliament of Canada](/wiki/Parliament_of_Canada
+        \\\"Parliament of\\nCanada\\\") in 1964 voted to adopt a new design for the
+        [Canadian\\nflag](/wiki/Flag_of_Canada \\\"Flag of Canada\\\") and issued a
+        call for\\nsubmissions.[2]\\n\\nThis flag would replace the [Canadian Red Ensign](/wiki/Canadian_Red_Ensign\\n\\\"Canadian
+        Red Ensign\\\"), which had been, with various successive alterations,\\nin conventional
+        use as the national flag of [Canada](/wiki/Canada \\\"Canada\\\")\\nsince 1868.
+        Nearly 4,000 designs were submitted by Canadians.[2] On October\\n22, 1964,
+        the [Maple Leaf flag](/wiki/Maple_Leaf_flag \\\"Maple Leaf\\nflag\\\")\u2014designed
+        by historian [George Stanley](/wiki/George_Stanley \\\"George\\nStanley\\\")\u2014won
+        with a unanimous vote.[3] Under the leadership of [Prime\\nMinister](/wiki/Prime_Minister_of_Canada
+        \\\"Prime Minister of Canada\\\") [Lester\\nPearson](/wiki/Lester_B._Pearson
+        \\\"Lester B. Pearson\\\"), resolutions\\nrecommending the new design were passed
+        by the [House of\\nCommons](/wiki/House_of_Commons_of_Canada \\\"House of Commons
+        of Canada\\\") on\\nDecember 15, 1964, and by the [Senate](/wiki/Senate_of_Canada
+        \\\"Senate of\\nCanada\\\") two days later.[4]\\n\\nThe flag was proclaimed
+        by [Elizabeth II](/wiki/Elizabeth_II \\\"Elizabeth II\\\"),\\n[Queen of Canada](/wiki/Monarchy_of_Canada
+        \\\"Monarchy of Canada\\\"), on January\\n28, 1965,[3][5] and took effect \\\"upon,
+        from and after\\\" February 15 that\\nyear.[6]\\n\\n### Flag Day\\n\\n[[edit](/w/index.php?title=National_Flag_of_Canada_Day&action=edit&section=3\\n\\\"Edit
+        section: Flag Day\\\")]\\n\\nNational Flag of Canada Day was instituted in 1996
+        by an [Order in\\nCouncil](/wiki/Order_in_Council \\\"Order in Council\\\")
+        from [Governor\\nGeneral](/wiki/Governor_General_of_Canada \\\"Governor General
+        of Canada\\\") [Rom\xE9o\\nLeBlanc](/wiki/Rom%C3%A9o_LeBlanc \\\"Rom\xE9o LeBlanc\\\"),
+        on the initiative of Prime\\nMinister [Jean Chr\xE9tien](/wiki/Jean_Chr%C3%A9tien
+        \\\"Jean Chr\xE9tien\\\").[7] At the\\nfirst Flag Day ceremony in [Hull, Quebec](/wiki/Hull,_Quebec
+        \\\"Hull, Quebec\\\"),\\nChr\xE9tien was confronted by demonstrators against
+        proposed cuts to the\\n[un\\n\\n----\\n\\nQuestion: What is the national flag
+        of Canada?\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "6465"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA3RUTY/bNhC9+1cMeOlFNmyv12v7VrRJsEBbtEmLHOrAGJEjiRtqRiApe53F/veC
+          lNcfaHLRYd68x3nzoZcRgLJGbUDpBqNuOzf+GZef1/s/nx+mq/vPi4+rrnpwT+v9/BnLp39UkRhS
+          PpGOb6yJlrZzFK3wAGtPGCmpzh7u7mbL1Xx+n4FWDLlEq7s4Xsh4Pp0vxtPVeLo8ERuxmoLawL8j
+          AICX/E0lsqFntYFp8RZpKQSsSW3OSQDKi0sRhSHYEJGjKi6gFo7EueqXLQNsVejbFv1xqzawVX83
+          BIzJBDqoHNYgFfyCjAYL0NK2wu4IX1kODBggNgS/Y+cIfiOsMqGAAwZAI10kA8Lwnkrfoz/C7L6A
+          2Xp5P4HHmJMMBVszGSiP0NgQxVtk+EDia4JPEdnREZANeOocajL5vVxNSvxIBt5xkijg0FjdQIMG
+          SiIGy9AHgmBZE8xWy9UEkrNsqCKMvacACCEenf1G6QEDbfbhkg/L+SVNHMkP1GzICqd+JIzpMMgN
+          JqAS5+RABhA68lZMSkzN9rInHwYfhkqMVNz270Pak4urk+iQmEipU1JVVlt07gidF+3QtkPb/uqT
+          3XfOfsOSYgOPjxP4421+72/mB7/iEWwAKQP5faqUuc+St0OCKHnS1IrHSLnGVNRPASxjX/c+60+2
+          qhgWyJOjPbKmXdDiaVik9VZt+fV68zxVfcC0+Nw7d4q/nlfZSd15KcMJP8cryzY0O08YhNPahiid
+          yujrCOBLPpn+5gpU56Xt4i7KV+KQD3C1GATV5Uqv4LvTRakoEd0VsJ698W4kd4YiWheu7k5p1A2Z
+          K+5yuTibwN5YuWDT0ZX3/5f0PfnBv+X6SuWH8hdAa0p3uOs8GatvbV/SPKU/2Y/Szr3OBatwDJHa
+          XWW5Jt95O/xMqm73UC1LuqOqnKrR6+g/AAAA//8DABIbScNVBQAA
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdc5011d51ed3b-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:37:09 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=YcI4J2fbK8ZSDdlmN0cIRID9pNZbap4BnXROskGPhqU-1733168229-1.0.1.1-sOqfpqmcTjHN95ZH7AZhc16s6B6HjQygbP5JAn97HQf_gP8FVg82vg1YcGNYFwyVVbVi.F_KKBxW8EjJ_g9AFA;
+            path=/; expires=Mon, 02-Dec-24 20:07:09 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=Ch8TW27svElU.4WkZKqQpOsX08LlSnzwgp84RMynJNk-1733168229383-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "3827"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998458"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 3ms
+        x-request-id:
+          - req_6733ff011efe7e1f87025a14a036c679
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_doi_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes0].yaml
@@ -34,27 +34,150 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Via:
-          - 1.1 a2df2413207d4bf6462c2592b304bffe.cloudfront.net (CloudFront)
+          - 1.1 29474fd3a24c6552dfdc04ee03c03aa2.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - gFr-7nwsfG-6xhjjlVu8DVVrYzq6mDZfFwVy9gRKgnfDwa5r3rscVg==
+          - ubfBzmq7YHSX38Ewnwgg5G36wmzFJA_LhR-X2rkHiaKO_C93_6NK3Q==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81P7GFRPHcEKew=
+          - CLbZTGsbvHcEXDg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1325"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 6dd0355f-2603-4466-aaf2-e36c853a40f4
+          - 72d3483b-4629-4199-8766-c1f40565fcba
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.openalex.org/works/https://doi.org/10.1101%2F2024.04.01.587366
+    response:
+      body:
+        string:
+          '{"id":"https://openalex.org/W4393448183","doi":"https://doi.org/10.1101/2024.04.01.587366","title":"High-throughput
+          screening of human genetic variants by pooled prime editing","display_name":"High-throughput
+          screening of human genetic variants by pooled prime editing","publication_year":2024,"publication_date":"2024-04-01","ids":{"openalex":"https://openalex.org/W4393448183","doi":"https://doi.org/10.1101/2024.04.01.587366"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
+          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
+          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
+          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false},"type":"preprint","type_crossref":"posted-content","indexed_in":["crossref"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5067011895","display_name":"Michael
+          Herger","orcid":"https://orcid.org/0000-0002-5390-2695"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Michael
+          Herger","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5003387836","display_name":"Christina
+          M. Kajba","orcid":"https://orcid.org/0000-0002-7896-0744"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Christina
+          M. Kajba","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5054087528","display_name":"Megan
+          Buckley","orcid":"https://orcid.org/0000-0003-4450-8474"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Megan
+          Buckley","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5061084011","display_name":"Ana
+          Cunha","orcid":"https://orcid.org/0000-0002-7651-5858"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Ana
+          Cunha","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5109336004","display_name":"Molly
+          Strom","orcid":null},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Molly
+          Strom","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"last","author":{"id":"https://openalex.org/A5084597634","display_name":"Gregory
+          M. Findlay","orcid":"https://orcid.org/0000-0002-7767-8608"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
+          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Gregory
+          M. Findlay","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
+          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":true,"fulltext_origin":"pdf","cited_by_count":2,"citation_normalized_percentile":{"value":0.999923,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":94,"max":96},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T10878","display_name":"Clustered
+          Regularly Interspaced Short Palindromic Repeats and CRISPR-associated proteins","score":0.9999,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
+          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
+          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
+          Sciences"}},"topics":[{"id":"https://openalex.org/T10878","display_name":"Clustered
+          Regularly Interspaced Short Palindromic Repeats and CRISPR-associated proteins","score":0.9999,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
+          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
+          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
+          Sciences"}},{"id":"https://openalex.org/T10207","display_name":"DNA Nanotechnology
+          and Bioanalytical Applications","score":0.9972,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
+          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
+          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
+          Sciences"}},{"id":"https://openalex.org/T10521","display_name":"Ribosome Structure
+          and Translation Mechanisms","score":0.9943,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
+          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
+          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
+          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/multiplex-genome-editing","display_name":"Multiplex
+          Genome Editing","score":0.568746},{"id":"https://openalex.org/keywords/gene-editing","display_name":"Gene
+          Editing","score":0.531232},{"id":"https://openalex.org/keywords/negative-selection","display_name":"Negative
+          selection","score":0.48653165}],"concepts":[{"id":"https://openalex.org/C70721500","wikidata":"https://www.wikidata.org/wiki/Q177005","display_name":"Computational
+          biology","level":1,"score":0.6271358},{"id":"https://openalex.org/C86803240","wikidata":"https://www.wikidata.org/wiki/Q420","display_name":"Biology","level":0,"score":0.5850787},{"id":"https://openalex.org/C81917197","wikidata":"https://www.wikidata.org/wiki/Q628760","display_name":"Selection
+          (genetic algorithm)","level":2,"score":0.52266854},{"id":"https://openalex.org/C2779343474","wikidata":"https://www.wikidata.org/wiki/Q3109175","display_name":"Context
+          (archaeology)","level":2,"score":0.5084159},{"id":"https://openalex.org/C7386963","wikidata":"https://www.wikidata.org/wiki/Q3954859","display_name":"Negative
+          selection","level":4,"score":0.48653165},{"id":"https://openalex.org/C54355233","wikidata":"https://www.wikidata.org/wiki/Q7162","display_name":"Genetics","level":1,"score":0.44161588},{"id":"https://openalex.org/C144501496","wikidata":"https://www.wikidata.org/wiki/Q5533489","display_name":"Genome
+          editing","level":4,"score":0.41460347},{"id":"https://openalex.org/C141231307","wikidata":"https://www.wikidata.org/wiki/Q7020","display_name":"Genome","level":3,"score":0.39861494},{"id":"https://openalex.org/C104317684","wikidata":"https://www.wikidata.org/wiki/Q7187","display_name":"Gene","level":2,"score":0.3876987},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
+          science","level":0,"score":0.33935452},{"id":"https://openalex.org/C119857082","wikidata":"https://www.wikidata.org/wiki/Q2539","display_name":"Machine
+          learning","level":1,"score":0.101546764},{"id":"https://openalex.org/C151730666","wikidata":"https://www.wikidata.org/wiki/Q7205","display_name":"Paleontology","level":1,"score":0.0}],"mesh":[],"locations_count":1,"locations":[{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
+          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
+          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
+          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
+          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
+          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
+          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[],"grants":[],"datasets":[],"versions":[],"referenced_works_count":50,"referenced_works":["https://openalex.org/W1973260880","https://openalex.org/W2014747507","https://openalex.org/W2031211461","https://openalex.org/W2045435533","https://openalex.org/W2051978340","https://openalex.org/W2068427957","https://openalex.org/W2101868032","https://openalex.org/W2110951885","https://openalex.org/W2174602966","https://openalex.org/W2174686320","https://openalex.org/W2252568502","https://openalex.org/W2512645103","https://openalex.org/W2774216375","https://openalex.org/W2788593837","https://openalex.org/W2791921618","https://openalex.org/W2887461405","https://openalex.org/W2889874867","https://openalex.org/W2909194804","https://openalex.org/W2915459742","https://openalex.org/W2954501063","https://openalex.org/W2967059818","https://openalex.org/W2981137429","https://openalex.org/W3062028978","https://openalex.org/W3087701445","https://openalex.org/W3098409330","https://openalex.org/W3115988811","https://openalex.org/W3121904305","https://openalex.org/W3129351841","https://openalex.org/W3131839988","https://openalex.org/W3132864675","https://openalex.org/W3161833585","https://openalex.org/W3192108213","https://openalex.org/W3199622685","https://openalex.org/W3202931255","https://openalex.org/W3206354438","https://openalex.org/W3213536168","https://openalex.org/W4213232054","https://openalex.org/W4220887281","https://openalex.org/W4226280654","https://openalex.org/W4288060326","https://openalex.org/W4303199315","https://openalex.org/W4307446592","https://openalex.org/W4312190539","https://openalex.org/W4316507374","https://openalex.org/W4317689970","https://openalex.org/W4367311810","https://openalex.org/W4378976943","https://openalex.org/W4386861232","https://openalex.org/W4389398607","https://openalex.org/W4390063959"],"related_works":["https://openalex.org/W4388142354","https://openalex.org/W4377564400","https://openalex.org/W4366822718","https://openalex.org/W4365811064","https://openalex.org/W4320032841","https://openalex.org/W4280502984","https://openalex.org/W2998674376","https://openalex.org/W2770215042","https://openalex.org/W2607137613","https://openalex.org/W2580221256"],"abstract_inverted_index":{"ABSTRACT":[0],"Understanding":[1],"the":[2,92],"effects":[3],"of":[4,19,28,38,42,70,94,110,128,199],"rare":[5],"genetic":[6],"variants":[7,39,61,71,120,142,152,164],"remains":[8],"challenging,":[9],"both":[10,183],"in":[11,54,62,91,121,132,158],"coding":[12],"and":[13,79,107,139,185],"non-coding":[14,150],"regions.":[15],"While":[16],"multiplexed":[17],"assays":[18],"variant":[20],"effect":[21],"(MAVEs)":[22],"have":[23],"enabled":[24],"scalable":[25,196],"functional":[26,197],"assessment":[27,198],"variants,":[29],"established":[30],"MAVEs":[31],"are":[32],"limited":[33],"by":[34,97],"either":[35],"exogenous":[36],"expression":[37],"or":[40],"constraints":[41],"genome":[43],"editing.":[44],"Here,":[45],"we":[46,147],"introduce":[47],"a":[48,81,133,154,159],"pooled":[49],"prime":[50],"editing":[51,105],"(PE)":[52],"platform":[53,90,191],"haploid":[55],"human":[56,200],"cells":[57],"to":[58,72,193],"scalably":[59],"assay":[60,148],"their":[63],"endogenous":[64],"context.":[65],"We":[66,87,117],"first":[67],"optimized":[68],"delivery":[69],"HAP1":[73],"cells,":[74],"defining":[75],"optimal":[76],"pegRNA":[77],"designs":[78],"establishing":[80],"co-selection":[82],"strategy":[83],"for":[84,104,177],"improved":[85],"efficiency.":[86],"characterize":[88],"our":[89,190],"context":[93],"negative":[95,186],"selection":[96,187],"testing":[98],"over":[99],"7,500":[100],"pegRNAs":[101,113,180],"targeting":[102],"SMARCB1":[103],"activity":[106],"observing":[108],"depletion":[109],"highly":[111,178,195],"active":[112,179],"installing":[114],"loss-of-function":[115],"variants.":[116,201],"next":[118],"assess":[119],"MLH1":[122,151],"via":[123,166],"6-thioguanine":[124],"selection,":[125],"assaying":[126],"65.3%":[127],"all":[129],"possible":[130],"SNVs":[131],"200-bp":[134],"region":[135,157],"spanning":[136],"exon":[137],"10":[138],"distinguishing":[140],"LoF":[141],"with":[143,169],"high":[144,170],"accuracy.":[145],"Lastly,":[146],"362":[149],"across":[153],"60":[155],"kb":[156],"single":[160],"experiment,":[161],"identifying":[162],"pathogenic":[163],"acting":[165],"multiple":[167],"mechanisms":[168],"specificity.":[171],"Our":[172],"analyses":[173],"detail":[174],"how":[175],"filtering":[176],"can":[181],"facilitate":[182],"positive":[184],"screens.":[188],"Accordingly,":[189],"promises":[192],"enable":[194]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4393448183","counts_by_year":[{"year":2024,"cited_by_count":1}],"updated_date":"2024-11-26T12:01:03.811397","created_date":"2024-04-03"}
+
+          '
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Authorization,
+            Cache-Control
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Authorization, Cache-Control
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "3766"
+        Content-Security-Policy:
+          - default-src 'self'; object-src 'none'
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:27 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168187&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=At1PRdLamgIs29FO04hd83SDefX37E5N0UGszOtQgBI%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168187&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=At1PRdLamgIs29FO04hd83SDefX37E5N0UGszOtQgBI%3D
+        Server:
+          - gunicorn
+        Strict-Transport-Security:
+          - max-age=31556926; includeSubDomains
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
+        X-Api-Pool:
+          - common
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Xss-Protection:
+          - 1; mode=block
       status:
         code: 200
         message: OK
@@ -66,7 +189,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,4,5]],"date-time":"2024-04-05T00:42:23Z","timestamp":1712277743507},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
+          '{"status":"ok","message-type":"work","message-version":"1.0.0","message":{"institution":[{"name":"bioRxiv"}],"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:09:55Z","timestamp":1732043395754},"posted":{"date-parts":[[2024,4,1]]},"group-title":"Genomics","reference-count":50,"publisher":"Cold
           Spring Harbor Laboratory","content-domain":{"domain":[],"crossmark-restriction":false},"short-container-title":[],"accepted":{"date-parts":[[2024,4,1]]},"abstract":"<jats:title>ABSTRACT<\/jats:title><jats:p>Understanding
           the effects of rare genetic variants remains challenging, both in coding and
           non-coding regions. While multiplexed assays of variant effect (MAVEs) have
@@ -86,7 +209,7 @@ interactions:
           acting via multiple mechanisms with high specificity. Our analyses detail
           how filtering for highly active pegRNAs can facilitate both positive and negative
           selection screens. Accordingly, our platform promises to enable highly scalable
-          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":0,"title":["High-throughput
+          functional assessment of human variants.<\/jats:p>","DOI":"10.1101\/2024.04.01.587366","type":"posted-content","created":{"date-parts":[[2024,4,2]],"date-time":"2024-04-02T02:05:17Z","timestamp":1712023517000},"source":"Crossref","is-referenced-by-count":1,"title":["High-throughput
           screening of human genetic variants by pooled prime editing"],"prefix":"10.1101","author":[{"given":"Michael","family":"Herger","sequence":"first","affiliation":[]},{"given":"Christina
           M.","family":"Kajba","sequence":"additional","affiliation":[]},{"given":"Megan","family":"Buckley","sequence":"additional","affiliation":[]},{"given":"Ana","family":"Cunha","sequence":"additional","affiliation":[]},{"given":"Molly","family":"Strom","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-7767-8608","authenticated-orcid":false,"given":"Gregory
           M.","family":"Findlay","sequence":"additional","affiliation":[]}],"member":"246","reference":[{"key":"2024040415500652000_2024.04.01.587366v1.1","doi-asserted-by":"publisher","DOI":"10.1038\/gim.2015.30"},{"key":"2024040415500652000_2024.04.01.587366v1.2","doi-asserted-by":"crossref","first-page":"116","DOI":"10.1016\/j.cels.2017.11.003","article-title":"Quantitative
@@ -126,11 +249,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3214"
+          - "3221"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -207,142 +330,19 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107839&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=XFcI6L69f0FCYAtbCfIpvvg1RbSo02xhP0uUA0yPr58%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168187&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=Pg5In04%2BFl1685SdKPTmADxGRdq4WLJvgzxuv39xX8E%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107839&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=XFcI6L69f0FCYAtbCfIpvvg1RbSo02xhP0uUA0yPr58%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168187&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=Pg5In04%2BFl1685SdKPTmADxGRdq4WLJvgzxuv39xX8E%3D
         Server:
           - gunicorn
         Vary:
           - Accept-Encoding
         Via:
           - 1.1 vegur
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.openalex.org/works/https://doi.org/10.1101%2F2024.04.01.587366
-    response:
-      body:
-        string:
-          '{"id":"https://openalex.org/W4393448183","doi":"https://doi.org/10.1101/2024.04.01.587366","title":"High-throughput
-          screening of human genetic variants by pooled prime editing","display_name":"High-throughput
-          screening of human genetic variants by pooled prime editing","publication_year":2024,"publication_date":"2024-04-01","ids":{"openalex":"https://openalex.org/W4393448183","doi":"https://doi.org/10.1101/2024.04.01.587366"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
-          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
-          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
-          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false},"type":"preprint","type_crossref":"posted-content","indexed_in":["crossref"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5067011895","display_name":"Michael
-          Herger","orcid":"https://orcid.org/0000-0002-5390-2695"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Michael
-          Herger","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5003387836","display_name":"Christina
-          M. Kajba","orcid":"https://orcid.org/0000-0002-7896-0744"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Christina
-          M. Kajba","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5054087528","display_name":"Megan
-          Buckley","orcid":"https://orcid.org/0000-0003-4450-8474"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Megan
-          Buckley","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5061084011","display_name":"Ana
-          Cunha","orcid":"https://orcid.org/0000-0002-7651-5858"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Ana
-          Cunha","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5109336004","display_name":"Molly
-          Strom","orcid":null},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Molly
-          Strom","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]},{"author_position":"last","author":{"id":"https://openalex.org/A5084597634","display_name":"Gregory
-          M. Findlay","orcid":"https://orcid.org/0000-0002-7767-8608"},"institutions":[{"id":"https://openalex.org/I2801081054","display_name":"The
-          Francis Crick Institute","ror":"https://ror.org/04tnbqb63","country_code":"GB","type":"facility","lineage":["https://openalex.org/I2801081054"]}],"countries":["GB"],"is_corresponding":false,"raw_author_name":"Gregory
-          M. Findlay","raw_affiliation_strings":["The Francis Crick Institute"],"affiliations":[{"raw_affiliation_string":"The
-          Francis Crick Institute","institution_ids":["https://openalex.org/I2801081054"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":true,"fulltext_origin":"pdf","cited_by_count":1,"citation_normalized_percentile":{"value":0.999883,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":86,"max":94},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T10878","display_name":"Clustered
-          Regularly Interspaced Short Palindromic Repeats and CRISPR-associated proteins","score":0.9999,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
-          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
-          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
-          Sciences"}},"topics":[{"id":"https://openalex.org/T10878","display_name":"Clustered
-          Regularly Interspaced Short Palindromic Repeats and CRISPR-associated proteins","score":0.9999,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
-          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
-          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
-          Sciences"}},{"id":"https://openalex.org/T10207","display_name":"DNA Nanotechnology
-          and Bioanalytical Applications","score":0.9972,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
-          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
-          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
-          Sciences"}},{"id":"https://openalex.org/T10521","display_name":"Ribosome Structure
-          and Translation Mechanisms","score":0.9943,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
-          Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
-          Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
-          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/multiplex-genome-editing","display_name":"Multiplex
-          Genome Editing","score":0.568746},{"id":"https://openalex.org/keywords/gene-editing","display_name":"Gene
-          Editing","score":0.531232},{"id":"https://openalex.org/keywords/negative-selection","display_name":"Negative
-          selection","score":0.48653165}],"concepts":[{"id":"https://openalex.org/C70721500","wikidata":"https://www.wikidata.org/wiki/Q177005","display_name":"Computational
-          biology","level":1,"score":0.6271358},{"id":"https://openalex.org/C86803240","wikidata":"https://www.wikidata.org/wiki/Q420","display_name":"Biology","level":0,"score":0.5850787},{"id":"https://openalex.org/C81917197","wikidata":"https://www.wikidata.org/wiki/Q628760","display_name":"Selection
-          (genetic algorithm)","level":2,"score":0.52266854},{"id":"https://openalex.org/C2779343474","wikidata":"https://www.wikidata.org/wiki/Q3109175","display_name":"Context
-          (archaeology)","level":2,"score":0.5084159},{"id":"https://openalex.org/C7386963","wikidata":"https://www.wikidata.org/wiki/Q3954859","display_name":"Negative
-          selection","level":4,"score":0.48653165},{"id":"https://openalex.org/C54355233","wikidata":"https://www.wikidata.org/wiki/Q7162","display_name":"Genetics","level":1,"score":0.44161588},{"id":"https://openalex.org/C144501496","wikidata":"https://www.wikidata.org/wiki/Q5533489","display_name":"Genome
-          editing","level":4,"score":0.41460347},{"id":"https://openalex.org/C141231307","wikidata":"https://www.wikidata.org/wiki/Q7020","display_name":"Genome","level":3,"score":0.39861494},{"id":"https://openalex.org/C104317684","wikidata":"https://www.wikidata.org/wiki/Q7187","display_name":"Gene","level":2,"score":0.3876987},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
-          science","level":0,"score":0.33935452},{"id":"https://openalex.org/C119857082","wikidata":"https://www.wikidata.org/wiki/Q2539","display_name":"Machine
-          learning","level":1,"score":0.101546764},{"id":"https://openalex.org/C151730666","wikidata":"https://www.wikidata.org/wiki/Q7205","display_name":"Paleontology","level":1,"score":0.0}],"mesh":[],"locations_count":1,"locations":[{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
-          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
-          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
-          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1101/2024.04.01.587366","pdf_url":"https://www.biorxiv.org/content/biorxiv/early/2024/04/01/2024.04.01.587366.full.pdf","source":{"id":"https://openalex.org/S4306402567","display_name":"bioRxiv
-          (Cold Spring Harbor Laboratory)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I2750212522","host_organization_name":"Cold
-          Spring Harbor Laboratory","host_organization_lineage":["https://openalex.org/I2750212522"],"host_organization_lineage_names":["Cold
-          Spring Harbor Laboratory"],"type":"repository"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[],"grants":[],"datasets":[],"versions":[],"referenced_works_count":50,"referenced_works":["https://openalex.org/W1973260880","https://openalex.org/W2014747507","https://openalex.org/W2031211461","https://openalex.org/W2045435533","https://openalex.org/W2051978340","https://openalex.org/W2068427957","https://openalex.org/W2101868032","https://openalex.org/W2110951885","https://openalex.org/W2174602966","https://openalex.org/W2174686320","https://openalex.org/W2252568502","https://openalex.org/W2512645103","https://openalex.org/W2774216375","https://openalex.org/W2788593837","https://openalex.org/W2791921618","https://openalex.org/W2887461405","https://openalex.org/W2889874867","https://openalex.org/W2909194804","https://openalex.org/W2915459742","https://openalex.org/W2954501063","https://openalex.org/W2967059818","https://openalex.org/W2981137429","https://openalex.org/W3062028978","https://openalex.org/W3087701445","https://openalex.org/W3098409330","https://openalex.org/W3115988811","https://openalex.org/W3121904305","https://openalex.org/W3129351841","https://openalex.org/W3131839988","https://openalex.org/W3132864675","https://openalex.org/W3161833585","https://openalex.org/W3192108213","https://openalex.org/W3199622685","https://openalex.org/W3202931255","https://openalex.org/W3206354438","https://openalex.org/W3213536168","https://openalex.org/W4213232054","https://openalex.org/W4220887281","https://openalex.org/W4226280654","https://openalex.org/W4288060326","https://openalex.org/W4303199315","https://openalex.org/W4307446592","https://openalex.org/W4312190539","https://openalex.org/W4316507374","https://openalex.org/W4317689970","https://openalex.org/W4367311810","https://openalex.org/W4378976943","https://openalex.org/W4386861232","https://openalex.org/W4389398607","https://openalex.org/W4390063959"],"related_works":["https://openalex.org/W4388142354","https://openalex.org/W4377564400","https://openalex.org/W4366822718","https://openalex.org/W4365811064","https://openalex.org/W4320032841","https://openalex.org/W4280502984","https://openalex.org/W2998674376","https://openalex.org/W2770215042","https://openalex.org/W2607137613","https://openalex.org/W2580221256"],"abstract_inverted_index":{"ABSTRACT":[0],"Understanding":[1],"the":[2,92],"effects":[3],"of":[4,19,28,38,42,70,94,110,128,199],"rare":[5],"genetic":[6],"variants":[7,39,61,71,120,142,152,164],"remains":[8],"challenging,":[9],"both":[10,183],"in":[11,54,62,91,121,132,158],"coding":[12],"and":[13,79,107,139,185],"non-coding":[14,150],"regions.":[15],"While":[16],"multiplexed":[17],"assays":[18],"variant":[20],"effect":[21],"(MAVEs)":[22],"have":[23],"enabled":[24],"scalable":[25,196],"functional":[26,197],"assessment":[27,198],"variants,":[29],"established":[30],"MAVEs":[31],"are":[32],"limited":[33],"by":[34,97],"either":[35],"exogenous":[36],"expression":[37],"or":[40],"constraints":[41],"genome":[43],"editing.":[44],"Here,":[45],"we":[46,147],"introduce":[47],"a":[48,81,133,154,159],"pooled":[49],"prime":[50],"editing":[51,105],"(PE)":[52],"platform":[53,90,191],"haploid":[55],"human":[56,200],"cells":[57],"to":[58,72,193],"scalably":[59],"assay":[60,148],"their":[63],"endogenous":[64],"context.":[65],"We":[66,87,117],"first":[67],"optimized":[68],"delivery":[69],"HAP1":[73],"cells,":[74],"defining":[75],"optimal":[76],"pegRNA":[77],"designs":[78],"establishing":[80],"co-selection":[82],"strategy":[83],"for":[84,104,177],"improved":[85],"efficiency.":[86],"characterize":[88],"our":[89,190],"context":[93],"negative":[95,186],"selection":[96,187],"testing":[98],"over":[99],"7,500":[100],"pegRNAs":[101,113,180],"targeting":[102],"SMARCB1":[103],"activity":[106],"observing":[108],"depletion":[109],"highly":[111,178,195],"active":[112,179],"installing":[114],"loss-of-function":[115],"variants.":[116,201],"next":[118],"assess":[119],"MLH1":[122,151],"via":[123,166],"6-thioguanine":[124],"selection,":[125],"assaying":[126],"65.3%":[127],"all":[129],"possible":[130],"SNVs":[131],"200-bp":[134],"region":[135,157],"spanning":[136],"exon":[137],"10":[138],"distinguishing":[140],"LoF":[141],"with":[143,169],"high":[144,170],"accuracy.":[145],"Lastly,":[146],"362":[149],"across":[153],"60":[155],"kb":[156],"single":[160],"experiment,":[161],"identifying":[162],"pathogenic":[163],"acting":[165],"multiple":[167],"mechanisms":[168],"specificity.":[171],"Our":[172],"analyses":[173],"detail":[174],"how":[175],"filtering":[176],"can":[181],"facilitate":[182],"positive":[184],"screens.":[188],"Accordingly,":[189],"promises":[192],"enable":[194]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4393448183","counts_by_year":[{"year":2024,"cited_by_count":1}],"updated_date":"2024-10-25T14:10:59.765466","created_date":"2024-04-03"}
-
-          '
-      headers:
-        Access-Control-Allow-Credentials:
-          - "true"
-        Access-Control-Allow-Headers:
-          - Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Authorization,
-            Cache-Control
-        Access-Control-Allow-Methods:
-          - POST, GET, OPTIONS, PUT, DELETE, PATCH
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Authorization, Cache-Control
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "3767"
-        Content-Security-Policy:
-          - default-src 'self'; object-src 'none'
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Nel:
-          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
-        Referrer-Policy:
-          - strict-origin-when-cross-origin
-        Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107839&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=savWMBIX%2FuigNk%2BB3oRRW5YgYPj3kIdhOkW0Tn87mXQ%3D"}]}'
-        Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107839&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=savWMBIX%2FuigNk%2BB3oRRW5YgYPj3kIdhOkW0Tn87mXQ%3D
-        Server:
-          - gunicorn
-        Strict-Transport-Security:
-          - max-age=31556926; includeSubDomains
-        Vary:
-          - Accept-Encoding
-        Via:
-          - 1.1 vegur
-        X-Api-Pool:
-          - common
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        X-Xss-Protection:
-          - 1; mode=block
       status:
         code: 200
         message: OK
@@ -372,7 +372,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_doi_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes1].yaml
@@ -38,27 +38,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Via:
-          - 1.1 6cbbecc3198d4b8fe84dc82e5f121ae6.cloudfront.net (CloudFront)
+          - 1.1 fe4ffdbe245129b7503870df74adcb46.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - x74xzo1Vgtf0sHjNYMASzYWHeeaxPOZbFamNxgd55X3Wlg5uBEGjZQ==
+          - OhnynmwOGmRMGIeORgcMem7RrBNgBKtVwoV5QLn60XvnqfhjMIAr1g==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PnEJPPHcEkMA=
+          - CLbZfFGXvHcEQGw=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1446"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 84d31e03-de14-4703-8f90-16f811730d2a
+          - 0e07ad61-bdfb-47eb-92e8-24f5193c0fdc
       status:
         code: 200
         message: OK
@@ -97,7 +97,7 @@ interactions:
           Institute of Chemical Biology","ror":"https://ror.org/01kh0x418","country_code":"IN","type":"facility","lineage":["https://openalex.org/I160344538","https://openalex.org/I2799351866","https://openalex.org/I4210134808","https://openalex.org/I66760702"]}],"countries":["IN"],"is_corresponding":false,"raw_author_name":"Ranajit
           K. Banerjee","raw_affiliation_strings":["Department of Physiology, Indian
           Institute of Chemical Biology, Calcutta, India"],"affiliations":[{"raw_affiliation_string":"Department
-          of Physiology, Indian Institute of Chemical Biology, Calcutta, India","institution_ids":["https://openalex.org/I160344538"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":0.377,"has_fulltext":true,"fulltext_origin":"ngrams","cited_by_count":7,"citation_normalized_percentile":{"value":0.512852,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":77,"max":78},"biblio":{"volume":"218","issue":"1/2","first_page":"1","last_page":"11"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11848","display_name":"Heme
+          of Physiology, Indian Institute of Chemical Biology, Calcutta, India","institution_ids":["https://openalex.org/I160344538"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":0.345,"has_fulltext":true,"fulltext_origin":"ngrams","cited_by_count":7,"citation_normalized_percentile":{"value":0.499122,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":77,"max":78},"biblio":{"volume":"218","issue":"1/2","first_page":"1","last_page":"11"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11848","display_name":"Heme
           Oxygenase and Carbon Monoxide Research","score":0.9979,"subfield":{"id":"https://openalex.org/subfields/1312","display_name":"Molecular
           Biology"},"field":{"id":"https://openalex.org/fields/13","display_name":"Biochemistry,
           Genetics and Molecular Biology"},"domain":{"id":"https://openalex.org/domains/1","display_name":"Life
@@ -139,8 +139,8 @@ interactions:
           Science+Business Media","host_organization_lineage":["https://openalex.org/P4310319965","https://openalex.org/P4310319900"],"host_organization_lineage_names":["Springer
           Nature","Springer Science+Business Media"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false},{"is_oa":false,"landing_page_url":"https://pubmed.ncbi.nlm.nih.gov/11330823","pdf_url":null,"source":{"id":"https://openalex.org/S4306525036","display_name":"PubMed","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I1299303238","host_organization_name":"National
           Institutes of Health","host_organization_lineage":["https://openalex.org/I1299303238"],"host_organization_lineage_names":["National
-          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"id":"https://metadata.un.org/sdg/6","display_name":"Clean
-          water and sanitation","score":0.74}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":36,"referenced_works":["https://openalex.org/W105515906","https://openalex.org/W1515075543","https://openalex.org/W1565240752","https://openalex.org/W1565691495","https://openalex.org/W1571455001","https://openalex.org/W1578742674","https://openalex.org/W1581359855","https://openalex.org/W1587806072","https://openalex.org/W1589479912","https://openalex.org/W1590103084","https://openalex.org/W1799674254","https://openalex.org/W1849424407","https://openalex.org/W1967044424","https://openalex.org/W1971827843","https://openalex.org/W1986659402","https://openalex.org/W1989790643","https://openalex.org/W1990052170","https://openalex.org/W1998706402","https://openalex.org/W1999881926","https://openalex.org/W2002978594","https://openalex.org/W2003479580","https://openalex.org/W2005601978","https://openalex.org/W2006822851","https://openalex.org/W2017379977","https://openalex.org/W2023180351","https://openalex.org/W2024117678","https://openalex.org/W2055799504","https://openalex.org/W2095100183","https://openalex.org/W2095873332","https://openalex.org/W2154061135","https://openalex.org/W2165898505","https://openalex.org/W2179092050","https://openalex.org/W2411439573","https://openalex.org/W2418888804","https://openalex.org/W91326892","https://openalex.org/W955725593"],"related_works":["https://openalex.org/W2327133413","https://openalex.org/W2122752058","https://openalex.org/W2072464466","https://openalex.org/W2062221185","https://openalex.org/W2044979688","https://openalex.org/W1996602571","https://openalex.org/W1991900549","https://openalex.org/W1978474786","https://openalex.org/W1975984439","https://openalex.org/W1530487393"],"abstract_inverted_index":null,"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W1554322594","counts_by_year":[{"year":2023,"cited_by_count":1}],"updated_date":"2024-10-18T04:09:30.104891","created_date":"2016-06-24"}
+          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"score":0.74,"display_name":"Clean
+          water and sanitation","id":"https://metadata.un.org/sdg/6"}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":36,"referenced_works":["https://openalex.org/W105515906","https://openalex.org/W1515075543","https://openalex.org/W1565240752","https://openalex.org/W1565691495","https://openalex.org/W1571455001","https://openalex.org/W1578742674","https://openalex.org/W1581359855","https://openalex.org/W1587806072","https://openalex.org/W1589479912","https://openalex.org/W1590103084","https://openalex.org/W1799674254","https://openalex.org/W1849424407","https://openalex.org/W1967044424","https://openalex.org/W1971827843","https://openalex.org/W1986659402","https://openalex.org/W1989790643","https://openalex.org/W1990052170","https://openalex.org/W1998706402","https://openalex.org/W1999881926","https://openalex.org/W2002978594","https://openalex.org/W2003479580","https://openalex.org/W2005601978","https://openalex.org/W2006822851","https://openalex.org/W2017379977","https://openalex.org/W2023180351","https://openalex.org/W2024117678","https://openalex.org/W2055799504","https://openalex.org/W2095100183","https://openalex.org/W2095873332","https://openalex.org/W2154061135","https://openalex.org/W2165898505","https://openalex.org/W2179092050","https://openalex.org/W2411439573","https://openalex.org/W2418888804","https://openalex.org/W91326892","https://openalex.org/W955725593"],"related_works":["https://openalex.org/W2327133413","https://openalex.org/W2122752058","https://openalex.org/W2072464466","https://openalex.org/W2062221185","https://openalex.org/W2044979688","https://openalex.org/W1996602571","https://openalex.org/W1991900549","https://openalex.org/W1978474786","https://openalex.org/W1975984439","https://openalex.org/W1530487393"],"abstract_inverted_index":null,"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W1554322594","counts_by_year":[{"year":2023,"cited_by_count":1}],"updated_date":"2024-11-30T23:11:19.324656","created_date":"2016-06-24"}
 
           '
       headers:
@@ -160,21 +160,21 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3185"
+          - "3192"
         Content-Security-Policy:
           - default-src 'self'; object-src 'none'
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Referrer-Policy:
           - strict-origin-when-cross-origin
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168188&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=%2Fn6z%2F81qLDUQjrRv90qOIcddDEtGM24evga%2FzNg%2Bk%2Bg%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168188&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=%2Fn6z%2F81qLDUQjrRv90qOIcddDEtGM24evga%2FzNg%2Bk%2Bg%3D
         Server:
           - gunicorn
         Strict-Transport-Security:
@@ -223,7 +223,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -267,7 +267,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -323,13 +323,13 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168188&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=NFjez%2F60EtbxhurHvF9P2WUSxXGEWAMrN9YVU9nnw8M%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168188&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=NFjez%2F60EtbxhurHvF9P2WUSxXGEWAMrN9YVU9nnw8M%3D
         Server:
           - gunicorn
         Vary:

--- a/tests/cassettes/test_doi_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_doi_search[paper_attributes2].yaml
@@ -29,76 +29,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Via:
-          - 1.1 b735cef950dccc7c59398fa8df6c4f7e.cloudfront.net (CloudFront)
+          - 1.1 dad2c265b31314a82611ea10bc334572.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - sEJhCtQa6wO3K8rg3g9c03CAerUXX3oLud79QYTb6NaAt6pYKFkb3w==
+          - EzwPbRLkMV19FuinANI8QLBY_hiykiUBPEwcJnjTx6OR5nl3TWFh4Q==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81QMHqyvHcEQJw=
+          - CLbaKEedPHcEdsg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "837"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - ba2ffc0f-306e-4d65-a107-62155f755f8c
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.unpaywall.org/v2/10.1007/s40278-023-41815-2?email=example@papercrow.ai
-    response:
-      body:
-        string:
-          '{"doi": "10.1007/s40278-023-41815-2", "doi_url": "https://doi.org/10.1007/s40278-023-41815-2",
-          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "genre": "journal-article",
-          "is_paratext": false, "published_date": "2023-06-24", "year": 2023, "journal_name":
-          "Reactions Weekly", "journal_issns": "1179-2051", "journal_issn_l": "0114-9954",
-          "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Springer
-          Science and Business Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
-          false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
-          [], "oa_locations_embargoed": [], "updated": "2023-06-24T05:46:22.445497",
-          "data_standard": 2, "z_authors": null}'
-      headers:
-        Access-Control-Allow-Headers:
-          - origin, content-type, accept, x-requested-with
-        Access-Control-Allow-Methods:
-          - POST, GET, OPTIONS, PUT, DELETE, PATCH
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "396"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
-        Nel:
-          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
-        Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107841&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=E4uTMpvD5PQCdpgIXEEdxp7SxZE3OEKR5KlJaFoWfSQ%3D"}]}'
-        Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107841&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=E4uTMpvD5PQCdpgIXEEdxp7SxZE3OEKR5KlJaFoWfSQ%3D
-        Server:
-          - gunicorn
-        Vary:
-          - Accept-Encoding
-        Via:
-          - 1.1 vegur
+          - 2c66b7de-afe9-4aa5-9d00-a9e4e429292b
       status:
         code: 200
         message: OK
@@ -113,7 +64,7 @@ interactions:
           '{"id":"https://openalex.org/W4381738344","doi":"https://doi.org/10.1007/s40278-023-41815-2","title":"Convalescent-anti-sars-cov-2-plasma/immune-globulin","display_name":"Convalescent-anti-sars-cov-2-plasma/immune-globulin","publication_year":2023,"publication_date":"2023-06-23","ids":{"openalex":"https://openalex.org/W4381738344","doi":"https://doi.org/10.1007/s40278-023-41815-2"},"language":"en","primary_location":{"is_oa":false,"landing_page_url":"https://doi.org/10.1007/s40278-023-41815-2","pdf_url":null,"source":{"id":"https://openalex.org/S14436165","display_name":"Reactions
           Weekly","issn_l":"0114-9954","issn":["0114-9954","1179-2051"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310320330","host_organization_name":"Adis,
           Springer Healthcare","host_organization_lineage":["https://openalex.org/P4310319965","https://openalex.org/P4310320330"],"host_organization_lineage_names":["Springer
-          Nature","Adis, Springer Healthcare"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false},"type":"article","type_crossref":"journal-article","indexed_in":["crossref"],"open_access":{"is_oa":false,"oa_status":"closed","oa_url":null,"any_repository_has_fulltext":false},"authorships":[],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":0.0,"has_fulltext":false,"cited_by_count":0,"citation_normalized_percentile":{"value":0.0,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":0,"max":70},"biblio":{"volume":"1962","issue":"1","first_page":"145","last_page":"145"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T12796","display_name":"Cutaneous
+          Nature","Adis, Springer Healthcare"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false},"type":"article","type_crossref":"journal-article","indexed_in":["crossref"],"open_access":{"is_oa":false,"oa_status":"closed","oa_url":null,"any_repository_has_fulltext":false},"authorships":[],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":0.0,"has_fulltext":false,"cited_by_count":0,"citation_normalized_percentile":{"value":0.0,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":0,"max":69},"biblio":{"volume":"1962","issue":"1","first_page":"145","last_page":"145"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T12796","display_name":"Cutaneous
           Manifestations of COVID-19: A Comprehensive Review","score":0.9358,"subfield":{"id":"https://openalex.org/subfields/2708","display_name":"Dermatology"},"field":{"id":"https://openalex.org/fields/27","display_name":"Medicine"},"domain":{"id":"https://openalex.org/domains/4","display_name":"Health
           Sciences"}},"topics":[{"id":"https://openalex.org/T12796","display_name":"Cutaneous
           Manifestations of COVID-19: A Comprehensive Review","score":0.9358,"subfield":{"id":"https://openalex.org/subfields/2708","display_name":"Dermatology"},"field":{"id":"https://openalex.org/fields/27","display_name":"Medicine"},"domain":{"id":"https://openalex.org/domains/4","display_name":"Health
@@ -130,8 +81,8 @@ interactions:
           disease (medical specialty)","level":3,"score":0.07111758},{"id":"https://openalex.org/C116675565","wikidata":"https://www.wikidata.org/wiki/Q3241045","display_name":"Outbreak","level":2,"score":0.059273064},{"id":"https://openalex.org/C2779134260","wikidata":"https://www.wikidata.org/wiki/Q12136","display_name":"Disease","level":2,"score":0.041250974}],"mesh":[],"locations_count":1,"locations":[{"is_oa":false,"landing_page_url":"https://doi.org/10.1007/s40278-023-41815-2","pdf_url":null,"source":{"id":"https://openalex.org/S14436165","display_name":"Reactions
           Weekly","issn_l":"0114-9954","issn":["0114-9954","1179-2051"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310320330","host_organization_name":"Adis,
           Springer Healthcare","host_organization_lineage":["https://openalex.org/P4310319965","https://openalex.org/P4310320330"],"host_organization_lineage_names":["Springer
-          Nature","Adis, Springer Healthcare"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"score":0.4,"display_name":"Good
-          health and well-being","id":"https://metadata.un.org/sdg/3"}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":1,"referenced_works":["https://openalex.org/W4308075214"],"related_works":["https://openalex.org/W4206669628","https://openalex.org/W4205317059","https://openalex.org/W4200329650","https://openalex.org/W3127156785","https://openalex.org/W3113664224","https://openalex.org/W3084498529","https://openalex.org/W3018906908","https://openalex.org/W3009669391","https://openalex.org/W3007868867","https://openalex.org/W3005417802"],"abstract_inverted_index":null,"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4381738344","counts_by_year":[],"updated_date":"2024-10-14T01:43:04.487577","created_date":"2023-06-24"}
+          Nature","Adis, Springer Healthcare"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"display_name":"Good
+          health and well-being","score":0.4,"id":"https://metadata.un.org/sdg/3"}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":1,"referenced_works":["https://openalex.org/W4308075214"],"related_works":["https://openalex.org/W4206669628","https://openalex.org/W4205317059","https://openalex.org/W4200329650","https://openalex.org/W3127156785","https://openalex.org/W3113664224","https://openalex.org/W3084498529","https://openalex.org/W3018906908","https://openalex.org/W3009669391","https://openalex.org/W3007868867","https://openalex.org/W3005417802"],"abstract_inverted_index":null,"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4381738344","counts_by_year":[],"updated_date":"2024-11-12T04:32:55.600912","created_date":"2023-06-24"}
 
           '
       headers:
@@ -157,15 +108,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Referrer-Policy:
           - strict-origin-when-cross-origin
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107840&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=tUNezc7%2B4vONI4v7CJ5Qw%2FeSu1zDVTz7xMdnDSZNVFw%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168192&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=WzrrO0uMYZrwdXF6nTj390M%2F%2BiRzDIOCZJwZqsf96HM%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107840&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=tUNezc7%2B4vONI4v7CJ5Qw%2FeSu1zDVTz7xMdnDSZNVFw%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168192&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=WzrrO0uMYZrwdXF6nTj390M%2F%2BiRzDIOCZJwZqsf96HM%3D
         Server:
           - gunicorn
         Strict-Transport-Security:
@@ -220,7 +171,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -237,6 +188,55 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.unpaywall.org/v2/10.1007/s40278-023-41815-2?email=example@papercrow.ai
+    response:
+      body:
+        string:
+          '{"doi": "10.1007/s40278-023-41815-2", "doi_url": "https://doi.org/10.1007/s40278-023-41815-2",
+          "title": "Convalescent-anti-sars-cov-2-plasma/immune-globulin", "genre": "journal-article",
+          "is_paratext": false, "published_date": "2023-06-24", "year": 2023, "journal_name":
+          "Reactions Weekly", "journal_issns": "1179-2051", "journal_issn_l": "0114-9954",
+          "journal_is_oa": false, "journal_is_in_doaj": false, "publisher": "Springer
+          Science and Business Media LLC", "is_oa": false, "oa_status": "closed", "has_repository_copy":
+          false, "best_oa_location": null, "first_oa_location": null, "oa_locations":
+          [], "oa_locations_embargoed": [], "updated": "2023-06-24T05:46:22.445497",
+          "data_standard": 2, "z_authors": null}'
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "396"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:33 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168192&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=LqmqL4E3lYtXOy34G1aDK6FyQcvHdt1Jyr1ojaUWRDc%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168192&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=LqmqL4E3lYtXOy34G1aDK6FyQcvHdt1Jyr1ojaUWRDc%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
       status:
         code: 200
         message: OK
@@ -263,7 +263,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_ensure_sequential_run.yaml
+++ b/tests/cassettes/test_ensure_sequential_run.yaml
@@ -20,7 +20,7 @@ interactions:
         Content-Type:
           - text/plain
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -64,27 +64,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Via:
-          - 1.1 f36785ff79b1d07dbaa3721ed491b772.cloudfront.net (CloudFront)
+          - 1.1 7dbcbf3457f77b741952e31c6826a8dc.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - Uh1hdGgK2HTdOzGRrzuSa6JW2GD61WEnyfUORbJwkf36d5bbzl9BLA==
+          - cGeLKjg4d8tiFbydiqQoH92H2tl1beLevLY336_U60TqPK1A4zycFw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PqH5_PHcErYw=
+          - CLbZYEvlPHcEn6Q=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "277"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - b18e2aff-ab06-45a3-a734-2f46e454ad1e
+          - 91c16d98-30a3-4999-8972-34e8fe4de41f
       status:
         code: 200
         message: OK
@@ -109,7 +109,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -249,7 +249,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -296,7 +296,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -350,27 +350,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Via:
-          - 1.1 f36785ff79b1d07dbaa3721ed491b772.cloudfront.net (CloudFront)
+          - 1.1 7dbcbf3457f77b741952e31c6826a8dc.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - j0QYNVW7VDRb38UUtHv3Zu5cfhKOVPazZoOejo41HJQwfDj3HXpyNw==
+          - EtZAoslhEzsekfr7xVfXe85lgNus54lur8Heh6pa8ZSapsdSYE8hoA==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81P3EagvHcED1Q=
+          - CLbZnGx0vHcEQmQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "1072"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 186d8264-ed36-4698-97f3-4398f3b10a28
+          - 141e3859-3a24-462d-85ac-835a5a4f4fdd
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_ensure_sequential_run_early_stop.yaml
+++ b/tests/cassettes/test_ensure_sequential_run_early_stop.yaml
@@ -23,27 +23,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Via:
-          - 1.1 11b74b29b8e5fb6f06701002e26ee6ae.cloudfront.net (CloudFront)
+          - 1.1 30dc54066252ce01682df0394718d89c.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - ytUXTHj6uufF6OiJO2HLHdQpdQYOj8s2trNu1tGiwJzhZMQvKBxyHA==
+          - MXDMSMatUs-RAzQOQ-VxUhPgrYLO_XR4yn4DX9q5Z6EaPArW6F86gg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PnEO9vHcEDKQ=
+          - CLbZpEc7PHcEQsA=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "277"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 898f691c-a6d8-4d0a-92c8-e8cd7bdd696e
+          - c3a1d516-60c5-4055-b816-a626f6aa94e0
       status:
         code: 200
         message: OK
@@ -68,7 +68,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_minimal_fields_filtering.yaml
+++ b/tests/cassettes/test_minimal_fields_filtering.yaml
@@ -3,11 +3,60 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "title": "Augmenting large language models with chemistry tools",
+          "matchScore": 176.67178}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "348"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        Via:
+          - 1.1 f8b122b964bc12ee7f052daf895c865c.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - S809487N_Ii20sUTQA4amMR2TIa3eN6VNi2DrPACCS_2Q3EMT8ALUA==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbaWF-7vHcEJug=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "348"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 526f806d-d338-4be2-b812-108e548b31c4
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1&select=DOI,title
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
@@ -22,7 +71,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -39,55 +88,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "title": "Augmenting large language models with chemistry tools",
-          "matchScore": 176.78436}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "348"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Via:
-          - 1.1 0cb53c06b4d3d66446893feb6331dc78.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - yaiXz_Uo8E2FWzeCDDWlOpCOJRJXc7HDlaP2ixGuw7SNvEBR03g14w==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PoGAmPHcEUyQ=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "348"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 8292cd13-397d-4762-8e0b-5dae49cc7819
       status:
         code: 200
         message: OK
@@ -112,7 +112,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_odd_client_requests.yaml
+++ b/tests/cassettes/test_odd_client_requests.yaml
@@ -7,7 +7,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5685,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":5727,"items":[{"DOI":"10.1038\/s42256-024-00832-8","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
@@ -24,11 +24,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "450"
+          - "451"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -64,7 +64,7 @@ interactions:
           "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773", "name": "Oliver
           Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"}, {"authorId":
           "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853", "name":
-          "P. Schwaller"}], "matchScore": 176.3838}]}
+          "P. Schwaller"}], "matchScore": 178.39174}]}
 
           '
       headers:
@@ -73,31 +73,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "683"
+          - "684"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Via:
-          - 1.1 edc643c7c426bec36e205453aa531064.cloudfront.net (CloudFront)
+          - 1.1 f8b122b964bc12ee7f052daf895c865c.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - T5_1MUB4qtA4IwcYE0JpsGhKd0xoaJu7JbRWSSH4vKKnlr2YD92B9g==
+          - yKFvmUVUczU4QFiruYdAf-4pbiDWov0M4o3i4JTwpAT1ZT37S8BKqg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PoE_wPHcEGcQ=
+          - CLbaOHBmPHcERdQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "683"
+          - "684"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 36d028ac-aad8-4ea1-81fc-4a8418794225
+          - c85f2082-f108-4a49-aa28-f9bebf3d2ee8
       status:
         code: 200
         message: OK
@@ -122,7 +122,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -154,7 +154,7 @@ interactions:
           {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
           "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
           "38799228"}, "title": "Augmenting large language models with chemistry tools",
-          "matchScore": 176.78436}]}
+          "matchScore": 176.67178}]}
 
           '
       headers:
@@ -167,27 +167,160 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        Via:
+          - 1.1 b0797f10be715dcb685d992d17347df4.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - -tfmEPKCpG3d64bK5MNheFpy5CZYWkkSKc91baPwTAp-pUoGgWHLNA==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbaYHhxPHcEfZQ=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "348"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 99c2be1d-61d8-4b3d-a297-8d00e3292ea7
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works/10.48550%2FarXiv.2304.05376/transform/application/x-bibtex
+    response:
+      body:
+        string: Resource not found.
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Content-Type:
+          - text/plain;charset=utf-8
+        Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 404
+        message: Not Found
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1&select=DOI,title
+    response:
+      body:
+        string:
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
+          large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+      headers:
+        Access-Control-Allow-Headers:
+          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
+            Accept-Ranges, Cache-Control
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Link
+        Connection:
+          - close
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:34 GMT
+        Server:
+          - Jetty(9.4.40.v20210413)
+        Transfer-Encoding:
+          - chunked
+        permissions-policy:
+          - interest-cohort=()
+        x-api-pool:
+          - plus
+        x-rate-limit-interval:
+          - 1s
+        x-rate-limit-limit:
+          - "150"
+        x-ratelimit-interval:
+          - 1s
+        x-ratelimit-limit:
+          - "150"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "title": "Augmenting large language models with chemistry tools",
+          "matchScore": 176.67178}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "348"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:35 GMT
         Via:
           - 1.1 30dc54066252ce01682df0394718d89c.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - UZKJXNrbmrbKcWB8tztZbO13FTgIjNaLAABz6ZI2mWRCkYh8sOJqGg==
+          - oYseCGJt3gbHalkmpCicgyfQLuhDgkfv4aqBoBKewb29x3chbUAQjw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81P0FzfPHcEvjg=
+          - CLbajHJCvHcEQXg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "348"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:35 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 3d98445c-a2c4-4bb1-9113-c94291ca5603
+          - f29a29e8-3fbd-4c96-9d4a-9bd525733ae7
       status:
         code: 200
         message: OK
@@ -199,7 +332,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
           large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
@@ -214,7 +347,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:35 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -255,140 +388,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 404
-        message: Not Found
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=externalIds,title
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "title": "Augmenting large language models with chemistry tools",
-          "matchScore": 176.3838}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "347"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Via:
-          - 1.1 97354ec70bdda7ac06cc29aed9bfdb3c.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - kCkzT-Z_OrlxyTcaTbwzbRfbog0h6ZhyjHvo4Ntxdp5h6YJm3BdkAg==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81P8G9gPHcEWfg=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "347"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 98df1a22-6b0a-4ac5-8e4c-e39d4bd6d6df
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1&select=DOI,title
-    response:
-      body:
-        string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"DOI":"10.1038\/s42256-024-00832-8","title":["Augmenting
-          large language models with chemistry tools"]}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Server:
-          - Jetty(9.4.40.v20210413)
-        Transfer-Encoding:
-          - chunked
-        permissions-policy:
-          - interest-cohort=()
-        x-api-pool:
-          - plus
-        x-rate-limit-interval:
-          - 1s
-        x-rate-limit-limit:
-          - "150"
-        x-ratelimit-interval:
-          - 1s
-        x-ratelimit-limit:
-          - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.crossref.org/works/10.48550%2FarXiv.2304.05376/transform/application/x-bibtex
-    response:
-      body:
-        string: Resource not found.
-      headers:
-        Access-Control-Allow-Headers:
-          - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
-            Accept-Ranges, Cache-Control
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Link
-        Connection:
-          - close
-        Content-Type:
-          - text/plain;charset=utf-8
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:35 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -430,27 +430,27 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:36 GMT
         Via:
-          - 1.1 97354ec70bdda7ac06cc29aed9bfdb3c.cloudfront.net (CloudFront)
+          - 1.1 6cbbecc3198d4b8fe84dc82e5f121ae6.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - 3dSXXZLF93hef9phZr69scS0dnaih_zqvJL7mVSBmfCoAncIPiNsFA==
+          - XpSwBrnWCDjkdeJ7qOssbh719MN0jC9_tviDYpCiAsyJIW4E1tG4PQ==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81QEHnMvHcEQJw=
+          - CLbatEUUvHcEGQg=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
           - "197"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:36 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 12e9dad4-3121-4f54-944c-e6b8d2acb998
+          - c5357fe1-9e8f-4106-b930-eccdd82a814f
       status:
         code: 200
         message: OK
@@ -489,7 +489,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:36 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -532,7 +532,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:36 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -575,7 +575,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:20 GMT
+          - Mon, 02 Dec 2024 19:36:37 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_partly_embedded_texts[False].yaml
+++ b/tests/cassettes/test_partly_embedded_texts[False].yaml
@@ -1,8 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"input": ["I like turtles."], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+      body: '{"input":["I like turtles."],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -11,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "94"
+          - "89"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -27,7 +25,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -154,7 +152,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946bcebbb17d2-SJC
+          - 8ebdc510a9ec1574-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -162,7 +160,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:24 GMT
+          - Mon, 02 Dec 2024 19:37:08 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -180,7 +178,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "46"
+          - "99"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -192,20 +190,18 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9999996"
+          - "9929345"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 0s
+          - 423ms
         x-request-id:
-          - req_5bc89c44c4e884bb297bd85aa82c44b9
+          - req_f388a5da00381187f9a29d9bbb274360
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["I like cats."], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+      body: '{"input":["I like cats."],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -214,13 +210,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "91"
+          - "86"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -230,7 +226,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -244,120 +240,120 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA1R6S9OyPLfm/PsVTz1TepecE94ZAspRopzUrq4uQERRQQIEkl37v3dx31/t7p44
-          QEoMWes6rfznv/78+dsVTVWOf//58/f9HMa//2O9dsvH/O8/f/7nv/78+fPnP38+/787q09R3W7P
-          tv65/efLZ3urlr///OH/+8r/vemfP38Vkm7D8XW3gRBL9Ufj8quDqq+rxH3D67oGh14hYSEc46Vf
-          IlWLqikIl+y2j5nbyRNsGz8KufBhN4Lg5S8opkuCbrNxKsRqvkXqkJ6yiX+XRsM/dQzhYGYf4shO
-          Y9INSELYOakXTo0I/O5b3HTQptszSkxlatimO1AAKi1FZdY7WOjKJte2+miSoqoPQEpO/gA+wwMT
-          37R6fxbcIABOKigTC5qPT6ql6WDj7HxUWs8DmL3wykGC9ZC4+XIvRO18zYHul3cU1fOHMeNYVcBc
-          jia5nJ9lTDcf6aIdrclBu+fuG7Mtv/8AARcNsu10Gy+21UK1uM3lxI47i4m+FchwO0AZmee2KejE
-          wg4+Xr2BrF0f+gLxlQTu/aNN8tnRiuGgohneOLEie5jfY8kJahkOYn+dgAJPWLrtnRo6zcVG+Vde
-          ALnifq8+nDxAUQOThm2Vy15b9PRG4qFKwXzL1BA6ij9MnHTi/SUKywgcfbpDZnoxmITBs9c8Z0wJ
-          KrM9IzpjMlxUciAe9t4+jV+RA32/3hP9YuqFpN/vFtRftwPJ4MkypRy9ODC3GSFeWE4mfxn1Shts
-          tyAuTOKCaT6ONBwMG1KGyRnM2vdUQldtc7K9PUwgaJlvgKpNPHR6mAYWTvtHpIXNUqKz4XPNrKLD
-          DJ8+7YnfMAzYul4w2H5BwtsHAUmzPE65CXIZig86NhM33SdYNjZGxmI/C2ka+AlyzVVEwe1oMT7Y
-          XCPYcP2eWArvsOXTLLpW1ccDKVXwNefru3M0boYWuhyiky+5SazCzzK+UICNCSwv5D61VyP3E7Qn
-          0MxT5Eew8bM4XNC1A3TZ0b326QZxksuzUlD/8pi0GzrX4fOQHph4vz56bX1fyKyynLGsimQ4NMUJ
-          bSNgY14fF6gVaruZQKRZhbDNcQ0F6wiIrhFUsPaKOeWdJhcSORvNH52q5qBYW/kk95pQUI+kmabc
-          LifkhienES+hrwK1FceQxvuDL9LlFoASMYmY5+gWL8nsRFqmtQ6yx/MjFhvQJdrotG5IC+CC+Y6/
-          Awztx4fswDw2jDbHo0YGOSa5EzzBLFzOtWZX/RuZ0yjG8/Zz7WCxWEdUGktYSFdVyJU4BfV0tDq7
-          4MWwzrW1P1A+Q1KQ6nlJgMgFCYrjmcMsipEIvpkxIUvRRdBp8jDDzqpT5KuziZfSvO6hZOYHdIzm
-          pz93m4MH29Q8Iz9sGZ67+GloB3yakW1XJR7TxHdg6YzqRHvTAowjnz0E2TYm5/H8KBZ16/DQSv0G
-          mbWtFmzFDxgOpEK7qulxh68XGZ41Z0HmJjfw5LZ9oqLKDQgScF7Qkwr2sHu9dbRvm4HR9f3CLuqP
-          yDN2UTOKd2MPbvSbICfJJjxnEaTgKoR7knAxz4YnIzm0zJCFy6J4Pn3dcQjb2+ZK/F0i4DHaOKqm
-          C+Jxkny9iOdpivdqL3yNadPmlj8/HOsIPwt5ERNvvnhh3afWHJtwxHPdo886Y87ggXvKk5xkIRZ3
-          ichpyalL0PG4MdjSuGMGVU1/T6qhWJiGhkNhx6k7lJTtjrFFNWUo6e6OlG199Fl/j3hAauKG6nAz
-          Yz7fzgbcZe8TKiLNinn91HswbFiJdBnc4jGJ5VIFLzecWs8MfX4UwAW8ufMOBfZRjQm/oRTukQXR
-          Tz0vrjpT6FuVi5B32JokdZuLtsHKg+TMR4AS/EkgtvUdivanuWDejAdQ4koPGXk4Bdb85qi5Vfoi
-          xi4xfWGRiAPjNmqQedpsYsLFWQT3jrGZ5Ns3wJL6DEKot1OKHIe9zfkhy6pmilAjhTo3zSLeDQtc
-          8PmM9tUxBLQKRg9clFtETovS+6wVGIVfenyhUyzzjO0UrYQZ7i4k4R8eow/vYYB7VVJUcMWtYePb
-          ncC6XlLJu0+Md4pQQl70dWKSR1ewT0BK2LzSLXK5hgEcW3YInNrZEOM9JqbUesdeW5bFJ+cGfeJZ
-          2z0y7eJHA8oXpcSYvMsLLB3n8PM8TMtNKmuHpt8TJ0hNIJZNuFeKF5+jc64ImGi5+FGlU+2gcxAr
-          Dc3jeq8NQxojK226YuiC7QDWepw4RXw3VIwLCLAQYOS4My1o+44seENpjdypV5opTa9POFJORc67
-          P8f0vrNETRuCJ3Hv71Mxp+Igg/KmUJJzkxIvMlte8LHc32jr8BJemuzBazGX1CjaUqsQg/EaQvU6
-          UbLnvne2NG/Nga6OerLbREMx/+DJ2O3tUEnTvT+WnF1rD92UCHqdF0z2m2sPH2rRTtrC5uaXz3gs
-          qGj/oAfMvleuh3YjVuQmvQijs36TYTiMFdkb+tVc1GPpQSXdwum9O9OCntNXCC6vU04OemgXUqpe
-          dHi55m3IT7na0IP72GvlyQHE/sQmEL/q9gMP6dMnh5NcM9Z2myM8ixaPqlw2fQm1Jw7eFHIi29np
-          2VpfDoyVQ4wCODiNNG9fkea/njzZtZc2np+HutTAyw/J4aGKxfK4vCFc95OYs57gxbSMF9zV8hnp
-          u3eCeZniALbL6UDcoVBMqm96HVhOopO7vl/83/66XC8tsqZcxdP+ASq44huKz5EWd+SjzvAV0C2y
-          pFHG367EOfzZf/f8+jTL7qJasL1p15Axs/Wnobo7cOXn6SNgGywPXphhlM4eiqUn89lwjEJtIWKO
-          3HlxV/43dfhp2m8oWm+vkTbdbtby4GiSasCyOQ+TftGIALbhlB7v/jyc5Jf2g4+BR68m/zifX+pd
-          z2QUnESx6U5fXweVv0/ItqoWcwQOE7V3dczJjsmV2bMvlFWTM1S0beORDepGvUDTmc/kaPKC3wmK
-          LGqez91IUkZ3MEmX2dGkppTRCV27la9zGfK15iDnG4gmHZPOgNly5dCt4xibQfLgoODY87Thp4NP
-          D+9Z1m5WNU3csnUA/1wuH3huoULC9P32W+NYlXBrLzrKpYeOeajvPO15G/OQwfNsjo07JnCm6Dmp
-          QlT7Y12HR6g1xzrcSKWCp514OUKzEwwSbzUXzO3+XUPcQQHp5xHFgnq79L94GhRu0lCrvEcKf3Mi
-          sjuMjU+nstDhim/EpYFcsNhCAZRIZ4TUER+MuUmhwvfyCpHb3mpAr4WeQ27mLGI23gAWGm8MtV4S
-          RI7nkRQsdi8T/MF3ayJ6MyvZtP/Bh3AGngaoeuqfShKUBbm/Ew4wRXwY2tNpnuF4knXAdAZU9Ux0
-          ERmFfWazUSkJNE/LLmTSM/bp1LAEmulbJakKAWbK91VDN70+ycU33vgbFxcKJ/pskLX1n74g38sZ
-          /qz3vOqB5aS8Jnh8UUaQd3j4ks6Yqi3pIw3FxqoZbUCdwIJyKbE8bTBna9Br7W2HN3SA14HRodQz
-          aA57D91JMbElm3MIlNSExHqoJhCD8RTAfuEPpFAVDszO1qBqXoVsYqu+oPeOhzDy7xbRV/6VtmCS
-          AbGHYlKE6Ww2SX3WoaCXe3IQ2yeeeWh38EDPEzlsNx88b74vD3jaxSdmH3oFFfyaA1123xGfKzRM
-          +3BxtBWPCNpKc7EoYHjBH7wKr7bJqAwpB3fOLSNm8prZcHWPiTZ0dTUp5bXBw6r3QGmaOjI/A8Zs
-          uI81HLpntdZvx6QRCAncIIyJbRhmPJ2ddoD2wl3RNrIF/KM3NNEUX0h37biY9oeqg0wR72SbDLY5
-          VMzToZFWL+QJUW2yzPAteFLqJKTTcwa/+pW/eRGxmVNjPiPBB+7QI56gdO0Laj1qqjlXexsCVeEY
-          Kw81D53ItBCaqgeeUVLU8HmV3+TwpTuw3PnGgq7GP5EPH6YvckixoFiN2UQVZzRpWB0/WnarbySJ
-          tt+GvTT3omZO9p6GIT2YfCtFHnwM8YACE6Fm5QcVnm/7/aRaveXz3WbnwNVvhpKxOTbMLh61dsnc
-          O9pxVV4s0kfYaz94+BQ+YcHXaHiBXp0R2fZCgOef3xdVLSA/fmB2tt4MIv0VoR0FR8Dgs5Ih7ZI9
-          ukT7xqeLrD0BU/j7JHLfDZt+/MUjRWSi75H32+7ueICniowOFyco+EPPV7Cxjhk6zMYppjw3XCCw
-          rIY4xsEBokduCXzYNo9sT6p9Er/rpyajYSSuTJOGcoMuaxvVLIlumClYrldqwCcFMfrp/xVPjvAc
-          sS1ByuFqTt1NmeGN4uTHb5s0Vdzuhx8mJSRfwPzrvIeSjQxkfBFlo/QRLCgqtk3si+/64k3SPlC0
-          v1cS5EFbUOy2Pfi81C3yjocRz98iNaBZNZDoU9+aCz11ATwTQ/z1RxRl81FTnPC6vn+1oK6f1zBC
-          J2WSX2NvTv14p2An7lFIy1w0p8vC61qaydKvvhfKhzRAn3YEZdU0m4NchTmEp9kmR0+mDb3c7gG0
-          8uNMjEM6gsWCz0Bb8Z6Y05jFs6s8c9gg30F+Mplg1muh1M4vzwq5hxM287MEFJ4xm5CHjrrJi2GX
-          w1hB8SS6Vobn7TVd9YYJ0YG/GL5A570IOVSnaOc7p4b86METrc4kqHD8i++gp1cV7bYCa1j1vGTq
-          ml9M9CgFmEfdnGlrv03aZ3JiysfbCDav8xa5qtWycREuGbRVuUBRcsXxr5+9p/VM7HaK4lnech91
-          1WtoN+B3Q9k+mMEZLxM5uME9nmMxD7W+fdjIxP65GUfJpVBzZIJSK9+ZUiqENexa0QmVVR+SH/6U
-          G+MRjrIU+ixVLwaMqZsR398lgEcYeWDNB8KpvVyZ2LreEdA88ImZPipzVqkmA4fuCPntr2AweLij
-          go2SNtP8n/rUTHWhyLsafcG2Dq7gLFQ9CcZWj5dUAkeIl01D9rf40VC37TMw1xENuduHsOUYuh/Y
-          KzcJud9QLyi2LzzklseC/FVPT4LldLCKvChUhw/XkPs+DsCax5ACPkxT+l7FHm5uyydsTaixb8g0
-          Xu0EaKIsqV5smQnvwAg/CDquecoyx69MC0/8QAwx1+Npf8g62DZuNGnV5dyMzy3NQF4FbN3fGNMx
-          qXXt2gjmdHU4D0tC0idwFEMDGW0Vx4woSgB//L/Zfi+MDk3XadnrVZBj+RziuXlNFMb28g4Xc6M2
-          8yn5BLAWXIsE02tsKJGfPBQbBU19zr7Nqlcj6C74EvJfu8TSmudAAbnjJLl7nfG6dojAyt/I46br
-          qkdHDm6e2p34uvBtmLW9iWBONwNa9Zo/PU19gE39DEgQNHIzfKWXCOvKKELoUcWnX3X70gb1HpIt
-          vH/iWck+FnS7vkeucBTYkEyLqq15yQQckY87yXb2YPU7IfV3z5h1jwxC/1XzyH16TzCO0nYGqma8
-          0U4xtr547l0Dpo0zovCpjICoh/YC3wqSp2X1Hz9+CGwcfRtu4g32R9Z9nmBE3z25oMeC33ok19oD
-          lS6xw2duCs+tmsDQHJYQ/uRDySb+wERTXeR9rTug2c2qoY8S8Ov/pmtfTDBPowVZWtZiKvmgg15j
-          74n7Hh547mM4AFBnVxQcFTfuDtm5B+Nt2aLqAXUs5hs/hDcnbkJFOKZMJDYXQl7RBHL3Ob0Qdhdq
-          ac51tyUG5i2TXZiXQy57xSQoXB7P5vmqwyeWUmTAHgNa9J8cqtmtJ3fTbZrFqTezOr/sNhyY5ONp
-          9XfaGQdbEnobBwjHRZkA95pC8uNPGYz9D3zbwW1yF4T9ec0DNKVxpUkD+7Bho7PIv/7BKc9KvFh1
-          lAMhysWpeeeX4ks1M9F++IHjmzUvFoQBCu1rQhHWI3/1hx/A21xOvH3RFIICXi/4SmcyKY199PFO
-          0Sr4bk8OuTmI+jOy7zrgqoP2y3fLUpwz6NgjR9DXb/Cslt4RYs4bkfEIHVMyHc6DaWpQ5GjF1hTR
-          x3xB0eRf6PTkt4DQEJRQwXWArg+hBHw0cwaUnX5GW9+U/RF/1ReMOCqRA4pJsaz9Djdi0E6C4sNi
-          5m8PHVQ6Q9NbOm3xvNlBA1LTCdH9ae/NZYqvPcxtR0Tu5vz+1ZPQe2k+qnr10tDnhEU464wnxnNj
-          x1+89yqYvT7FL5/wISWluuIBsc9nEczOLXrBXrlLYRA739+8Et6Dp4F2TObMiUPK/ifPDfuvvDAh
-          osEFhnbzmV6rv6OHtyyDRYMpSaxRB8tzq2bq7dp/pnnlf+YF4KN+0ttEotUfkC0fvsDztVyIMb5N
-          TPvKqrTD8HHC2fH2Jl+42IB8Z+4minXqL8msRxqHZ5/o0fw0GcPmUTsIL3HdryUmoO1ysK6foNPc
-          NxRlcgQ31qxMS/pNCrbfnDpo3jgUip2I/Z88Bd5ut2IStyYG5JzRF7xwn/tU2xljk70TE9g67DEt
-          xk43aU73048/IPvwzOMlCS4e3BH9hLL70/Bn6f2ZVEOPBnJoAhczT6sDqOrTLtRqVzKZbQcTfKjX
-          lhhr/vT12LHUXHF+T/B9InjVKx3cOO0UCtLpgYeFdzkoo2n8rZc3PxkDLF8XkxhMmABT5A0Pzwr4
-          ImPN79d8w4N+dlFI7NE9rt+9B8FLsZ4kMJYp/smjtI99ZiHIt1u2zhs4IDWVTLb3yPQXhbeOMKND
-          hmxZ7dmySK0D0hvk0Q3spx++S37wiDjDMcbSFnxkSPSuIvnW2RWLejt2ml73F7L6ezwXLtZBj8/w
-          l5/mJ2sv8Fphb5KMzYzrjFgfiINpQ2x9Pvqz338p4EVXR0aZZ/5ya2P1J/9AhxUP+rLZ7yHMJxeh
-          6t3GuMD8rFU300KGI26BGKFnB3Hq6GjVxw37imEJr/rjGMKTKGLC7MKDJBUzZE9JiH/8trYQPifb
-          tV9FDi0WPL2yMlTKJwfmWr9GcHOFCypKMmFq4rsKYfpZ16zYgFUH9oRJdfXD5brZ+cOqd6Da8iPy
-          z+VckJkeZa3HKUTWUNc+HXHRA/mlflBgLGHM2p3twLBTv8STNdVfgNKVEKUHD+1PShxLUYx48GjS
-          HnnTWWMLnUMRljdA0Y//Hg6JI2qL+XqjY/LY4nW9FRSD+ROeajRjqlw9Eei3AoWiucjxDMuEgxfu
-          dV/ziwOj55dUw7BqGxKkFyGej80kwnvTYWRg/uWzmV7kn/lVOIt4AewkbjiYqHhLwqmUivEHb73c
-          upAqiRdGjuaDB1SNRBJeqAaG5itHUKuslviOmBTUIV4PAT25KLU/FDBxph54qVyLrH1Vm4J3khy5
-          cF4v5K55XB8a+gxPt2OFkFReG15QZB6GnfxFO+1x8EWCP5n6Ow9Kv3xBnKBT4THrZHIMvtRn54x+
-          IFWPIqmKbVUMa74D20wpSXw1SzB+U9+CvBZqE13sZ7wsFp7gXqnG3/nF6jcsrePkHfrxy0uAgAGv
-          7d4PgXDbYX6vy/vfedrB008xgc9MheesFZG+4gcbzHTS6tS6IiN4FIAVTtCDp+gUo7DqCZ4fYAIv
-          aPdAhy99//t7a7leSbbmlSs+VNotu1bE46vJ7NTSOAILbfoJZ/fGXJq34IGtCf31/g3A+s2JYEki
-          AfkKXDB9RokBN8T7Em/N2+fhNL/gEX3UqV/nc0u0cWR4vmE2cYoRr/x+0rWf/PC28hFZ6w/qKE4m
-          ajcmZo31pbDIhjtKYy0seC88QQiisEIWFydsCY+HCSbN2woV7ORM8q/yXnHJ0CJrnaQK1SBbUOdo
-          hPwUn0zh1F8v8JN/AAqFmgfzofg6cK7AhNb5XzzWsLJgG+hfkhZbn0m7vWr8zlt+6m/e5BcRlpkg
-          TK27r3/1KvS03Ee24VfNEjJBhLpzOCN/9mxMMdY5+WOnjOx3Twl8k9k5QrTcdHKfqkczh7Qtf+qL
-          lIezhyeslhGk6Z772U8wa/JAVamKNhPPwqAhpT4kcDzpHkkXrsGLbFocdM2KEksaL3hyRaH/5c99
-          eE4a6vNLDa+c5/xbP74tWMJWRSjk5oMIph//eUYPOQRPI2jo++LJoKAwRcmar84c50A4Es8iBtap
-          ObupGoE1jyD2mucvAWK6Vi8ZQk60N30RGl8ZDkHUoUMuymB+9wb309/k6IJ3TIM6+a1PctOw7ks/
-          /8d3Im7NT3Q8p+3186NvkZczt/nNO/e3UEKeFntMtPPY0XDq6cROPxKed87xov39ORXwX//68+d/
-          /Zww+HS36r0eDBirZfyP/z4q8B/Sfwyf/P3+PYYwDXld/f3n3ycQ/n5x9/mO/3vsXlU7/P3nj/x7
-          1ODv2I35+/+5/K/1Qf/1r/8DAAD//wMAnIVQ194gAAA=
+          H4sIAAAAAAAAA1R6SxO6ypPl/v8pbtyt0yEvqeTuEBCQVyGg4sTEBCiKKCKPKqA6+rt34K+nZ2bj
+          AiqQojJPnnMy//1ff/31d5NXxXX4+5+//n4/++Hv/7Fcu2VD9vc/f/3Pf/31119//fvv9/9bWdR5
+          cbs9P4/f8t/N5+dWTH//8xf331f+76J//vpbCH0jeKaGhbiPqNaK6vI2vtQnuWqv7KEqF9puqCZX
+          YTU6SiQrXZd5AUiTWU2XbTPDY/dJgk0kWZWIsPyCx+6d4IteH1xxWPum3Df+iUxDplV8aLoARhXU
+          FN/jJ2MXlYt+64O2dMFtdurNQPz0PeMECaQaUa4QhKbNCZ/OW7sT7JxlyhhsNJqZho/4etW90AHf
+          OuqccOuOpAEbRTwvkZH6dT6sddbDUdy4+ECQ3zFe/spAjVdA98Vwz/lWvJzQ3Q3vOE+Hmk2fPHii
+          9WTo9L7fXOMJXc6pYr5qGwdC/o0njT8VKHRxhfd7so1nXvwY8ku+XskUXg3GT19PAssbJbxrzlXH
+          5DlooD2ZGt4yL3AFtvqGUK45i17BUHJC+/sIStEW1LJP95jPdqMELNJSwibr0PHnjX0F78VZONSU
+          2e3XZqbJcRp5+FLeEjbzkmQqm1650gKKYzc7JyeA6nkeyGr75dy5kfsAHW/BDusHqjEht55E+d63
+          CfWpYTLi90yCWBUDahzNdz5N4WyDnqcm1aRMzcW5uBswvXyfXipdZ6J9OZpo/XEoddsL0UW+Dwul
+          UL85Vd177E6nQx4p3/6xprepOKNJvG6vMGTnjKpHSUfc+MlN1GWJg4uvqnWiuy4DxRaGK86b56qa
+          d5/bCJoftFTznN4dudZxUCCscxr4FUYCf3Dkzf4R3gP+/SE6tYY7AfoUO6z7xTMXEjMhIO5vAnYu
+          H4OJ4/sSgRpHFsUPz2ZsuE6qci17n4anx1efb6JkK+Wt13HY3A4ud18zGdSpfGE/WhPEVsHlqfRP
+          uyVrsUXV3Ct5BDU5xcFqdho0H+dIU0j6EMiqjzf5tC8ORFk5eR28tpHPxHVUtsorlym2zShjS/5I
+          MJvnA9Yd0+p4GLagHEpJpf6FGjl/uaAHELmRqZ+HOJ8CV3E2Lu+l9CJm0BHlVGrwWNsnMs8ynzOn
+          5E8KX8MBqxG2K954dyu0O2V9INKr74pOqSRo3+ci3e+/t3gaeClSUrK2sbk7lrFgIjtR2kl0Al6/
+          79Ekv749dJ/yTX3pPrBpcwpDJbuOMQ3X6bObh0p8KL2q1dibv0LMtG7TgPOAECe7KsiF7PDSNnLU
+          SaQoz1YuNtYjUxT/dcWHfU9zEuVNguwMEnyTN6tuvN3WMkomh+C9UAqo0UQYQdgbR2zYsY7mSdhr
+          wHGCjzM1euaj6CgB3Eh1wqoys24avaemsGI/YlNdXxHl1NwGsXvLhD2ZgUZmmw6sGiWmx3Nc5nPl
+          2xyIjV5hQ2nknD3CvIcB7gXeWWObtxClEiiqMWPVP2mInGU5lNVB8ahrZlnOODV3YG2VKt7jR8+Y
+          XCkenOZniB1pHVcDtQ8y+uGfHxCSMz4Cgoq6NekBPrzeb911ATjWWMCq3HHHuesCeKkoo/vvmkf9
+          YdXIyvI8st6e85idWu0pt8FXJ9yqNtwFL0O4GN2L4oZ8EbM/9UOxzvcVVe8II4a18AThKdgQuPZB
+          J6qxsFLW22uCbzZobLRs5QSV1XwIF/IGYl2SzlCSeYfPt3HHGN3EEkBZ7uhR6EJ32pBKRbnkOgE7
+          qXrMazpdodk8HnBcPI1YvCuyCWNVXfFezK5VD7QJ5bU8mKSp1cDl02OXIqGMTewnk1z1z1UkQDxe
+          FZx9B8Vl0kYVgIvIHjvfeatTwWapojfvkl6He+iyWBdSUBx1hw+nYMzn17fr0ceT1UBuOxM1tauH
+          yi9e7eauu8JNoDY8388K+wd7HZNycwrgmxcK4RPO68R3eQ1gsw2OWBuntz6tu0ZW+EFVaCIfq2rE
+          RmSjX3zp+RygMXr7DjK+h4gWdtu6rEwqAYzIfuHfec7r3fAA6K4pvfSFw6ZP+1ihKLdnfJvPt2ra
+          FxeC0C0EetopddWud+8H1K9cpb7PN924dddXuPXbLbbMF+vaHf8J0CM21tSSxEQX21BtFSUZXFqk
+          fB1Pu0N5UgSv7XG+xGMDB0jhjWwfX9Zw6ybZ3YHSSoFJt5asd9zkr0+b/A4XHL99HlHteg5kOQIb
+          3zy8qZiiqqZyhUuE/f2rcanWTQ0q1C4na7N+V9O17iRUbcYOB09pzmc51QzodpcSb7nVhpGwvDzB
+          L8wNxofnuRo1kZuVa+I9qWetD+601EP0uX1nmm2kTcyyfnqBPOE3du+W2M0SLjnlfX09cJjtjZyT
+          +k0AsrWaqWEHd7bgnw2+ELfUNIU+n/ZJmCnlWrCCjbYz3WFUrIeSCpZIPTucENW6TQvbuGsITONY
+          Te8xskHldwg7nOkjdvSKFhq9LWh4R5QxPCscHC/Hgtqf8qIz5Xl1YB1qW9IU5pzPesIFaMiOGd2l
+          npWL/kZS4Wyan2Cz8CP2hIOm8C4gqmcHHQk3c9uCymcutc/5g037YB1CyUsczmRBd7m1GWnwhO5A
+          8RS2/2d/8xBjfy3aMedYSaQcXyeOmlB+qnGOw6vyq8/mIAr573zh9U0z6uAgcafb9fn61QNsSDTp
+          hFhyPbhsdz71LrDRp9RtDaSlnkqjFTe5dKdVqfLAjw/GnS13tLBQAQu+/fC4+oq1MwKc5S3WTr7k
+          dqLvPgE8qcOeQ+uKiStZhUy8XYLpPX1ymt3uNmS785GQd2MhVjN+BJNvHBy6d+YyC2ZHKcsox/sK
+          9h2/4AkYvfgNkP10Kt5W35xiyy+dpsVa0scVG1NlLHUrIJN3d9nBkV5KJt4vVHvSi853Q6rKCosk
+          bPtI0Bt32xkI9qeE7ofzWA14ywSlLMOcmoR/6N98HDwZeYGM1UAcWC/ObQo3UT3TS3njUCdtbEHp
+          3PlGz6vvvSPfNLQVhYUSLlT7q09Sm0kwNBsLu3ASdHbJUg1O5X6F7+XA2FR9JhkypI9klBo/n4J3
+          KCnZlA1k/fDshU/bNXCytKEOKpq8RtrqCu5+r+ITM9VOcOe3qQjxlAfiiVLWW7aSwHvnPglnB3c0
+          vCISgtekRbC5cJuu975pCDV/02hyuDnurBf8AxrL47H5uOJK2OylFvL1wldFSOL58ibt5qAn8YKP
+          lTvvsKuClpwvVJX3Us7WOvag9JptoKhZyeaLn8vg3CUfG6Vaur98g80oGNR0rR7NvEhN2bg3AQ3z
+          luYswjaB9k53WCeDWs39kZig3i/3AKJYQfNR7Z6b4mvnNLOLFZpVOmlK9IzLoN8LKprSY5fJ3JcT
+          l3hL9VGe9gmsv18jGH98kp6qBO7pTaZH6YbQRK7JA967/ZNGrvruvn5pz3/wPnjRp8v9+MPjpkb0
+          cD1cO8ZHHIH8VTPqE7f8w++UIOHPgbTk52wiNYFDkh2pVcu9zm5d+FCILt+wudn3jOnleAKxkx18
+          i9aEsdW1BfQsO/jDZ4X6Mnnw45Npk61dtrGik1y+hJmsOF7OZ8S9AF5BblDHqDQm6EMA6DO/roRd
+          O449nPtHBU8fd9QSvGfHCnJuIEhzQvXtq+6YdzUcJPOGR21773TjYfWQ0dGgO2oNb6Wb/aS0lcpq
+          P9Tea2M+d9a1AXeYLtQ/Fvryvs8VLPqJWvfDyIbyGCaK/lAfhF/0Sa8omx7xK3ONnY/WdbNeKA/g
+          6uhB+Ne6YfwhOaYg9XH3q696nx/PDRyDNsXbSOC7aeDHSAlj8sJ23cQ5PXpFA91VuNOF31bDq3dU
+          4O3shZ0yfOjjkq9w4K/nYMruIxp78j4pj5sWUZOZj453ZKhBTG4eWa2UNp9Wn3BWKuWsBcJJX7Gp
+          rkMO2qDTsYmasmOi7z7AqLyaqi3s0FQOlQErdayw20i6y3P4YsAJ9jGBeNOz6XUba0X0kxu9nc7f
+          atakSyg3gvAiNIl8XZR0LYAsRT22jQmz0b0oAux7YpG5wYYrpOejB1J/6AKhWYXV9Mi3D8XE3wL/
+          +OH8y+cFr8hr4cMiF/Qv9DUSTN1b7XUzRXPww1v60wMz/jg9WvITB6ddiOacBBKI+9HEh6mrXOa1
+          txqZjX0n44WtGf0cSqLsgvVA4KKz/FOvbfOnd7E+3r2cS8ek+FMPdgf3EE+l2KfgaGlF3WGykeAj
+          PwHd0TlspMXDHdz08VRKrSd06yRJNY/TKCnlRbxSK2+O3U/fgD/TGHvxpkdzm99DSKLPluJnfamG
+          Z/UdwZrvCWH0+Gazudv3sOhRMq3NL5q6IdSAWbqG9+FlZv1OPRowNMiizpraSFz296snNCjPn3zU
+          kzNBL2Pe4n08DTmL+ZcM8XkNdB98PjpbG6kHTRqJ1BUQdv/oEw2Ey/L95Zw9nfYBEzoiMt61Vqd9
+          jGfEH2UcoAW/h1vLqYpYgojVdap1XCNbPeTaleKj0I16z4ckAzUOLXrTuLn6g49HzRupYxoDWs7P
+          Uxa8p841OsVMdp8FjLO1x85hp6M5u/NXRZCIEQi5HMRsc+zmXz7jPQtUnbsEdvbzS8h6p546Nqx3
+          5m9/2L4rW8QlSBCgXqdHrB30A6NzcTbRJorOVLsJccwrld0ic9nQon+q6fM9r2QrC6s//JZ7k8dJ
+          Ob21N+HU1q7Y+D5EsLHiLcbn9lMNR046Qdv2Ob5VTqf/9DoUeTPS4ClF8RR32JSFz3HGu03+ribY
+          XUdUo5JQ/Lnf45kiOVD+1MO7da6Itb8I4EojxffxvNNF+0Me8N5r+1+9quj7nElw0uQyqOLQR0xR
+          bRNc93ukO6olSAgPaxMt/kDwco8XJrhZlqD7l/OoXUk3xmqmjChIL4QGHJ/lU2w8JUhvGxOfUKS4
+          o3Z/agp2yhm78qvNJzXpCkju2pd6u7cas5veJT+9R93rrqzm173NkGpHU4CQRytW+5capr0vYk/8
+          qO40mxIH7nScsPMdbi7Z7KUG6lt0CJh/WcWkSGIDLX4MjapBY+LRO7WwLr4keAc9xE3wLAw5NUId
+          n4/Bi00FNWyw0z3Fd05V8ymJuJPymJqe7sW7WpGprl+w6AuyRvGJkSXfkNdKDPv4FHfskoWq0nyT
+          DUkX/OezxEmgMJ7acv5xxdz11wNnViPsy2rKJqWyG8U01ZxeNoc+Hq1zMENTHKsASYPMWPEwPfiY
+          pUGDthyq6f7WOFj4PxkWPJwIRyOwk08aiKV+7fhffCz+GpmhU9mCHyd0RPcn9j18WfSGv4IF/+jW
+          Zt9qOa8ZbXnWY8u9XfJh0h49kOrp0f0hkqrB0xMZvPPpGkifcuNOw3p6KZySB9QomzqeLSqocDjJ
+          LXYdna8oL5eysvBlMi7x3hy3qYZW9wQH8/36jMfyUQMQ68ph9/V5dvSbbQHdV8UbW+/L1hVUutEg
+          oFyP9TgcEBFVK4WIFyWyyrHoDtxaqFHwHdVgM9IuH9ZXs0BjubXoaaXN3dtNm4fi8dKees8i0/ma
+          a0MYkpAEyuIPjd8za+Gpyg42i/cdMdxwD6i1EP7ov34n5ATy+DlhR5U/3bT4lfA5f0xqvA9lxxri
+          vVCRmhfsquq+ap/Wh6AgOmo4e5dqJxqrPIC7gaqAvf0j43IrCODYb3ianys1F7siMhQtnDS6lX1D
+          H7vIKeBbX+MFz7lu9sKLCq7bHbHeBx0ab7guwBcO7R+9O6kIN/Kil4L2o7kdWfSdAmdpSw1BsZEQ
+          vb8tejItoLgcGJr8Tf6En99pe1nnTqb10JRCOApkEm9BxcJkkiBB5hbbn3KzvI9WIBUVImlOt7P7
+          rQQ9+fmFRIDSqoRbc+zhsFEJPl6GKJ8NdapRehYyui/mKhcbYrwA1ipd9FzYfYuNX8Cn+do0a7zZ
+          ncPD2kCrm6LgRW/qc5SdT3CX3yv681/Hg92G8HKEATs719aFJCEOHONo/uM3CGTHXiCpjxe++Ost
+          6nGQX0EE8PB1P10R7+wDE9ohGP/oIbL6Oi/wfU2k+Puh3Rx5vvTjH2SztSBf9D8gX/1g8jC4LZqz
+          Q7/ohWuAIyU2dbaOvi3Efijg/WjV+kgrB2DR9/ieGWk1iiqSIYopR7Ejmnq332UFLN8j4L9SUPEP
+          vPZkCG86xSgW0CgJ8wMYZ1+DXIi/aKTJ5gnaN9KwirSV3pvPiwnyS3WC5shPTDgokEKc5G/Sfb5S
+          NzHXBpQN3JEWV3/rTru8beVF3xIevY5ovIl5K//wN837Mv7xO3QmhzP17q6es8+XK5QuOznBZrRM
+          nU9spEHAcoMw6zS7I9BHpExd41J9/XjqY9ZWoaI8PWHhJ1M8yFmToVzaO9TKrLYavW8awaKnyUqE
+          JJ8F99DD1zjhQFribRbcCwFNuN0IWGaX9/0pegERzYp8U8QY7QwhgRzRkrD2qurz9lWT331qYZPr
+          xtOucSBz+wOO1w/NZUt9lTfG3FP/dN537KOHIbQfxwg2Qimwn38H4XD8LP4aRd/zRr0q92tSks2L
+          p//F1+3UpQG67squzx7fFYzXbMBmHSD3VcpaD+7c6/SPn7wR19xP/2L/LC18K705sOA7vX1ltasy
+          QZaQuL6WVI1tEo/5azaUJR6C9WnaMrYRRQFdilqkwXDQXeY/khDO7/6E7dW1ZeOiJ5DZNhwumE6q
+          GR5tAleJQ3TxJztuU9YS6AXcaHI0dzlrQ7VRXD5IqRY/644FpwxQhyygu2BSY2a8xCtwbuyQNR47
+          9LTKVw2LXqD+vcSI6eN+RvXromL97R/R7PdMBq6aXbz1Fcy6AzqZcLGKPXbf+MOadfEaFZu5O+yr
+          2RYJdaM1sPjfeOHHFXs05ArPrPQD8eEIqH+ZyIHzm5ywTQ5Bx77ZdqV8Do+MelG6RcIkbFXY34Nr
+          wOn9qmOw20SQ5umET7lM8mnd3mVwPhpQbelvzUe1eoJJfDdYj+edSzx1VQPcYMCaGo45fUiqpMRn
+          BfA22T3csYm7J7oKpxo7zjGIx7NxtqFKyZeqiSy7jO/TK7QT7+AfPxNLYS2hBV+xlpsKmxkNBPjc
+          uhlr1fBEPf+wBWV14N74GljbfK62qycIXtMH4csbu/nqygLSRTcImPeQqunSGCs4Ttwd7xMt0Mdg
+          /Dxg6T9Rr7X4mI3HlQDuqelw4E4vd2z1jYqOnq0HU7Wd0HjchppyyO5bap9uoktXHN//8SvTBQ+G
+          6jNJ6LTLBKojR+lIAXYEiz/0x18abU5uYZx3e3zoqhkxU3pqiF6CD/75K/zKV1SRt9MX3keS1bWn
+          Juzhqad3vOsul0qUNjYHtA2/OKhD3xWF0nTk3VBlVE22XE5cz5bBMSTpD54zZ/+sYemn0LPOFS5p
+          OaT+9AT94TEpktyA215WyLjfPeNprSMCNq2HYCX3ezQ+a9VQ0mOyw15TO/n0w6MfPvGbfNct/p0G
+          aZ1a2LPDAyM5MWUwYyxgl0aMsQveEaW9NBe8J1LejfMGWrT4eUP5+Gxdgb9fEyDF+4mt2/hGf+5/
+          p/2FJnpfVE09j4XCYLjRn3/Q3L6ah5Z8J10jVfoYvXcO4qrR/eOHND+889CKx6ZVTB1zz5wGCAlf
+          up06XR/Z+fGC4X0aCdWOb/eH1+DFd56I5ivuZuVUqsrS38AJWDQf5h3l/uixcfEn5rbdECAJ3Jd8
+          CHKu3m4B8tksMG5xwiZJGwg8eF8PVq6RMdGo7WIjPZsGq9zZQ3zcpwZIoxPj/dQcdFGtLilsbzXC
+          +rXjEKPl3oZ10REcdFkc98wObEju6pdGK89l/Oi12o+/YFO4iPloXCQBEnmayBO6B5uHb9qAb65c
+          bAlWUc2Rt5PBTt4p3r4nK2fC+KilKB64P35Vs/QXYOYVlWZEL6uxnj5XqNL+S6Pp4uQk3PQRnPft
+          Cu/qB0MTffSt3L/aNdngh8eGO7uGcMLJnh54qLoRX1/yjw9Q75Cl7iBpb/KnX/vDZzYP0+NPf0KF
+          zYCoZnhXuGZx8AefBjtUQ0WNFDGQ6curpm7XcuiQpMdf/7xje9EGYGO9o+ZmmvWx2bcBWvwnaorr
+          Op53WFeVpb7h5bxdzkcbDg47ocHWFEiIMdBWsN6pHc1u0juezvcXUSLzcaFxe1XdP/W8yoMV9Zf6
+          MX/rbw1dupZwsFKc+I/fuehlrPGtw/ijr9vKjRUq3Z2OYjeL2zBV/v5NBfzHv/7663/9Jgzq5la8
+          l8GAoZiGf/vvUYF/E/+tr7P3+88YAumzR/H3P/81gfD3t2vq7/C/h+ZVfPq///lL+jNq8PfQDNn7
+          /7n8r+WP/uNf/wkAAP//AwAkUor53iAAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946bdfd4217d2-SJC
+          - 8ebdc511cb021574-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -365,7 +361,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:25 GMT
+          - Mon, 02 Dec 2024 19:37:08 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -383,7 +379,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "217"
+          - "131"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -395,20 +391,18 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9999996"
+          - "9973792"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 0s
+          - 157ms
         x-request-id:
-          - req_4a5fb42a02808790c382c1516cfeeea1
+          - req_411bb4b168739f579a7ebf863b3e00a0
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["What do I like?"], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+      body: '{"input":["What do I like?"],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -417,13 +411,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "94"
+          - "89"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -433,7 +427,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -447,120 +441,120 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAAwAAAP//VJrLsrJMt6X7/1W88XapPxYgkpOvxxk5SCIgSkVFhaggICKnBHLHvvcK
-          XTt2VXVWg4WmkYcxx3xG/se//vz522bV/Tr+/efP32c5jH//x+fZ7TJe/v7z53/+68+fP3/+4/v3
-          /3vz3mT32618Fd/Xv/8sX7f78vefP+x/P/m/L/3z5y9wtxpjoVd7DuWuCdrjgieki4I2C6e1gc3P
-          o8NeLxQVNYvlIsm6nWI7yki/3DuHgVCvV3IqQ1Gb9PSxk7i8ELF7rr2M1UaI0Y9u2VhW1E00bzhZ
-          l4KjdMSmfrM07kgGAZmFrOPLyQjR7LSpCMJ9R/CBf/xUkw5RDaV57sjRZ+Z+yayzLHK44Il25FJ3
-          /WmiRiJ2/SbGhYn7OS8RAEvKjsjro6uWxbrPcJWvN5y6y09G5+DcQL0fOpKcb3uXG+s+QDH7bIjn
-          pGE29GKxSuLzKhC1cREl/RHNUky9HNuPoKe0ye4TPKXRJ8rdfVJaHhcZTCXVRhSmj2xJOvkuHdim
-          wzhVuoyK1Je/80nuW0XONhDECXp7J4vIQlIhWh7nFcr9oJKDPJz7xeF8E3ZK9pq2aZNVc9IeO2le
-          o2USoday5erBhEgg+MTflCla77EHqMYGR66xv+83tjZcgJ92LgmfnOOyd9kuwfXbgJze4GZ0pVoJ
-          l8NGJw42MBr6W6RK5wN/9at9rkebn+CWwIbnLHxgXIIWTqENEoy7Pkmez1R019xrcJmuIO6F8BrH
-          KkgHFd1GbIah4lJKPVUaHBCw6bcrmn/C807iTDYi4U7u3cUi7QV11Vsm/qs8opXvuVJ63chETCbE
-          2oMo2xpur/VInLPouux+3MTw7pgdVoqEoKX2Nh7U48QTo6aELnWnM6A/zhU2WBoh/sSzAuyfzIP4
-          t1OnrUk6iWAWskyiJ8doQ31LVXR2CkTSH8OlXNf5E4xluGCrttZsei3HO+S2C74Uany/sv5LBfS8
-          7bCvnB5al/LSBc3vl00coVYzflpOd8nexFe8f44O2uwLdAHmSq9YlbhFm+fTbEr64ZIT/Djl7lJ6
-          zAA1n92xfyoJWtV8H4NXKAKx0wZVY0h6Ea7KpvUFvIzRyOWKiS7prsBamu8yDnNWA3HkR9i8hLW2
-          XmPdB+F594jnaHLFT/26wk3hgDhpcKOrBpkOaffIiF+VFC0bBUy4LBuPuDtR1L7nQ7oeNgNW4sSj
-          3WOJrqCqqzjVAlUoq7j2WQrjmic3z79X8649nCVvczpj/3FyNZaI5e96k/tyClwWG28PTgsb4EPi
-          anS1IG7g8Vre+DKIB23V08dZ8gxGwYciCdCicJouvWi7wxcry3tyY0wH0WB7J/jHy915PQkssOe9
-          g69meohoxDgiAKxAFH1IK24XRo5E1sONGCWTVMuVvBxIbWeHLRvkbBMxqgjpgZ3JvS95tECuxSiN
-          9gg7IvG0VnUVUVp/CgdbEiwRXYNDLJXNZcVWvygZfR+RjJiBFsS4Uo+SvfYUYSojg7jnesjGrQI8
-          GOfBxfdTiREvNIdEVLJ8P0mWYPfzfvyJUegKDlZX9wetevo+ow2u7v5mhCHqnn4XghXIAfHKVIzm
-          2OgAOocJiHMVB3d9+mUoTWl9I5HCRe6GDVIWvutlv4MRzbeS3iXn3unTKsutRr56c9nuWox77+zy
-          aaz50vOpvvzpVGI6b08iD4cx2vuMclI0rleEBPZ+K2DfOKka54ZXR1RFvSEZ+EY1K659kax2QsR/
-          jFe6QE1W6KIOfEq6jbbOPSpgCMPUXyA5034+ciFSO/OOLbQ02fKuSxlE7g5YT3OIXhzVC2QWqk5w
-          qjjR7LjeBSppaPAZL140Igh46TAe9uSkhrM7rvkuBhHmM/btk+7yqz8VwOZlQwym3VOOWnkAa+t1
-          WG6HoF+iMGklKmB1gqtPepoLnS8Na/AgBtxql2ZCy8D+/pYn6TG+0UxPW1OS0MXGZkwZRBbhNcCD
-          v5Q4u5OTy/9o7zOwuCjJ/qN/Cw5vDjw5tce6YpfV8qzbWWqjLiAXEHntux4gZRcFY0XRMjZw/R0w
-          ur4QjcvnbCRWIiPOZDE5a4udkZ+x1+Hy4HY+x9IYzSKn6HB+sAVO4LZ1h7JkGUCsbhBZH57VauUm
-          L+1agrHVhZJLeOrN0Iehgfe6f61WaEIWwvHwwCnJhGrxyEOAz3xiG2dTRTOhANgFau1zezut+Dw2
-          fMkNlALfP+f5ex5BLuc7CYMkR7Q4zqG4m9UZOx15uUsQ3lr0qXdkfxh1xN5lpQRTGHp8XdN79Kun
-          unI+kfMTpGioZFcGmbXfJFtTJ1rJkgMcu8Iilm69s2VUtjrYu/FEtCp+RDQtfnaoeNHjJEhNWHGp
-          hwA4AXdEtbmHS/VCaMFspxcxVgaqVU3bFhym84hTi5M2irnaQFjXoo+6tI3Wm9+qaNtw/cR89GlZ
-          lFUXrVm+kijvQu0zvonwGDyw9orLbMbuXoC31hbEJ+UJffRkB4puj1id5Y07R0Z3harJTJ/rmLRi
-          NdfZwbvqBnKQkyfdKE0cg6K745StqZtt4oJrQWLNEe/GZuwpGh+89Ngso7/NDYXyGkQ66KLh4Fzz
-          PI1NS9GH4kfnpmVOODRowVSjZ5NN/qQJ0K+PeD8AYmzqrxJ3cNmLUU/wfMov7L9Pe3eTZZkHh+fP
-          MolCXUYse1oS8PehgdWfrnXpm8ozvKpWx6c3ONGmo4qKfjw6YN8V7n1Lb7cZbql99Rf+kffTZ/6A
-          /pT3SbyKnvZbf37KycT+xmu18V13MsJMP2Oc8EW2bprUBGWdebLPhaDnSitUpY9fm6qPfrHPUpqg
-          yPX3VOyGVzWn5RYk55UM2H4GHuIeHu9B48UuudGypsPBeDAS8uYr3qvaUi29dV1//c2uX47RyvWc
-          CvYrPpOLLhrawuYyD+Cts19e5cVdOAXVwGSXoy8dRg0tcnhuYZM/SnLbjyqid+HBwLLzHHJ10jWj
-          B8Y5w+4V6+T0WuRs7srNFYDLa//pMLiiHiOLUiQdttOIBbfi8+UywWg3Bt6R5ZSNLmfGkicrMzYD
-          CnS4G0/m6z+J0rgW+tX329ausXIe8uqzHxO4B/neL8zNFPWu9twh0Vt3WC6GqV9luMRw6R49MYvb
-          7K77tN4B6OaepM9goMMgvgNwZGWHIyN/RFRy5p3Ur8EBf/WRz5eQAeVimsQhxhbR7kgDCXF5QNLc
-          KBDNGOMCycLKOPFunbZubK2BY+URrGXd4i6iIplwXTYsNs60R0vmwV2cC6EhJyeMtEWomxlZ7YDw
-          DQt9T7fjI/n6PazIiYnYk9EPoIVLSNQ9V7mrl1YiRJGvYbVzb3TdQ5JIxm6wsKFTHS0SpMlXD/yZ
-          TUq66vmeBQloQNwkVbPPeAVE9cuf5m4jZgtfNyq8DEXDLtTnjH/wPyLihH1H8sg7uKwcjDwIuFqJ
-          tcA+45QTl0itl9DP5y/RIuSODov9PPrzUZWy4V3y8KufH/2jC+Zwg3JsHrDRtSYadFc9S+VtMonL
-          +mU/3q3zuvWfDIf1vW32fLVcfUTKQ4qNHW0o3QZZg3yDeWP1wNXazJ6WGF7XpJq4gO4Qn/M/F/ST
-          Xd7EFMNJ6xln7gAxLp22j+ZWrQpcGlCz2/P7/dWmzXIPErGoSPoIXMSX/rtA/ukoEK/UrH4TZwGA
-          qVx+iJdoWk/NYutAEnkIm+1t1QbL1S7otR8bLBvqOSKONoiCWlL1Wx/6mTstrHh7zSnen4Spmgfx
-          IQPcbUTsH6Ojix4eBOlTv6e5GKbqVR63qvTVU+/sT9XihFErdQ4ExBX8uiLjEULR3Zx0YtVWmNFr
-          Fl2lnSwXn/qMq6VTZlP6+CHiiumYkavw8OC5nxiSC33Zz8dSYNB16wbEt0eOzvxJNL96jy2yaNn8
-          3f+va1zhm69xFS2yK6BV3qoTpXGTrZJWCNLeOhXT9aIZFd/6VQCmMPUE5x6rLX4YixBIoeQ3YDXR
-          eloCD8a0sadbLhyqeTkJCQxr+CA7ugjZLI8ogeaa4EmoMrnq86MgSx8/gv1XydJ5Oc2NxNS6NDGP
-          8YqWr16W5qXxuUv7oGNuHWTpXuQH4gU1k01l7PsQ6LWDNa1ztHdhHQpJE03e59V2QjQpmAv61A9i
-          JExUrWJzMYGdtyLWrdjL5qqUfGCuyxVbKRgZ++lfUf5jPrDHaEG/Iq3YSfzd0fBu32gVd+mUAV5H
-          zcLYKhk62COTwONFn9ho2icd53oIIHs7wlS78T4bzuV2gsQpol8/zJmk3X37VyyzSYnoTXjfYbYb
-          iWh7jndnOFFWMpRzT6yrNWcLqfsZwTALOKgH3A+x0U0i2/AWCeZEppsXlUNJd3QGhzfOcrmqbmXE
-          33cWzhyyaCOb73hpLZD/2U96xfmecN0i367I/ke4VJQNLqZQJ2mCzfq2aGuaEhE5Z0KITYwnomfG
-          61CdZMn0c/JWd/n0C2Ap6Qkrraxo68N/BN/+++PfAzpbAeFR7Iorsa3MqziPlDtQV+r4P0fFztZm
-          ieHXj7kJYTWaFpsdOtwi4+NndhmlVJul1HZ0rL46xV0sztDBackG77fjTKcyNhiE7+/Wn/nNLVsT
-          nm3BvbdnXzg2Tf9bXxb1sPVfD2ijuZE9GfzTSZiEV1ZWS9MZ0+/6K19esM3VBD2ayx1/9MNdz0sw
-          SfVTxtgarGP04SP1V6+woicvNDUxvqJj5L2wkxBZYw+ufxFaTnsRRU6eaIm91QNDpbxPo85357fY
-          hjDZ9XFqN5nZs2F7vaCLspE/+t5QemL0M5rtWsKHOlnofGjjHSytl2CzaVM6BXCKwZ26K7Fk6xW1
-          q4xLmNXDk2S7+pUtF4/10OnA77C25DjigvDYQv2UI7K7NW21mKcfHV1Te0e0NG+jReM0Fm7ydcGx
-          ZB/72RqlBrEzEj9+ca3ocAQZvNcx9hlSblD39MsCniNxiH5hip48s+QOP+GgEt2Np2jW27MjbRPu
-          hW0jUBF3CvMW8FOyv/sBzbFrnX/9tc4zdr8WS+bDy4vzz+8l0bIP4xaNonSdNiN4EWecmAYdexT6
-          /IdnrKMtxyChs43Ph6bu3z8QmtIPuixEaZOQ8qz/ktEpwtgvFPUU0cdRKNE9uO2nSutsjWiFcAGO
-          lIw/C0NSUcX2a+B4PvfXA6e7fBEbdzBndUecVgw0jua7Gs4LX/ull0j0vVFYU9I6c8VeqKnV5pHd
-          fCTV5tsXUNb2S9l5ProG1yc5f+abVtlxAKMzLvjTz7gT25xjYEnRESwpx4itZS0AObYf2P4xHDRW
-          nTeJ9OzxOLnesMayp20MD/McTh9e4tJFIAPamDz69ROzFkwNcgolxrdN+USr0DPyh0/F2BP8c7/c
-          PJaBwqK2P7D+piKl0HvwfiobrOFu1JY13yVwVvizz0ZxEHFnMopoe9/9EP9x6rVZc1UH+BaLWKWd
-          ofVofPOgrCs/QZjGGX3RXQDHyOsJ3itmtBgnpkZhJoYTk3uyu7kz5hkp5bySpAwtbb7IciAlGSqx
-          nDwePZ2Cs462sOrYu2jPfr60dwEKYo7++uoUbS5ldUbG4UKxVYaZu5w7xQNV1Et8NppHNVWxfwXT
-          sZppvbspohDEDYxrwGHXq9/R1PaLLKnZ7YGPFyau6FV4+NLyft7IjQh89f74L2SfSeZvXkuRzV+/
-          /ulHiL8/PbU1j/e+KMIa491m2UZruWQDpG8nwI4dnBGnhqkDan97k2ujtRVVte4CJ3e7Yp2zw4p2
-          VJFhVMM30Rf70G8+/To4m2QmxnCTXfbLDya7OZJ9Jaz9mHgiA3vmvSOGcNM0bpMrLBjtFGFvI+jV
-          phC6K1gXiyHu4BfVmi4BbLsOriQc5ETjhSaNgeV5F8duvI+4sbMmdI7wCxshc+g381EKYRJ/ZqLZ
-          eRUtU92XsM4onL719MMzWFA605lkcZNH46ZuQqia1MQ6idPslze1URvj69Un1dyVP1exNlQLa7IM
-          2piRqUNalnPYV0aKaMngDvLgdvv20/2nPgXSt3/CksJFa+8PIWiO3vnSMo6UegXaiR++i5Vr4lPq
-          MrsOLvbuTCIUtxmJGM2R6tsw4T0VNtWsBk0Ct9S9TqXqBnTWR6jRtB5s7KlpkK335XJFvcPUk3QY
-          KzpYbepA1Iud/3azfUW9Jq/RNAsqcRrydOk2iBqI62eJv/q2lrHpo/PCtkSeExmtud+WUD/VaFqS
-          B1ex9HYr0JcPWjYo2SYTWoBzV1lEvm/4iPJjG4tVkqokGIa1mpkT23x5xrTNs6hqH7dAFStivLEr
-          iyeXQHBt4Mv7/ccIlBZCd4eLWFFfeGVKxX3qFbrato691qfVooaH3ZfXYf+nvKLutJx9dD6wV59l
-          aYE+/oGXNtxVxhZrbaLlYR1W6Vj5BPtW2dGhvJ1DUETdx7Ft6/1afYh4XHnZtJJOc4eH0QBc367n
-          L4JsaJsyu103ojfvcHTkUq1LYtUH6ZgP05Zm2+qddPIAtiyz2NFF3f3wow4AFpnYOPOrfj0y8tcv
-          TDzczu6Xh3z0YSLxnXn0S0CqncQG25U4diBQgqgZIE05a1jdya62AKS6QC6S8OFPusvHsT0gdrc3
-          fa6ge/o5j7tvvSVmElbusipiA/goGf48DGtPGWqFqOWUF94v44jWwm9Xkf4UF5JXHu+2DOckaHt3
-          NWwkrYw2X36Zy3mK5cvmGK1GbuqIM/lo4mdLzfjVb8rPeWb9WusYdw7aSJAaL3HxnpQamnL+5wzX
-          4PogkZLLGW2P4gzX4P7AVmyN0dhasYq4dl9iLPJuRFfqFmJ71DL/cXcNxFKxCiFmX50PX/8p9IwK
-          P+vkY31l2mqSc72WPvM7SVQ49bPr6q2kltTEtiAqGtvLRiHG+vNC9EfOREtthTNY54li5Zzs0XqK
-          nQlpysUi+sSYPbu9nUpopLEkuz7Tel5RNjFU41D6iCeMNt14XoQvb8v3SpP1CaOJEEdehBXfLdAo
-          1iT48nOMO96MFps8drDbEY3spVPhLnIYtNIbTqdJUBq5WrW0EAHVpkL2Hz4xm64jfPQwxbtH01Xr
-          dz83EGf4qvu7ivv6sw9vI9g4JS6lRz6UfvrLOL0Cy4soEYiHxugtYJ1h+n5+3g4BSM+c/fCE5FOv
-          ZFmM49f9+3vp6JDHGeRwTT56KvecTR4Omi4/9VQ0D7NaGEgbOD14Dxsm4/e0FqrpW698SuJnNGfG
-          ACgr7sepw0ZAV7KcGGDzoiH4oFjZ97z+6teH9yKq27hGo/hzxaZOBbTaOY5hcBjhw9uwxhrt+Qyf
-          /HD6uSl99vzyTT2kDbG1zKmWkPSCRGYhwZleN9k8yMaMvvVETh5K/8mTEhG8eSbhyHnaSKy7CpEU
-          bT/f72v80+8C4Fpckr2phT3NssgDACpP5OSF2rLUdSndbXvwhWjxow8/iKE5qpR8+59FyrVGipAw
-          EXMKO41yR36GOX0av35g/uYXX/4RNm6G5rRcGOl5VHP8HX/45B0wC55J8om3Mvrl1x8eMyGv3mXz
-          5nZSIenK/Nef0gOjXoA/49X/8mHCja2JNoxTffp3o6JzELDSJw8g96ic0ELqav3mq2SfjibaHAtO
-          AIHnMnKy4RGNn3wNffKaif/klfOxPZ63QxikvhQJY1V/x6+JJWHl4uqIPRgP+OaRv/nlWFlhKflH
-          GH/zz6E2XgzspUDB52fjViw9LSZky6bAzk40tQV78yB9/Dsx7+HTZWMXn7fWklX/xS/Wk8DDIa5L
-          fJjc7tOf8o5Y36YJ71+lggZ5RDFc5+tILp/+gruQ6QwltvY+34Vv98uHoObUE7HtoKL0KdSeNG6b
-          A9m/yoJSU+tb+Pin6Yd6SHsIuapLN2UDWD4PfbV8/TlcV9ann36ZVUdWB3OWd988hP6u71IIItk7
-          Gq3Gjx+Hq3y/YaVz34g4xXqWfrLzc5oVNYnI6yiW8M3vtD7WM37yxxB9eSH3yXs+vGKQmP6cEu+u
-          mT1bl9xd/ImtPd4TgasG1/U6MX9RZRI/eer49d+7Uyzjq5/SaJLsfQJf/+YrY4iWfXjtvnxx4ltL
-          jtgvX6gN2SLWE94Z53Cm/u2np3s6iogiahYwRO+C2O9gT3/z7jEMR7LbN1VPP7xZMoThROxXxve0
-          zm6MuGk2GpHNjZ8tOqebCN/C229ex+/4eQfIdyufZt3hN/+Dv99bAf/5rz9//tf3hkHT3u7Pz8WA
-          8b6M//7vqwL/3vx7aC7P5+81hGm4FPe///zXDYS/775t3uP/Htv6/hr+/vNn+3vV4O/Yjpfn//P4
-          X5+B/vNf/wcAAP//AwDJsMK63iAAAA==
+          H4sIAAAAAAAAA1Say7KyTLel+/9VvPF2qT8WIJKTr8cZOUgiIEpFRYWoICAipwRyx773Cl07dlV1
+          VoOFppGHMcd8Rv7Hv/78+dtm1f06/v3nz99nOYx//8fn2e0yXv7+8+d//uvPnz9//uP79/97895k
+          99utfBXf17//LF+3+/L3nz/sfz/5vy/98+cvcLcaY6FXew7lrgna44InpIuCNguntYHNz6PDXi8U
+          FTWL5SLJup1iO8pIv9w7h4FQr1dyKkNRm/T0sZO4vBCxe669jNVGiNGPbtlYVtRNNG84WZeCo3TE
+          pn6zNO5IBgGZhazjy8kI0ey0qQjCfUfwgX/8VJMOUQ2lee7I0WfmfsmssyxyuOCJduRSd/1pokYi
+          dv0mxoWJ+zkvEQBLyo7I66OrlsW6z3CVrzecustPRufg3EC9HzqSnG97lxvrPkAx+2yI56RhNvRi
+          sUri8yoQtXERJf0RzVJMvRzbj6CntMnuEzyl0SfK3X1SWh4XGUwl1UYUpo9sSTr5Lh3YpsM4VbqM
+          itSXv/NJ7ltFzjYQxAl6eyeLyEJSIVoe5xXK/aCSgzyc+8XhfBN2SvaatmmTVXPSHjtpXqNlEqHW
+          suXqwYRIIPjE35QpWu+xB6jGBkeusb/vN7Y2XICfdi4Jn5zjsnfZLsH124Cc3uBmdKVaCZfDRicO
+          NjAa+lukSucDf/Wrfa5Hm5/glsCG5yx8YFyCFk6hDRKMuz5Jns9UdNfca3CZriDuhfAaxypIBxXd
+          RmyGoeJSSj1VGhwQsOm3K5p/wvNO4kw2IuFO7t3FIu0FddVbJv6rPKKV77lSet3IREwmxNqDKNsa
+          bq/1SJyz6LrsftzE8O6YHVaKhKCl9jYe1OPEE6OmhC51pzOgP84VNlgaIf7EswLsn8yD+LdTp61J
+          OolgFrJMoifHaEN9S1V0dgpE0h/DpVzX+ROMZbhgq7bWbHotxzvktgu+FGp8v7L+SwX0vO2wr5we
+          Wpfy0gXN75dNHKFWM35aTnfJ3sRXvH+ODtrsC3QB5kqvWJW4RZvn02xK+uGSE/w45e5SeswANZ/d
+          sX8qCVrVfB+DVygCsdMGVWNIehGuyqb1BbyM0cjlioku6a7AWprvMg5zVgNx5EfYvIS1tl5j3Qfh
+          efeI52hyxU/9usJN4YA4aXCjqwaZDmn3yIhflRQtGwVMuCwbj7g7UdS+50O6HjYDVuLEo91jia6g
+          qqs41QJVKKu49lkK45onN8+/V/OuPZwlb3M6Y/9xcjWWiOXvepP7cgpcFhtvD04LG+BD4mp0tSBu
+          4PFa3vgyiAdt1dPHWfIMRsGHIgnQonCaLr1ou8MXK8t7cmNMB9Fgeyf4x8vdeT0JLLDnvYOvZnqI
+          aMQ4IgCsQBR9SCtuF0aORNbDjRglk1TLlbwcSG1nhy0b5GwTMaoI6YGdyb0vebRArsUojfYIOyLx
+          tFZ1FVFafwoHWxIsEV2DQyyVzWXFVr8oGX0fkYyYgRbEuFKPkr32FGEqI4O453rIxq0CPBjnwcX3
+          U4kRLzSHRFSyfD9JlmD38378iVHoCg5WV/cHrXr6PqMNru7+ZoQh6p5+F4IVyAHxylSM5tjoADqH
+          CYhzFQd3ffplKE1pfSORwkXuhg1SFr7rZb+DEc23kt4l597p0yrLrUa+enPZ7lqMe+/s8mms+dLz
+          qb786VRiOm9PIg+HMdr7jHJSNK5XhAT2fitg3zipGueGV0dURb0hGfhGNSuufZGsdkLEf4xXukBN
+          VuiiDnxKuo22zj0qYAjD1F8gOdN+PnIhUjvzji20NNnyrksZRO4OWE9ziF4c1QtkFqpOcKo40ey4
+          3gUqaWjwGS9eNCIIeOkwHvbkpIazO675LgYR5jP27ZPu8qs/FcDmZUMMpt1Tjlp5AGvrdVhuh6Bf
+          ojBpJSpgdYKrT3qaC50vDWvwIAbcapdmQsvA/v6WJ+kxvtFMT1tTktDFxmZMGUQW4TXAg7+UOLuT
+          k8v/aO8zsLgoyf6jfwsObw48ObXHumKX1fKs21lqoy4gFxB57bseIGUXBWNF0TI2cP0dMLq+EI3L
+          52wkViIjzmQxOWuLnZGfsdfh8uB2PsfSGM0ip+hwfrAFTuC2dYeyZBlArG4QWR+e1WrlJi/tWoKx
+          1YWSS3jqzdCHoYH3un+tVmhCFsLx8MApyYRq8chDgM98YhtnU0UzoQDYBWrtc3s7rfg8NnzJDZQC
+          3z/n+XseQS7nOwmDJEe0OM6huJvVGTsdeblLEN5a9Kl3ZH8YdcTeZaUEUxh6fF3Te/Srp7pyPpHz
+          E6RoqGRXBpm13yRbUydayZIDHLvCIpZuvbNlVLY62LvxRLQqfkQ0LX52qHjR4yRITVhxqYcAOAF3
+          RLW5h0v1QmjBbKcXMVYGqlVN2xYcpvOIU4uTNoq52kBY16KPurSN1pvfqmjbcP3EfPRpWZRVF61Z
+          vpIo70LtM76J8Bg8sPaKy2zG7l6At9YWxCflCX30ZAeKbo9YneWNO0dGd4WqyUyf65i0YjXX2cG7
+          6gZykJMn3ShNHIOiu+OUrambbeKCa0FizRHvxmbsKRofvPTYLKO/zQ2F8hpEOuii4eBc8zyNTUvR
+          h+JH56ZlTjg0aMFUo2eTTf6kCdCvj3g/AGJs6q8Sd3DZi1FP8HzKL+y/T3t3k2WZB4fnzzKJQl1G
+          LHtaEvD3oYHVn6516ZvKM7yqVsenNzjRpqOKin48OmDfFe59S2+3GW6pffUX/pH302f+gP6U90m8
+          ip72W39+ysnE/sZrtfFddzLCTD9jnPBFtm6a1ARlnXmyz4Wg50orVKWPX5uqj36xz1KaoMj191Ts
+          hlc1p+UWJOeVDNh+Bh7iHh7vQePFLrnRsqbDwXgwEvLmK96r2lItvXVdf/3Nrl+O0cr1nAr2Kz6T
+          iy4a2sLmMg/grbNfXuXFXTgF1cBkl6MvHUYNLXJ4bmGTP0py248qonfhwcCy8xxyddI1owfGOcPu
+          Fevk9FrkbO7KzRWAy2v/6TC4oh4ji1IkHbbTiAW34vPlMsFoNwbekeWUjS5nxpInKzM2Awp0uBtP
+          5us/idK4FvrV99vWrrFyHvLqsx8TuAf53i/MzRT1rvbcIdFbd1guhqlfZbjEcOkePTGL2+yu+7Te
+          AejmnqTPYKDDIL4DcGRlhyMjf0RUcuad1K/BAX/1kc+XkAHlYprEIcYW0e5IAwlxeUDS3CgQzRjj
+          AsnCyjjxbp22bmytgWPlEaxl3eIuoiKZcF02LDbOtEdL5sFdnAuhIScnjLRFqJsZWe2A8A0LfU+3
+          4yP5+j2syImJ2JPRD6CFS0jUPVe5q5dWIkSRr2G1c2903UOSSMZusLChUx0tEqTJVw/8mU1Kuur5
+          ngUJaEDcJFWzz3gFRPXLn+ZuI2YLXzcqvAxFwy7U54x/8D8i4oR9R/LIO7isHIw8CLhaibXAPuOU
+          E5dIrZfQz+cv0SLkjg6L/Tz681GVsuFd8vCrnx/9owvmcINybB6w0bUmGnRXPUvlbTKJy/plP96t
+          87r1nwyH9b1t9ny1XH1EykOKjR1tKN0GWYN8g3lj9cDV2syelhhe16SauIDuEJ/zPxf0k13exBTD
+          SesZZ+4AMS6dto/mVq0KXBpQs9vz+/3Vps1yDxKxqEj6CFzEl/67QP7pKBCv1Kx+E2cBgKlcfoiX
+          aFpPzWLrQBJ5CJvtbdUGy9Uu6LUfGywb6jkijjaIglpS9Vsf+pk7Lax4e80p3p+EqZoH8SED3G1E
+          7B+jo4seHgTpU7+nuRim6lUet6r01VPv7E/V4oRRK3UOBMQV/Loi4xFC0d2cdGLVVpjRaxZdpZ0s
+          F5/6jKulU2ZT+vgh4orpmJGr8PDguZ8Ykgt92c/HUmDQdesGxLdHjs78STS/eo8tsmjZ/N3/r2tc
+          4ZuvcRUtsiugVd6qE6Vxk62SVgjS3joV0/WiGRXf+lUApjD1BOceqy1+GIsQSKHkN2A10XpaAg/G
+          tLGnWy4cqnk5CQkMa/ggO7oI2SyPKIHmmuBJqDK56vOjIEsfP4L9V8nSeTnNjcTUujQxj/GKlq9e
+          lual8blL+6Bjbh1k6V7kB+IFNZNNZez7EOi1gzWtc7R3YR0KSRNN3ufVdkI0KZgL+tQPYiRMVK1i
+          czGBnbci1q3Yy+aqlHxgrssVWykYGfvpX1H+Yz6wx2hBvyKt2En83dHwbt9oFXfplAFeR83C2CoZ
+          Otgjk8DjRZ/YaNonHed6CCB7O8JUu/E+G87ldoLEKaJfP8yZpN19+1css0mJ6E1432G2G4loe453
+          ZzhRVjKUc0+sqzVnC6n7GcEwCzioB9wPsdFNItvwFgnmRKabF5VDSXd0Boc3znK5qm5lxN93Fs4c
+          smgjm+94aS2Q/9lPesX5nnDdIt+uyP5HuFSUDS6mUCdpgs36tmhrmhIROWdCiE2MJ6JnxutQnWTJ
+          9HPyVnf59AtgKekJK62saOvDfwTf/vvj3wM6WwHhUeyKK7GtzKs4j5Q7UFfq+D9Hxc7WZonh14+5
+          CWE1mhabHTrcIuPjZ3YZpVSbpdR2dKy+OsVdLM7QwWnJBu+340ynMjYYhO/v1p/5zS1bE55twb23
+          Z184Nk3/W18W9bD1Xw9oo7mRPRn800mYhFdWVkvTGdPv+itfXrDN1QQ9mssdf/TDXc9LMEn1U8bY
+          Gqxj9OEj9VevsKInLzQ1Mb6iY+S9sJMQWWMPrn8RWk57EUVOnmiJvdUDQ6W8T6POd+e32IYw2fVx
+          ajeZ2bNhe72gi7KRP/reUHpi9DOa7VrChzpZ6Hxo4x0srZdgs2lTOgVwisGduiuxZOsVtauMS5jV
+          w5Nku/qVLReP9dDpwO+wtuQ44oLw2EL9lCOyuzVttZinHx1dU3tHtDRvo0XjNBZu8nXBsWQf+9ka
+          pQaxMxI/fnGt6HAEGbzXMfYZUm5Q9/TLAp4jcYh+YYqePLPkDj/hoBLdjado1tuzI20T7oVtI1AR
+          dwrzFvBTsr/7Ac2xa51//bXOM3a/Fkvmw8uL88/vJdGyD+MWjaJ0nTYjeBFnnJgGHXsU+vyHZ6yj
+          LccgobONz4em7t8/EJrSD7osRGmTkPKs/5LRKcLYLxT1FNHHUSjRPbjtp0rrbI1ohXABjpSMPwtD
+          UlHF9mvgeD731wOnu3wRG3cwZ3VHnFYMNI7muxrOC1/7pZdI9L1RWFPSOnPFXqip1eaR3Xwk1ebb
+          F1DW9kvZeT66BtcnOX/mm1bZcQCjMy7408+4E9ucY2BJ0REsKceIrWUtADm2H9j+MRw0Vp03ifTs
+          8Ti53rDGsqdtDA/zHE4fXuLSRSAD2pg8+vUTsxZMDXIKJca3TflEq9Az8odPxdgT/HO/3DyWgcKi
+          tj+w/qYipdB78H4qG6zhbtSWNd8lcFb4s89GcRBxZzKKaHvf/RD/ceq1WXNVB/gWi1ilnaH1aHzz
+          oKwrP0GYxhl90V0Ax8jrCd4rZrQYJ6ZGYSaGE5N7sru5M+YZKeW8kqQMLW2+yHIgJRkqsZw8Hj2d
+          grOOtrDq2Ltoz36+tHcBCmKO/vrqFG0uZXVGxuFCsVWGmbucO8UDVdRLfDaaRzVVsX8F07Gaab27
+          KaIQxA2Ma8Bh16vf0dT2iyyp2e2BjxcmruhVePjS8n7eyI0IfPX++C9kn0nmb15Lkc1fv/7pR4i/
+          Pz21NY/3vijCGuPdZtlGa7lkA6RvJ8COHZwRp4apA2p/e5Nro7UVVbXuAid3u2Kds8OKdlSRYVTD
+          N9EX+9BvPv06OJtkJsZwk132yw8muzmSfSWs/Zh4IgN75r0jhnDTNG6TKywY7RRhbyPo1aYQuitY
+          F4sh7uAX1ZouAWy7Dq4kHORE44UmjYHleRfHbryPuLGzJnSO8AsbIXPoN/NRCmESf2ai2XkVLVPd
+          l7DOKJy+9fTDM1hQOtOZZHGTR+OmbkKomtTEOonT7Jc3tVEb4+vVJ9XclT9XsTZUC2uyDNqYkalD
+          WpZz2FdGimjJ4A7y4Hb79tP9pz4F0rd/wpLCRWvvDyFojt750jKOlHoF2okfvouVa+JT6jK7Di72
+          7kwiFLcZiRjNkerbMOE9FTbVrAZNArfUvU6l6gZ01keo0bQebOypaZCt9+VyRb3D1JN0GCs6WG3q
+          QNSLnf92s31FvSav0TQLKnEa8nTpNogaiOtnib/6tpax6aPzwrZEnhMZrbnfllA/1WhakgdXsfR2
+          K9CXD1o2KNkmE1qAc1dZRL5v+IjyYxuLVZKqJBiGtZqZE9t8eca0zbOoah+3QBUrYryxK4snl0Bw
+          beDL+/3HCJQWQneHi1hRX3hlSsV96hW62raOvdan1aKGh92X12H/p7yi7rScfXQ+sFefZWmBPv6B
+          lzbcVcYWa22i5WEdVulY+QT7VtnRobydQ1BE3cexbev9Wn2IeFx52bSSTnOHh9EAXN+u5y+CbGib
+          MrtdN6I373B05FKtS2LVB+mYD9OWZtvqnXTyALYss9jRRd398KMOABaZ2Djzq349MvLXL0w83M7u
+          l4d89GEi8Z159EtAqp3EBtuVOHYgUIKoGSBNOWtY3cmutgCkukAukvDhT7rLx7E9IHa3N32uoHv6
+          OY+7b70lZhJW7rIqYgP4KBn+PAxrTxlqhajllBfeL+OI1sJvV5H+FBeSVx7vtgznJGh7dzVsJK2M
+          Nl9+mct5iuXL5hitRm7qiDP5aOJnS8341W/Kz3lm/VrrGHcO2kiQGi9x8Z6UGppy/ucM1+D6IJGS
+          yxltj+IM1+D+wFZsjdHYWrGKuHZfYizybkRX6hZie9Qy/3F3DcRSsQohZl+dD1//KfSMCj/r5GN9
+          ZdpqknO9lj7zO0lUOPWz6+qtpJbUxLYgKhrby0YhxvrzQvRHzkRLbYUzWOeJYuWc7NF6ip0JacrF
+          IvrEmD27vZ1KaKSxJLs+03peUTYxVONQ+ognjDbdeF6EL2/L90qT9QmjiRBHXoQV3y3QKNYk+PJz
+          jDvejBabPHaw2xGN7KVT4S5yGLTSG06nSVAauVq1tBAB1aZC9h8+MZuuI3z0MMW7R9NV63c/NxBn
+          +Kr7u4r7+rMPbyPYOCUupUc+lH76yzi9AsuLKBGIh8boLWCdYfp+ft4OAUjPnP3whORTr2RZjOPX
+          /ft76eiQxxnkcE0+eir3nE0eDpouP/VUNA+zWhhIGzg9eA8bJuP3tBaq6VuvfEriZzRnxgAoK+7H
+          qcNGQFeynBhg86Ih+KBY2fe8/urXh/ciqtu4RqP4c8WmTgW02jmOYXAY4cPbsMYa7fkMn/xw+rkp
+          ffb88k09pA2xtcyplpD0gkRmIcGZXjfZPMjGjL71RE4eSv/JkxIRvHkm4ch52kisuwqRFG0/3+9r
+          /NPvAuBaXJK9qYU9zbLIAwAqT+Tkhdqy1HUp3W178IVo8aMPP4ihOaqUfPufRcq1RoqQMBFzCjuN
+          ckd+hjl9Gr9+YP7mF1/+ETZuhua0XBjpeVRz/B1/+OQdMAueSfKJtzL65dcfHjMhr95l8+Z2UiHp
+          yvzXn9IDo16AP+PV//Jhwo2tiTaMU336d6OicxCw0icPIPeonNBC6mr95qtkn44m2hwLTgCB5zJy
+          suERjZ98DX3ymon/5JXzsT2et0MYpL4UCWNVf8eviSVh5eLqiD0YD/jmkb/55VhZYSn5Rxh/88+h
+          Nl4M7KVAwedn41YsPS0mZMumwM5ONLUFe/Mgffw7Me/h02VjF5+31pJV/8Uv1pPAwyGuS3yY3O7T
+          n/KOWN+mCe9fpYIGeUQxXOfrSC6f/oK7kOkMJbb2Pt+Fb/fLh6Dm1BOx7aCi9CnUnjRumwPZv8qC
+          UlPrW/j4p+mHekh7CLmqSzdlA1g+D321fP05XFfWp59+mVVHVgdzlnffPIT+ru9SCCLZOxqtxo8f
+          h6t8v2Glc9+IOMV6ln6y83OaFTWJyOsolvDN77Q+1jN+8scQfXkh98l7PrxikJj+nBLvrpk9W5fc
+          XfyJrT3eE4GrBtf1OjF/UWUSP3nq+PXfu1Ms46uf0miS7H0CX//mK2OIln147b58ceJbS47YL1+o
+          Ddki1hPeGedwpv7tp6d7OoqIImoWMETvgtjvYE9/8+4xDEey2zdVTz+8WTKE4UTsV8b3tM5ujLhp
+          NhqRzY2fLTqnmwjfwttvXsfv+HkHyHcrn2bd4Tf/g7/fWwH/+a8/f/7X94ZB097uz8/FgPG+jP/+
+          76sC/978e2guz+fvNYRpuBT3v//81w2Ev+++bd7j/x7b+v4a/v7zZ/t71eDv2I6X5//z+F+fgf7z
+          X/8HAAD//wMAybDCut4gAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946bf9f5917d2-SJC
+          - 8ebdc5139cdd1574-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -568,7 +562,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:25 GMT
+          - Mon, 02 Dec 2024 19:37:08 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -586,7 +580,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "42"
+          - "75"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -598,26 +592,25 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9988261"
+          - "9959281"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 70ms
+          - 244ms
         x-request-id:
-          - req_b34519c5897b1597bcd9e9c4faec367b
+          - req_9ba81fbc4182250c3f2b60f445ca46ee
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence2: stub\n\n----\n\nI
-        like cats.\n\n----\n\nQuestion: What do I like?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence1: stub\n\n----\n\nI
+        like turtles.\n\n----\n\nQuestion: What do I like?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -626,13 +619,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "613"
+          - "602"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -642,7 +635,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -656,19 +649,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSTW/bMAy9+1cQPCeFnTpL59uwr9MwIBswbPNgqDJtq5ElQWSKdkH++2A7jVOs
-          A3bRgY/v6T2ShwQATY0FoO6U6D7Y5Zvtl2/v3n7/0Mb0c/y9Jb398bHN3t9vPu02d7gYGP72jrQ8
-          sa6074MlMd5NsI6khAbVbHOdZenmJl+PQO9rsgOtDbLM/XKVrvJlerNMX52InTeaGAv4mQAAHMZ3
-          sOhqesAC0sVTpSdm1RIW5yYAjN4OFVTMhkU5wcUMau+E3Oj6UDqAEnnf9yo+llhAiV87AnrQFIMA
-          ixJikE4JSEfAgdSOIlizIwathK9KXEwikSzdK6epYu0jTWJZWmLpjpffR2r2rIb0bm/tqX4857G+
-          DdHf8gk/1xvjDHdVJMXeDd5ZfMARPSYAv8a57Z+NAkP0fZBK/I7cIJilryc9nDc1o6v1CRQvyl6w
-          rvPFC3pVTaKM5YvJo1a6o3qmzmtS+9r4CyC5SP23m5e0p+TGtf8jPwNaUxCqqxCpNvp54rkt0nDI
-          /2o7T3k0jPzIQn3VGNdSDNFMt9SEKl/rZp3XpAiTY/IHAAD//wMAkKFndVQDAAA=
+          H4sIAAAAAAAAA4xSy27bMBC86ysWe5YCWXZtV7cgQYGc+8ihKgSaWkmMKZIgV00Cw/9eSHIsBU2B
+          XniY2RnMzvIUAaCqMAeUrWDZOZ3ciu3jXdPv7rsH9WNrHr7fZ6r+evel2j0+P2M8KOzhiSS/qW6k
+          7ZwmVtZMtPQkmAbX1W69Xm33WbYfic5WpAdZ4zjZ2CRLs02S7pN0exG2VkkKmMPPCADgNL5DRFPR
+          C+aQxm9IRyGIhjC/DgGgt3pAUISgAgvDGM+ktIbJjKlPhQEoMPRdJ/xrgTkU+K0loBdJ3jEEFkwB
+          uBUM3BIER+JIHrQ6DnDvWVO4KTCefDxp+i2MpDJI62nyW6UFFua8TOCp7oMYCjC91hf8fF1J28Z5
+          ewgX/orXyqjQlp5EsGaIH9g6HNlzBPBrrK5/1wY6bzvHJdsjmcFwlX6e/HA+1sxmny4kWxZ6oVpv
+          4g/8yopYKB0W5aMUsqVqls6XEn2l7IKIFlv/neYj72lzZZr/sZ8JKckxVaXzVCn5fuN5zNPwl/81
+          dm15DIzhNTB1Za1MQ955NX2n2pW7enugNdWHFKNz9AcAAP//AwDfKcuLVwMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946c0fc3d96cc-SJC
+          - 8ebdc514f89ceb24-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -676,14 +669,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:25 GMT
+          - Mon, 02 Dec 2024 19:37:09 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=2yaWaGVjAW9nR9JeZSDdfDJ83_dHZpmrG_Fx4Mhv9Q4-1731107845-1.0.1.1-PIdRz.XLftcZU0el6x0ws5gEmlbQ4BqffajI9vmzjzs5qqIbhnnH4Q7tybi4XiH9Mh1gNHFqU7J6p_.GpMxrlA;
-            path=/; expires=Fri, 08-Nov-24 23:47:25 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=4ppEld2Z4xxaveK7sc.AjA4ksPcwN5Ax94Yy3pYKh8s-1733168229-1.0.1.1-Xf45D1XrBTVajyNbxl__xFDQpqg4ztzV73XvnsGLgLUcST.SE.5aXrdSNQwcd1a6ce1zHe15X7RdYWZzKmjwVA;
+            path=/; expires=Mon, 02-Dec-24 20:07:09 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=LaHjnQLrWDdp_B8_S_.ujatz4aB35skv97a2aimO7XM-1731107845971-0.0.1.1-604800000;
+          - _cfuvid=l0e0eMSa9aE1vp5187oImVUsXd2tzYWAKjpM3FeaIZo-1733168229293-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -696,7 +689,116 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "588"
+          - "549"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29999870"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_8ad9829b9a8b1c2db5acc47b69240428
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
+        information that could help answer the question based on the excerpt. Respond
+        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
+        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
+        words words and `relevance_score` is the relevance of `summary` to answer question
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence2: stub\n\n----\n\nI
+        like cats.\n\n----\n\nQuestion: What do I like?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "599"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xSwWrcMBC9+ysGndfB9m42G9+SFHoolBZKQ6mLUeSxra4sCc04ZFn234vtzdqh
+          KfSiw7x5T+/NzDECELoSOQjVSladN/Gd3D4+yPru6/Wnj/zlvn/efv7+ePih8EN1y2I1MNzTb1T8
+          yrpSrvMGWTs7wSqgZBxU05v1Ot3usmw3Ap2r0Ay0xnO8cXGWZJs42cXJ9kxsnVZIIoefEQDAcXwH
+          i7bCF5FDsnqtdEgkGxT5pQlABGeGipBEmljaye4ZVM4y2tH1sbAAhaC+62Q4FCKHQnxrEfBFYfAM
+          xJKRgFvJwC0CeZR7DGD0HgmUZLoqxGoSCWjwWVqFJSkXcBJLk0IU9rT8PmDdkxzS296Yc/10yWNc
+          44N7ojN+qdfaamrLgJKcHbwTOy9G9BQB/Brn1r8ZhfDBdZ5Ldnu0g2Ca3E56Yt7UjGbXZ5AdS7Ng
+          rTerd/TKCllqQ4vJCyVVi9VMndck+0q7BRAtUv/t5j3tKbm2zf/Iz4BS6Bmr0gestHqbeG4LOBzy
+          v9ouUx4NCzoQY1fW2jYYfNDTLdW+3K1TTLY31S4T0Sn6AwAA//8DAFPbKu5UAwAA
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdc514ecc9cf13-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:37:09 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=LszsnjZbWZtzwHyM3EXKIq85BXJNzwGsHx9vbp8sHmM-1733168229-1.0.1.1-hIGTdsW7YXZHbhTNIy2JHds8122gQNv9ScbbzUUK0TqeXjzR9Ce7NT_4Ce.HGYxXwszElEf_kuSClRAxoCIs4Q;
+            path=/; expires=Mon, 02-Dec-24 20:07:09 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=_Fg.TABHZSLWAwWW0ZGO8y9DVuXW20SalPWu.llbMxQ-1733168229978-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "1239"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -714,20 +816,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_e774bec7b268b3e635ccf20578d07aa9
+          - req_1b3ed6065b23dc584a3754f425fbc1dd
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence1: stub\n\n----\n\nI
-        like turtles.\n\n----\n\nQuestion: What do I like?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+      body: '{"input":["What was it that I liked?"],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -736,13 +830,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "616"
+          - "99"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -752,111 +846,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xSy27bMBC86ysWe7YCyZYbx7e2OeTQFn2k6KEqBIZcW6wpkiBXrV3D/x5IciwF
-          TYFeeJjZGczO8pgAoFa4BpS1YNl4k77+/OXb7Z8lvbn9uH93X+zv6t3vw+brW3X34dN7nHUK9/CT
-          JD+prqRrvCHWzg60DCSYOtf8epHn2fWqWPZE4xSZTrb1nBYunWfzIs1WafbqLKydlhRxDd8TAIBj
-          /3YRraI9riGbPSENxSi2hOvLEAAGZzoERYw6srCMs5GUzjLZPvWxtAAlxrZpRDiUuIYS72sC2ksK
-          niGyYIrAtWDgmiB6EjsKYPSug9vAhuJVibPBJ5ChX8JKqqJ0gQa/PCuxtKdpgkCbNoquANsac8ZP
-          l5WM2/rgHuKZv+AbbXWsq0AiOtvFj+w89uwpAfjRV9c+awN9cI3nit2ObGeYZzeDH47HGtn58kyy
-          Y2EmqkUxe8GvUsRCmzgpH6WQNalROl5KtEq7CZFMtv47zUvew+babv/HfiSkJM+kKh9Iafl843Es
-          UPeX/zV2abkPjPEQmZpqo+2Wgg96+E4bX+XLG7VaFLmUmJySRwAAAP//AwBU07F2VwMAAA==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8df946c0fef7cedd-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:26 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=R_27ZcloAwamURH_2lO5pZNyWtXWfA_2xOtV5hBAPlU-1731107846-1.0.1.1-0lS9vOG7fJpuiP5ZjL3GsS46CcnttCZ2kXMnyl.iVwZIBY0osZ13JbW1AzLIY2OjePHeGQDeG2UutdQMZJTFhQ;
-            path=/; expires=Fri, 08-Nov-24 23:47:26 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=nBNxwRdTFpBVzNqUPn8UOXqBUrm4GaT8_3TLUh8YGLc-1731107846434-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "1051"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9998"
-        x-ratelimit-remaining-tokens:
-          - "29999870"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 0s
-        x-request-id:
-          - req_2397ce941c669b394187842093777b98
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"input": ["What was it that I liked?"], "model": "text-embedding-3-small",
-        "encoding_format": "base64"}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "104"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.54.3
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -983,7 +973,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946c8597317d2-SJC
+          - 8ebdc51d7ebe1574-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -991,7 +981,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:26 GMT
+          - Mon, 02 Dec 2024 19:37:10 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -1009,7 +999,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "147"
+          - "95"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1021,26 +1011,25 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9991745"
+          - "9999994"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 49ms
+          - 0s
         x-request-id:
-          - req_3ce73e1403d7e97f8592c0d8a700042d
+          - req_807378626c4d9bf6e04cd8d24110c237
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence1: stub\n\n----\n\nI
-        like turtles.\n\n----\n\nQuestion: What was it that I liked?\n\n"}], "model":
-        "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence2: stub\n\n----\n\nI
+        like cats.\n\n----\n\nQuestion: What was it that I liked?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -1049,13 +1038,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "626"
+          - "609"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1065,7 +1054,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1079,19 +1068,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSQW7bMBC86xWLPduBZDu261sKNNemTYMArQqBptYWa4okuKsiqeG/F5IcS0FT
-          IBceZnYGs7M8JgBoStwA6kqJroOd3ny9f7x9+BT4vrq7+3Obfpk/fn/46D6n23rJOGkVfvuLtLyo
-          rrSvgyUx3vW0jqSEWtdsNc+ydLVerDqi9iXZVrYPMl346SydLabpepouz8LKG02MG/iRAAAcu7eN
-          6Ep6wg2kkxekJma1J9xchgAwetsiqJgNi3KCk4HU3gm5LvUxdwA5clPXKj7nuIEcv1UE9KQpBgEW
-          JcQglRKQioADqQNFsObQwk0US3yV46T3iWTpt3KaCtY+Uu+XpTnm7jROEGnXsGoLcI21Z/x0Wcn6
-          fYh+y2f+gu+MM1wVkRR718Zn8QE79pQA/Oyqa161gSH6Okgh/kCuNcyyrPfD4VgDO7s+k+JF2ZFq
-          vpy84VeUJMpYHpWPWumKykE6XEo1pfEjIhlt/W+at7z7zY3bv8d+ILSmIFQWIVJp9OuNh7FI7V/+
-          39il5S4w8jML1cXOuD3FEE3/nXahyK4/lOv5ItMak1PyFwAA//8DANj7PxhXAwAA
+          H4sIAAAAAAAAA4xSTW/bMAy9+1cQPCeFPzonyK0Ychiwy7BhO8yDocqMrUWWVJEpGgT574PtLE7R
+          DthFBz6+p/dInhIANA1uAHWnRPfBLh9U+WP7tD1+Xn96kLL9Xjyttu3X8Pwl8sccFwPDP/4mLX9Z
+          d9r3wZIY7yZYR1JCg2q2KoqsXOdFOgK9b8gOtDbI8t4v8zS/X6brZVpeiJ03mhg38DMBADiN72DR
+          NfSCGxhlxkpPzKol3FybADB6O1RQMRsW5QQXM6i9E3Kj61PlACrkQ9+reKxwAxV+6wjoRVMMAixK
+          iEE6JSAdAQdSe4pgzZ4YtBK+q3AxiUSy9Kycppq1jzSJZWmFlTvffh9pd2A1pHcHay/18zWP9W2I
+          /pEv+LW+M85wV0dS7N3gncUHHNFzAvBrnNvh1SgwRN8HqcXvyQ2CWZZNejhvakbzDxdQvCh7wyrK
+          xTt6dUOijOWbyaNWuqNmps5rUofG+BsguUn91s172lNy49r/kZ8BrSkINXWI1Bj9OvHcFmk45H+1
+          Xac8GkY+slBf74xrKYZoplvahXpdZJSWq2adY3JO/gAAAP//AwAzPGJGVAMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946cabb0d9441-SJC
+          - 8ebdc51ec8bff98f-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1099,14 +1088,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:27 GMT
+          - Mon, 02 Dec 2024 19:37:10 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=.kzTnFGCyc788_tSTs8HFfgDu0m_OetYpMOunWSXcDk-1731107847-1.0.1.1-utZKdoHa9h5B9GbbASuyw2mG5GTihgUge5G.3.Q6scWeueSK6ynVqXdc2YLOPG93X9J6OggPIiaUsmy_ZB2Wug;
-            path=/; expires=Fri, 08-Nov-24 23:47:27 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=l0BDgnTuG_59rBM9hE6GFMojRPldz7KJmv4HZHW3lIs-1733168230-1.0.1.1-656loZqDvP_CNlbm0w.jIU6LALBeY2saUKETNGuMdEZtZ28XpTuZc5zb9H34lfgS5LxHk2Hx7B07wq4Oz0WGOg;
+            path=/; expires=Mon, 02-Dec-24 20:07:10 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=TuvOQl8rcNwd88SN3lDSMXS7.nhcCmn8uPEzzGeXOGE-1731107847557-0.0.1.1-604800000;
+          - _cfuvid=n5PT4cpaVKLsnWhKGMUit_jLjRmhQHohokRUN_yVclM-1733168230812-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1119,7 +1108,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "624"
+          - "479"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1129,28 +1118,27 @@ interactions:
         x-ratelimit-limit-tokens:
           - "30000000"
         x-ratelimit-remaining-requests:
-          - "9998"
+          - "9996"
         x-ratelimit-remaining-tokens:
-          - "29999869"
+          - "29996524"
         x-ratelimit-reset-requests:
-          - 6ms
+          - 18ms
         x-ratelimit-reset-tokens:
-          - 0s
+          - 6ms
         x-request-id:
-          - req_a7ea794a3a664a26ac972bfb6362d04b
+          - req_7b83955558c238318ea47d0066acae3c
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence2: stub\n\n----\n\nI
-        like cats.\n\n----\n\nQuestion: What was it that I liked?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence1: stub\n\n----\n\nI
+        like turtles.\n\n----\n\nQuestion: What was it that I liked?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -1159,13 +1147,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "623"
+          - "612"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1175,7 +1163,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1189,19 +1177,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSwW7bMAy9+ysInpPCTtI0821AB2y3rVs3oPNgqDJja5ElQaSDFkH+fbCdxinW
-          AbvowMf39B7JQwKApsIcUDdKdBvs/P3d1x8f7mm/qeW+evDfb+9uP+2/fK4f+GMacNYz/ONv0vLC
-          utK+DZbEeDfCOpIS6lWzm2WWpTeb1XoAWl+R7Wl1kPnKzxfpYjVPN/N0fSI23mhizOFnAgBwGN7e
-          oqvoCXNIZy+VlphVTZifmwAwettXUDEbFuUEZxOovRNyg+tD4QAK5K5tVXwuMIcCvzUE9KQpBgEW
-          JcQgjRKQhoADqR1FsGZHDFoJXxU4G0UiWdorp6lk7SONYllaYOGOl99H2nas+vSus/ZUP57zWF+H
-          6B/5hJ/rW+MMN2Ukxd713ll8wAE9JgC/hrl1r0aBIfo2SCl+R64XzLJs1MNpUxO6uD6B4kXZC9Zy
-          PXtDr6xIlLF8MXnUSjdUTdRpTaqrjL8AkovUf7t5S3tMblz9P/IToDUFoaoMkSqjXyee2iL1h/yv
-          tvOUB8PIzyzUllvjaoohmvGWtqHMrt9Vm+Uq0xqTY/IHAAD//wMA8j9vhlQDAAA=
+          H4sIAAAAAAAAA4xSy27bMBC86ysWe7YCPWLH9S0FeuglyKGAD1UhMNTaYkyRBHcVxDD874Uk13LQ
+          FOiFh5mdwewsTwkAmgY3gLpVortg00e12n77nr19fVrunov1lo5P2y/Prsl7XgZcDAr/8kpa/qju
+          tO+CJTHeTbSOpIQG1/yhLPPVuiizkeh8Q3aQ7YOk9z4tsuI+zdZptroIW280MW7gZwIAcBrfIaJr
+          6B03MNqMSEfMak+4uQ4BYPR2QFAxGxblBBczqb0TcmPqU+UAKuS+61Q8VriBCn+0BPSuKQYBFiXE
+          IK0SkJaAA6kDRbDmMMB9FEt8V+Fi8olk6U05TTVrH2nyy7MKK3e+TRBp17MaCnC9tRf8fF3J+n2I
+          /oUv/BXfGWe4rSMp9m6Iz+IDjuw5Afg1Vtd/aAND9F2QWvyB3GCY5/nkh/OxZrZYXkjxouyNqlwt
+          PvGrGxJlLN+Uj1rplppZOl9K9Y3xN0Rys/XfaT7znjY3bv8/9jOhNQWhpg6RGqM/bjyPRRr+8r/G
+          ri2PgZGPLNTVO+P2FEM003fahXpd5pStHpp1gck5+Q0AAP//AwDeUBHKVwMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946cabd24cf1a-SJC
+          - 8ebdc51ecd6eed37-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1209,14 +1197,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:27 GMT
+          - Mon, 02 Dec 2024 19:37:10 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=ZesLHf.9QNSoCj0D5.zP4xMQpDCBeYFoDnntLK4JEX8-1731107847-1.0.1.1-WWXNWp0hVtkJ6tsgTkHBTd0uUYhWv2fS5aM0BXhAHBIbVG607ztCjbHqUQASMBRyg6r3ZFULqnn0WFmOvplEJA;
-            path=/; expires=Fri, 08-Nov-24 23:47:27 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=DKx1S9CwL30DgixEjSLGuWNYbty4fQ6tbPDoCdacaBw-1733168230-1.0.1.1-9c_qdDxEzbHFE_.LOCS1e8oGYWuzlA5yuVyXyRRji8z4Mvm_.vpLW31o9aw_cueztNcvGi3EqPm5WeSQscki8g;
+            path=/; expires=Mon, 02-Dec-24 20:07:10 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=B7EARzWV0hcmGEXO1FGZosxBETVyxETtxs91iwigAag-1731107847609-0.0.1.1-604800000;
+          - _cfuvid=cNv2r_hlKZgCbriDiFHNNQecEF6tTCKRj4pIlXE07.w-1733168230998-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1229,7 +1217,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "681"
+          - "628"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1247,7 +1235,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_d3d2541c67003331c1ef2168219dc628
+          - req_d9e1466d9fd7144c36a5f1992c037223
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_partly_embedded_texts[True].yaml
+++ b/tests/cassettes/test_partly_embedded_texts[True].yaml
@@ -1,8 +1,6 @@
 interactions:
   - request:
-      body:
-        '{"input": ["I like turtles."], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+      body: '{"input":["I like turtles."],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -11,13 +9,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "94"
+          - "89"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -27,11 +25,11 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
-          - "0"
+          - "1"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
@@ -154,7 +152,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a5cea0ce80-SJC
+          - 8ebdc4ed58777ad0-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -162,216 +160,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=S9hjlywEV8PADwWw6e4js05cQ9KRzWyWDhmmGjXxBos-1731107841-1.0.1.1-dLhK9yQV_CKyEIAPAoavg8MCtfrRLHqsi0MNBAt8Wpxn6_sTdn8t91i1w8yPu98DldRAmqcphG5V2NCq0YOmYQ;
-            path=/; expires=Fri, 08-Nov-24 23:47:21 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=.UfGRcl50Hf4P2wpb9GHWWAlm0SU2aQSV3cR.CnVvtY-1731107841116-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-allow-origin:
-          - "*"
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-model:
-          - text-embedding-3-small
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "95"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "10000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "9979912"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 120ms
-        x-request-id:
-          - req_a64e6e87a3443e548014dec2ee1a07b0
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"input": ["I like cats."], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "91"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.54.3
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.54.3
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/embeddings
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA1R6SxO6ypPl/v8pbtyt0yEvqeTuEBCQVyGg4sTEBCiKKCKPKqA6+rt34K+nZ2bj
-          AiqQojJPnnMy//1ff/31d5NXxXX4+5+//n4/++Hv/7Fcu2VD9vc/f/3Pf/31119//fvv9/9bWdR5
-          cbs9P4/f8t/N5+dWTH//8xf331f+76J//vpbCH0jeKaGhbiPqNaK6vI2vtQnuWqv7KEqF9puqCZX
-          YTU6SiQrXZd5AUiTWU2XbTPDY/dJgk0kWZWIsPyCx+6d4IteH1xxWPum3Df+iUxDplV8aLoARhXU
-          FN/jJ2MXlYt+64O2dMFtdurNQPz0PeMECaQaUa4QhKbNCZ/OW7sT7JxlyhhsNJqZho/4etW90AHf
-          OuqccOuOpAEbRTwvkZH6dT6sddbDUdy4+ECQ3zFe/spAjVdA98Vwz/lWvJzQ3Q3vOE+Hmk2fPHii
-          9WTo9L7fXOMJXc6pYr5qGwdC/o0njT8VKHRxhfd7so1nXvwY8ku+XskUXg3GT19PAssbJbxrzlXH
-          5DlooD2ZGt4yL3AFtvqGUK45i17BUHJC+/sIStEW1LJP95jPdqMELNJSwibr0PHnjX0F78VZONSU
-          2e3XZqbJcRp5+FLeEjbzkmQqm1650gKKYzc7JyeA6nkeyGr75dy5kfsAHW/BDusHqjEht55E+d63
-          CfWpYTLi90yCWBUDahzNdz5N4WyDnqcm1aRMzcW5uBswvXyfXipdZ6J9OZpo/XEoddsL0UW+Dwul
-          UL85Vd177E6nQx4p3/6xprepOKNJvG6vMGTnjKpHSUfc+MlN1GWJg4uvqnWiuy4DxRaGK86b56qa
-          d5/bCJoftFTznN4dudZxUCCscxr4FUYCf3Dkzf4R3gP+/SE6tYY7AfoUO6z7xTMXEjMhIO5vAnYu
-          H4OJ4/sSgRpHFsUPz2ZsuE6qci17n4anx1efb6JkK+Wt13HY3A4ud18zGdSpfGE/WhPEVsHlqfRP
-          uyVrsUXV3Ct5BDU5xcFqdho0H+dIU0j6EMiqjzf5tC8ORFk5eR28tpHPxHVUtsorlym2zShjS/5I
-          MJvnA9Yd0+p4GLagHEpJpf6FGjl/uaAHELmRqZ+HOJ8CV3E2Lu+l9CJm0BHlVGrwWNsnMs8ynzOn
-          5E8KX8MBqxG2K954dyu0O2V9INKr74pOqSRo3+ci3e+/t3gaeClSUrK2sbk7lrFgIjtR2kl0Al6/
-          79Ekv749dJ/yTX3pPrBpcwpDJbuOMQ3X6bObh0p8KL2q1dibv0LMtG7TgPOAECe7KsiF7PDSNnLU
-          SaQoz1YuNtYjUxT/dcWHfU9zEuVNguwMEnyTN6tuvN3WMkomh+C9UAqo0UQYQdgbR2zYsY7mSdhr
-          wHGCjzM1euaj6CgB3Eh1wqoys24avaemsGI/YlNdXxHl1NwGsXvLhD2ZgUZmmw6sGiWmx3Nc5nPl
-          2xyIjV5hQ2nknD3CvIcB7gXeWWObtxClEiiqMWPVP2mInGU5lNVB8ahrZlnOODV3YG2VKt7jR8+Y
-          XCkenOZniB1pHVcDtQ8y+uGfHxCSMz4Cgoq6NekBPrzeb911ATjWWMCq3HHHuesCeKkoo/vvmkf9
-          YdXIyvI8st6e85idWu0pt8FXJ9yqNtwFL0O4GN2L4oZ8EbM/9UOxzvcVVe8II4a18AThKdgQuPZB
-          J6qxsFLW22uCbzZobLRs5QSV1XwIF/IGYl2SzlCSeYfPt3HHGN3EEkBZ7uhR6EJ32pBKRbnkOgE7
-          qXrMazpdodk8HnBcPI1YvCuyCWNVXfFezK5VD7QJ5bU8mKSp1cDl02OXIqGMTewnk1z1z1UkQDxe
-          FZx9B8Vl0kYVgIvIHjvfeatTwWapojfvkl6He+iyWBdSUBx1hw+nYMzn17fr0ceT1UBuOxM1tauH
-          yi9e7eauu8JNoDY8388K+wd7HZNycwrgmxcK4RPO68R3eQ1gsw2OWBuntz6tu0ZW+EFVaCIfq2rE
-          RmSjX3zp+RygMXr7DjK+h4gWdtu6rEwqAYzIfuHfec7r3fAA6K4pvfSFw6ZP+1ihKLdnfJvPt2ra
-          FxeC0C0EetopddWud+8H1K9cpb7PN924dddXuPXbLbbMF+vaHf8J0CM21tSSxEQX21BtFSUZXFqk
-          fB1Pu0N5UgSv7XG+xGMDB0jhjWwfX9Zw6ybZ3YHSSoFJt5asd9zkr0+b/A4XHL99HlHteg5kOQIb
-          3zy8qZiiqqZyhUuE/f2rcanWTQ0q1C4na7N+V9O17iRUbcYOB09pzmc51QzodpcSb7nVhpGwvDzB
-          L8wNxofnuRo1kZuVa+I9qWetD+601EP0uX1nmm2kTcyyfnqBPOE3du+W2M0SLjnlfX09cJjtjZyT
-          +k0AsrWaqWEHd7bgnw2+ELfUNIU+n/ZJmCnlWrCCjbYz3WFUrIeSCpZIPTucENW6TQvbuGsITONY
-          Te8xskHldwg7nOkjdvSKFhq9LWh4R5QxPCscHC/Hgtqf8qIz5Xl1YB1qW9IU5pzPesIFaMiOGd2l
-          npWL/kZS4Wyan2Cz8CP2hIOm8C4gqmcHHQk3c9uCymcutc/5g037YB1CyUsczmRBd7m1GWnwhO5A
-          8RS2/2d/8xBjfy3aMedYSaQcXyeOmlB+qnGOw6vyq8/mIAr573zh9U0z6uAgcafb9fn61QNsSDTp
-          hFhyPbhsdz71LrDRp9RtDaSlnkqjFTe5dKdVqfLAjw/GnS13tLBQAQu+/fC4+oq1MwKc5S3WTr7k
-          dqLvPgE8qcOeQ+uKiStZhUy8XYLpPX1ymt3uNmS785GQd2MhVjN+BJNvHBy6d+YyC2ZHKcsox/sK
-          9h2/4AkYvfgNkP10Kt5W35xiyy+dpsVa0scVG1NlLHUrIJN3d9nBkV5KJt4vVHvSi853Q6rKCosk
-          bPtI0Bt32xkI9qeE7ofzWA14ywSlLMOcmoR/6N98HDwZeYGM1UAcWC/ObQo3UT3TS3njUCdtbEHp
-          3PlGz6vvvSPfNLQVhYUSLlT7q09Sm0kwNBsLu3ASdHbJUg1O5X6F7+XA2FR9JhkypI9klBo/n4J3
-          KCnZlA1k/fDshU/bNXCytKEOKpq8RtrqCu5+r+ITM9VOcOe3qQjxlAfiiVLWW7aSwHvnPglnB3c0
-          vCISgtekRbC5cJuu975pCDV/02hyuDnurBf8AxrL47H5uOJK2OylFvL1wldFSOL58ibt5qAn8YKP
-          lTvvsKuClpwvVJX3Us7WOvag9JptoKhZyeaLn8vg3CUfG6Vaur98g80oGNR0rR7NvEhN2bg3AQ3z
-          luYswjaB9k53WCeDWs39kZig3i/3AKJYQfNR7Z6b4mvnNLOLFZpVOmlK9IzLoN8LKprSY5fJ3JcT
-          l3hL9VGe9gmsv18jGH98kp6qBO7pTaZH6YbQRK7JA967/ZNGrvruvn5pz3/wPnjRp8v9+MPjpkb0
-          cD1cO8ZHHIH8VTPqE7f8w++UIOHPgbTk52wiNYFDkh2pVcu9zm5d+FCILt+wudn3jOnleAKxkx18
-          i9aEsdW1BfQsO/jDZ4X6Mnnw45Npk61dtrGik1y+hJmsOF7OZ8S9AF5BblDHqDQm6EMA6DO/roRd
-          O449nPtHBU8fd9QSvGfHCnJuIEhzQvXtq+6YdzUcJPOGR21773TjYfWQ0dGgO2oNb6Wb/aS0lcpq
-          P9Tea2M+d9a1AXeYLtQ/Fvryvs8VLPqJWvfDyIbyGCaK/lAfhF/0Sa8omx7xK3ONnY/WdbNeKA/g
-          6uhB+Ne6YfwhOaYg9XH3q696nx/PDRyDNsXbSOC7aeDHSAlj8sJ23cQ5PXpFA91VuNOF31bDq3dU
-          4O3shZ0yfOjjkq9w4K/nYMruIxp78j4pj5sWUZOZj453ZKhBTG4eWa2UNp9Wn3BWKuWsBcJJX7Gp
-          rkMO2qDTsYmasmOi7z7AqLyaqi3s0FQOlQErdayw20i6y3P4YsAJ9jGBeNOz6XUba0X0kxu9nc7f
-          atakSyg3gvAiNIl8XZR0LYAsRT22jQmz0b0oAux7YpG5wYYrpOejB1J/6AKhWYXV9Mi3D8XE3wL/
-          +OH8y+cFr8hr4cMiF/Qv9DUSTN1b7XUzRXPww1v60wMz/jg9WvITB6ddiOacBBKI+9HEh6mrXOa1
-          txqZjX0n44WtGf0cSqLsgvVA4KKz/FOvbfOnd7E+3r2cS8ek+FMPdgf3EE+l2KfgaGlF3WGykeAj
-          PwHd0TlspMXDHdz08VRKrSd06yRJNY/TKCnlRbxSK2+O3U/fgD/TGHvxpkdzm99DSKLPluJnfamG
-          Z/UdwZrvCWH0+Gazudv3sOhRMq3NL5q6IdSAWbqG9+FlZv1OPRowNMiizpraSFz296snNCjPn3zU
-          kzNBL2Pe4n08DTmL+ZcM8XkNdB98PjpbG6kHTRqJ1BUQdv/oEw2Ey/L95Zw9nfYBEzoiMt61Vqd9
-          jGfEH2UcoAW/h1vLqYpYgojVdap1XCNbPeTaleKj0I16z4ckAzUOLXrTuLn6g49HzRupYxoDWs7P
-          Uxa8p841OsVMdp8FjLO1x85hp6M5u/NXRZCIEQi5HMRsc+zmXz7jPQtUnbsEdvbzS8h6p546Nqx3
-          5m9/2L4rW8QlSBCgXqdHrB30A6NzcTbRJorOVLsJccwrld0ic9nQon+q6fM9r2QrC6s//JZ7k8dJ
-          Ob21N+HU1q7Y+D5EsLHiLcbn9lMNR046Qdv2Ob5VTqf/9DoUeTPS4ClF8RR32JSFz3HGu03+ribY
-          XUdUo5JQ/Lnf45kiOVD+1MO7da6Itb8I4EojxffxvNNF+0Me8N5r+1+9quj7nElw0uQyqOLQR0xR
-          bRNc93ukO6olSAgPaxMt/kDwco8XJrhZlqD7l/OoXUk3xmqmjChIL4QGHJ/lU2w8JUhvGxOfUKS4
-          o3Z/agp2yhm78qvNJzXpCkju2pd6u7cas5veJT+9R93rrqzm173NkGpHU4CQRytW+5capr0vYk/8
-          qO40mxIH7nScsPMdbi7Z7KUG6lt0CJh/WcWkSGIDLX4MjapBY+LRO7WwLr4keAc9xE3wLAw5NUId
-          n4/Bi00FNWyw0z3Fd05V8ymJuJPymJqe7sW7WpGprl+w6AuyRvGJkSXfkNdKDPv4FHfskoWq0nyT
-          DUkX/OezxEmgMJ7acv5xxdz11wNnViPsy2rKJqWyG8U01ZxeNoc+Hq1zMENTHKsASYPMWPEwPfiY
-          pUGDthyq6f7WOFj4PxkWPJwIRyOwk08aiKV+7fhffCz+GpmhU9mCHyd0RPcn9j18WfSGv4IF/+jW
-          Zt9qOa8ZbXnWY8u9XfJh0h49kOrp0f0hkqrB0xMZvPPpGkifcuNOw3p6KZySB9QomzqeLSqocDjJ
-          LXYdna8oL5eysvBlMi7x3hy3qYZW9wQH8/36jMfyUQMQ68ph9/V5dvSbbQHdV8UbW+/L1hVUutEg
-          oFyP9TgcEBFVK4WIFyWyyrHoDtxaqFHwHdVgM9IuH9ZXs0BjubXoaaXN3dtNm4fi8dKees8i0/ma
-          a0MYkpAEyuIPjd8za+Gpyg42i/cdMdxwD6i1EP7ov34n5ATy+DlhR5U/3bT4lfA5f0xqvA9lxxri
-          vVCRmhfsquq+ap/Wh6AgOmo4e5dqJxqrPIC7gaqAvf0j43IrCODYb3ianys1F7siMhQtnDS6lX1D
-          H7vIKeBbX+MFz7lu9sKLCq7bHbHeBx0ab7guwBcO7R+9O6kIN/Kil4L2o7kdWfSdAmdpSw1BsZEQ
-          vb8tejItoLgcGJr8Tf6En99pe1nnTqb10JRCOApkEm9BxcJkkiBB5hbbn3KzvI9WIBUVImlOt7P7
-          rQQ9+fmFRIDSqoRbc+zhsFEJPl6GKJ8NdapRehYyui/mKhcbYrwA1ipd9FzYfYuNX8Cn+do0a7zZ
-          ncPD2kCrm6LgRW/qc5SdT3CX3yv681/Hg92G8HKEATs719aFJCEOHONo/uM3CGTHXiCpjxe++Ost
-          6nGQX0EE8PB1P10R7+wDE9ohGP/oIbL6Oi/wfU2k+Puh3Rx5vvTjH2SztSBf9D8gX/1g8jC4LZqz
-          Q7/ohWuAIyU2dbaOvi3Efijg/WjV+kgrB2DR9/ieGWk1iiqSIYopR7Ejmnq332UFLN8j4L9SUPEP
-          vPZkCG86xSgW0CgJ8wMYZ1+DXIi/aKTJ5gnaN9KwirSV3pvPiwnyS3WC5shPTDgokEKc5G/Sfb5S
-          NzHXBpQN3JEWV3/rTru8beVF3xIevY5ovIl5K//wN837Mv7xO3QmhzP17q6es8+XK5QuOznBZrRM
-          nU9spEHAcoMw6zS7I9BHpExd41J9/XjqY9ZWoaI8PWHhJ1M8yFmToVzaO9TKrLYavW8awaKnyUqE
-          JJ8F99DD1zjhQFribRbcCwFNuN0IWGaX9/0pegERzYp8U8QY7QwhgRzRkrD2qurz9lWT331qYZPr
-          xtOucSBz+wOO1w/NZUt9lTfG3FP/dN537KOHIbQfxwg2Qimwn38H4XD8LP4aRd/zRr0q92tSks2L
-          p//F1+3UpQG67squzx7fFYzXbMBmHSD3VcpaD+7c6/SPn7wR19xP/2L/LC18K705sOA7vX1ltasy
-          QZaQuL6WVI1tEo/5azaUJR6C9WnaMrYRRQFdilqkwXDQXeY/khDO7/6E7dW1ZeOiJ5DZNhwumE6q
-          GR5tAleJQ3TxJztuU9YS6AXcaHI0dzlrQ7VRXD5IqRY/644FpwxQhyygu2BSY2a8xCtwbuyQNR47
-          9LTKVw2LXqD+vcSI6eN+RvXromL97R/R7PdMBq6aXbz1Fcy6AzqZcLGKPXbf+MOadfEaFZu5O+yr
-          2RYJdaM1sPjfeOHHFXs05ArPrPQD8eEIqH+ZyIHzm5ywTQ5Bx77ZdqV8Do+MelG6RcIkbFXY34Nr
-          wOn9qmOw20SQ5umET7lM8mnd3mVwPhpQbelvzUe1eoJJfDdYj+edSzx1VQPcYMCaGo45fUiqpMRn
-          BfA22T3csYm7J7oKpxo7zjGIx7NxtqFKyZeqiSy7jO/TK7QT7+AfPxNLYS2hBV+xlpsKmxkNBPjc
-          uhlr1fBEPf+wBWV14N74GljbfK62qycIXtMH4csbu/nqygLSRTcImPeQqunSGCs4Ttwd7xMt0Mdg
-          /Dxg6T9Rr7X4mI3HlQDuqelw4E4vd2z1jYqOnq0HU7Wd0HjchppyyO5bap9uoktXHN//8SvTBQ+G
-          6jNJ6LTLBKojR+lIAXYEiz/0x18abU5uYZx3e3zoqhkxU3pqiF6CD/75K/zKV1SRt9MX3keS1bWn
-          Juzhqad3vOsul0qUNjYHtA2/OKhD3xWF0nTk3VBlVE22XE5cz5bBMSTpD54zZ/+sYemn0LPOFS5p
-          OaT+9AT94TEpktyA215WyLjfPeNprSMCNq2HYCX3ezQ+a9VQ0mOyw15TO/n0w6MfPvGbfNct/p0G
-          aZ1a2LPDAyM5MWUwYyxgl0aMsQveEaW9NBe8J1LejfMGWrT4eUP5+Gxdgb9fEyDF+4mt2/hGf+5/
-          p/2FJnpfVE09j4XCYLjRn3/Q3L6ah5Z8J10jVfoYvXcO4qrR/eOHND+889CKx6ZVTB1zz5wGCAlf
-          up06XR/Z+fGC4X0aCdWOb/eH1+DFd56I5ivuZuVUqsrS38AJWDQf5h3l/uixcfEn5rbdECAJ3Jd8
-          CHKu3m4B8tksMG5xwiZJGwg8eF8PVq6RMdGo7WIjPZsGq9zZQ3zcpwZIoxPj/dQcdFGtLilsbzXC
-          +rXjEKPl3oZ10REcdFkc98wObEju6pdGK89l/Oi12o+/YFO4iPloXCQBEnmayBO6B5uHb9qAb65c
-          bAlWUc2Rt5PBTt4p3r4nK2fC+KilKB64P35Vs/QXYOYVlWZEL6uxnj5XqNL+S6Pp4uQk3PQRnPft
-          Cu/qB0MTffSt3L/aNdngh8eGO7uGcMLJnh54qLoRX1/yjw9Q75Cl7iBpb/KnX/vDZzYP0+NPf0KF
-          zYCoZnhXuGZx8AefBjtUQ0WNFDGQ6curpm7XcuiQpMdf/7xje9EGYGO9o+ZmmvWx2bcBWvwnaorr
-          Op53WFeVpb7h5bxdzkcbDg47ocHWFEiIMdBWsN6pHc1u0juezvcXUSLzcaFxe1XdP/W8yoMV9Zf6
-          MX/rbw1dupZwsFKc+I/fuehlrPGtw/ijr9vKjRUq3Z2OYjeL2zBV/v5NBfzHv/7663/9Jgzq5la8
-          l8GAoZiGf/vvUYF/E/+tr7P3+88YAumzR/H3P/81gfD3t2vq7/C/h+ZVfPq///lL+jNq8PfQDNn7
-          /7n8r+WP/uNf/wkAAP//AwAkUor53iAAAA==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8df946a71feace80-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
+          - Mon, 02 Dec 2024 19:37:02 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -389,7 +178,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "177"
+          - "117"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -407,14 +196,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_030ec07cb8e61a3f6789f85fc45bca33
+          - req_5095af9805595f12962128867d977e41
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["What do I like?"], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+      body: '{"input":["I like cats."],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -423,13 +210,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "94"
+          - "86"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -439,7 +226,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -453,120 +240,120 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA1Say7KyTLel+/9VvPF2qT8WIJKTr8cZOUgiIEpFRYWoICAipwRyx773Cl07dlV1
-          VoOFppGHMcd8Rv7Hv/78+dtm1f06/v3nz99nOYx//8fn2e0yXv7+8+d//uvPnz9//uP79/97895k
-          99utfBXf17//LF+3+/L3nz/sfz/5vy/98+cvcLcaY6FXew7lrgna44InpIuCNguntYHNz6PDXi8U
-          FTWL5SLJup1iO8pIv9w7h4FQr1dyKkNRm/T0sZO4vBCxe669jNVGiNGPbtlYVtRNNG84WZeCo3TE
-          pn6zNO5IBgGZhazjy8kI0ey0qQjCfUfwgX/8VJMOUQ2lee7I0WfmfsmssyxyuOCJduRSd/1pokYi
-          dv0mxoWJ+zkvEQBLyo7I66OrlsW6z3CVrzecustPRufg3EC9HzqSnG97lxvrPkAx+2yI56RhNvRi
-          sUri8yoQtXERJf0RzVJMvRzbj6CntMnuEzyl0SfK3X1SWh4XGUwl1UYUpo9sSTr5Lh3YpsM4VbqM
-          itSXv/NJ7ltFzjYQxAl6eyeLyEJSIVoe5xXK/aCSgzyc+8XhfBN2SvaatmmTVXPSHjtpXqNlEqHW
-          suXqwYRIIPjE35QpWu+xB6jGBkeusb/vN7Y2XICfdi4Jn5zjsnfZLsH124Cc3uBmdKVaCZfDRicO
-          NjAa+lukSucDf/Wrfa5Hm5/glsCG5yx8YFyCFk6hDRKMuz5Jns9UdNfca3CZriDuhfAaxypIBxXd
-          RmyGoeJSSj1VGhwQsOm3K5p/wvNO4kw2IuFO7t3FIu0FddVbJv6rPKKV77lSet3IREwmxNqDKNsa
-          bq/1SJyz6LrsftzE8O6YHVaKhKCl9jYe1OPEE6OmhC51pzOgP84VNlgaIf7EswLsn8yD+LdTp61J
-          OolgFrJMoifHaEN9S1V0dgpE0h/DpVzX+ROMZbhgq7bWbHotxzvktgu+FGp8v7L+SwX0vO2wr5we
-          Wpfy0gXN75dNHKFWM35aTnfJ3sRXvH+ODtrsC3QB5kqvWJW4RZvn02xK+uGSE/w45e5SeswANZ/d
-          sX8qCVrVfB+DVygCsdMGVWNIehGuyqb1BbyM0cjlioku6a7AWprvMg5zVgNx5EfYvIS1tl5j3Qfh
-          efeI52hyxU/9usJN4YA4aXCjqwaZDmn3yIhflRQtGwVMuCwbj7g7UdS+50O6HjYDVuLEo91jia6g
-          qqs41QJVKKu49lkK45onN8+/V/OuPZwlb3M6Y/9xcjWWiOXvepP7cgpcFhtvD04LG+BD4mp0tSBu
-          4PFa3vgyiAdt1dPHWfIMRsGHIgnQonCaLr1ou8MXK8t7cmNMB9Fgeyf4x8vdeT0JLLDnvYOvZnqI
-          aMQ4IgCsQBR9SCtuF0aORNbDjRglk1TLlbwcSG1nhy0b5GwTMaoI6YGdyb0vebRArsUojfYIOyLx
-          tFZ1FVFafwoHWxIsEV2DQyyVzWXFVr8oGX0fkYyYgRbEuFKPkr32FGEqI4O453rIxq0CPBjnwcX3
-          U4kRLzSHRFSyfD9JlmD38378iVHoCg5WV/cHrXr6PqMNru7+ZoQh6p5+F4IVyAHxylSM5tjoADqH
-          CYhzFQd3ffplKE1pfSORwkXuhg1SFr7rZb+DEc23kt4l597p0yrLrUa+enPZ7lqMe+/s8mms+dLz
-          qb786VRiOm9PIg+HMdr7jHJSNK5XhAT2fitg3zipGueGV0dURb0hGfhGNSuufZGsdkLEf4xXukBN
-          VuiiDnxKuo22zj0qYAjD1F8gOdN+PnIhUjvzji20NNnyrksZRO4OWE9ziF4c1QtkFqpOcKo40ey4
-          3gUqaWjwGS9eNCIIeOkwHvbkpIazO675LgYR5jP27ZPu8qs/FcDmZUMMpt1Tjlp5AGvrdVhuh6Bf
-          ojBpJSpgdYKrT3qaC50vDWvwIAbcapdmQsvA/v6WJ+kxvtFMT1tTktDFxmZMGUQW4TXAg7+UOLuT
-          k8v/aO8zsLgoyf6jfwsObw48ObXHumKX1fKs21lqoy4gFxB57bseIGUXBWNF0TI2cP0dMLq+EI3L
-          52wkViIjzmQxOWuLnZGfsdfh8uB2PsfSGM0ip+hwfrAFTuC2dYeyZBlArG4QWR+e1WrlJi/tWoKx
-          1YWSS3jqzdCHoYH3un+tVmhCFsLx8MApyYRq8chDgM98YhtnU0UzoQDYBWrtc3s7rfg8NnzJDZQC
-          3z/n+XseQS7nOwmDJEe0OM6huJvVGTsdeblLEN5a9Kl3ZH8YdcTeZaUEUxh6fF3Te/Srp7pyPpHz
-          E6RoqGRXBpm13yRbUydayZIDHLvCIpZuvbNlVLY62LvxRLQqfkQ0LX52qHjR4yRITVhxqYcAOAF3
-          RLW5h0v1QmjBbKcXMVYGqlVN2xYcpvOIU4uTNoq52kBY16KPurSN1pvfqmjbcP3EfPRpWZRVF61Z
-          vpIo70LtM76J8Bg8sPaKy2zG7l6At9YWxCflCX30ZAeKbo9YneWNO0dGd4WqyUyf65i0YjXX2cG7
-          6gZykJMn3ShNHIOiu+OUrambbeKCa0FizRHvxmbsKRofvPTYLKO/zQ2F8hpEOuii4eBc8zyNTUvR
-          h+JH56ZlTjg0aMFUo2eTTf6kCdCvj3g/AGJs6q8Sd3DZi1FP8HzKL+y/T3t3k2WZB4fnzzKJQl1G
-          LHtaEvD3oYHVn6516ZvKM7yqVsenNzjRpqOKin48OmDfFe59S2+3GW6pffUX/pH302f+gP6U90m8
-          ip72W39+ysnE/sZrtfFddzLCTD9jnPBFtm6a1ARlnXmyz4Wg50orVKWPX5uqj36xz1KaoMj191Ts
-          hlc1p+UWJOeVDNh+Bh7iHh7vQePFLrnRsqbDwXgwEvLmK96r2lItvXVdf/3Nrl+O0cr1nAr2Kz6T
-          iy4a2sLmMg/grbNfXuXFXTgF1cBkl6MvHUYNLXJ4bmGTP0py248qonfhwcCy8xxyddI1owfGOcPu
-          Fevk9FrkbO7KzRWAy2v/6TC4oh4ji1IkHbbTiAW34vPlMsFoNwbekeWUjS5nxpInKzM2Awp0uBtP
-          5us/idK4FvrV99vWrrFyHvLqsx8TuAf53i/MzRT1rvbcIdFbd1guhqlfZbjEcOkePTGL2+yu+7Te
-          AejmnqTPYKDDIL4DcGRlhyMjf0RUcuad1K/BAX/1kc+XkAHlYprEIcYW0e5IAwlxeUDS3CgQzRjj
-          AsnCyjjxbp22bmytgWPlEaxl3eIuoiKZcF02LDbOtEdL5sFdnAuhIScnjLRFqJsZWe2A8A0LfU+3
-          4yP5+j2syImJ2JPRD6CFS0jUPVe5q5dWIkSRr2G1c2903UOSSMZusLChUx0tEqTJVw/8mU1Kuur5
-          ngUJaEDcJFWzz3gFRPXLn+ZuI2YLXzcqvAxFwy7U54x/8D8i4oR9R/LIO7isHIw8CLhaibXAPuOU
-          E5dIrZfQz+cv0SLkjg6L/Tz681GVsuFd8vCrnx/9owvmcINybB6w0bUmGnRXPUvlbTKJy/plP96t
-          87r1nwyH9b1t9ny1XH1EykOKjR1tKN0GWYN8g3lj9cDV2syelhhe16SauIDuEJ/zPxf0k13exBTD
-          SesZZ+4AMS6dto/mVq0KXBpQs9vz+/3Vps1yDxKxqEj6CFzEl/67QP7pKBCv1Kx+E2cBgKlcfoiX
-          aFpPzWLrQBJ5CJvtbdUGy9Uu6LUfGywb6jkijjaIglpS9Vsf+pk7Lax4e80p3p+EqZoH8SED3G1E
-          7B+jo4seHgTpU7+nuRim6lUet6r01VPv7E/V4oRRK3UOBMQV/Loi4xFC0d2cdGLVVpjRaxZdpZ0s
-          F5/6jKulU2ZT+vgh4orpmJGr8PDguZ8Ykgt92c/HUmDQdesGxLdHjs78STS/eo8tsmjZ/N3/r2tc
-          4ZuvcRUtsiugVd6qE6Vxk62SVgjS3joV0/WiGRXf+lUApjD1BOceqy1+GIsQSKHkN2A10XpaAg/G
-          tLGnWy4cqnk5CQkMa/ggO7oI2SyPKIHmmuBJqDK56vOjIEsfP4L9V8nSeTnNjcTUujQxj/GKlq9e
-          lual8blL+6Bjbh1k6V7kB+IFNZNNZez7EOi1gzWtc7R3YR0KSRNN3ufVdkI0KZgL+tQPYiRMVK1i
-          czGBnbci1q3Yy+aqlHxgrssVWykYGfvpX1H+Yz6wx2hBvyKt2En83dHwbt9oFXfplAFeR83C2CoZ
-          Otgjk8DjRZ/YaNonHed6CCB7O8JUu/E+G87ldoLEKaJfP8yZpN19+1css0mJ6E1432G2G4loe453
-          ZzhRVjKUc0+sqzVnC6n7GcEwCzioB9wPsdFNItvwFgnmRKabF5VDSXd0Boc3znK5qm5lxN93Fs4c
-          smgjm+94aS2Q/9lPesX5nnDdIt+uyP5HuFSUDS6mUCdpgs36tmhrmhIROWdCiE2MJ6JnxutQnWTJ
-          9HPyVnf59AtgKekJK62saOvDfwTf/vvj3wM6WwHhUeyKK7GtzKs4j5Q7UFfq+D9Hxc7WZonh14+5
-          CWE1mhabHTrcIuPjZ3YZpVSbpdR2dKy+OsVdLM7QwWnJBu+340ynMjYYhO/v1p/5zS1bE55twb23
-          Z184Nk3/W18W9bD1Xw9oo7mRPRn800mYhFdWVkvTGdPv+itfXrDN1QQ9mssdf/TDXc9LMEn1U8bY
-          Gqxj9OEj9VevsKInLzQ1Mb6iY+S9sJMQWWMPrn8RWk57EUVOnmiJvdUDQ6W8T6POd+e32IYw2fVx
-          ajeZ2bNhe72gi7KRP/reUHpi9DOa7VrChzpZ6Hxo4x0srZdgs2lTOgVwisGduiuxZOsVtauMS5jV
-          w5Nku/qVLReP9dDpwO+wtuQ44oLw2EL9lCOyuzVttZinHx1dU3tHtDRvo0XjNBZu8nXBsWQf+9ka
-          pQaxMxI/fnGt6HAEGbzXMfYZUm5Q9/TLAp4jcYh+YYqePLPkDj/hoBLdjado1tuzI20T7oVtI1AR
-          dwrzFvBTsr/7Ac2xa51//bXOM3a/Fkvmw8uL88/vJdGyD+MWjaJ0nTYjeBFnnJgGHXsU+vyHZ6yj
-          LccgobONz4em7t8/EJrSD7osRGmTkPKs/5LRKcLYLxT1FNHHUSjRPbjtp0rrbI1ohXABjpSMPwtD
-          UlHF9mvgeD731wOnu3wRG3cwZ3VHnFYMNI7muxrOC1/7pZdI9L1RWFPSOnPFXqip1eaR3Xwk1ebb
-          F1DW9kvZeT66BtcnOX/mm1bZcQCjMy7408+4E9ucY2BJ0REsKceIrWUtADm2H9j+MRw0Vp03ifTs
-          8Ti53rDGsqdtDA/zHE4fXuLSRSAD2pg8+vUTsxZMDXIKJca3TflEq9Az8odPxdgT/HO/3DyWgcKi
-          tj+w/qYipdB78H4qG6zhbtSWNd8lcFb4s89GcRBxZzKKaHvf/RD/ceq1WXNVB/gWi1ilnaH1aHzz
-          oKwrP0GYxhl90V0Ax8jrCd4rZrQYJ6ZGYSaGE5N7sru5M+YZKeW8kqQMLW2+yHIgJRkqsZw8Hj2d
-          grOOtrDq2Ltoz36+tHcBCmKO/vrqFG0uZXVGxuFCsVWGmbucO8UDVdRLfDaaRzVVsX8F07Gaab27
-          KaIQxA2Ma8Bh16vf0dT2iyyp2e2BjxcmruhVePjS8n7eyI0IfPX++C9kn0nmb15Lkc1fv/7pR4i/
-          Pz21NY/3vijCGuPdZtlGa7lkA6RvJ8COHZwRp4apA2p/e5Nro7UVVbXuAid3u2Kds8OKdlSRYVTD
-          N9EX+9BvPv06OJtkJsZwk132yw8muzmSfSWs/Zh4IgN75r0jhnDTNG6TKywY7RRhbyPo1aYQuitY
-          F4sh7uAX1ZouAWy7Dq4kHORE44UmjYHleRfHbryPuLGzJnSO8AsbIXPoN/NRCmESf2ai2XkVLVPd
-          l7DOKJy+9fTDM1hQOtOZZHGTR+OmbkKomtTEOonT7Jc3tVEb4+vVJ9XclT9XsTZUC2uyDNqYkalD
-          WpZz2FdGimjJ4A7y4Hb79tP9pz4F0rd/wpLCRWvvDyFojt750jKOlHoF2okfvouVa+JT6jK7Di72
-          7kwiFLcZiRjNkerbMOE9FTbVrAZNArfUvU6l6gZ01keo0bQebOypaZCt9+VyRb3D1JN0GCs6WG3q
-          QNSLnf92s31FvSav0TQLKnEa8nTpNogaiOtnib/6tpax6aPzwrZEnhMZrbnfllA/1WhakgdXsfR2
-          K9CXD1o2KNkmE1qAc1dZRL5v+IjyYxuLVZKqJBiGtZqZE9t8eca0zbOoah+3QBUrYryxK4snl0Bw
-          beDL+/3HCJQWQneHi1hRX3hlSsV96hW62raOvdan1aKGh92X12H/p7yi7rScfXQ+sFefZWmBPv6B
-          lzbcVcYWa22i5WEdVulY+QT7VtnRobydQ1BE3cexbev9Wn2IeFx52bSSTnOHh9EAXN+u5y+CbGib
-          MrtdN6I373B05FKtS2LVB+mYD9OWZtvqnXTyALYss9jRRd398KMOABaZ2Djzq349MvLXL0w83M7u
-          l4d89GEi8Z159EtAqp3EBtuVOHYgUIKoGSBNOWtY3cmutgCkukAukvDhT7rLx7E9IHa3N32uoHv6
-          OY+7b70lZhJW7rIqYgP4KBn+PAxrTxlqhajllBfeL+OI1sJvV5H+FBeSVx7vtgznJGh7dzVsJK2M
-          Nl9+mct5iuXL5hitRm7qiDP5aOJnS8341W/Kz3lm/VrrGHcO2kiQGi9x8Z6UGppy/ucM1+D6IJGS
-          yxltj+IM1+D+wFZsjdHYWrGKuHZfYizybkRX6hZie9Qy/3F3DcRSsQohZl+dD1//KfSMCj/r5GN9
-          ZdpqknO9lj7zO0lUOPWz6+qtpJbUxLYgKhrby0YhxvrzQvRHzkRLbYUzWOeJYuWc7NF6ip0JacrF
-          IvrEmD27vZ1KaKSxJLs+03peUTYxVONQ+ognjDbdeF6EL2/L90qT9QmjiRBHXoQV3y3QKNYk+PJz
-          jDvejBabPHaw2xGN7KVT4S5yGLTSG06nSVAauVq1tBAB1aZC9h8+MZuuI3z0MMW7R9NV63c/NxBn
-          +Kr7u4r7+rMPbyPYOCUupUc+lH76yzi9AsuLKBGIh8boLWCdYfp+ft4OAUjPnP3whORTr2RZjOPX
-          /ft76eiQxxnkcE0+eir3nE0eDpouP/VUNA+zWhhIGzg9eA8bJuP3tBaq6VuvfEriZzRnxgAoK+7H
-          qcNGQFeynBhg86Ih+KBY2fe8/urXh/ciqtu4RqP4c8WmTgW02jmOYXAY4cPbsMYa7fkMn/xw+rkp
-          ffb88k09pA2xtcyplpD0gkRmIcGZXjfZPMjGjL71RE4eSv/JkxIRvHkm4ch52kisuwqRFG0/3+9r
-          /NPvAuBaXJK9qYU9zbLIAwAqT+Tkhdqy1HUp3W178IVo8aMPP4ihOaqUfPufRcq1RoqQMBFzCjuN
-          ckd+hjl9Gr9+YP7mF1/+ETZuhua0XBjpeVRz/B1/+OQdMAueSfKJtzL65dcfHjMhr95l8+Z2UiHp
-          yvzXn9IDo16AP+PV//Jhwo2tiTaMU336d6OicxCw0icPIPeonNBC6mr95qtkn44m2hwLTgCB5zJy
-          suERjZ98DX3ymon/5JXzsT2et0MYpL4UCWNVf8eviSVh5eLqiD0YD/jmkb/55VhZYSn5Rxh/88+h
-          Nl4M7KVAwedn41YsPS0mZMumwM5ONLUFe/Mgffw7Me/h02VjF5+31pJV/8Uv1pPAwyGuS3yY3O7T
-          n/KOWN+mCe9fpYIGeUQxXOfrSC6f/oK7kOkMJbb2Pt+Fb/fLh6Dm1BOx7aCi9CnUnjRumwPZv8qC
-          UlPrW/j4p+mHekh7CLmqSzdlA1g+D321fP05XFfWp59+mVVHVgdzlnffPIT+ru9SCCLZOxqtxo8f
-          h6t8v2Glc9+IOMV6ln6y83OaFTWJyOsolvDN77Q+1jN+8scQfXkh98l7PrxikJj+nBLvrpk9W5fc
-          XfyJrT3eE4GrBtf1OjF/UWUSP3nq+PXfu1Ms46uf0miS7H0CX//mK2OIln147b58ceJbS47YL1+o
-          Ddki1hPeGedwpv7tp6d7OoqIImoWMETvgtjvYE9/8+4xDEey2zdVTz+8WTKE4UTsV8b3tM5ujLhp
-          NhqRzY2fLTqnmwjfwttvXsfv+HkHyHcrn2bd4Tf/g7/fWwH/+a8/f/7X94ZB097uz8/FgPG+jP/+
-          76sC/978e2guz+fvNYRpuBT3v//81w2Ev+++bd7j/x7b+v4a/v7zZ/t71eDv2I6X5//z+F+fgf7z
-          X/8HAAD//wMAybDCut4gAAA=
+          H4sIAAAAAAAAA1R6S9OyPLfm/PsVTz1TepecE94ZAspRopzUrq4uQERRQQIEkl37v3dx31/t7p44
+          QEoMWes6rfznv/78+dsVTVWOf//58/f9HMa//2O9dsvH/O8/f/7nv/78+fPnP38+/787q09R3W7P
+          tv65/efLZ3urlr///OH/+8r/vemfP38Vkm7D8XW3gRBL9Ufj8quDqq+rxH3D67oGh14hYSEc46Vf
+          IlWLqikIl+y2j5nbyRNsGz8KufBhN4Lg5S8opkuCbrNxKsRqvkXqkJ6yiX+XRsM/dQzhYGYf4shO
+          Y9INSELYOakXTo0I/O5b3HTQptszSkxlatimO1AAKi1FZdY7WOjKJte2+miSoqoPQEpO/gA+wwMT
+          37R6fxbcIABOKigTC5qPT6ql6WDj7HxUWs8DmL3wykGC9ZC4+XIvRO18zYHul3cU1fOHMeNYVcBc
+          jia5nJ9lTDcf6aIdrclBu+fuG7Mtv/8AARcNsu10Gy+21UK1uM3lxI47i4m+FchwO0AZmee2KejE
+          wg4+Xr2BrF0f+gLxlQTu/aNN8tnRiuGgohneOLEie5jfY8kJahkOYn+dgAJPWLrtnRo6zcVG+Vde
+          ALnifq8+nDxAUQOThm2Vy15b9PRG4qFKwXzL1BA6ij9MnHTi/SUKywgcfbpDZnoxmITBs9c8Z0wJ
+          KrM9IzpjMlxUciAe9t4+jV+RA32/3hP9YuqFpN/vFtRftwPJ4MkypRy9ODC3GSFeWE4mfxn1Shts
+          tyAuTOKCaT6ONBwMG1KGyRnM2vdUQldtc7K9PUwgaJlvgKpNPHR6mAYWTvtHpIXNUqKz4XPNrKLD
+          DJ8+7YnfMAzYul4w2H5BwtsHAUmzPE65CXIZig86NhM33SdYNjZGxmI/C2ka+AlyzVVEwe1oMT7Y
+          XCPYcP2eWArvsOXTLLpW1ccDKVXwNefru3M0boYWuhyiky+5SazCzzK+UICNCSwv5D61VyP3E7Qn
+          0MxT5Eew8bM4XNC1A3TZ0b326QZxksuzUlD/8pi0GzrX4fOQHph4vz56bX1fyKyynLGsimQ4NMUJ
+          bSNgY14fF6gVaruZQKRZhbDNcQ0F6wiIrhFUsPaKOeWdJhcSORvNH52q5qBYW/kk95pQUI+kmabc
+          LifkhienES+hrwK1FceQxvuDL9LlFoASMYmY5+gWL8nsRFqmtQ6yx/MjFhvQJdrotG5IC+CC+Y6/
+          Awztx4fswDw2jDbHo0YGOSa5EzzBLFzOtWZX/RuZ0yjG8/Zz7WCxWEdUGktYSFdVyJU4BfV0tDq7
+          4MWwzrW1P1A+Q1KQ6nlJgMgFCYrjmcMsipEIvpkxIUvRRdBp8jDDzqpT5KuziZfSvO6hZOYHdIzm
+          pz93m4MH29Q8Iz9sGZ67+GloB3yakW1XJR7TxHdg6YzqRHvTAowjnz0E2TYm5/H8KBZ16/DQSv0G
+          mbWtFmzFDxgOpEK7qulxh68XGZ41Z0HmJjfw5LZ9oqLKDQgScF7Qkwr2sHu9dbRvm4HR9f3CLuqP
+          yDN2UTOKd2MPbvSbICfJJjxnEaTgKoR7knAxz4YnIzm0zJCFy6J4Pn3dcQjb2+ZK/F0i4DHaOKqm
+          C+Jxkny9iOdpivdqL3yNadPmlj8/HOsIPwt5ERNvvnhh3afWHJtwxHPdo886Y87ggXvKk5xkIRZ3
+          ichpyalL0PG4MdjSuGMGVU1/T6qhWJiGhkNhx6k7lJTtjrFFNWUo6e6OlG199Fl/j3hAauKG6nAz
+          Yz7fzgbcZe8TKiLNinn91HswbFiJdBnc4jGJ5VIFLzecWs8MfX4UwAW8ufMOBfZRjQm/oRTukQXR
+          Tz0vrjpT6FuVi5B32JokdZuLtsHKg+TMR4AS/EkgtvUdivanuWDejAdQ4koPGXk4Bdb85qi5Vfoi
+          xi4xfWGRiAPjNmqQedpsYsLFWQT3jrGZ5Ns3wJL6DEKot1OKHIe9zfkhy6pmilAjhTo3zSLeDQtc
+          8PmM9tUxBLQKRg9clFtETovS+6wVGIVfenyhUyzzjO0UrYQZ7i4k4R8eow/vYYB7VVJUcMWtYePb
+          ncC6XlLJu0+Md4pQQl70dWKSR1ewT0BK2LzSLXK5hgEcW3YInNrZEOM9JqbUesdeW5bFJ+cGfeJZ
+          2z0y7eJHA8oXpcSYvMsLLB3n8PM8TMtNKmuHpt8TJ0hNIJZNuFeKF5+jc64ImGi5+FGlU+2gcxAr
+          Dc3jeq8NQxojK226YuiC7QDWepw4RXw3VIwLCLAQYOS4My1o+44seENpjdypV5opTa9POFJORc67
+          P8f0vrNETRuCJ3Hv71Mxp+Igg/KmUJJzkxIvMlte8LHc32jr8BJemuzBazGX1CjaUqsQg/EaQvU6
+          UbLnvne2NG/Nga6OerLbREMx/+DJ2O3tUEnTvT+WnF1rD92UCHqdF0z2m2sPH2rRTtrC5uaXz3gs
+          qGj/oAfMvleuh3YjVuQmvQijs36TYTiMFdkb+tVc1GPpQSXdwum9O9OCntNXCC6vU04OemgXUqpe
+          dHi55m3IT7na0IP72GvlyQHE/sQmEL/q9gMP6dMnh5NcM9Z2myM8ixaPqlw2fQm1Jw7eFHIi29np
+          2VpfDoyVQ4wCODiNNG9fkea/njzZtZc2np+HutTAyw/J4aGKxfK4vCFc95OYs57gxbSMF9zV8hnp
+          u3eCeZniALbL6UDcoVBMqm96HVhOopO7vl/83/66XC8tsqZcxdP+ASq44huKz5EWd+SjzvAV0C2y
+          pFHG367EOfzZf/f8+jTL7qJasL1p15Axs/Wnobo7cOXn6SNgGywPXphhlM4eiqUn89lwjEJtIWKO
+          3HlxV/43dfhp2m8oWm+vkTbdbtby4GiSasCyOQ+TftGIALbhlB7v/jyc5Jf2g4+BR68m/zifX+pd
+          z2QUnESx6U5fXweVv0/ItqoWcwQOE7V3dczJjsmV2bMvlFWTM1S0beORDepGvUDTmc/kaPKC3wmK
+          LGqez91IUkZ3MEmX2dGkppTRCV27la9zGfK15iDnG4gmHZPOgNly5dCt4xibQfLgoODY87Thp4NP
+          D+9Z1m5WNU3csnUA/1wuH3huoULC9P32W+NYlXBrLzrKpYeOeajvPO15G/OQwfNsjo07JnCm6Dmp
+          QlT7Y12HR6g1xzrcSKWCp514OUKzEwwSbzUXzO3+XUPcQQHp5xHFgnq79L94GhRu0lCrvEcKf3Mi
+          sjuMjU+nstDhim/EpYFcsNhCAZRIZ4TUER+MuUmhwvfyCpHb3mpAr4WeQ27mLGI23gAWGm8MtV4S
+          RI7nkRQsdi8T/MF3ayJ6MyvZtP/Bh3AGngaoeuqfShKUBbm/Ew4wRXwY2tNpnuF4knXAdAZU9Ux0
+          ERmFfWazUSkJNE/LLmTSM/bp1LAEmulbJakKAWbK91VDN70+ycU33vgbFxcKJ/pskLX1n74g38sZ
+          /qz3vOqB5aS8Jnh8UUaQd3j4ks6Yqi3pIw3FxqoZbUCdwIJyKbE8bTBna9Br7W2HN3SA14HRodQz
+          aA57D91JMbElm3MIlNSExHqoJhCD8RTAfuEPpFAVDszO1qBqXoVsYqu+oPeOhzDy7xbRV/6VtmCS
+          AbGHYlKE6Ww2SX3WoaCXe3IQ2yeeeWh38EDPEzlsNx88b74vD3jaxSdmH3oFFfyaA1123xGfKzRM
+          +3BxtBWPCNpKc7EoYHjBH7wKr7bJqAwpB3fOLSNm8prZcHWPiTZ0dTUp5bXBw6r3QGmaOjI/A8Zs
+          uI81HLpntdZvx6QRCAncIIyJbRhmPJ2ddoD2wl3RNrIF/KM3NNEUX0h37biY9oeqg0wR72SbDLY5
+          VMzToZFWL+QJUW2yzPAteFLqJKTTcwa/+pW/eRGxmVNjPiPBB+7QI56gdO0Laj1qqjlXexsCVeEY
+          Kw81D53ItBCaqgeeUVLU8HmV3+TwpTuw3PnGgq7GP5EPH6YvckixoFiN2UQVZzRpWB0/WnarbySJ
+          tt+GvTT3omZO9p6GIT2YfCtFHnwM8YACE6Fm5QcVnm/7/aRaveXz3WbnwNVvhpKxOTbMLh61dsnc
+          O9pxVV4s0kfYaz94+BQ+YcHXaHiBXp0R2fZCgOef3xdVLSA/fmB2tt4MIv0VoR0FR8Dgs5Ih7ZI9
+          ukT7xqeLrD0BU/j7JHLfDZt+/MUjRWSi75H32+7ueICniowOFyco+EPPV7Cxjhk6zMYppjw3XCCw
+          rIY4xsEBokduCXzYNo9sT6p9Er/rpyajYSSuTJOGcoMuaxvVLIlumClYrldqwCcFMfrp/xVPjvAc
+          sS1ByuFqTt1NmeGN4uTHb5s0Vdzuhx8mJSRfwPzrvIeSjQxkfBFlo/QRLCgqtk3si+/64k3SPlC0
+          v1cS5EFbUOy2Pfi81C3yjocRz98iNaBZNZDoU9+aCz11ATwTQ/z1RxRl81FTnPC6vn+1oK6f1zBC
+          J2WSX2NvTv14p2An7lFIy1w0p8vC61qaydKvvhfKhzRAn3YEZdU0m4NchTmEp9kmR0+mDb3c7gG0
+          8uNMjEM6gsWCz0Bb8Z6Y05jFs6s8c9gg30F+Mplg1muh1M4vzwq5hxM287MEFJ4xm5CHjrrJi2GX
+          w1hB8SS6Vobn7TVd9YYJ0YG/GL5A570IOVSnaOc7p4b86METrc4kqHD8i++gp1cV7bYCa1j1vGTq
+          ml9M9CgFmEfdnGlrv03aZ3JiysfbCDav8xa5qtWycREuGbRVuUBRcsXxr5+9p/VM7HaK4lnech91
+          1WtoN+B3Q9k+mMEZLxM5uME9nmMxD7W+fdjIxP65GUfJpVBzZIJSK9+ZUiqENexa0QmVVR+SH/6U
+          G+MRjrIU+ixVLwaMqZsR398lgEcYeWDNB8KpvVyZ2LreEdA88ImZPipzVqkmA4fuCPntr2AweLij
+          go2SNtP8n/rUTHWhyLsafcG2Dq7gLFQ9CcZWj5dUAkeIl01D9rf40VC37TMw1xENuduHsOUYuh/Y
+          KzcJud9QLyi2LzzklseC/FVPT4LldLCKvChUhw/XkPs+DsCax5ACPkxT+l7FHm5uyydsTaixb8g0
+          Xu0EaKIsqV5smQnvwAg/CDquecoyx69MC0/8QAwx1+Npf8g62DZuNGnV5dyMzy3NQF4FbN3fGNMx
+          qXXt2gjmdHU4D0tC0idwFEMDGW0Vx4woSgB//L/Zfi+MDk3XadnrVZBj+RziuXlNFMb28g4Xc6M2
+          8yn5BLAWXIsE02tsKJGfPBQbBU19zr7Nqlcj6C74EvJfu8TSmudAAbnjJLl7nfG6dojAyt/I46br
+          qkdHDm6e2p34uvBtmLW9iWBONwNa9Zo/PU19gE39DEgQNHIzfKWXCOvKKELoUcWnX3X70gb1HpIt
+          vH/iWck+FnS7vkeucBTYkEyLqq15yQQckY87yXb2YPU7IfV3z5h1jwxC/1XzyH16TzCO0nYGqma8
+          0U4xtr547l0Dpo0zovCpjICoh/YC3wqSp2X1Hz9+CGwcfRtu4g32R9Z9nmBE3z25oMeC33ok19oD
+          lS6xw2duCs+tmsDQHJYQ/uRDySb+wERTXeR9rTug2c2qoY8S8Ov/pmtfTDBPowVZWtZiKvmgg15j
+          74n7Hh547mM4AFBnVxQcFTfuDtm5B+Nt2aLqAXUs5hs/hDcnbkJFOKZMJDYXQl7RBHL3Ob0Qdhdq
+          ac51tyUG5i2TXZiXQy57xSQoXB7P5vmqwyeWUmTAHgNa9J8cqtmtJ3fTbZrFqTezOr/sNhyY5ONp
+          9XfaGQdbEnobBwjHRZkA95pC8uNPGYz9D3zbwW1yF4T9ec0DNKVxpUkD+7Bho7PIv/7BKc9KvFh1
+          lAMhysWpeeeX4ks1M9F++IHjmzUvFoQBCu1rQhHWI3/1hx/A21xOvH3RFIICXi/4SmcyKY199PFO
+          0Sr4bk8OuTmI+jOy7zrgqoP2y3fLUpwz6NgjR9DXb/Cslt4RYs4bkfEIHVMyHc6DaWpQ5GjF1hTR
+          x3xB0eRf6PTkt4DQEJRQwXWArg+hBHw0cwaUnX5GW9+U/RF/1ReMOCqRA4pJsaz9Djdi0E6C4sNi
+          5m8PHVQ6Q9NbOm3xvNlBA1LTCdH9ae/NZYqvPcxtR0Tu5vz+1ZPQe2k+qnr10tDnhEU464wnxnNj
+          x1+89yqYvT7FL5/wISWluuIBsc9nEczOLXrBXrlLYRA739+8Et6Dp4F2TObMiUPK/ifPDfuvvDAh
+          osEFhnbzmV6rv6OHtyyDRYMpSaxRB8tzq2bq7dp/pnnlf+YF4KN+0ttEotUfkC0fvsDztVyIMb5N
+          TPvKqrTD8HHC2fH2Jl+42IB8Z+4minXqL8msRxqHZ5/o0fw0GcPmUTsIL3HdryUmoO1ysK6foNPc
+          NxRlcgQ31qxMS/pNCrbfnDpo3jgUip2I/Z88Bd5ut2IStyYG5JzRF7xwn/tU2xljk70TE9g67DEt
+          xk43aU73048/IPvwzOMlCS4e3BH9hLL70/Bn6f2ZVEOPBnJoAhczT6sDqOrTLtRqVzKZbQcTfKjX
+          lhhr/vT12LHUXHF+T/B9InjVKx3cOO0UCtLpgYeFdzkoo2n8rZc3PxkDLF8XkxhMmABT5A0Pzwr4
+          ImPN79d8w4N+dlFI7NE9rt+9B8FLsZ4kMJYp/smjtI99ZiHIt1u2zhs4IDWVTLb3yPQXhbeOMKND
+          hmxZ7dmySK0D0hvk0Q3spx++S37wiDjDMcbSFnxkSPSuIvnW2RWLejt2ml73F7L6ezwXLtZBj8/w
+          l5/mJ2sv8Fphb5KMzYzrjFgfiINpQ2x9Pvqz338p4EVXR0aZZ/5ya2P1J/9AhxUP+rLZ7yHMJxeh
+          6t3GuMD8rFU300KGI26BGKFnB3Hq6GjVxw37imEJr/rjGMKTKGLC7MKDJBUzZE9JiH/8trYQPifb
+          tV9FDi0WPL2yMlTKJwfmWr9GcHOFCypKMmFq4rsKYfpZ16zYgFUH9oRJdfXD5brZ+cOqd6Da8iPy
+          z+VckJkeZa3HKUTWUNc+HXHRA/mlflBgLGHM2p3twLBTv8STNdVfgNKVEKUHD+1PShxLUYx48GjS
+          HnnTWWMLnUMRljdA0Y//Hg6JI2qL+XqjY/LY4nW9FRSD+ROeajRjqlw9Eei3AoWiucjxDMuEgxfu
+          dV/ziwOj55dUw7BqGxKkFyGej80kwnvTYWRg/uWzmV7kn/lVOIt4AewkbjiYqHhLwqmUivEHb73c
+          upAqiRdGjuaDB1SNRBJeqAaG5itHUKuslviOmBTUIV4PAT25KLU/FDBxph54qVyLrH1Vm4J3khy5
+          cF4v5K55XB8a+gxPt2OFkFReG15QZB6GnfxFO+1x8EWCP5n6Ow9Kv3xBnKBT4THrZHIMvtRn54x+
+          IFWPIqmKbVUMa74D20wpSXw1SzB+U9+CvBZqE13sZ7wsFp7gXqnG3/nF6jcsrePkHfrxy0uAgAGv
+          7d4PgXDbYX6vy/vfedrB008xgc9MheesFZG+4gcbzHTS6tS6IiN4FIAVTtCDp+gUo7DqCZ4fYAIv
+          aPdAhy99//t7a7leSbbmlSs+VNotu1bE46vJ7NTSOAILbfoJZ/fGXJq34IGtCf31/g3A+s2JYEki
+          AfkKXDB9RokBN8T7Em/N2+fhNL/gEX3UqV/nc0u0cWR4vmE2cYoRr/x+0rWf/PC28hFZ6w/qKE4m
+          ajcmZo31pbDIhjtKYy0seC88QQiisEIWFydsCY+HCSbN2woV7ORM8q/yXnHJ0CJrnaQK1SBbUOdo
+          hPwUn0zh1F8v8JN/AAqFmgfzofg6cK7AhNb5XzzWsLJgG+hfkhZbn0m7vWr8zlt+6m/e5BcRlpkg
+          TK27r3/1KvS03Ee24VfNEjJBhLpzOCN/9mxMMdY5+WOnjOx3Twl8k9k5QrTcdHKfqkczh7Qtf+qL
+          lIezhyeslhGk6Z772U8wa/JAVamKNhPPwqAhpT4kcDzpHkkXrsGLbFocdM2KEksaL3hyRaH/5c99
+          eE4a6vNLDa+c5/xbP74tWMJWRSjk5oMIph//eUYPOQRPI2jo++LJoKAwRcmar84c50A4Es8iBtap
+          ObupGoE1jyD2mucvAWK6Vi8ZQk60N30RGl8ZDkHUoUMuymB+9wb309/k6IJ3TIM6+a1PctOw7ks/
+          /8d3Im7NT3Q8p+3186NvkZczt/nNO/e3UEKeFntMtPPY0XDq6cROPxKed87xov39ORXwX//68+d/
+          /Zww+HS36r0eDBirZfyP/z4q8B/Sfwyf/P3+PYYwDXld/f3n3ycQ/n5x9/mO/3vsXlU7/P3nj/x7
+          1ODv2I35+/+5/K/1Qf/1r/8DAAD//wMAnIVQ194gAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946a8893dce80-SJC
+          - 8ebdc4eeeb067ad0-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -574,7 +361,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:21 GMT
+          - Mon, 02 Dec 2024 19:37:04 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -592,7 +379,208 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
+          - "2340"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "10000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "9999996"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_4b3ad06e21a0e74911f2f83c1d770806
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"input":["What do I like?"],"model":"text-embedding-3-small","encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
           - "89"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1SaS7OyTLOm59+veOKZ0l/IuYp3xhkEpFAQsaOjAxCRkyhQxWHH/u8drLVjd/fE
+          AZYhFJWZ931l/se//vz522d1kU9///nzt63G6e//2K890in9+8+f//mvP3/+/PmPn8//b2XRZcXj
+          Ub3Ln+U/X1bvR7H8/ecP/d9X/u+if/78FT5Lg07nUR1odBlMaF0LhClG57VlctUOWpswILnMy21+
+          Rkoq+ZJwR97lQ4b1HjsUhP24kgtlieG4ZWdbipJZRN48ehmrvfIIJAdkI8c0uXDppVmXUtBGyLsq
+          lkYfhZwHHC41FB3i0N144y7Cz0gTdBmkQzjyfd3Atfa+5DY087AqfGKLIuWxxORud3fm+7qTSMZ/
+          iOt8o2F9iwDCXlYH4sjyd1sPCZ5hN/MPlIbqIZvpi93BW+F9yfk9eICrgiEA2nNpiesbl4wEnbxK
+          Ss5zBFEDqIn9zGbpeqafSFXDYZufCGO4jA+fuBLdbttmLzIsgtbzjTB9ZYveBIX0WtIv0gr9m82W
+          S+kwOlA+eVwtOWPLgL6AS/m2icLcarCeinmFaAxUEntsMiy3uTBh75AOC8cs2za/vn4ldLjNWHy0
+          WraUFsRglPoTQet6B0sLPAhI/2DIwxVOGRtQYwxR0bgkVjnHpZEiVDBSxzMpWMrNNnXUCtjrSCfe
+          5YOGUXiGqgQ+XeO/Ok0PGfU1xRDdzxa6TywBS8WEFZgvXwNvfErV6yf0G1ghsyQnELMae9SADoXc
+          mJA/PRR3U5hclayh5BFC/grmJeRtKTTykDxpa3BXt+xj8KHGA7EFPXaX5G1U0qvIMDHo7qxVxBEa
+          +Fzxlehy67ps+74FUHBjGykBJGDjZc6DIuWzxHjcybbmrU7Bl0LXyIbPEHAXpEN4G8QXOT6eX21b
+          T1iEjJAdiDyZlEa6oacAzGRAYn92N3YFBYZsai7Ib6Y1G221raCuIMmnXyE7zK3KqVBnDRvt7zf8
+          ZPkpBSN/OxKkf9WMo2irkOpPkyM1AQ6gq9pNIbOCB1L646ItWVmaUqd9nwTl/dPdz88IDwlXIL+3
+          Z3dRX1MEVfrOE4OyQEj0bybC5/L++vwhn8KJrV4OiKLmhY7nzs44/Wp9YWgUIbLaotHWpdYdOK++
+          R6zrKNeceVtX+IxPkCAje2zz5+Ta8GN8MnKilg1s3DNX4YFGHtEXQ9RmwfFnyXXRgBxX8MKBj7Uc
+          yuQr4HcvKBuXe59E4lieJSGfFvX2+SyJRMdWgnQ2dTVGZ1RVusYyT7JzGbiMdxU8WFz5AN2TXNuW
+          OdU7+I2WD3pq17O2VNk5kZioUFD+YQOwVlSoSwwt2+hpG6U7ajHrA8E5PYjF1E93qS82DSPx46Cs
+          n87hbH5TEaoChsSQ7/eaGaPQkdahzYmpS/G2nw8f9vfKRqc93mgYXUSYrdFMLvjKghVxWgSu8xkg
+          zZ+drQfeIkrxN3fQUROXcDbvr0iCPV6R/miVbIHdIINJ2EpycoVTOHERI0LB1HSy5wMw3t2RheCa
+          uOhiLgjQkhhg0WgHhA+5eATL+XRIwH2ZXWRw5wNYtukTgD7JHv7h/hy1Typ+fUhuY0DUPX+uHi/y
+          8DX5AdFaaXTnJqgukjvwD/KUtNBl/e4+Q8K6I/JJPQ0/8SxdT18D02HUa0TEhQxbBvZI426Jy5r+
+          5kvvsmh88pACbblrIguJmnk+NT0UjVOcPoas0PNI+RSqxkSv3BTFMerI2c2McL0b91TCcwWJfBXy
+          bXVYtP7svz+DG6dtWTeUcFjx3RdH9boN7bO9ACXBBXLXsstWqrvI8JSLABkVlrfvPEYjiB1RIwqb
+          OtoWGjCFbuF16NogNxxFIxClNFdOpNjjY7LuSQS1OU+QywDd5cInVUJp+76JNrGnjU0cFMATH3yQ
+          wj2CbDmYcS+dtU3Dh+lMhmXfX8kU9RcxuU8N5s9mU/DFtBqmn6cPmO+lYEq4d44I5f3BnaSEmyGM
+          2QoF4HZzOUTuEVy2viaa2VLhQuqHAz2gDkgpnKregs6epeIqBiS/jcy28bFWwBQVCnL2fE1HH1+H
+          ThisxAlu84Bfr5YGvaAjEj+eRxdXVKbDfltcH8BnBLYjVGSYlXmJ7okjuJh5tircPtAgx+ba1svz
+          xbISByyEFAtDQGLdo+Gen5F5jfJ6m0hFwys0Xuj5bPl6Bt7CQ/MinJAfAbzNn02GsIy61l/a5V4z
+          Rtz60n3+lCg5qa62xi9Nh89WLsijiJ9gpkzyFVy5mpFRL293oSipAWdt0YiSEh3QSFkqeKzHAWXP
+          ZxHS40hhOBIYk6vOSfVEjpkMucO5J8VzcbRtVQJZMlveJt65+2SrSQsyxNbjRmysvsJ5LZEMTAPF
+          GDLkUrO+nEGotOGXWGbycpf0w/dQcdU3sXgKbrNjJD20VXwiskBwTd7wUsHCH4HPiFQfbo59o4B/
+          eY348JACdzUopRGxN2fkwfIXbR29jwOOS1Ih3ZSqbFvMEw/Pp6AkR126gaW9WjZko2VCrqBz7vZd
+          0gRO7dvy16y718z5kuqwpJ2R3JZbu7GiG0Xw7LkMjlPdzZhoNXoIMnFCJwlPw7KyCytd2M/iw8FV
+          Nvpz0uzf/Bagq6fRty31YdnlDBZLzGbEVHEJ9uf3SalBsETrqYciL6z++qDOLtfFEYZX3e6Rei1P
+          LoMa4MHlcljwQf9WIadelBi2h8JA6Kz07uLcyhnaQaKjTDk6If3ZZAqc79yIXJl7DoODHzOsOCX1
+          D3s+ntTOVqEeqE/MwtbT6OVz6+DHXE3kGdO7xlSXymDXJ0gzUDmsJbmbUHVshri0EgAGPFX1p35g
+          8pO/lk3CUEnGAo/779dmEKAU3r8jkhfWA0x96mz4OOouuW+fZpuu1pmSjEeQI/NpLfV2COAKqXF0
+          iRadr+GyJlcV3oQm2dfr21JfZBaOtDP7r/64uL/5yfXi2F+YmwY2S+IbKFHXiqS9oILF/ioifOeB
+          QzLfWLOVttIcTm6kk7v4lLOlGKwEFtHW+g1pUL2Eh1mUfJ1hcJl+3JreRgdDPWMNZBf5zZ20jxlJ
+          5vFOkI99WE/KlxHhT/42zYsF5tD6QmhF1wZpj/VZrxy8XOD7GCK/a6VJ+67f1gY/9cubzniYIyqN
+          4IiZgbjncna3lND673kvknisp2MpRLC+3G2U7PGzDoZsS1rAn5F8808bx942FY6FaRIbTQKY20QL
+          JJcOA3K+nEuwGcAo9oQgo/uul1aK0zo4vRKMrDxYstnQHybs1JpGilcMYJlTrxOvS9KRO9pCbTav
+          Zg+GjwfQvU0GsBzLJf7Re8h3D+bAFHI2ws5TzkTx2dpdaGMT4WXrNGQHbqGt5hzH0jqOFkKbrg+r
+          1x9jGB+XxF/DQ1VvTS/RcCYoIHaYqtkcv+MS1ssB4ZWyxGwTcazC9X3XkJyTJONuLaGAPrZfkrL8
+          2eVu7sTCZw024sX6KWPBhYmlm1zR+PAu0nD5id89//hU2EnD2KqcDG2lrdCe/7aV4w4d6F32jJxK
+          szKcemsiZePFJHJ/rYZJEzhROKgrg3QpMAdOuowxcLv2jo6HqqtXinM7MOrdB9lZ2Ggz1F4RHFq1
+          wjAXbcCeS1SBE3/5EHu0sfYNwvkL9QJsmB1fj23RqLSDr9FokTxvZk0bxdODjAPrH/0KuPvtU4LD
+          pHDEMyZrYMqHDOGFulDE/r61YYPL0YGnnAdIOb1WbfLIFgPzZnQIfYVEI5k8YV7YQhUZvILBqh6V
+          WRQeXvJf9eJeLjoUhxMgSL18t596InUQa5g/l0R7b7agSqnWZ8TCBxxubhT2UkOXZ2KlTlOPt1Oe
+          ikNW6wSl1SXb62Mu+ZtXYLaqUDi7UFal8KI9iX3Ipwzn4tmDi9NRJH9yVTY/rjwFgJoFBOGI2dbo
+          /jVhfcMeQhmnZStLCwE0IF2jR8Qw9co8Jxkkz4+C+RvfZRsrzbR0TdEZp6lj1Oxl1Dx4rPFAtFWg
+          tVWIGhG6VSb7+BZ22hw1gQfD0HFwKD/P2+a/+RieT5eS2MyHzxaPgPhHn2Furz8NY/OyNCnsG53K
+          I6Mt3D3opOYRQTxfhRysHMd1kLuqnX8IqVdNdr8o1To5//gRd5Js34fqK3J+9H3YI2Uppafgc/52
+          8zFYyy+Vgnt/mYj5lsPw9/m99Cr86PVsVtHDh6Q550jvNCPjxHXG4LikFXKCWzD85gM7SHXkKUir
+          WX5TRugpBwsZuU5t5MjhGMr2s0UytDqNNIkXQGdlBUxeyQlMzCBgWHNBuPsfJWN3/w1oHdlIDQ/V
+          MKvNp4Cp40hELh3W3V73jZaGWzQQT3DmbFECMIMffXkdJ5SN9V1kxfPRtEhQ5vLG8XR5kRSYUyia
+          oOWyxZvXQRQkNkqVXWV8y56VHvXNJ8686jUzHkxaiCimJop7TOsteHUm/52PN2TQ3aKtzUxY0LSE
+          EG/7tGCFx3EFaHBvWGL51V2EpXbg4/q5IffCKNr6ub0CuDx5FQVsFGxzoB9YsOt/4m61V7O6dfF+
+          /JIv9NtxWFqgQ6jopUFQl9HafAZvDzRoMIhscra7RbCeJerk6L/+YU1mQ4fwSrjf+yM0MDCobeHr
+          A9F6ZEv4bXrIXvnEF45TN/zWl5ZmJL81jn24LAGUoQEIj5ddb67LxmCIXh8RqfI9GdbvU72Ai1MV
+          6IRT7M67/5CEL4+QO7nXcAFkayRHLExkXrt3Rpb4kIMK92+kO4mssYaARR5q3JtojdiCRZFVD0bh
+          k/UXkffdlZ6SCySOfMefQ2UOTBqNKcgjJCODGF09zxadAz7OJZQOzVIvU0bbsDtHMfLexT0c+fAW
+          wW4WH/v+9FrvnkkFR3RuyIMf3tl8anUPREFqI2OcUMi6udHD5TWHxBGCvl55TGTweSlHYvzsR9/X
+          NCQgn/d4vw7bcJE6sBihiOmEWevtq3oyNI1T7HPnA+/2X21toCW7LrGtVzlgoY0LyGezQlyQ43Cm
+          FtuRDu7xjXwmVgGnX1EP3Wg6onN/PLvzz/2f2dhA5sU9DgtqgA/JpymRgw8k3A4BPQNV/iRYSHUv
+          ZDqX6oAG3NA/8C3SNsUpI7gc8iOKT3adfV/sako7byDKrF42lsdvGex63p9yfAt/+BQI5SPCYy7a
+          2/QK+RReme6w84i43sa0aOD1zD59ri10l1U2poCkTa1dHwQaJ735BmZlUfpNqErhh8K6Kp2+3YqO
+          ClJr9gpOPpBP68c/gKofNucx+oAq+ZbE49bXaxO3I9x6JkV3LLAu8d98BJlv+f3VW0yuagFUVumF
+          7Dx2BnyMxq94TxsWZaONNNbrjxE85q8Yq7r5cpcFkBH8+D/1QS3u4p2LCrByG6HAubRglSVfhpfE
+          uyJLHZJhjuOGgvJSO/7r43HheBeBB9PV4JDboCn8zcdRdUl81hKDkJPqhwjsTD+QE4oGbaar1YGX
+          /iCi464He0w+LJxCzOF1maNhWTo7+PErBB1tM1xzhiqB8aVCTDuJ7HL1aiagJ81CgtfT0tZsnT0p
+          d0iFVPx+DasxJTLI75WOzEPVDjtf4n/0/a+fnkOrgoD4/oq87Za521N5BfBkjxUKDPq1ETji/Jfv
+          HX74XQ3p6kfvo90PhaPcnWWpm4QXet6sqN5/f5F+eMg1tNl6EB9jAbLBzXzKhGW2UufTDOPWNYlK
+          3VttrZLHRZwmP0J2pgjh1vpghAFIA+TJUgLY3e/AaTQ+JLy4fT2/sm8KKfm0IdlLLvWiTS8ZOiX1
+          Ib7qnQcmfjYlJKCYCbIN2WUfrsPC2lGvxNPENSP5I6Xg9S3YxPNqTWP7cqHh8lpDZKODXrOO+M1h
+          QD0p4oxRWc9scJaFnZeRoHRijfnRr+CaumjnlyFbSLcKHHHWIWdozgPXPqcLxO4wE1Ue6nBt4VDB
+          T3i7YPpyfm1beUlpGKRTgX/09PjF3QXG7dFEut/cs1/e9L3yEcpymtSrrh5K8bSsFjo5DQyxV+Mv
+          IP2TQfqsbmC5KQjDIzQe6MTf82GvT4H0o++tEjPhnKr5Be71zQcRmLaZ/Wa2yNYd2vWTvy1vy8a/
+          fiQVgn6YVKv2JeXbYOQ9W65epTSOYUvdUlzu9WbdXnkDus9kI8Xog2x7w7QE08FsMJDNRpvY6uNA
+          KvSx38WfUz0vn2cD3h+o/LzvX/4NP8ypQgh35bAEZpwCxZXfRC5zGayRzVcw8J0LXm82U3Pn5FEC
+          XTlJxBOfSsbWTQIhuocWcS81G84vpQ9EYTurJGkvaz0Ls95BUJsq5kp8DfuWLU3xubRfpAqfOMPb
+          K++gSQUikq8C3GZ9dApYAbT5wHopNUudjRWc0ElHzvbYwvm3P/A85/v6HPS44C/gkcLMhzeqHObm
+          FbISZmgZHYMzF84HZVmla43JzhsHjQy35AK3PPDRLXX0YQnG3INfJs8wv+vdMWk7CNvx6fjCHv8M
+          E7c5f5Q8G2Uv7rr1Tqz6sAvQgPnvld8GcZ1HmN5oeuepurt6dfeFEsfIxKLC09Y34AGhKglXvIbT
+          Dez5PAa7PyKZ9XoNM/sNbel+Pa/EeCp8iJ029sDO8xGiLVdbx64OeANMPEFerbt0a91HQC8Pcz8/
+          p42r2Y/+U2+J8Qxrd5lcp4O3y133+fayDsu63hyA79c3Qq9k2vsF/CrGMErJ/dmyQx9RaQwYimjo
+          BHoZMAdniaQOvBPkHOKrtvsj+Te/scOsuox3jitYAErwP4Ch3MUVNF56HE0X+SnWwDTYzxxq1fwi
+          EX+Ss1ULvjOMou6FjNmetFHsaBX8+CNNy91wtU9uLzrCLfMHiTYAB10t/tlff9afAVjoJ6XC3GVP
+          yCVGX+PtFTXSzv8x9whvwyZTTSPx9mb+3P+217NcfJLpTpzPlwq3ualG+Krxhsz4cxqWb+xgUNSd
+          RZSqNwf2XFoVHOGrIgY6aMNvv2D3A74AGEobPTumoHXNEcl2HjmcrZqCOM0v6GRsJRiL5BBA+lh5
+          6BQ7Zr2w1cuG6zvTCBLE0l2DcO5/eDfmdr4+73wS7vyanPxzs80wSnkYTPiOjr77rZfG5i9g50so
+          tTI7ZN9fNQUx/tZEH9+xOz/O8UXa/QeuW8nb9SPxwEueeCSnn2FYtukVQKtDNLJMM84WuglG8aRl
+          xU9812Tn77A7xzHx+UUeONNSfKCsh9ePPqtX2B87iIrO3fmBP8xut61g16P+4mZtuBFqpEHSsTFu
+          1SXYFj6wVfjDe9Xj0croob1i6CA9+eG9YD2XqATr8M6RRZc8WKnXIYLWUPFENzSksQufJNBNhAoz
+          p/eYvR8Uq4NmyzpiKNipF1dweUmfxitK4dBl8/nL9ECW4pmo+K0MK/f2VVGWdj6vhu5GprOvwkk6
+          CMSDra/RTfANoJuAiugJcxlW09+8H3+Lp53fzWESVdLO93wh/vj18lNP9vNC/JwOho15aZ1U+x7+
+          7QfN48iOMDBfBuYXN8o2V6tM6Zd/HIIMzMXjTEm7vkKWXZy26VguEXTE3CQ3IbCGOaij/pcnCns/
+          5rc/9HGoJzkVWh8us6wWUHxrla/Ta1VPvcSbgHGoGmmNaPzwKVr64U2RoRF3PTPhCnc/QMxSNAHt
+          yAyEVqVk5P7kXiHegkEGmvv2MHVUT+7MbPUoJB0d+wyv4K3j8VuFH8+VkC3ROmDsr8LDHz6rRi7U
+          piioKonXmwmd5fCQTcHNon70L0oU7NZseFFM+M7cJzKou6ktb0seJYuR49/6wqzr0xZmjat3/t5o
+          20NLWDi0coXiT/IFO//5isq3w0g722o22v0QwTiAE0liRtbY8ksl0HvVvk/pzcedL+wSw6dR3H76
+          n9t2E2lP4qXvmezxuO28pIG7/8KsgZT6fStXXXrGCCJbwUO98+gevteY9qmdJ7O3vtHh+ahbSIXK
+          tP2+XzLNAnGaI62RMS06aDwu+a7fPwN5RGoilVHTYn6a43oMjmkFKarJkKNKekb379MFAAtH/vIe
+          vG19WfUovZ7lnRyPkzlwfdQ64k0nJ/TDI7A85oV4XjQFz08LDZNCkgYWuiyjc4O3kKxQusA+uT9+
+          9D5YzFP+hbHDaxjWF1njfvRsEkHzl4dze/zAz0s74vTOi2AmL7aBD0sqf/sdv/1uWrqMxKLXetis
+          vomkcwpv5LjXg+00Yl98MW+NyK7oZxv3jFTwtf0Hsne+z4FPaUMrujU+2Ptpv/3xvz9TAf/5rz9/
+          /tfPhEHXP4p2HwyYimX693+PCvyb+/fYpW37O4aAx7Qs/v7zXxMIfz9D332m/z31TfEe//7zR/gd
+          Nfg79VPa/j+X/7X/0X/+6/8AAAD//wMAWOnf7t4gAAA=
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdc4fe7dd27ad0-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:37:05 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-model:
+          - text-embedding-3-small
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "226"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -610,20 +598,19 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_d4fb271f24fa217a3859aec6294bedcb
+          - req_3abe633ff82a978892bc086d09204823
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence2: stub\n\n----\n\nI
-        like cats.\n\n----\n\nQuestion: What do I like?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence2: stub\n\n----\n\nI
+        like cats.\n\n----\n\nQuestion: What do I like?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -632,13 +619,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "613"
+          - "599"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -648,7 +635,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -662,19 +649,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSwW7bMAy9+ysInpPCTp2lya23FuiwYRuwAfNgqDJtq5UlQWSGBkH+fbCdxi7W
-          AbvowMf39B7JYwKApsIdoG6V6C7Y5e2Xr9+34aCaz5ut8T9y+hjrh7v7p+w2PnzCRc/wj0+k5ZV1
-          pX0XLInxboR1JCXUq2ab6yxLNzd5NgCdr8j2tCbIMvfLVbrKl+nNMv1wJrbeaGLcwc8EAOA4vL1F
-          V9EL7iBdvFY6YlYN4e7SBIDR276CitmwKCe4mEDtnZAbXB8LB1Ag77tOxUOBOyjwW0tAL5piEGBR
-          QgzSKgFpCQJF9g6seSYGrYSvClyMGpEs/VZOU8naRxq1srTAwp3mv0eq96z68G5v7bl+usSxvgnR
-          P/IZv9Rr4wy3ZSTF3vXWWXzAAT0lAL+Gse3fTAJD9F2QUvwzuV4wS7ejHk6LmtDV+gyKF2VnrOt8
-          8Y5eWZEoY3k2eNRKt1RN1GlLal8ZPwOSWeq/3bynPSY3rvkf+QnQmoJQVYZIldFvE09tkfo7/lfb
-          ZcqDYeQDC3VlbVxDMUQznlIdynyt63VekSJMTskfAAAA//8DAF39Ui1TAwAA
+          H4sIAAAAAAAAA4xSQY7bMAy8+xUEz8nCdtJs4lsfUOTSomjrwlBkxtZalgSRaXcR5O+F7WycRbdA
+          LzpwOKMZkucEAE2NBaBuleg+2OVHtfm6+73vvm908+nLLj1kNe+fvnFHu26Pi4HhD0+k5ZX1oH0f
+          LInxboJ1JCU0qGaPq1W22eb5hxHofU12oDVBlmu/zNN8vUy3y3RzJbbeaGIs4EcCAHAe38Giq+kZ
+          C0gXr5WemFVDWNyaADB6O1RQMRsW5QQXM6i9E3Kj63PpAErkU9+r+FJiASV+bgnoWVMMAixKiEFa
+          JSAtQaDI3oE1HTFoJfxQ4mLSiGTpl3KaKtY+0qSVpSWW7nL/e6TjidUQ3p2svdYvtzjWNyH6A1/x
+          W/1onOG2iqTYu8E6iw84opcE4Oc4ttObSWCIvg9Sie/IDYJZupv0cF7UjE6rAUDxouwda7VevKNX
+          1STKWL4bPGqlW6pn6rwldaqNvwOSu9R/u3lPe0puXPM/8jOgNQWhugqRaqPfJp7bIg13/K+225RH
+          w8gvLNRXR+MaiiGa6ZSOodquMko3j/U2x+SS/AEAAP//AwClu+9JUwMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946aaca7f16a2-SJC
+          - 8ebdc5009cd56462-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -682,14 +669,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:22 GMT
+          - Mon, 02 Dec 2024 19:37:06 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=LasYVrJH_fDdGXUJNoR88W683CH2r5G68NDHxks.DUo-1731107842-1.0.1.1-3Zu110pZGf2mLRbcfIWd84clLl_vb913.Nd7xDB_LZgSeF6flpbb5fsNwSeuLN8OeyP47JRmgPd5LJCVoQEj_A;
-            path=/; expires=Fri, 08-Nov-24 23:47:22 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=Xmk_0sUgyJ96_SqN1EQcJ3Z1FUYxOd2z7sbEu_ypwBQ-1733168226-1.0.1.1-lt3LtGS7OeRfnnXovheNoa1FytJJLaGW53IRNF34oe59mtnXNyA.SwwYAoKI535j7.4Vr.2qCHLWE5x422kP6Q;
+            path=/; expires=Mon, 02-Dec-24 20:07:06 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=mFCHOr4d4E1061KEQD.oRRX400dWSsWlKQiVkPQUkuc-1731107842746-0.0.1.1-604800000;
+          - _cfuvid=37x9eoc.HI_UiLEdOo8y8kbKWXNhajNiXze2SGcnbEs-1733168226029-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -702,7 +689,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "924"
+          - "532"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -720,20 +707,19 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_61ddcf530c72a6c110d019271fb3a033
+          - req_743ee266299e5b912243f3598df09e90
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence1: stub\n\n----\n\nI
-        like turtles.\n\n----\n\nQuestion: What do I like?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence1: stub\n\n----\n\nI
+        like turtles.\n\n----\n\nQuestion: What do I like?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -742,13 +728,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "616"
+          - "602"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -758,7 +744,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -772,19 +758,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSwW6cMBC98xWjOUPEbthuwi3JsT1UbaSqLRVyzAAuxnbtIU202n+vgM1C1FTq
-          xYf35j29eeNDBICqwhxQtoJl73Ry8+nzl5vH4fdXl76vf1WZ/Jbu727vu48fuusO41FhH36S5BfV
-          hbS908TKmpmWngTT6LrZX2426f4q205EbyvSo6xxnGQ22abbLEmvkvTdSdhaJSlgDt8jAIDD9I4R
-          TUVPmEMavyA9hSAawvw8BIDe6hFBEYIKLAxjvJDSGiYzpT4UBqDAMPS98M8F5lDgfUtAT5K8Ywgs
-          mAJwKxi4JQiOREcetOpGePCsKVwUGM8+njQ9CiOpDNJ6mv02aYGFOa4TeKqHIMYCzKD1CT+eV9K2
-          cd4+hBN/xmtlVGhLTyJYM8YPbB1O7DEC+DFVN7xqA523veOSbUdmNNyk17MfLsda2O3uRLJloVeq
-          yyx+w6+siIXSYVU+SiFbqhbpcikxVMquiGi19d9p3vKeN1em+R/7hZCSHFNVOk+Vkq83XsY8jX/5
-          X2PnlqfAGJ4DU1/WyjTknVfzd6pdme1kvcsqEoTRMfoDAAD//wMAMGaqp1cDAAA=
+          H4sIAAAAAAAAA4xSQW7bMBC86xWLPUuBZLtO4lsv6akoiiZtgSoQKGolsaZIglwFTgz/vZDkWAqa
+          Ar3wMLMzmJ3lMQJAVeEOULaCZed08lFsf9w+vbz0D5+/8s/DXXl/9/2L858eMu+/YTwobPmbJL+q
+          rqTtnCZW1ky09CSYBtfser3Otjer1YeR6GxFepA1jpONTVbpapOkN0m6PQtbqyQF3MGvCADgOL5D
+          RFPRAXeQxq9IRyGIhnB3GQJAb/WAoAhBBRaGMZ5JaQ2TGVMfcwOQY+i7TvjnHHeQ431LQAdJ3jEE
+          FkwBuBUM3BIER2JPHrTaD3DvWVO4yjGefDxpehJGUhGk9TT5ZWmOuTktE3iq+yCGAkyv9Rk/XVbS
+          tnHeluHMX/BaGRXawpMI1gzxA1uHI3uKAB7H6vo3baDztnNcsN2TGQyz9Hbyw/lYMzudBwDZstAL
+          1XoTv+NXVMRC6bAoH6WQLVWzdL6U6CtlF0S02PrvNO95T5sr0/yP/UxISY6pKpynSsm3G89jnoa/
+          /K+xS8tjYAzPgakramUa8s6r6TvVrriutyWtqS5TjE7RHwAAAP//AwAK6HE6VwMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946aacccc7aaf-SJC
+          - 8ebdc5009d4e16a2-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -792,14 +778,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:22 GMT
+          - Mon, 02 Dec 2024 19:37:06 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=O9WUHTGSg0LWjUcJtsvHSVJQKJD9FylgtimLRmAl6Uc-1731107842-1.0.1.1-xVrHcSF75sYtgbAXzBusaXrlzZcNpzdKoNV5xh38BtT0sa8aKAOF84_3coC8WYNT8bS4mC6gvyJwfyWtWIPUJQ;
-            path=/; expires=Fri, 08-Nov-24 23:47:22 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=rYLaFYZJlpWWCACZBpjL2tWLKjzaUxec5XVCeWeMmIs-1733168226-1.0.1.1-K2MsucsvHLa1SnE0oZFVdZsQ6vA7YTQ1HxJ3WBnKfAZtSZVFhNrMOH3DxflveOZ7ffKVLj4eg.ITBcGtR192bg;
+            path=/; expires=Mon, 02-Dec-24 20:07:06 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=ZiKM2dzB97iYHgLZd8YcnQfa8NlAvIqE1utlX8VbWQ0-1731107842790-0.0.1.1-604800000;
+          - _cfuvid=QoqWkHB4KkIhzQQiejcm5qcHo2agbmXC2kppw77luhY-1733168226341-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -812,7 +798,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "758"
+          - "863"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -830,14 +816,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_de26d4a0f9febddbc3b7b6da8baea8d5
+          - req_81a0e7104ef4104d6f0683f1265587e8
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["What was it that I liked?"], "model": "text-embedding-3-small",
-        "encoding_format": "base64"}'
+      body: '{"input":["What was it that I liked?"],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -846,13 +830,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "104"
+          - "99"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -862,7 +846,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -989,7 +973,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946b18981ce80-SJC
+          - 8ebdc506df367ad0-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -997,7 +981,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:22 GMT
+          - Mon, 02 Dec 2024 19:37:06 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -1015,7 +999,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "74"
+          - "84"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1027,26 +1011,25 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "9991647"
+          - "9999994"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
-          - 50ms
+          - 0s
         x-request-id:
-          - req_1769edde64f9131106c3b1dc79bb0973
+          - req_fc15ed6859d03be29d880ba06d643c2a
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence1: stub\n\n----\n\nI
-        like turtles.\n\n----\n\nQuestion: What was it that I liked?\n\n"}], "model":
-        "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence2: stub\n\n----\n\nI
+        like cats.\n\n----\n\nQuestion: What was it that I liked?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -1055,13 +1038,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "626"
+          - "609"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1071,7 +1054,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1085,19 +1068,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSQW7bMBC86xWLPUuBZDuJo1sCtGjRQ4skaA5RITDUWmJNkSy5ah0Y/nshybEU
-          NAF64WFmZzA7y30EgKrCHFA2gmXrdHJ9e/dw8+327kr9+bBWv77Yh++fdvpr9/n+5uMO415hn36S
-          5BfVmbSt08TKmpGWngRT75pdLrMsvVyvlgPR2op0L6sdJyubLNLFKknXSXpxFDZWSQqYw2MEALAf
-          3j6iqWiHOaTxC9JSCKImzE9DAOit7hEUIajAwjDGEymtYTJD6n1hAAoMXdsK/1xgDgXeNwS0k+Qd
-          Q2DBFIAbwcANQXAktuRBq20Pd541hbMC49HHk6bfwkgqg7SeRr8sLbAwh3kCT5suiL4A02l9xA+n
-          lbStnbdP4cif8I0yKjSlJxGs6eMHtg4H9hAB/Biq6161gc7b1nHJdkumN8yybPTD6VgTuzg/kmxZ
-          6JlqeRG/4VdWxELpMCsfpZANVZN0upToKmVnRDTb+t80b3mPmytT/4/9REhJjqkqnadKydcbT2Oe
-          +r/83tip5SEwhufA1JYbZWryzqvxO21cmZ1fVevlKpMSo0P0FwAA//8DAMbI9d1XAwAA
+          H4sIAAAAAAAAA4xSwW7bMAy9+ysInpPCdlo3yC2nHYodhg0rhnkwZJmO1ciSIDJDiiD/PthO4xTr
+          gF104ON7eo/kKQFA0+AGUHdKdB/scquK52225uf68w95iMenba1W3afvPuZfvuJiYPj6hbS8se60
+          74MlMd5NsI6khAbV7HG1yop1nhcj0PuG7EDbBVne+2We5vfLdL1Miwux80YT4wZ+JgAAp/EdLLqG
+          jriBdPFW6YlZ7Qg31yYAjN4OFVTMhkU5wcUMau+E3Oj6VDqAEvnQ9yq+lriBEr91BHTUFIMAixJi
+          kE4JSEfAgdSeIlizJwathO9KXEwikSz9Vk5TxdpHmsSytMTSnW+/j9QeWA3p3cHaS/18zWP9LkRf
+          8wW/1lvjDHdVJMXeDd5ZfMARPScAv8a5Hd6NAkP0fZBK/J7cIJhl2aSH86ZmNH+4gOJF2RvWqlh8
+          oFc1JMpYvpk8aqU7ambqvCZ1aIy/AZKb1H+7+Uh7Sm7c7n/kZ0BrCkJNFSI1Rr9PPLdFGg75X23X
+          KY+GkV9ZqK9a43YUQzTTLbWhemyLmlbU1ikm5+QPAAAA//8DAKT+961UAwAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946b30efa963f-SJC
+          - 8ebdc5083ea1f9ea-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1105,14 +1088,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:23 GMT
+          - Mon, 02 Dec 2024 19:37:07 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=34Ehu9Ac10Z5hDiZtUUsVBaUeL1KKpKGrvkkBAUNTOw-1731107843-1.0.1.1-oO4SP6lm3G5k9_cGVVeM4Iz8mhw0mbbBCl19YqyK5gB_DZ7M_5a0RsWj1lRlTqHeOPTYZxBdFD4ACVrrWhzZLw;
-            path=/; expires=Fri, 08-Nov-24 23:47:23 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=fOmDRlrjlAc4kXqFa0DpWjxSnCigpbnlQoBpPuQ1NDc-1733168227-1.0.1.1-O_kkKrrHCLBDJJhSsADfTZVAjFPCpWm_mfvXphq96sSZymn7wLZUxpVSIyndxWaGjDjMGnB6ur.xBvbIOoD4sg;
+            path=/; expires=Mon, 02-Dec-24 20:07:07 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=527jkXfX0iueL26teFC40blX9AyQRMq5cuCiYvYl7oA-1731107843736-0.0.1.1-604800000;
+          - _cfuvid=QCU7TOTm7EVH3jRqzi.T8faYIdQt.nPlG4DtKKlr2F8-1733168227247-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1125,7 +1108,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "551"
+          - "532"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1143,20 +1126,19 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_ac27dacd4f188b7579e8285a7b825915
+          - req_82b6c154a2bd2f793e49afc61fcd34ab
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
+        '{"messages":[{"role":"system","content":"Provide a summary of the relevant
         information that could help answer the question based on the excerpt. Respond
         with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
         \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
         words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from sentence2: stub\n\n----\n\nI
-        like cats.\n\n----\n\nQuestion: What was it that I liked?\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        (out of 10).\n"},{"role":"user","content":"Excerpt from sentence1: stub\n\n----\n\nI
+        like turtles.\n\n----\n\nQuestion: What was it that I liked?\n\n"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -1165,13 +1147,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "623"
+          - "612"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.54.3
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1181,7 +1163,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.54.3
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1195,19 +1177,19 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSTW/bMAy9+1cQPCeFlY9+5LZddhiGAluBAZsHQ5UZW4ssaSK9NQjy3wfbaZyi
-          HbCLDnx8T++RPGQAaCvcAJpGi2mjm7/7/OXr+4/3Da/V4s/iU3evlh9+ebn7Vj/IHmc9Izz+JCPP
-          rCsT2uhIbPAjbBJpoV5V3SyVym9uV8sBaENFrqfVUearMF/ki9U8v53n1ydiE6whxg18zwAADsPb
-          W/QVPeEG8tlzpSVmXRNuzk0AmILrK6iZLYv2grMJNMEL+cH1ofAABXLXtjrtC9xAgQ8NAT0ZSlGA
-          RQsxSKMFpCHgSHpHCZzdEYPRwlcFzkaRRI5+a2+oZBMSjWIqL7Dwx8vvE2071n163zl3qh/PeVyo
-          YwqPfMLP9a31lpsykebge+8sIeKAHjOAH8PcuhejwJhCG6WUsCPfCyqlRj2cNjWhi/UJlCDaXbCW
-          17M39MqKRFvHF5NHo01D1USd1qS7yoYLILtI/drNW9pjcuvr/5GfAGMoClVlTFRZ8zLx1JaoP+R/
-          tZ2nPBhG3rNQW26trynFZMdb2sZSre+q2+VKGYPZMfsLAAD//wMAA0c5uVQDAAA=
+          H4sIAAAAAAAAA4xSQW7bMBC86xWLPduBJLtKoJsLtH1ADfRQFQJNrSzWFElwV0UCw38vJDmWg6RA
+          LzzM7AxmZ3lOANA0WALqTonug13vVPFjt/vKnG+y/Zc9fz4UUaXb3fes+7bD1ajwh9+k5VX1oH0f
+          LInxbqZ1JCU0umaPm01WPOV5MRG9b8iOsmOQ9dav8zTfrtOndVpchZ03mhhL+JkAAJynd4zoGnrG
+          EtLVK9ITszoSlrchAIzejggqZsOinOBqIbV3Qm5Kfa4cQIU89L2KLxWWUOG+I6BnTTEIsCghBumU
+          gHQEHEidKII1pxEeoljihwpXs08kS3+U01Sz9pFmvyytsHKX+wSR2oHVWIAbrL3il9tK1h9D9Ae+
+          8je8Nc5wV0dS7N0Yn8UHnNhLAvBrqm540waG6PsgtfgTudEwy7LZD5djLWz+6UqKF2XvVJti9YFf
+          3ZAoY/mufNRKd9Qs0uVSamiMvyOSu63fp/nIe97cuOP/2C+E1hSEmjpEaox+u/EyFmn8y/8au7U8
+          BUZ+YaG+bo07UgzRzN+pDfVjWxxoQ+0hxeSS/AUAAP//AwAq80zvVwMAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8df946b2f8417ad0-SJC
+          - 8ebdc5081bca7af1-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -1215,14 +1197,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:24 GMT
+          - Mon, 02 Dec 2024 19:37:07 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=uCE2Lcfw7VssnL078cx3blaQGDeFhZl6X7ufPFfqE0o-1731107844-1.0.1.1-azFFFQ0nUSn7pFxibamtYCGQIzZx1VvPIh1xAjkLHgJkMHs9c4tri3tDcEWmkqWid_f_mIYWr1ayCAg_u4mz8A;
-            path=/; expires=Fri, 08-Nov-24 23:47:24 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=OEilTF9X4MgnHxmnro.sEY5H4HDmQmYu07x8JjK8nIc-1733168227-1.0.1.1-JEwkP6lF5Gqj.w4KgzCAkwI_Zgy9u7D.0fnNiwUkO1bvaTtGLkunBYhSAnkPMBSLOTZMhHD6PKGOZ5pEZRiuxA;
+            path=/; expires=Mon, 02-Dec-24 20:07:07 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=UKiFTsdam4lfI6EeVLgfDNf7IQ28xzvXR8e.EoVdXXc-1731107844150-0.0.1.1-604800000;
+          - _cfuvid=yyfP4hkrTh4aFDrm5g7YZWfydSKoAoVbl4ieUfzRtF8-1733168227479-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -1235,7 +1217,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "1007"
+          - "783"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -1253,7 +1235,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_1df7c60ef7195ea25a1df68cff9d2798
+          - req_a206953e12a1194c59e3c254306f91d2
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_pdf_reader_match_doc_details.yaml
+++ b/tests/cassettes/test_pdf_reader_match_doc_details.yaml
@@ -1,12 +1,11 @@
 interactions:
   - request:
       body:
-        '{"messages": [{"role": "user", "content": "Extract the title, authors,
-        and doi as a JSON from this MLA citation. If any field can not be found, return
+        '{"messages":[{"role":"user","content":"Extract the title, authors, and
+        doi as a JSON from this MLA citation. If any field can not be found, return
         it as null. Use title, authors, and doi as keys, author''s value should be a
         list of authors. Wellawatte et al, A Perspective on Explanations of Molecular
-        Prediction Models, XAI Review, 2023\n\nCitation JSON:"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        Prediction Models, XAI Review, 2023\n\nCitation JSON:"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
       headers:
         accept:
           - application/json
@@ -15,13 +14,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "429"
+          - "419"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -31,7 +30,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -45,20 +44,20 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xSPW/bMBDd9SsON9uFLcWO7S1D4S6B06Fo2iiQaOokM6VIgjy1KQz/94KyYzmo
-          C3Th8L5w7477BABVhStAuRMsW6fHd4/f1vXm05csbJp2MV+vH2chnYrPm9l3pXEUHXb7QpLfXB+k
-          bZ0mVtYcaelJMMXU6W2WzmbL5TTridZWpKOtcTy+seN0kt6MJ4vxZH4y7qySFHAFTwkAwL5/44im
-          oldcwWT0hrQUgmgIV2cRAHqrI4IiBBVYGMbRQEprmEw/dVmWL8Ga3OxzA5AjK9aU4wpyvIMH8sGR
-          ZPWTwBr4+Oq0MCK2C2BruLeaZKeFhwdPlZKRgPtYLOQ4OuaJjnfWh5j4lONX0lr8EswExCB0js8n
-          XWVV1JhO69wcclOW5eXEnuouCH1SnPDDeQXaNs7bbTjxZ7xWRoVd4UkEa2LdwNZhzx4SgOd+1d27
-          7aHztnVcsP1BJgYusmMcDrcdyGx5Itmy0AM+TdPRlbiiIhZKh4tboRRyR9VgHQ4rukrZCyK5KP33
-          NNeyj8WVaf4nfiCkJMdUFe581msyT/Hr/0t2XnI/MIbfgaktamUa8s6r4++rXXFbz7eUUb2dYHJI
-          /gAAAP//AwDg7TU0hgMAAA==
+          H4sIAAAAAAAAA4xSS2vjMBC++1cMOidLHsVJfGtLj4XSUpalLrYijxM1skZI422WkP++yHHjLJuF
+          vejwvZhvRocEQOhKZCDUVrJqnBnfyvRzr1f1bpa2Ly/Pq9f7H3x3n97tHpbNXoyig9YfqPjL9U1R
+          4wyyJnuilUfJGFOni/l8mq6Wy0VHNFShibaN4/ENjWeT2c14shxP0t64Ja0wiAzeEgCAQ/fGEW2F
+          e5HBZPSFNBiC3KDIziIA4clERMgQdGBpWYwGUpFltN3UZVl+BLK5PeQWIBes2WAuMsjFLTyhDw4V
+          658IZOFh74y0MrYLQDU8kkHVGunhyWOlVSTgMRYLuRid8mTLW/IhJr7l4jsaIz8lMwIySJOL915X
+          kY4a2xqT22Nuy7K8nNhj3QZpekWPH88rMLRxntah5894ra0O28KjDGRj3cDkRMceE4D3btXtH9sT
+          zlPjuGDaoY2By/kpTgy3Hcj5qieZWJoBn85moytxRYUstQkXtxJKqi1Wg3U4rGwrTRdEclH672mu
+          ZZ+Ka7v5n/iBUAodY1W481mvyTzGr/8v2XnJ3cAi/AqMTVFru0HvvD79vtoVizpd4xzr9UQkx+Q3
+          AAAA//8DAM1HCSGGAwAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1a27f9f942c-SJC
+          - 8ebded939912eb21-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -66,14 +65,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:34 GMT
+          - Mon, 02 Dec 2024 20:04:48 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=g23i0HBU.WtBdth6oIUeubH2aCtEhvXqhgmSY7xqo4s-1732559914-1.0.1.1-bAyWV8xjlARWssgrh85JLPP4WXuZSxSXE0KK7hYmXGTaaxPsK2p3X2d2rVUVHakpw0TLNtAohtuYZ.TG7YLo2A;
-            path=/; expires=Mon, 25-Nov-24 19:08:34 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=18W6iQ8vqb415F5xVrk3Ge4dUhGPkgrhNozopGG2HXw-1733169888-1.0.1.1-pnvay9pz3s5sG0RmkI7UdARtXP7nf3paIE38K29QjHBqYQ.nNVEYmzAn3ixUbbc45NzeYsu0qXXUtBZjJN_kPw;
+            path=/; expires=Mon, 02-Dec-24 20:34:48 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=wkHxvSCXgainJojwXL9.b47wJQArZp3NomQCW9MYJWs-1732559914390-0.0.1.1-604800000;
+          - _cfuvid=mag22BiQ6y4WuIP4sC0PP_aDhc1fsuhVAGnDMd1pkvg-1733169888860-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -86,7 +85,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "926"
+          - "1451"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -104,7 +103,7 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_d35834aad30071b8706a3f4af797071e
+          - req_ad8dc5dcd249e38cabbcc829f73418c1
       status:
         code: 200
         message: OK
@@ -116,7 +115,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":17807,"items":[{"DOI":"10.26434\/chemrxiv-2022-qfv02","author":[{"given":"Geemi
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":17889,"items":[{"DOI":"10.26434\/chemrxiv-2022-qfv02","author":[{"given":"Geemi
           P.","family":"Wellawatte","sequence":"first","affiliation":[{"name":"University
           of Rochester"}]},{"given":"Heta A.","family":"Gandhi","sequence":"additional","affiliation":[{"name":"University
           of Rochester"}]},{"given":"Aditi","family":"Seshadri","sequence":"additional","affiliation":[{"name":"University
@@ -141,1029 +140,1073 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:38 GMT
+          - Mon, 02 Dec 2024 20:04:50 GMT
         Server:
           - Jetty(9.4.40.v20210413)
-        Set-Cookie:
-          - AWSALB=TyK+JlIvasx/4g3mmJfKDsM+N3FbIOAguspHge4kO+U7S+tvXLCdi6wp0lb+EH+i+p03+KhcqYjUhX6nJrzN4BxMUfSSrOhW2DS39kfbv/ep0zjynIsIHxu9heVv;
-            Expires=Mon, 02 Dec 2024 18:38:34 GMT; Path=/
-          - AWSALBCORS=TyK+JlIvasx/4g3mmJfKDsM+N3FbIOAguspHge4kO+U7S+tvXLCdi6wp0lb+EH+i+p03+KhcqYjUhX6nJrzN4BxMUfSSrOhW2DS39kfbv/ep0zjynIsIHxu9heVv;
-            Expires=Mon, 02 Dec 2024 18:38:34 GMT; Path=/; SameSite=None
         Vary:
           - Accept-Encoding
         permissions-policy:
           - interest-cohort=()
         x-api-pool:
-          - polite
+          - plus
         x-rate-limit-interval:
           - 1s
         x-rate-limit-limit:
-          - "50"
+          - "150"
         x-ratelimit-interval:
           - 1s
         x-ratelimit-limit:
-          - "50"
+          - "150"
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"input": [" A Perspective on Explanations of Molecular\n\n              Prediction
-        Models\n\n\nGeemi P. Wellawatte,\u2020   Heta A. Gandhi,\u2021   Aditi Seshadri,\u2021
-        and  Andrew\n\n                           D. White\u2217,\u2021\n\n     \u2020Department
-        of Chemistry, University of Rochester, Rochester, NY, 14627\n\u2021Department
-        of Chemical Engineering, University of Rochester, Rochester, NY, 14627\n             \u00b6Vial
-        Health Technology, Inc., San Francisco, CA 94111\n\n                           E-mail:
-        andrew.white@rochester.edu\n\n\n\n                                 Abstract\n\n\n      Chemists
-        can be skeptical in using deep learning (DL) in decision making, due to\n\n   the
-        lack of interpretability in \u201cblack-box\u201d models.  Explainable artificial
-        intelligence\n\n   (XAI) is a branch of AI which addresses this drawback by
-        providing tools to interpret\n\n  DL models and their predictions. We review
-        the principles of XAI in the domain of\n\n   chemistry and emerging methods
-        for creating and evaluating explanations. Then we\n\n   focus on methods developed
-        by our group and their applications in predicting solubil-\n\n    ity, blood-brain
-        barrier permeability, and the scent of molecules. We show that XAI\n\n   methods
-        like chemical counterfactuals and descriptor explanations can explain DL pre-\n\n   dictions
-        while giving insight into structure-property relationships. Finally, we discuss\n\n   how
-        a two-step process of developing a black-box model and explaining predictions
-        can\n\n   uncover structure-property relationships.\n\n\n\n\n\n                                     1Introduction\n\n\nDeep
+        "{\"input\":[\" A Perspective on Explanations of Molecular\\n\\n              Prediction
+        Models\\n\\n\\nGeemi P. Wellawatte,\u2020   Heta A. Gandhi,\u2021   Aditi Seshadri,\u2021
+        and  Andrew\\n\\n                           D. White\u2217,\u2021\\n\\n     \u2020Department
+        of Chemistry, University of Rochester, Rochester, NY, 14627\\n\u2021Department
+        of Chemical Engineering, University of Rochester, Rochester, NY, 14627\\n             \xB6Vial
+        Health Technology, Inc., San Francisco, CA 94111\\n\\n                           E-mail:
+        andrew.white@rochester.edu\\n\\n\\n\\n                                 Abstract\\n\\n\\n
+        \     Chemists can be skeptical in using deep learning (DL) in decision making,
+        due to\\n\\n   the lack of interpretability in \u201Cblack-box\u201D models.
+        \ Explainable artificial intelligence\\n\\n   (XAI) is a branch of AI which
+        addresses this drawback by providing tools to interpret\\n\\n  DL models and
+        their predictions. We review the principles of XAI in the domain of\\n\\n   chemistry
+        and emerging methods for creating and evaluating explanations. Then we\\n\\n
+        \  focus on methods developed by our group and their applications in predicting
+        solubil-\\n\\n    ity, blood-brain barrier permeability, and the scent of molecules.
+        We show that XAI\\n\\n   methods like chemical counterfactuals and descriptor
+        explanations can explain DL pre-\\n\\n   dictions while giving insight into
+        structure-property relationships. Finally, we discuss\\n\\n   how a two-step
+        process of developing a black-box model and explaining predictions can\\n\\n
+        \  uncover structure-property relationships.\\n\\n\\n\\n\\n\\n                                     1Introduction\\n\\n\\nDeep
         learning (DL) is advancing the boundaries of computational chemistry because
-        it can\n\naccurately model non-linear structure-function relationships.1\u20133
-        Applications of DL can be\n\nfound in a broad spectrum spanning from quantum
-        computing4,5 to drug discovery6\u201310 to\n\nmaterials design.11,12 According
-        to Kre 13, DL models can contribute to scientific discovery\n\nin three \u201cdimensions\u201d
-        - 1) as a \u2018computational microscope\u2019 to gain insight which are not\n\nattainable
+        it can\\n\\naccurately model non-linear structure-function relationships.1\u20133
+        Applications of DL can be\\n\\nfound in a broad spectrum spanning from quantum
+        computing4,5 to drug discovery6\u201310 to\\n\\nmaterials design.11,12 According
+        to Kre 13, DL models can contribute to scientific discovery\\n\\nin three \u201Cdimensions\u201D
+        - 1) as a \u2018computational microscope\u2019 to gain insight which are not\\n\\nattainable
         through experiments 2) as a \u2018resource of inspiration\u2019 to motivate
-        scientific thinking\n\n3) as an \u2018agent of understanding\u2019 to uncover
-        new observations. However, the rationale of\n\na DL prediction is not always
-        apparent due to the model architecture consisting a large\n\nparameter count.14,15
-        DL models are thus often termed\u201cblack box\u201d models. We can only\n\nreason
+        scientific thinking\\n\\n3) as an \u2018agent of understanding\u2019 to uncover
+        new observations. However, the rationale of\\n\\na DL prediction is not always
+        apparent due to the model architecture consisting a large\\n\\nparameter count.14,15
+        DL models are thus often termed\u201Cblack box\u201D models. We can only\\n\\nreason
         about the input and output of an DL model, not the underlying cause that leads
-        to\n\na specific prediction.\n\n    It is routine in chemistry now for DL to
-        exceed human level performance \u2014 humans are\n\nnot good at predicting solubility
-        from structure for example161 \u2014 and so understanding how\n\na model makes
-        predictions can guide hypotheses. This is in contrast to a topic like finding\n\na
-        stop sign in an image, where there is little new to be learned about visual
-        perception\n\nby explaining a DL model. However, the black box nature of DL
-        has its own limitations.\n\nUsers are more likely to trust and use predictions
-        from a model if they can understand why\n\nthe prediction was made.17 Explaining
-        predictions can help developers of DL models ensure\n\nthe model is not learning
-        spurious correlations.18,19 Two infamous examples are, 1)neural\n\nnetworks
-        that learned to recognize horses by looking for a photographer\u2019s watermark20
-        and,\n\n2) neural networks that predicted a COVID-19 diagnoses by looking at
-        the font choice\n\non medical images.21 As a result, there is an emerging regulatory
-        framework for when any\n\ncomputer algorithms impact humans.22\u201324 Although
-        we know of no examples yet in chemistry,\n\none can assume the use of AI in
-        predicting toxicity, carcinogenicity, and environmental\n\npersistence will
-        require rationale for the predictions due to regulatory consequences.\n\n   1there
-        does happen to be one human solubility savant, participant 11, who matched machine
-        performance\n\n\n                                        2   EXplainable Artificial
-        Intelligence (XAI) is a field of growing importance that aims to\n\nprovide
-        model interpretations of DL predictions Three terms highly associated with XAI
-        are,\n\ninterpretability, justifications and explainability. Miller 25 defines
-        that interpretability of a\n\nmodel refers to the degree of human understandability
-        intrinsic within the model. Murdoch\n\net al. 26 clarify that interpretability
-        can be perceived as \u201cknowledge\u201d which provide insight\n\nto a particular
-        problem.  Justifications are quantitative metrics tell the users \u201cwhy the\n\nmodel
-        should be trusted,\u201d like test error.27 Justifications are evidence which
-        defend why a\n\nprediction is trustworthy.25 An \u201cexplanation\u201d is a
-        description on why a certain prediction was\n\nmade.9,28 Interpretability and
-        explanation are often used interchangeably. Arrieta et al. 14\n\ndistinguish
-        that interpretability is a passive characteristic of a model, whereas explainability\n\nis
+        to\\n\\na specific prediction.\\n\\n    It is routine in chemistry now for DL
+        to exceed human level performance \u2014 humans are\\n\\nnot good at predicting
+        solubility from structure for example161 \u2014 and so understanding how\\n\\na
+        model makes predictions can guide hypotheses. This is in contrast to a topic
+        like finding\\n\\na stop sign in an image, where there is little new to be learned
+        about visual perception\\n\\nby explaining a DL model. However, the black box
+        nature of DL has its own limitations.\\n\\nUsers are more likely to trust and
+        use predictions from a model if they can understand why\\n\\nthe prediction
+        was made.17 Explaining predictions can help developers of DL models ensure\\n\\nthe
+        model is not learning spurious correlations.18,19 Two infamous examples are,
+        1)neural\\n\\nnetworks that learned to recognize horses by looking for a photographer\u2019s
+        watermark20 and,\\n\\n2) neural networks that predicted a COVID-19 diagnoses
+        by looking at the font choice\\n\\non medical images.21 As a result, there is
+        an emerging regulatory framework for when any\\n\\ncomputer algorithms impact
+        humans.22\u201324 Although we know of no examples yet in chemistry,\\n\\none
+        can assume the use of AI in predicting toxicity, carcinogenicity, and environmental\\n\\npersistence
+        will require rationale for the predictions due to regulatory consequences.\\n\\n
+        \  1there does happen to be one human solubility savant, participant 11, who
+        matched machine performance\\n\\n\\n                                        2
+        \  EXplainable Artificial Intelligence (XAI) is a field of growing importance
+        that aims to\\n\\nprovide model interpretations of DL predictions Three terms
+        highly associated with XAI are,\\n\\ninterpretability, justifications and explainability.
+        Miller 25 defines that interpretability of a\\n\\nmodel refers to the degree
+        of human understandability intrinsic within the model. Murdoch\\n\\net al. 26
+        clarify that interpretability can be perceived as \u201Cknowledge\u201D which
+        provide insight\\n\\nto a particular problem.  Justifications are quantitative
+        metrics tell the users \u201Cwhy the\\n\\nmodel should be trusted,\u201D like
+        test error.27 Justifications are evidence which defend why a\\n\\nprediction
+        is trustworthy.25 An \u201Cexplanation\u201D is a description on why a certain
+        prediction was\\n\\nmade.9,28 Interpretability and explanation are often used
+        interchangeably. Arrieta et al. 14\\n\\ndistinguish that interpretability is
+        a passive characteristic of a model, whereas explainability\\n\\nis an active
+        characteristic which is used to clarify the internal decision-making process.\\n\\nNamely,
+        an explanation is extra information that gives the context and a cause for one
+        or\\n\\nmore pre\",\"passive characteristic of a model, whereas explainability\\n\\nis
         an active characteristic which is used to clarify the internal decision-making
-        process.\n\nNamely, an explanation is extra information that gives the context
-        and a cause for one or\n\nmore pre", "passive characteristic of a model, whereas
-        explainability\n\nis an active characteristic which is used to clarify the internal
-        decision-making process.\n\nNamely, an explanation is extra information that
-        gives the context and a cause for one or\n\nmore predictions.29 We adopt the
-        same nomenclature in this perspective.\n\n   Accuracy and interpretability are
-        two attractive characteristics of DL models. However,\n\nDL models are often
-        highly accurate and less interpretable.28,30 XAI provides a way to avoid\n\nthat
-        trade-off in chemical property prediction. XAI can be viewed as a two-step process.\n\nFirst,
+        process.\\n\\nNamely, an explanation is extra information that gives the context
+        and a cause for one or\\n\\nmore predictions.29 We adopt the same nomenclature
+        in this perspective.\\n\\n   Accuracy and interpretability are two attractive
+        characteristics of DL models. However,\\n\\nDL models are often highly accurate
+        and less interpretable.28,30 XAI provides a way to avoid\\n\\nthat trade-off
+        in chemical property prediction. XAI can be viewed as a two-step process.\\n\\nFirst,
         we develop an accurate but uninterpretable DL model. Next, we add explanations
-        to\n\npredictions. Ideally, if the DL model has correctly learned the input-output
-        relations, then\n\nthe explanations should give insight into the underlying
-        mechanism.\n\n   In the remainder of this article, we review recent approaches
-        for XAI of chemical property\n\nprediction while drawing specific examples from
-        our recent XAI work.9,10,31 We show how\n\nin various systems these methods
-        yield explanations that are consistent with known and\n\nmechanisms in structure-property
-        relationships.\n\n\n\n\n\n                                        3Theory\n\n\nIn
-        this work, we aim to assemble a common taxonomy for the landscape of XAI while\n\nproviding
-        our perspectives. We utilized the vocabulary proposed by Das and Rad 32 to classify\n\nXAI.
+        to\\n\\npredictions. Ideally, if the DL model has correctly learned the input-output
+        relations, then\\n\\nthe explanations should give insight into the underlying
+        mechanism.\\n\\n   In the remainder of this article, we review recent approaches
+        for XAI of chemical property\\n\\nprediction while drawing specific examples
+        from our recent XAI work.9,10,31 We show how\\n\\nin various systems these methods
+        yield explanations that are consistent with known and\\n\\nmechanisms in structure-property
+        relationships.\\n\\n\\n\\n\\n\\n                                        3Theory\\n\\n\\nIn
+        this work, we aim to assemble a common taxonomy for the landscape of XAI while\\n\\nproviding
+        our perspectives. We utilized the vocabulary proposed by Das and Rad 32 to classify\\n\\nXAI.
         According to their classification, interpretations can be categorized as global
-        or local\n\ninterpretations on the basis of \u201cwhat is being explained?\u201d.
-        For example, counterfactuals are\n\nlocal interpretations, as these can explain
-        only a given instance. The second classification is\n\nbased on the relation
-        between the model and the interpretation \u2013 is interpretability post-hoc\n\n(extrinsic)
-        or intrinsic to the model?.32,33 An intrinsic XAI method is part of the model\n\nand
+        or local\\n\\ninterpretations on the basis of \u201Cwhat is being explained?\u201D.
+        For example, counterfactuals are\\n\\nlocal interpretations, as these can explain
+        only a given instance. The second classification is\\n\\nbased on the relation
+        between the model and the interpretation \u2013 is interpretability post-hoc\\n\\n(extrinsic)
+        or intrinsic to the model?.32,33 An intrinsic XAI method is part of the model\\n\\nand
         is self-explanatory32 These are also referred to as white-box models to contrast
-        them\n\nwith non-interpretable black box models.28 An extrinsic method is one
-        that can be applied\n\npost-training to any model.33 Post-hoc methods found
-        in the literature focus on interpreting\n\nmodels through 1) training data34
-        and feature attribution,35 2) surrogate models10 and, 3)\n\ncounterfactual9
-        or contrastive explanations.36\n\n   Often, what is a \u201cgood\u201d explanation
-        and what are the required components of an ex-\n\nplanation are debated.32,37,38
-        Palacio et al. 29 state that the lack of a standard framework\n\nhas caused
-        the inability to evaluate the interpretability of a model.  In physical sciences,\n\nwe
-        may instead consider if the explanations somehow reflect and expand our understanding\n\nof
-        physical phenomena.  For example, Oviedo et al. 39 propose that a model explanation\n\ncan
+        them\\n\\nwith non-interpretable black box models.28 An extrinsic method is
+        one that can be applied\\n\\npost-training to any model.33 Post-hoc methods
+        found in the literature focus on interpreting\\n\\nmodels through 1) training
+        data34 and feature attribution,35 2) surrogate models10 and, 3)\\n\\ncounterfactual9
+        or contrastive explanations.36\\n\\n   Often, what is a \u201Cgood\u201D explanation
+        and what are the required components of an ex-\\n\\nplanation are debated.32,37,38
+        Palacio et al. 29 state that the lack of a standard framework\\n\\nhas caused
+        the inability to evaluate the interpretability of a model.  In physical sciences,\\n\\nwe
+        may instead consider if the explanations somehow reflect and expand our understanding\\n\\nof
+        physical phenomena.  For example, Oviedo et al. 39 propose that a model explanation\\n\\ncan
         be evaluated by considering its agreement with physical observations, which
-        they term\n\n\u201ccorrectness.\u201d For example, if an explanation suggests
-        that polarity affects solubility of a\n\nmolecule, and the experimental evidence
-        strengthen the hypothesis, then the explanation\n\nis assumed \u201ccorrect\u201d.
-        In instances where such mechanistic knowledge is sparse, expert bi-\n\nases
+        they term\\n\\n\u201Ccorrectness.\u201D For example, if an explanation suggests
+        that polarity affects solubility of a\\n\\nmolecule, and the experimental evidence
+        strengthen the hypothesis, then the explanation\\n\\nis assumed \u201Ccorrect\u201D.
+        In instances where such mechanistic knowledge is sparse, expert bi-\\n\\nases
         and subjectivity can be used to measure the correctness.40 Other similar metrics
-        of\n\ncorrectness such as \u201cexplanation satisfaction scale\u201d can be
-        found in the literature.41,42 In a\n\nrecent study, Humer et al. 43 introduced
-        CIME an interactive web-based tool that allows the\n\nusers to inspect model
-        explanations. The aim of this study is to bridge the gap between\n\nanalysis
-        of XAI methods. Based on the above discussion, we identify that an agreed upon\n\n\n                                        4evaluation
-        metric is necessary in XAI. We suggest the following attributes can be used
-        to\n\nevaluate explanations. However, the relative importance of each attribute
-        may depend on\n\nthe application - actionability may not be as important as
-        faithfulness when evaluating the\n\ninterpretability of a static physics based
-        model. Therefore, one can select relative importance\n\nof each attribute based
-        on the application.\n\n   \u2022 Actionable. Is it clear how we could change
-        the input features to modify the output?\n\n   \u2022 Complete. Does the explanation
-        completely account for the prediction? Did features\n\n     not included in
-        the explanation really contribute zero effect to the prediction?44\n\n   \u2022
-        Correct. Does the explanation agree with hypothesized or known underlying physical\n\n     mechanism?39\n\n   \u2022
-        Domain Applicable. Does the explanation use language and concepts of domain
-        ex-\n\n      perts?\n\n   \u2022 Fidelity/Faithful. Does the explanation agree
-        with the black box model?\n\n   \u2022 Robust. Does the explanation change significantly
-        with small changes to the model or\n\n      instance being explained?\n\n   \u2022
-        Sparse/Succinct. Is the explanation succinct?\n\n\n  We present an example evaluation
-        of the SHAP explanation method based on the above\n\nattributes.44 Shapley values
-        were proposed as a local explanation method based on feature\n\nattribution,
-        as they offer a complete explanation - each feature is assign", " We present
-        an example evaluation of the SHAP explanation method based on the above\n\nattributes.44
-        Shapley values were proposed as a local explanation method based on feature\n\nattribution,
-        as they offer a complete explanation - each feature is assigned a fraction of\n\nthe
+        of\\n\\ncorrectness such as \u201Cexplanation satisfaction scale\u201D can be
+        found in the literature.41,42 In a\\n\\nrecent study, Humer et al. 43 introduced
+        CIME an interactive web-based tool that allows the\\n\\nusers to inspect model
+        explanations. The aim of this study is to bridge the gap between\\n\\nanalysis
+        of XAI methods. Based on the above discussion, we identify that an agreed upon\\n\\n\\n
+        \                                       4evaluation metric is necessary in XAI.
+        We suggest the following attributes can be used to\\n\\nevaluate explanations.
+        However, the relative importance of each attribute may depend on\\n\\nthe application
+        - actionability may not be as important as faithfulness when evaluating the\\n\\ninterpretability
+        of a static physics based model. Therefore, one can select relative importance\\n\\nof
+        each attribute based on the application.\\n\\n   \u2022 Actionable. Is it clear
+        how we could change the input features to modify the output?\\n\\n   \u2022
+        Complete. Does the explanation completely account for the prediction? Did features\\n\\n
+        \    not included in the explanation really contribute zero effect to the prediction?44\\n\\n
+        \  \u2022 Correct. Does the explanation agree with hypothesized or known underlying
+        physical\\n\\n     mechanism?39\\n\\n   \u2022 Domain Applicable. Does the explanation
+        use language and concepts of domain ex-\\n\\n      perts?\\n\\n   \u2022 Fidelity/Faithful.
+        Does the explanation agree with the black box model?\\n\\n   \u2022 Robust.
+        Does the explanation change significantly with small changes to the model or\\n\\n
+        \     instance being explained?\\n\\n   \u2022 Sparse/Succinct. Is the explanation
+        succinct?\\n\\n\\n  We present an example evaluation of the SHAP explanation
+        method based on the above\\n\\nattributes.44 Shapley values were proposed as
+        a local explanation method based on feature\\n\\nattribution, as they offer
+        a complete explanation - each feature is assign\",\" We present an example evaluation
+        of the SHAP explanation method based on the above\\n\\nattributes.44 Shapley
+        values were proposed as a local explanation method based on feature\\n\\nattribution,
+        as they offer a complete explanation - each feature is assigned a fraction of\\n\\nthe
         prediction value.44,45 Completeness is a clearly measurable and well-defined
-        metric, but\n\nyields explanations with many components. Yet Shapley values
-        are not actionable nor sparse.\n\nThey are non-sparse as every feature has a
-        non-zero attribution and not-actionable because\n\nthey do not provide a set
-        of features which changes the outcome.46 Ribeiro et al. 35 proposed\n\na surrogate
-        model method that aims to provide sparse/succinct explanations that have high\n\n\n                                        5fidelity
-        to the original model. In Wellawatte et al. 9 we argue that counterfactuals
-        are \u201cbet-\n\nter\u201d explanations because they are actionable and sparse.
-        We highlight that, evaluation of\n\nexplanations is a difficult task because
-        explanations are fundamentally for and by humans.\n\nTherefore, these evaluations
-        are subjective, as they depend on \u201ccomplex human factors and\n\napplication
-        scenarios.\u201d37\n\n\nSelf-explaining models\n\nA self-explanatory model is
-        one that is intrinsically interpretable to an expert.47 Two com-\n\nmon examples
-        found in the literature are linear regression models and decision trees (DT).\n\nIntrinsic
-        models can be found in other XAI applications acting as surrogate models (proxy\n\nmodels)
-        due to their transparent nature.48,49 A linear model is described by the equation\n\n1
+        metric, but\\n\\nyields explanations with many components. Yet Shapley values
+        are not actionable nor sparse.\\n\\nThey are non-sparse as every feature has
+        a non-zero attribution and not-actionable because\\n\\nthey do not provide a
+        set of features which changes the outcome.46 Ribeiro et al. 35 proposed\\n\\na
+        surrogate model method that aims to provide sparse/succinct explanations that
+        have high\\n\\n\\n                                        5fidelity to the original
+        model. In Wellawatte et al. 9 we argue that counterfactuals are \u201Cbet-\\n\\nter\u201D
+        explanations because they are actionable and sparse. We highlight that, evaluation
+        of\\n\\nexplanations is a difficult task because explanations are fundamentally
+        for and by humans.\\n\\nTherefore, these evaluations are subjective, as they
+        depend on \u201Ccomplex human factors and\\n\\napplication scenarios.\u201D37\\n\\n\\nSelf-explaining
+        models\\n\\nA self-explanatory model is one that is intrinsically interpretable
+        to an expert.47 Two com-\\n\\nmon examples found in the literature are linear
+        regression models and decision trees (DT).\\n\\nIntrinsic models can be found
+        in other XAI applications acting as surrogate models (proxy\\n\\nmodels) due
+        to their transparent nature.48,49 A linear model is described by the equation\\n\\n1
         where, W\u2019s are the weight parameters and x\u2019s are the input features
-        associated with the\n\nprediction \u02c6y. Therefore, we observe that the weights
-        can be used to derive a complete expla-\n\nnation of the model - trained weights
-        quantify the importance of each feature.47 DT models\n\nare another type of
-        self-explaining models which have been used in classification and high-\n\nthroughput
-        screening tasks.  Gajewicz et al. 50 used DT models to classify nanomaterials\n\nthat
+        associated with the\\n\\nprediction \u02C6y. Therefore, we observe that the
+        weights can be used to derive a complete expla-\\n\\nnation of the model - trained
+        weights quantify the importance of each feature.47 DT models\\n\\nare another
+        type of self-explaining models which have been used in classification and high-\\n\\nthroughput
+        screening tasks.  Gajewicz et al. 50 used DT models to classify nanomaterials\\n\\nthat
         identify structural features responsible for surface activity. In another study
-        by Han\n\net al. 51, a DT model was developed to filter compounds by their bioactivity
-        based on the\n\nchemical fingerprints.\n\n\n\n                                                              \u02c6y
-        = \u03a3iWixi                                      (1)\n\n\n   Regularization
-        techniques such as EXPO52 and RRR53 are designed to enhance the black-\n\nbox
-        model interpretability.54 Although one can argue that \u201csimplicity\u201d
-        of models are posi-\n\ntively correlated with interpretability, this is based
-        on how the interpretability is evaluated.\n\nFor example, Lipton 55 argue that,
-        from the notion of \u201csimulatability\u201d (the degree to which a\n\nhuman
-        can predict the outcome based on inputs), self-explanatory linear models, rule-based\n\n\n\n                                        6systems,
-        and DT\u2019s can be claimed uninterpretable. A human can predict the outcome
-        given\n\nthe inputs only if the input features are interpretable. Therefore,
-        a linear model which takes\n\nin non-descriptive inputs may not be as transparent.
-        On the other hand, a linear model\n\nis not innately accurate as they fail to
-        capture non-linear relationships in data, limiting is\n\napplicability. Similarly,
-        a DT is a rule-based model and lacks physics informed knowledge.\n\nTherefore,
-        an existing drawback is the trade-off between the degree of understandability
-        and\n\nthe accuracy of a model. For example, an intrinsic model (linear regression
-        or decision trees)\n\ncan be described through the trainable parameters, but
-        it may fail to \u201ccorrectly\u201d capture\n\nnon-linear relations in the
-        data.\n\n\nAttribution methods\n\n\nFeature attribution methods explain black
-        box predictions by assigning each input feature\n\na numerical value, which
-        indicates its importance or contribution to the prediction. Feature\n\nattributions
-        provide local explanations, but can be averaged or combined to explain multi-\n\nple
-        instances. Atom-based numerical assignments are commonly referred to as heatmaps.56\n\nSheridan
-        57 describes an atom-wise attribution method for interpreting QSAR models. Re-\n\ncently,
-        Rasmussen et al. 58 showed that Crippen logP models serve as a benchmark for\n\nheatmap
-        approaches. Other most widely used feature attribution approaches in the litera-\n\nture
+        by Han\\n\\net al. 51, a DT model was developed to filter compounds by their
+        bioactivity based on the\\n\\nchemical fingerprints.\\n\\n\\n\\n                                                              \u02C6y
+        = \u03A3iWixi                                      (1)\\n\\n\\n   Regularization
+        techniques such as EXPO52 and RRR53 are designed to enhance the black-\\n\\nbox
+        model interpretability.54 Although one can argue that \u201Csimplicity\u201D
+        of models are posi-\\n\\ntively correlated with interpretability, this is based
+        on how the interpretability is evaluated.\\n\\nFor example, Lipton 55 argue
+        that, from the notion of \u201Csimulatability\u201D (the degree to which a\\n\\nhuman
+        can predict the outcome based on inputs), self-explanatory linear models, rule-based\\n\\n\\n\\n
+        \                                       6systems, and DT\u2019s can be claimed
+        uninterpretable. A human can predict the outcome given\\n\\nthe inputs only
+        if the input features are interpretable. Therefore, a linear model which takes\\n\\nin
+        non-descriptive inputs may not be as transparent. On the other hand, a linear
+        model\\n\\nis not innately accurate as they fail to capture non-linear relationships
+        in data, limiting is\\n\\napplicability. Similarly, a DT is a rule-based model
+        and lacks physics informed knowledge.\\n\\nTherefore, an existing drawback is
+        the trade-off between the degree of understandability and\\n\\nthe accuracy
+        of a model. For example, an intrinsic model (linear regression or decision trees)\\n\\ncan
+        be described through the trainable parameters, but it may fail to \u201Ccorrectly\u201D
+        capture\\n\\nnon-linear relations in the data.\\n\\n\\nAttribution methods\\n\\n\\nFeature
+        attribution methods explain black box predictions by assigning each input feature\\n\\na
+        numerical value, which indicates its importance or contribution to the prediction.
+        Feature\\n\\nattributions provide local explanations, but can be averaged or
+        combined to explain multi-\\n\\nple instances. Atom-based numerical assignments
+        are commonly referred to as heatmaps.56\\n\\nSheridan 57 describes an atom-wise
+        attribution method for interpreting QSAR models. Re-\\n\\ncently, Rasmussen
+        et al. 58 showed that Crippen logP models serve as a benchmark for\\n\\nheatmap
+        approaches. Other most widely used feature attribution approaches in the litera-\\n\\nture
         are gradient based methods,59,60 Shapley Additive exPlanations (SHAP),44 and
-        layer-\n\nwise relevance prorogation.61\n\n   Gradient based approaches are
-        based on the hypothesis that gradients for neural net-\n\nworks are analogous
-        to coefficients for regression models.62 Class activation maps (CAM),63\n\ngradCAM,64
-        smoothGrad,,65 and integrated gradients62 are examples of this method. The\n\nmain
-        idea behind feature attributions with gradients can be represented with equation  2.\n\n\n                                          \u2206\u02c6f(\u20d7x)\n                                                                                           (2)                               \u2206xi  \u2248\u2202\u02c6f(\u20d7x)\u2202xi\n\n\n\n                            ",
-        "sented with equation  2.\n\n\n                                          \u2206\u02c6f(\u20d7x)\n                                                                                           (2)                               \u2206xi  \u2248\u2202\u02c6f(\u20d7x)\u2202xi\n\n\n\n                                        7                                                                     \u2206\u02c6f(\u20d7x)   where
-        \u02c6f(x) is the black-box model and       are used as our attributions. The
-        left-                                                 \u2206xi\n\nhand side
-        of equation 2 says that we attribute each input feature xi by how much one unit\n\nchange
-        in it would affect the output of \u02c6f(x).  If \u02c6f(x) is a linear surrogate
-        model, then this\nmethod reconciles with LIME.35 In DL models, \u2207xf(x),
-        suffers from the shattered gradients\nproblem.62 This means directly computing
-        the quantity leads to numeric problems. The\n\ndifferent gradient based approaches
-        are mostly distinguishable based on how the gradient is\n\napproximated.\n\n   Gradient
-        based explanations have been widely used to interpret chemistry predictions.60,66\u201370\n\nMcCloskey
-        et al. 60 used graph convolutional networks (GCNs) to predict protein-ligand\n\nbinding
-        and explained the binding logic for these predictions using integrated gradients.\n\nPope
-        et al. 66 and Jim\u00b4enez-Luna et al. 67 show application of gradCAM and integrated
-        gradi-\n\nents to explain molecular property predictions from trained graph
-        neural networks (GNNs).\n\nSanchez-Lengeling et al. 68 present comprehensive,
-        open-source XAI benchmarks to explain\n\nGNNs and other graph based models.
-        They compare the performance of class activation\n\nmaps (CAM),63 gradCAM,64
-        smoothGrad,,65 integrated gradients62 and attention mecha-\n\nnisms for explaining
-        outcomes of classification as well as regression tasks. They concluded\n\nthat
-        CAM and integrated gradients perform well for graph based models. Another attempt\n\nat
-        creating XAI benchmarks for graph models was made by Rao et al. 70. They compared\n\nthese
+        layer-\\n\\nwise relevance prorogation.61\\n\\n   Gradient based approaches
+        are based on the hypothesis that gradients for neural net-\\n\\nworks are analogous
+        to coefficients for regression models.62 Class activation maps (CAM),63\\n\\ngradCAM,64
+        smoothGrad,,65 and integrated gradients62 are examples of this method. The\\n\\nmain
+        idea behind feature attributions with gradients can be represented with equation
+        \ 2.\\n\\n\\n                                          \u2206\u02C6f(\u20D7x)\\n
+        \                                                                                          (2)
+        \                              \u2206xi  \u2248\u2202\u02C6f(\u20D7x)\u2202xi\\n\\n\\n\\n
+        \                           \",\"sented with equation  2.\\n\\n\\n                                          \u2206\u02C6f(\u20D7x)\\n
+        \                                                                                          (2)
+        \                              \u2206xi  \u2248\u2202\u02C6f(\u20D7x)\u2202xi\\n\\n\\n\\n
+        \                                       7                                                                     \u2206\u02C6f(\u20D7x)
+        \  where \u02C6f(x) is the black-box model and       are used as our attributions.
+        The left-                                                 \u2206xi\\n\\nhand
+        side of equation 2 says that we attribute each input feature xi by how much
+        one unit\\n\\nchange in it would affect the output of \u02C6f(x).  If \u02C6f(x)
+        is a linear surrogate model, then this\\nmethod reconciles with LIME.35 In DL
+        models, \u2207xf(x), suffers from the shattered gradients\\nproblem.62 This
+        means directly computing the quantity leads to numeric problems. The\\n\\ndifferent
+        gradient based approaches are mostly distinguishable based on how the gradient
+        is\\n\\napproximated.\\n\\n   Gradient based explanations have been widely used
+        to interpret chemistry predictions.60,66\u201370\\n\\nMcCloskey et al. 60 used
+        graph convolutional networks (GCNs) to predict protein-ligand\\n\\nbinding and
+        explained the binding logic for these predictions using integrated gradients.\\n\\nPope
+        et al. 66 and Jim\xB4enez-Luna et al. 67 show application of gradCAM and integrated
+        gradi-\\n\\nents to explain molecular property predictions from trained graph
+        neural networks (GNNs).\\n\\nSanchez-Lengeling et al. 68 present comprehensive,
+        open-source XAI benchmarks to explain\\n\\nGNNs and other graph based models.
+        They compare the performance of class activation\\n\\nmaps (CAM),63 gradCAM,64
+        smoothGrad,,65 integrated gradients62 and attention mecha-\\n\\nnisms for explaining
+        outcomes of classification as well as regression tasks. They concluded\\n\\nthat
+        CAM and integrated gradients perform well for graph based models. Another attempt\\n\\nat
+        creating XAI benchmarks for graph models was made by Rao et al. 70. They compared\\n\\nthese
         gradient based methods to find subgraph importance when predicting activity
-        cliffs\n\nand concluded that gradCAM and integrated gradients provided the most
-        interpretability\n\nfor GNNs.  The GNNExplainer69  is an approach for generating
-        explanations (local and\n\nglobal) for graph based models. This method focuses
-        on identifying which sub-graphs con-\n\ntribute most to the prediction by maximizing
-        mutual information between the prediction\n\nand distribution of all possible
-        sub-graphs. Ying et al. 69 show that GNNExplainer can be\n\nused to obtain model-agnostic
-        explanations. SubgraphX is a similar method that explains\n\nGNN predictions
-        by identifying important subgraphs.71\n\n   Another set of approaches like DeepLIFT72
-        and Layerwise Relevance backPropagation73\n\n\n\n                                        8(LRP)
-        are based on backpropagation of the prediction scores through each layer of
-        the neu-\n\nral network. The specific backpropagation logic across various activation
-        functions differs\n\nin these approaches, which means each layer must have its
-        own implementation. Baldas-\n\nsarre and Azizpour 74 showed application of LRP
-        to explain aqueous solubility prediction for\n\nmolecules.\n\n  SHAP is a model-agnostic
-        feature attribution method that is inspired from the game\n\ntheory concept
-        of Shapley values.44,46 SHAP has been popularly used in explaining molecular\n\nprediction
-        models.75\u201378 It\u2019s an additive feature contribution approach, which
-        assumes that\n\nan explanation model is a linear combination of binary variables
-        z.  If the Shapley value\nfor the ith feature is \u03d5i, then the explanation
-        is \u02c6f(\u20d7x) =      i \u03d5i(\u20d7x)zi(\u20d7x). Shapley values forfeatures
-        are computed using Equation 3.79,80     P\n\n\n\n                           M\n                                  1\n                                    \u03d5i(\u20d7x)
-        =         \u02c6f (\u20d7z+i)                                      (3)                 M         \u2212\u02c6f
-        (\u20d7z\u2212i)            X\n   Here \u20d7z is a fabricated example created
-        from the original \u20d7x and a random perturbation \u20d7x\u2032.\n\n\u20d7z+i
-        has the feature i from \u20d7x and \u20d7z\u2212i has the ith feature from \u20d7x\u2032.
-        Some care should be taken\nin constructing \u20d7z when working with molecular
-        descriptors to ensure that an impossible \u20d7z is\n\nnot sampled (e.g., high
-        count of acid groups but no hydrogen bond donors). M is the sample\n\nsize of
-        perturbations around \u20d7x. Shapley value computation is expensive, hence
-        M is chosen\n\naccordingly. Equation 3 is an approximation and gives contributions
-        with an expectation\nterm as \u03d50 +   i=1 \u03d5i(\u20d7x) = \u02c6f(\u20d7x).   VisualizationP
-        based feature attribution has also been used for molecular data. In com-\n\nputer
-        science, saliency maps are a way to measure spatial feature contribution.81
-        Simply put,\n\nsaliency maps draw a connection between the model\u2019s neural
-        fingerprint components (trained\n\nweights) and input features. Weber et al.
-        82 used saliency maps to build an explainable GCN\n\narchitecture that gives
-        subgraph importance for small molecule activity prediction. On the\n\nother
-        hand, similarity maps compare model predictions for two or more molecules bas",
-        " features. Weber et al. 82 used saliency maps to build an explainable GCN\n\narchitecture
-        that gives subgraph importance for small molecule activity prediction. On the\n\nother
+        cliffs\\n\\nand concluded that gradCAM and integrated gradients provided the
+        most interpretability\\n\\nfor GNNs.  The GNNExplainer69  is an approach for
+        generating explanations (local and\\n\\nglobal) for graph based models. This
+        method focuses on identifying which sub-graphs con-\\n\\ntribute most to the
+        prediction by maximizing mutual information between the prediction\\n\\nand
+        distribution of all possible sub-graphs. Ying et al. 69 show that GNNExplainer
+        can be\\n\\nused to obtain model-agnostic explanations. SubgraphX is a similar
+        method that explains\\n\\nGNN predictions by identifying important subgraphs.71\\n\\n
+        \  Another set of approaches like DeepLIFT72 and Layerwise Relevance backPropagation73\\n\\n\\n\\n
+        \                                       8(LRP) are based on backpropagation
+        of the prediction scores through each layer of the neu-\\n\\nral network. The
+        specific backpropagation logic across various activation functions differs\\n\\nin
+        these approaches, which means each layer must have its own implementation. Baldas-\\n\\nsarre
+        and Azizpour 74 showed application of LRP to explain aqueous solubility prediction
+        for\\n\\nmolecules.\\n\\n  SHAP is a model-agnostic feature attribution method
+        that is inspired from the game\\n\\ntheory concept of Shapley values.44,46 SHAP
+        has been popularly used in explaining molecular\\n\\nprediction models.75\u201378
+        It\u2019s an additive feature contribution approach, which assumes that\\n\\nan
+        explanation model is a linear combination of binary variables z.  If the Shapley
+        value\\nfor the ith feature is \u03D5i, then the explanation is \u02C6f(\u20D7x)
+        =      i \u03D5i(\u20D7x)zi(\u20D7x). Shapley values forfeatures are computed
+        using Equation 3.79,80     P\\n\\n\\n\\n                           M\\n                                  1\\n
+        \                                   \u03D5i(\u20D7x) =         \u02C6f (\u20D7z+i)
+        \                                     (3)                 M         \u2212\u02C6f
+        (\u20D7z\u2212i)            X\\n   Here \u20D7z is a fabricated example created
+        from the original \u20D7x and a random perturbation \u20D7x\u2032.\\n\\n\u20D7z+i
+        has the feature i from \u20D7x and \u20D7z\u2212i has the ith feature from \u20D7x\u2032.
+        Some care should be taken\\nin constructing \u20D7z when working with molecular
+        descriptors to ensure that an impossible \u20D7z is\\n\\nnot sampled (e.g.,
+        high count of acid groups but no hydrogen bond donors). M is the sample\\n\\nsize
+        of perturbations around \u20D7x. Shapley value computation is expensive, hence
+        M is chosen\\n\\naccordingly. Equation 3 is an approximation and gives contributions
+        with an expectation\\nterm as \u03D50 +   i=1 \u03D5i(\u20D7x) = \u02C6f(\u20D7x).
+        \  VisualizationP based feature attribution has also been used for molecular
+        data. In com-\\n\\nputer science, saliency maps are a way to measure spatial
+        feature contribution.81 Simply put,\\n\\nsaliency maps draw a connection between
+        the model\u2019s neural fingerprint components (trained\\n\\nweights) and input
+        features. Weber et al. 82 used saliency maps to build an explainable GCN\\n\\narchitecture
+        that gives subgraph importance for small molecule activity prediction. On the\\n\\nother
+        hand, similarity maps compare model predictions for two or more molecules bas\",\"
+        features. Weber et al. 82 used saliency maps to build an explainable GCN\\n\\narchitecture
+        that gives subgraph importance for small molecule activity prediction. On the\\n\\nother
         hand, similarity maps compare model predictions for two or more molecules based
-        on\n\ntheir chemical fingerprints.83 Similarity maps provide atomic weights
-        or predicted probabil-\n\n\n                                        9ity difference
-        between the molecules by removing one atom at a time. These weights can\n\nthen
-        be used to color the molecular graph and give a visual presentation. ChemInformatics\n\nModel
-        Explorer (CIME) is an interactive web based toolkit which allows visualization
-        and\n\ncomparison of different explanation methods for molecular property prediction
-        models.84\n\n\nSurrogate models\n\n\nOne approach to explain black box predictions
-        is to fit a self-explaining or interpretable\n\nmodel to the black box model,
-        in the vicinity of one or a few specific examples. These are\n\nknown as surrogate
-        models. Generally, one model per explanation is trained. However, if we\n\ncould
-        find one surrogate model that explained the whole DL model, then we would simply\n\nhave
-        a globally accurate interpretable model. This means that the black-box model
-        is no\n\nlonger needed.79 In the work by White 79, a weighted least squares
-        linear model is used as\n\nthe surrogate model. This model provides natural
-        language based descriptor explanations by\n\nreplacing input features with chemically
-        interpretable descriptors. This approach is similar\n\nto the concept-based
-        explanations approach used by McGrath et al. 85, where human under-\n\nstandable
-        concepts were used in place of input features in acquisition of chess knowledge
-        in\n\nAlphaZero. Any of the self-explaining models detailed in the Self-explaining
-        models section\n\ncan be used as a surrogate model.\n\n   The most commonly
-        used surrogate model based method is Locally Interpretable Model\n\nExplanations
-        (LIME).35 LIME creates perturbations around the example of interest and fits\n\nan
-        interpretable model to these local perturbations. Ribeiro et al. 35 mathematically
-        define\n\nan explanation \u03be for an example \u20d7x using Equation 4.\n\n\n                                   \u03be(\u20d7x)
-        = arg min L(f, g, \u03c0x) + \u2126(g)                           (4)                                      g\u2208G\n   Here
-        f is the black box model and g \u2208G is the interpretable explanation model.
-        G is\na class of potential interpretable models (e.g.:  linear models). \u03c0x
-        is a similarity measure\n\n\n\n                                       10between
-        original input \u20d7x and it\u2019s perturbed input \u20d7x\u2032. In context
-        of molecular data, this can\n\nbe a chemical similarity metric like Tanimoto86
-        similarity between fingerprints. The goal for\n\nLIME is to minimize the loss,
-        L, such that f is closely approximated by g. \u2126is a parameter\nthat controls
+        on\\n\\ntheir chemical fingerprints.83 Similarity maps provide atomic weights
+        or predicted probabil-\\n\\n\\n                                        9ity
+        difference between the molecules by removing one atom at a time. These weights
+        can\\n\\nthen be used to color the molecular graph and give a visual presentation.
+        ChemInformatics\\n\\nModel Explorer (CIME) is an interactive web based toolkit
+        which allows visualization and\\n\\ncomparison of different explanation methods
+        for molecular property prediction models.84\\n\\n\\nSurrogate models\\n\\n\\nOne
+        approach to explain black box predictions is to fit a self-explaining or interpretable\\n\\nmodel
+        to the black box model, in the vicinity of one or a few specific examples. These
+        are\\n\\nknown as surrogate models. Generally, one model per explanation is
+        trained. However, if we\\n\\ncould find one surrogate model that explained the
+        whole DL model, then we would simply\\n\\nhave a globally accurate interpretable
+        model. This means that the black-box model is no\\n\\nlonger needed.79 In the
+        work by White 79, a weighted least squares linear model is used as\\n\\nthe
+        surrogate model. This model provides natural language based descriptor explanations
+        by\\n\\nreplacing input features with chemically interpretable descriptors.
+        This approach is similar\\n\\nto the concept-based explanations approach used
+        by McGrath et al. 85, where human under-\\n\\nstandable concepts were used in
+        place of input features in acquisition of chess knowledge in\\n\\nAlphaZero.
+        Any of the self-explaining models detailed in the Self-explaining models section\\n\\ncan
+        be used as a surrogate model.\\n\\n   The most commonly used surrogate model
+        based method is Locally Interpretable Model\\n\\nExplanations (LIME).35 LIME
+        creates perturbations around the example of interest and fits\\n\\nan interpretable
+        model to these local perturbations. Ribeiro et al. 35 mathematically define\\n\\nan
+        explanation \u03BE for an example \u20D7x using Equation 4.\\n\\n\\n                                   \u03BE(\u20D7x)
+        = arg min L(f, g, \u03C0x) + \u2126(g)                           (4)                                      g\u2208G\\n
+        \  Here f is the black box model and g \u2208G is the interpretable explanation
+        model. G is\\na class of potential interpretable models (e.g.:  linear models).
+        \u03C0x is a similarity measure\\n\\n\\n\\n                                       10between
+        original input \u20D7x and it\u2019s perturbed input \u20D7x\u2032. In context
+        of molecular data, this can\\n\\nbe a chemical similarity metric like Tanimoto86
+        similarity between fingerprints. The goal for\\n\\nLIME is to minimize the loss,
+        L, such that f is closely approximated by g. \u2126is a parameter\\nthat controls
         the complexity (sparsity) of g. Ribeiro et al. 35 termed the agreement (how
-        low\n\nthe loss is) between f and g as the \u201cfidelity\u201d.\n\n   GraphLIME87
-        and LIMEtree88 are modifications to LIME as applicable to graph neural\n\nnetworks
-        and regression trees, respectively. LIME has been used in chemistry previously,\n\nsuch
+        low\\n\\nthe loss is) between f and g as the \u201Cfidelity\u201D.\\n\\n   GraphLIME87
+        and LIMEtree88 are modifications to LIME as applicable to graph neural\\n\\nnetworks
+        and regression trees, respectively. LIME has been used in chemistry previously,\\n\\nsuch
         as Whitmore et al. 89 who used LIME to explain octane number predictions of
-        molecules\n\nfrom a random forest classifier. Mehdi and Tiwary 90 used LIME
-        to explain thermodynamic\n\ncontributions of features.  Gandhi and White 10
-        use an approach similar to GraphLIME,\n\nbut use chemistry specific fragmentation
-        and descriptors to explain molecular property pre-\n\ndiction. Some examples
-        are highlighted in the Applications section.  In recent work by\n\nMehdi and
-        Tiwary 90, a thermodynamic-based surrogate model approach was used to inter-\n\npret
-        black-box models. The authors define an \u201cinterpretation free energy\u201d
-        which can be\n\nachieved by minimizing the surrogate model\u2019s uncertainty
-        and maximizing simplicity.\n\n\nCounterfactual explanations\n\n\nCounterfactual
-        explanations can be found in many fields such as statistics, mathematics and\n\nphilosophy.91\u201394
-        According to Woodward and Hitchcock 92, a counterfactual is an example\n\nwith
+        molecules\\n\\nfrom a random forest classifier. Mehdi and Tiwary 90 used LIME
+        to explain thermodynamic\\n\\ncontributions of features.  Gandhi and White 10
+        use an approach similar to GraphLIME,\\n\\nbut use chemistry specific fragmentation
+        and descriptors to explain molecular property pre-\\n\\ndiction. Some examples
+        are highlighted in the Applications section.  In recent work by\\n\\nMehdi and
+        Tiwary 90, a thermodynamic-based surrogate model approach was used to inter-\\n\\npret
+        black-box models. The authors define an \u201Cinterpretation free energy\u201D
+        which can be\\n\\nachieved by minimizing the surrogate model\u2019s uncertainty
+        and maximizing simplicity.\\n\\n\\nCounterfactual explanations\\n\\n\\nCounterfactual
+        explanations can be found in many fields such as statistics, mathematics and\\n\\nphilosophy.91\u201394
+        According to Woodward and Hitchcock 92, a counterfactual is an example\\n\\nwith
         minimum deviation from the initial instance but with a contrasting outcome.
-        They\n\ncan be used to answer the question, \u201cwhich smallest change could
-        alter the outcome of an\n\ninstance of interest?\u201d While the difference
-        between the two instances is based on the exis-\n\ntence of similar worlds in
-        philosophy,95 a distance metric based on molecular similarity is\n\nemployed
-        in XAI for chemistry. For example, in the work by Wellawatte et al. 9 distance\n\nbetween
-        two molecules is defined as the Tanimoto distance96 between ECFP4 fingerprints.97\n\nAdditionally,
-        Mohapatra et al. 98 introduced a chemistry-informed graph representation for\n\ncomputing
-        macromolecular similarity. Contrastive explanations are peripheral to counterfac-\n\n\n                                       11tual
-        explanations. Unlike the counterfactual approach, contrastive approach employ
-        a dual\n\noptimization method, which works by generating a similar and a dissimilar
-        (counterfactuals)\n\nexample.  Cont", "nterfac-\n\n\n                                       11tual
-        explanations. Unlike the counterfactual approach, contrastive approach employ
-        a dual\n\noptimization method, which works by generating a similar and a dissimilar
-        (counterfactuals)\n\nexample.  Contrastive explanations can interpret the model
-        by identifying contribution of\n\npresence and absence of subsets of features
-        towards a certain prediction.36,99\n\n  A counterfactual x\u2032 of an instance
-        x is one with a dissimilar prediction \u02c6f(x) in classi-\n\nfication tasks.
-        As shown in equation 5, counterfactual generation can be thought of as a\n\nconstrained
-        optimization problem which minimizes the vector distance d(x, x\u2032) between
-        the\n\nfeatures.9,100\n\n\n                              minimize  d(x, x\u2032)\n                                                                                           (5)\n                               such
-        that   \u02c6f(x) \u0338= \u02c6f(x\u2032)\n\n   For regression tasks, equation
-        6 adapted from equation 5 can be used. Here, a counter-\n\nfactual is one with
-        a defined increase or decrease in the prediction.\n\n\n                           minimize  d(x,
-        x\u2032)\n                                                                                           (6)\n                            such
-        that    \u02c6f(x) \u2212\u02c6f(x\u2032) \u2265\u2206\n\n   Counterfactuals
-        explanations have become a useful tool for XAI in chemistry, as they\n\nprovide
-        intuitive understanding of predictions and are able to uncover spurious relationships\n\nin
-        training data.101 Counterfactuals create local (instance-level), actionable
-        explanations.\n\nActionability of an explanation suggest which features can
-        be altered to change the outcome.\n\nFor example, changing a hydrophobic functional
-        group in a molecule to a hydrophilic group\n\nto increase solubility.\n\n   Counterfactual
-        generation is a demanding task as it requires gradient optimization over\n\ndiscrete
-        features that represents a molecule. Recent work by Fu et al. 102 and Shen et
-        al. 103\n\npresent two techniques which allow continuous gradient-based optimization.
-        Although, these\n\nmethodologies are shown to circumvent the issue of discrete
-        molecular optimization, counter-\n\nfactual explanation based model interpretation
-        still remains unexplored compared to other\n\n\n\n                                       12post-hoc
-        methods.\n\n   CF-GNNExplainer104 is a counterfactual explanation generating
-        method based on GN-\n\nNExplainer69 for graph data. This method generate counterfactuals
-        by perturbing the input\n\ndata (removing edges in the graph), and keeping account
-        of perturbations which lead to\n\nchanges in the output.  However, this method
-        is only applicable to graph-based models\n\nand can generate infeasible molecular
-        structures. Another related work by Numeroso and\n\nBacciu 105 focus on generating
-        counterfactual explanations for deep graph networks. Their\n\nmethod MEG (Molecular
-        counterfactual Explanation Generator) uses a reinforcement learn-\n\ning based
-        generator to create molecular counterfactuals (molecular graphs).  While this\n\nmethod
-        is able to generate counterfactuals through a multi-objective reinforcement
-        learner,\n\nthis is not a universal approach and requires training the generator
-        for each task.\n\n   Work by Wellawatte et al. 9 present a model agnostic counterfactual
-        generator MMACE\n\n(Molecular Model Agnostic Counterfactual Explanations) which
-        does not require training\n\nor computing gradients. This method firstly populates
-        a local chemical space through ran-\n\ndom string mutations of SELFIES106 molecular
-        representations using the STONED algo-\n\nrithm.107 Next, the labels (predictions)
-        of the molecules in the local space are generated\n\nusing the model that needs
-        to be explained. Finally, the counterfactuals are identified and\n\nsorted by
-        their similarities \u2013 Tanimoto distance96 between ECFP4 fingerprints.97
-        Unlike the\n\nCF-GNNExplainer104 and MEG105 methods, the MMACE algorithm ensures
-        that generated\n\nmolecules are valid, owing to the surjective property of SELFIES.
-        Additionally, the MMACE\n\nmethod can be applied to both regression and classification
-        models. However, like most XAI\n\nmethods for molecular prediction, MMACE does
-        not account for the chemical stability of\n\npredicted counterfactuals. To circumvent
-        this drawback, Wellawatte et al. 9 propose an-\n\nother approach, which identift
-        counterfactuals through a similarity search on the PubChem\n\ndatabase.108\n\n\n\n\n\n                                       13Similarity
-        to adjacent fields\n\n\nTangential examples to counterfactual explanations are
-        adversarial training and matched\n\nmolecular pairs.  Adversarial perturbations
-        are used during training to deceive the model\n\nto expose the vulnerabilities
-        of a model109,110 whereas counterfactuals are applied post-hoc.\n\nTherefore,
-        the main difference between adversarial and counterfactual examples are in the\n\napplication,
-        although both are derived from the same optimization problem.100 Grabocka\n\net
-        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\n\nwhich
-        improves model robustness via ex", "d counterfactual examples are in the\n\napplication,
-        although both are derived from the same optimization problem.100 Grabocka\n\net
-        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\n\nwhich
+        They\\n\\ncan be used to answer the question, \u201Cwhich smallest change could
+        alter the outcome of an\\n\\ninstance of interest?\u201D While the difference
+        between the two instances is based on the exis-\\n\\ntence of similar worlds
+        in philosophy,95 a distance metric based on molecular similarity is\\n\\nemployed
+        in XAI for chemistry. For example, in the work by Wellawatte et al. 9 distance\\n\\nbetween
+        two molecules is defined as the Tanimoto distance96 between ECFP4 fingerprints.97\\n\\nAdditionally,
+        Mohapatra et al. 98 introduced a chemistry-informed graph representation for\\n\\ncomputing
+        macromolecular similarity. Contrastive explanations are peripheral to counterfac-\\n\\n\\n
+        \                                      11tual explanations. Unlike the counterfactual
+        approach, contrastive approach employ a dual\\n\\noptimization method, which
+        works by generating a similar and a dissimilar (counterfactuals)\\n\\nexample.
+        \ Cont\",\"nterfac-\\n\\n\\n                                       11tual explanations.
+        Unlike the counterfactual approach, contrastive approach employ a dual\\n\\noptimization
+        method, which works by generating a similar and a dissimilar (counterfactuals)\\n\\nexample.
+        \ Contrastive explanations can interpret the model by identifying contribution
+        of\\n\\npresence and absence of subsets of features towards a certain prediction.36,99\\n\\n
+        \ A counterfactual x\u2032 of an instance x is one with a dissimilar prediction
+        \u02C6f(x) in classi-\\n\\nfication tasks. As shown in equation 5, counterfactual
+        generation can be thought of as a\\n\\nconstrained optimization problem which
+        minimizes the vector distance d(x, x\u2032) between the\\n\\nfeatures.9,100\\n\\n\\n
+        \                             minimize  d(x, x\u2032)\\n                                                                                           (5)\\n
+        \                              such that   \u02C6f(x) \u0338= \u02C6f(x\u2032)\\n\\n
+        \  For regression tasks, equation 6 adapted from equation 5 can be used. Here,
+        a counter-\\n\\nfactual is one with a defined increase or decrease in the prediction.\\n\\n\\n
+        \                          minimize  d(x, x\u2032)\\n                                                                                           (6)\\n
+        \                           such that    \u02C6f(x) \u2212\u02C6f(x\u2032) \u2265\u2206\\n\\n
+        \  Counterfactuals explanations have become a useful tool for XAI in chemistry,
+        as they\\n\\nprovide intuitive understanding of predictions and are able to
+        uncover spurious relationships\\n\\nin training data.101 Counterfactuals create
+        local (instance-level), actionable explanations.\\n\\nActionability of an explanation
+        suggest which features can be altered to change the outcome.\\n\\nFor example,
+        changing a hydrophobic functional group in a molecule to a hydrophilic group\\n\\nto
+        increase solubility.\\n\\n   Counterfactual generation is a demanding task as
+        it requires gradient optimization over\\n\\ndiscrete features that represents
+        a molecule. Recent work by Fu et al. 102 and Shen et al. 103\\n\\npresent two
+        techniques which allow continuous gradient-based optimization. Although, these\\n\\nmethodologies
+        are shown to circumvent the issue of discrete molecular optimization, counter-\\n\\nfactual
+        explanation based model interpretation still remains unexplored compared to
+        other\\n\\n\\n\\n                                       12post-hoc methods.\\n\\n
+        \  CF-GNNExplainer104 is a counterfactual explanation generating method based
+        on GN-\\n\\nNExplainer69 for graph data. This method generate counterfactuals
+        by perturbing the input\\n\\ndata (removing edges in the graph), and keeping
+        account of perturbations which lead to\\n\\nchanges in the output.  However,
+        this method is only applicable to graph-based models\\n\\nand can generate infeasible
+        molecular structures. Another related work by Numeroso and\\n\\nBacciu 105 focus
+        on generating counterfactual explanations for deep graph networks. Their\\n\\nmethod
+        MEG (Molecular counterfactual Explanation Generator) uses a reinforcement learn-\\n\\ning
+        based generator to create molecular counterfactuals (molecular graphs).  While
+        this\\n\\nmethod is able to generate counterfactuals through a multi-objective
+        reinforcement learner,\\n\\nthis is not a universal approach and requires training
+        the generator for each task.\\n\\n   Work by Wellawatte et al. 9 present a model
+        agnostic counterfactual generator MMACE\\n\\n(Molecular Model Agnostic Counterfactual
+        Explanations) which does not require training\\n\\nor computing gradients. This
+        method firstly populates a local chemical space through ran-\\n\\ndom string
+        mutations of SELFIES106 molecular representations using the STONED algo-\\n\\nrithm.107
+        Next, the labels (predictions) of the molecules in the local space are generated\\n\\nusing
+        the model that needs to be explained. Finally, the counterfactuals are identified
+        and\\n\\nsorted by their similarities \u2013 Tanimoto distance96 between ECFP4
+        fingerprints.97 Unlike the\\n\\nCF-GNNExplainer104 and MEG105 methods, the MMACE
+        algorithm ensures that generated\\n\\nmolecules are valid, owing to the surjective
+        property of SELFIES. Additionally, the MMACE\\n\\nmethod can be applied to both
+        regression and classification models. However, like most XAI\\n\\nmethods for
+        molecular prediction, MMACE does not account for the chemical stability of\\n\\npredicted
+        counterfactuals. To circumvent this drawback, Wellawatte et al. 9 propose an-\\n\\nother
+        approach, which identift counterfactuals through a similarity search on the
+        PubChem\\n\\ndatabase.108\\n\\n\\n\\n\\n\\n                                       13Similarity
+        to adjacent fields\\n\\n\\nTangential examples to counterfactual explanations
+        are adversarial training and matched\\n\\nmolecular pairs.  Adversarial perturbations
+        are used during training to deceive the model\\n\\nto expose the vulnerabilities
+        of a model109,110 whereas counterfactuals are applied post-hoc.\\n\\nTherefore,
+        the main difference between adversarial and counterfactual examples are in the\\n\\napplication,
+        although both are derived from the same optimization problem.100 Grabocka\\n\\net
+        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\\n\\nwhich
+        improves model robustness via ex\",\"d counterfactual examples are in the\\n\\napplication,
+        although both are derived from the same optimization problem.100 Grabocka\\n\\net
+        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\\n\\nwhich
         improves model robustness via exposure to adversarial examples.  While there
-        are\n\nconceptual disparities, we note that the counterfactual and adversarial
-        explanations are\n\nequivalent mathematical objects.\n\n   Matched molecular
-        pairs (MMPs) are pairs of molecules that differ structurally at only\n\none
+        are\\n\\nconceptual disparities, we note that the counterfactual and adversarial
+        explanations are\\n\\nequivalent mathematical objects.\\n\\n   Matched molecular
+        pairs (MMPs) are pairs of molecules that differ structurally at only\\n\\none
         site by a known transformation.112,113 MMPs are widely used in drug discovery
-        and\n\nmedicinal chemistry as these facilitate fast and easy understanding of
-        structure-activity re-\n\nlationships.114\u2013116 Counterfactuals and MMP examples
-        intersect if the structural change is\n\nassociated with a significant change
-        in the properties. In the case the associated changes in\n\nthe properties are
-        non-significant, the two molecules are known as bioisosteres.117,118 The con-\n\nnection
-        between MMPs and adversarial training examples has been explored by van Tilborg\n\net
-        al. 119. MMPs which belong to the counterfactual category are commonly used
-        in outlier\n\nand activity cliff detection.113 This approach is analogous to
-        counterfactual explanations,\n\nas the common objective is to uncover learned
-        knowledge pertaining to structure-property\n\nrelationships.70\n\n\nApplications\n\n\nModel
+        and\\n\\nmedicinal chemistry as these facilitate fast and easy understanding
+        of structure-activity re-\\n\\nlationships.114\u2013116 Counterfactuals and
+        MMP examples intersect if the structural change is\\n\\nassociated with a significant
+        change in the properties. In the case the associated changes in\\n\\nthe properties
+        are non-significant, the two molecules are known as bioisosteres.117,118 The
+        con-\\n\\nnection between MMPs and adversarial training examples has been explored
+        by van Tilborg\\n\\net al. 119. MMPs which belong to the counterfactual category
+        are commonly used in outlier\\n\\nand activity cliff detection.113 This approach
+        is analogous to counterfactual explanations,\\n\\nas the common objective is
+        to uncover learned knowledge pertaining to structure-property\\n\\nrelationships.70\\n\\n\\nApplications\\n\\n\\nModel
         interpretation is certainly not new and a common step in ML in chemistry, but
-        XAI for\n\nDL models is becoming more important60,66\u201369,73,88,104,105 Here
-        we illustrate some practical\n\nexamples drawn from our published work on how
-        model-agnostic XAI can be utilized to\n\n\n\n                                       14interpret
-        black-box models and connect the explanations to structure-property relationships.\n\nThe
-        methods are \u201cMolecular Model Agnostic Counterfactual Explanations\u201d
-        (MMACE)9\n\nand \u201cExplaining molecular properties with natural language\u201d.10
-        Then we demonstrate how\n\ncounterfactuals and descriptor explanations can propose
-        structure-property relationships in\n\nthe domain of molecular scent.31\n\n\nBlood-brain
-        barrier permeation prediction\n\n\nThe passive diffusion of drugs from the blood
-        stream to the brain is a critical aspect in drug\n\ndevelopment and discovery.120
-        Small molecule blood-brain barrier (BBB) permeation is a\n\nclassification problem
-        routinely assessed with DL models.121,122 To explain why DL models\n\nwork,
-        we trained two models a random forest (RF) model123 and a Gated Recurrent Unit\n\nRecurrent
-        Neural Network (GRU-RNN). Then we explained the RF model with generated\n\ncounterfactuals
-        explanations using the MMACE9 and the GRU-RNN with descriptor expla-\n\nnations.10
+        XAI for\\n\\nDL models is becoming more important60,66\u201369,73,88,104,105
+        Here we illustrate some practical\\n\\nexamples drawn from our published work
+        on how model-agnostic XAI can be utilized to\\n\\n\\n\\n                                       14interpret
+        black-box models and connect the explanations to structure-property relationships.\\n\\nThe
+        methods are \u201CMolecular Model Agnostic Counterfactual Explanations\u201D
+        (MMACE)9\\n\\nand \u201CExplaining molecular properties with natural language\u201D.10
+        Then we demonstrate how\\n\\ncounterfactuals and descriptor explanations can
+        propose structure-property relationships in\\n\\nthe domain of molecular scent.31\\n\\n\\nBlood-brain
+        barrier permeation prediction\\n\\n\\nThe passive diffusion of drugs from the
+        blood stream to the brain is a critical aspect in drug\\n\\ndevelopment and
+        discovery.120 Small molecule blood-brain barrier (BBB) permeation is a\\n\\nclassification
+        problem routinely assessed with DL models.121,122 To explain why DL models\\n\\nwork,
+        we trained two models a random forest (RF) model123 and a Gated Recurrent Unit\\n\\nRecurrent
+        Neural Network (GRU-RNN). Then we explained the RF model with generated\\n\\ncounterfactuals
+        explanations using the MMACE9 and the GRU-RNN with descriptor expla-\\n\\nnations.10
         Both the models were trained on the dataset developed by Martins et al. 124.
-        The\n\nRF model was implemented in Scikit-learn125 using Mordred molecular descriptors126
-        as the\n\ninput features. The GRU-RNN model was implemented in Keras.127 See
-        Wellawatte et al. 9\n\nand Gandhi and White 10 for more details.\n\n   According
-        to the counterfactuals of the instance molecule in figure 1, we observe that
-        the\n\nmodifications to the carboxylic acid group enable the negative example
-        molecule to permeate\n\nthe BBB. Experimental findings by Fischer et al. 120
-        show that the BBB permeation of\n\nmolecules are governed by hydrophobic interactions
-        and surface area. The carboxylic group is\n\na hydrophilic functional group
-        which hinders hydrophobic interactions and addition of atoms\n\nenhances the
-        surface area. This proves the advantage of using counterfactual explanations,\n\nas
-        they suggest actionable modification to the molecule to make it cross the BBB.\n\n   In
-        Figure 2 we show descriptor explanations generated for Alprozolam, a molecule
-        that\n\npermeates the BBB, using the method described by Gandhi and White 10.
-        We see that\n\npredicted permeability is positively correlated with the aromaticity
-        of the molecule, while\n\n\n                                       15negatively
-        correlated with the number of hydrogen bonds donors and acceptors. A similar\n\nstructure-property
-        relationship for BBB permeability is proposed in more mechanistic stud-\n\nies.128\u2013130
+        The\\n\\nRF model was implemented in Scikit-learn125 using Mordred molecular
+        descriptors126 as the\\n\\ninput features. The GRU-RNN model was implemented
+        in Keras.127 See Wellawatte et al. 9\\n\\nand Gandhi and White 10 for more details.\\n\\n
+        \  According to the counterfactuals of the instance molecule in figure 1, we
+        observe that the\\n\\nmodifications to the carboxylic acid group enable the
+        negative example molecule to permeate\\n\\nthe BBB. Experimental findings by
+        Fischer et al. 120 show that the BBB permeation of\\n\\nmolecules are governed
+        by hydrophobic interactions and surface area. The carboxylic group is\\n\\na
+        hydrophilic functional group which hinders hydrophobic interactions and addition
+        of atoms\\n\\nenhances the surface area. This proves the advantage of using
+        counterfactual explanations,\\n\\nas they suggest actionable modification to
+        the molecule to make it cross the BBB.\\n\\n   In Figure 2 we show descriptor
+        explanations generated for Alprozolam, a molecule that\\n\\npermeates the BBB,
+        using the method described by Gandhi and White 10. We see that\\n\\npredicted
+        permeability is positively correlated with the aromaticity of the molecule,
+        while\\n\\n\\n                                       15negatively correlated
+        with the number of hydrogen bonds donors and acceptors. A similar\\n\\nstructure-property
+        relationship for BBB permeability is proposed in more mechanistic stud-\\n\\nies.128\u2013130
         The substructure attributions indicates a reduction in hydrogen bond donors
-        and\n\nacceptors.  These descriptor explanations are quantitative and interpretable
-        by chemists.\n\nFinally, we can use a natural language model to summarize the
-        findings into a written\n\nexplanation, as shown in the printed text in Figure
-        2.\n\n\n\n\n\nFigure 1: Counterfactuals of a molecule which cannot permeate
-        the blood-brain barrier.\nSimilarity is the Tanimoto similarity of ECFP4 fingerprints.131
-        Red indicates deletions and\ngreen indicates substitutions and addition of atoms.
-        Republished from Ref.9 with permission\nfrom the Royal Society of Chemistry.\n\n\n\nSolubility
-        prediction\n\n\nSmall molecule solubility prediction is a classic cheminformatics
-        regression challenge and is\n\nimportant for chemical process design, drug design
-        and crystallization.133\u2013136 In our previous\n\nworks,9,10 we implemented
-        and trained an RNN", "y prediction\n\n\nSmall molecule solubility prediction
-        is a classic cheminformatics regression challenge and is\n\nimportant for chemical
-        process design, drug design and crystallization.133\u2013136 In our previous\n\nworks,9,10
-        we implemented and trained an RNN model in Keras to predict solubilities (log\n\nmolarity)
-        of small molecules.127 The AqSolDB curated database137 was used to train the\n\nRNN
-        model.\n\n   In this task, counterfactuals are based on equation 6. Figure 3
-        illustrates the generated\n\nlocal chemical space and the top four counterfactuals.
-        Based on the counterfactuals, we ob-\n\nserve that the modifications to the
-        ester group and other heteroatoms play an important role\n\nin solubility. These
-        findings align with known experimental and basic chemical intuition.134\n\nFigure
-        4 shows a quantitative measurement of how substructures are contributing to
-        the pre-\n\n\n\n                                       16Figure 2: Descriptor
-        explanations along with natural language explanation obtained for BBB\npermeability
-        of Alprozolam molecule. The green and red bars show descriptors that influ-\nence
-        predictions positively and negatively, respectively. Dotted yellow lines show
-        significance\nthreshold (\u03b1 = 0.05) for the t-statistic. Molecular descriptors
-        show molecule-level proper-\nties that are important for the prediction. ECFP
-        and MACCS descriptors indicate which\nsubstructures influence model predictions.
-        MACCS explanations lead to text explanations\nas shown. Republished from Ref.10
-        with permission from authors. SMARTS annotations for\nMACCS descriptors were
-        created using SMARTSviewer (smartsview.zbh.uni-hamburg.de,\nCopyright: ZBH,
-        Center for Bioinformatics Hamburg) developed by Schomburg et al. 132.\n\n\n\n\n\n                                       17diction.
-        For example, we see that adding acidic and basic groups as well as hydrogen
-        bond\n\nacceptors, increases solubility. Substructure importance from ECFP97
-        and MACCS138 de-\n\nscriptors indicate that adding heteroatoms increases solubility,
-        while adding rings structures\n\nmakes the molecule less soluble. Although these
-        are established hypotheses, it is interesting\n\nto see they can be derived
-        purely from the data via DL and XAI.\n\n\n\n\n\nFigure 3: Generated chemical
-        space for solubility prediction using the RNN model. The\nchemical space is
-        a 2D projection of the pairwise Tanimoto similarities of the local coun-\nterfactuals.
-        Each data point is colored by solubility. Top 4 counterfactuals are shown here.\nRepublished
-        from Ref.9 with permission from the Royal Society of Chemistry.\n\n\n\nGeneralizing
-        XAI \u2013 interpreting scent-structure relationships\n\n\nIn this example,
-        we show how non-local structure-property relationships can be learned with\n\nXAI
+        and\\n\\nacceptors.  These descriptor explanations are quantitative and interpretable
+        by chemists.\\n\\nFinally, we can use a natural language model to summarize
+        the findings into a written\\n\\nexplanation, as shown in the printed text in
+        Figure 2.\\n\\n\\n\\n\\n\\nFigure 1: Counterfactuals of a molecule which cannot
+        permeate the blood-brain barrier.\\nSimilarity is the Tanimoto similarity of
+        ECFP4 fingerprints.131 Red indicates deletions and\\ngreen indicates substitutions
+        and addition of atoms. Republished from Ref.9 with permission\\nfrom the Royal
+        Society of Chemistry.\\n\\n\\n\\nSolubility prediction\\n\\n\\nSmall molecule
+        solubility prediction is a classic cheminformatics regression challenge and
+        is\\n\\nimportant for chemical process design, drug design and crystallization.133\u2013136
+        In our previous\\n\\nworks,9,10 we implemented and trained an RNN\",\"y prediction\\n\\n\\nSmall
+        molecule solubility prediction is a classic cheminformatics regression challenge
+        and is\\n\\nimportant for chemical process design, drug design and crystallization.133\u2013136
+        In our previous\\n\\nworks,9,10 we implemented and trained an RNN model in Keras
+        to predict solubilities (log\\n\\nmolarity) of small molecules.127 The AqSolDB
+        curated database137 was used to train the\\n\\nRNN model.\\n\\n   In this task,
+        counterfactuals are based on equation 6. Figure 3 illustrates the generated\\n\\nlocal
+        chemical space and the top four counterfactuals. Based on the counterfactuals,
+        we ob-\\n\\nserve that the modifications to the ester group and other heteroatoms
+        play an important role\\n\\nin solubility. These findings align with known experimental
+        and basic chemical intuition.134\\n\\nFigure 4 shows a quantitative measurement
+        of how substructures are contributing to the pre-\\n\\n\\n\\n                                       16Figure
+        2: Descriptor explanations along with natural language explanation obtained
+        for BBB\\npermeability of Alprozolam molecule. The green and red bars show descriptors
+        that influ-\\nence predictions positively and negatively, respectively. Dotted
+        yellow lines show significance\\nthreshold (\u03B1 = 0.05) for the t-statistic.
+        Molecular descriptors show molecule-level proper-\\nties that are important
+        for the prediction. ECFP and MACCS descriptors indicate which\\nsubstructures
+        influence model predictions. MACCS explanations lead to text explanations\\nas
+        shown. Republished from Ref.10 with permission from authors. SMARTS annotations
+        for\\nMACCS descriptors were created using SMARTSviewer (smartsview.zbh.uni-hamburg.de,\\nCopyright:
+        ZBH, Center for Bioinformatics Hamburg) developed by Schomburg et al. 132.\\n\\n\\n\\n\\n\\n
+        \                                      17diction. For example, we see that adding
+        acidic and basic groups as well as hydrogen bond\\n\\nacceptors, increases solubility.
+        Substructure importance from ECFP97 and MACCS138 de-\\n\\nscriptors indicate
+        that adding heteroatoms increases solubility, while adding rings structures\\n\\nmakes
+        the molecule less soluble. Although these are established hypotheses, it is
+        interesting\\n\\nto see they can be derived purely from the data via DL and
+        XAI.\\n\\n\\n\\n\\n\\nFigure 3: Generated chemical space for solubility prediction
+        using the RNN model. The\\nchemical space is a 2D projection of the pairwise
+        Tanimoto similarities of the local coun-\\nterfactuals. Each data point is colored
+        by solubility. Top 4 counterfactuals are shown here.\\nRepublished from Ref.9
+        with permission from the Royal Society of Chemistry.\\n\\n\\n\\nGeneralizing
+        XAI \u2013 interpreting scent-structure relationships\\n\\n\\nIn this example,
+        we show how non-local structure-property relationships can be learned with\\n\\nXAI
         across multiple molecules. Molecular scent prediction is a multi-label classification
-        task\n\nbecause a molecule can be described by more than one scent. For example,
-        the molecule\n\njasmone can be described as having \u2018jasmine,\u2019 \u2018woody,\u2019
-        \u2018floral,\u2019 and \u2019herbal\u2019 scents.139 The\n\nscent-structure
-        relationship is not very well understood,140 although some relationships are\n\nknown.  For
-        example, molecules with an ester functional group are often associated with\n\n\n                                       18Figure
-        4: Descriptor explanations for solubility prediction model. The green and red
-        bars\nshow descriptors that influence predictions positively and negatively,
-        respectively. Dotted\nyellow lines show significance threshold (\u03b1 = 0.05)
-        for the t-statistic. The MACCS and\nECFP descriptors indicate which substructures
-        influence model predictions. MACCS sub-\nstructures may either be present in
-        the molecule as is or may represent a modification. ECFP\nfingerprints are substructures
-        in the molecule that affect the prediction. MACCS descriptor\nare used to obtain
-        text explanations as shown. Republished from Ref.10 with permission from\nauthors.
-        SMARTS annotations for MACCS descriptors were created using SMARTSviewer\n(smartsview.zbh.uni-hamburg.de,
-        Copyright: ZBH, Center for Bioinformatics Hamburg) de-\nveloped by Schomburg
-        et al. 132.\n\n\n\n\n\n                                       19the \u2018fruity\u2019
-        scent. There are some exceptions though, like tert-amyl acetate which has a\n\n\u2018camphoraceous\u2019
-        rather than \u2018fruity\u2019 scent.140,141\n\n   In Seshadri et al. 31, we
-        trained a GNN model to predict the scent of molecules and utilized\n\ncounterfactuals9
-        and descriptor explanations10 to quantify scent-structure relationships. The\n\nMMACE
+        task\\n\\nbecause a molecule can be described by more than one scent. For example,
+        the molecule\\n\\njasmone can be described as having \u2018jasmine,\u2019 \u2018woody,\u2019
+        \u2018floral,\u2019 and \u2019herbal\u2019 scents.139 The\\n\\nscent-structure
+        relationship is not very well understood,140 although some relationships are\\n\\nknown.
+        \ For example, molecules with an ester functional group are often associated
+        with\\n\\n\\n                                       18Figure 4: Descriptor explanations
+        for solubility prediction model. The green and red bars\\nshow descriptors that
+        influence predictions positively and negatively, respectively. Dotted\\nyellow
+        lines show significance threshold (\u03B1 = 0.05) for the t-statistic. The MACCS
+        and\\nECFP descriptors indicate which substructures influence model predictions.
+        MACCS sub-\\nstructures may either be present in the molecule as is or may represent
+        a modification. ECFP\\nfingerprints are substructures in the molecule that affect
+        the prediction. MACCS descriptor\\nare used to obtain text explanations as shown.
+        Republished from Ref.10 with permission from\\nauthors. SMARTS annotations for
+        MACCS descriptors were created using SMARTSviewer\\n(smartsview.zbh.uni-hamburg.de,
+        Copyright: ZBH, Center for Bioinformatics Hamburg) de-\\nveloped by Schomburg
+        et al. 132.\\n\\n\\n\\n\\n\\n                                       19the \u2018fruity\u2019
+        scent. There are some exceptions though, like tert-amyl acetate which has a\\n\\n\u2018camphoraceous\u2019
+        rather than \u2018fruity\u2019 scent.140,141\\n\\n   In Seshadri et al. 31,
+        we trained a GNN model to predict the scent of molecules and utilized\\n\\ncounterfactuals9
+        and descriptor explanations10 to quantify scent-structure relationships. The\\n\\nMMACE
         method was modified to account for the multi-label aspect of scent prediction.
-        This\n\nmodification defines molecules that differed from the instance molecule
-        by only the selected\n\nscent as counterfactuals. For instance, counterfactuals
-        of the jasmone molecule would be false\n\nfor the \u2018jasmine\u2019 scent
+        This\\n\\nmodification defines molecules that differed from the instance molecule
+        by only the selected\\n\\nscent as counterfactuals. For instance, counterfactuals
+        of the jasmone molecule would be false\\n\\nfor the \u2018jasmine\u2019 scent
         but would still be positive for \u2018woody,\u2019 \u2018floral\u2019 and \u2018herbal\u2019
-        scents.\n\n\n\n\n\nFigure 5:  Counterfactual for the 2,4 decadienal molecule.  The
-        counterfactual indicates\nstructural changes to ethyl benzoate that would result
-        in the model predicting the molecule\nto not contain the \u2018fruity\u2019
-        ", "ody,\u2019 \u2018floral\u2019 and \u2018herbal\u2019 scents.\n\n\n\n\n\nFigure
-        5:  Counterfactual for the 2,4 decadienal molecule.  The counterfactual indicates\nstructural
-        changes to ethyl benzoate that would result in the model predicting the molecule\nto
+        scents.\\n\\n\\n\\n\\n\\nFigure 5:  Counterfactual for the 2,4 decadienal molecule.
+        \ The counterfactual indicates\\nstructural changes to ethyl benzoate that would
+        result in the model predicting the molecule\\nto not contain the \u2018fruity\u2019
+        \",\"ody,\u2019 \u2018floral\u2019 and \u2018herbal\u2019 scents.\\n\\n\\n\\n\\n\\nFigure
+        5:  Counterfactual for the 2,4 decadienal molecule.  The counterfactual indicates\\nstructural
+        changes to ethyl benzoate that would result in the model predicting the molecule\\nto
         not contain the \u2018fruity\u2019 scent. The Tanimoto96 similarity between
-        the counterfactual and\n2,4 decadienal is also provided. Republished with permission
-        from authors.31\n\n\n   The molecule 2,4-decadienal, which is known to have
-        a \u2018fatty\u2019 scent, is analyzed in Fig-\n\nure 5.142,143 The resulting
-        counterfactual, which has a shorter carbon chain and no carbonyl\n\ngroups,
+        the counterfactual and\\n2,4 decadienal is also provided. Republished with permission
+        from authors.31\\n\\n\\n   The molecule 2,4-decadienal, which is known to have
+        a \u2018fatty\u2019 scent, is analyzed in Fig-\\n\\nure 5.142,143 The resulting
+        counterfactual, which has a shorter carbon chain and no carbonyl\\n\\ngroups,
         highlights the influence of these structural features on the \u2018fatty\u2019
-        scent of 2,4 deca-\n\ndienal. To generalize to other molecules, Seshadri et
-        al. 31 applied the descriptor attribution\n\nmethod to obtain global explanations
-        for the scents. The global explanation for the \u2018fatty\u2019\n\nscent was
-        generated by gathering chemical spaces around many \u2018fatty\u2019 scented
-        molecules.\n\nThe resulting natural language explanation is: \u201cThe molecular
-        property \u201cfatty scent\u201d can\n\nbe explained by the presence of a heptanyl
-        fragment, two CH2 groups separated by four\n\n                                       20bonds,
-        and a C=O double bond, as well as the lack of more than one or two O atoms.\u201d31\n\nThe
+        scent of 2,4 deca-\\n\\ndienal. To generalize to other molecules, Seshadri et
+        al. 31 applied the descriptor attribution\\n\\nmethod to obtain global explanations
+        for the scents. The global explanation for the \u2018fatty\u2019\\n\\nscent
+        was generated by gathering chemical spaces around many \u2018fatty\u2019 scented
+        molecules.\\n\\nThe resulting natural language explanation is: \u201CThe molecular
+        property \u201Cfatty scent\u201D can\\n\\nbe explained by the presence of a
+        heptanyl fragment, two CH2 groups separated by four\\n\\n                                       20bonds,
+        and a C=O double bond, as well as the lack of more than one or two O atoms.\u201D31\\n\\nThe
         importance of a heptanyl fragment aligns with that reported in the literature,
-        as \u2018fatty\u2019\n\nmolecules often have a long carbon chain.144 Furthermore,
-        the importance of a C=O dou-\n\nble bond is supported by the findings reported
-        by Licon et al. 145, where in addition to a\n\n\u201clarger carbon-chain skeleton\u201d,
-        they found that \u2018fatty\u2019 molecules also had \u201caldehyde or acid\n\nfunctions\u201d.145
+        as \u2018fatty\u2019\\n\\nmolecules often have a long carbon chain.144 Furthermore,
+        the importance of a C=O dou-\\n\\nble bond is supported by the findings reported
+        by Licon et al. 145, where in addition to a\\n\\n\u201Clarger carbon-chain skeleton\u201D,
+        they found that \u2018fatty\u2019 molecules also had \u201Caldehyde or acid\\n\\nfunctions\u201D.145
         For the \u2018pineapple\u2019 scent, the following natural language explanation
-        was ob-\n\ntained: \u201cThe molecular property \u201cpineapple scent\u201d
-        can be explained by the presence of ester,\n\nethyl/ether O group, alkene/ether
-        O group, and C=O double bond, as well as the absence of\n\nan Aromatic atom.\u201d31
-        Esters, such as ethyl 2-methylbutyrate, are present in many pineap-\n\nple volatile
-        compounds.146,147 The combination of a C=O double bond with an ether could\n\nalso
-        correspond to an ester group. Additionally, aldehydes and ketones, which contain
-        C=O\n\ndouble bonds, are also common in pineapple volatile compounds.146,148\n\n\nDiscussion\n\n\nWe
-        have shown two post-hoc XAI applications based on molecular counterfactual expla-\n\nnations9
-        and descriptor explanations.10 These methods can be used to explain black-box\n\nmodels
-        whose input is a molecule. These two methods can be applied for both classification\n\nand
-        regression tasks. Note that the \u201ccorrectness\u201d of the explanations
-        strongly depends on\n\nthe accuracy of the black-box model.\n\n  A molecular
-        counterfactual is one with a minimal distance from a base molecular, but\n\nwith
-        contrasting chemical properties.  In the above examples, we used Tanimoto similar-\n\nity96
+        was ob-\\n\\ntained: \u201CThe molecular property \u201Cpineapple scent\u201D
+        can be explained by the presence of ester,\\n\\nethyl/ether O group, alkene/ether
+        O group, and C=O double bond, as well as the absence of\\n\\nan Aromatic atom.\u201D31
+        Esters, such as ethyl 2-methylbutyrate, are present in many pineap-\\n\\nple
+        volatile compounds.146,147 The combination of a C=O double bond with an ether
+        could\\n\\nalso correspond to an ester group. Additionally, aldehydes and ketones,
+        which contain C=O\\n\\ndouble bonds, are also common in pineapple volatile compounds.146,148\\n\\n\\nDiscussion\\n\\n\\nWe
+        have shown two post-hoc XAI applications based on molecular counterfactual expla-\\n\\nnations9
+        and descriptor explanations.10 These methods can be used to explain black-box\\n\\nmodels
+        whose input is a molecule. These two methods can be applied for both classification\\n\\nand
+        regression tasks. Note that the \u201Ccorrectness\u201D of the explanations
+        strongly depends on\\n\\nthe accuracy of the black-box model.\\n\\n  A molecular
+        counterfactual is one with a minimal distance from a base molecular, but\\n\\nwith
+        contrasting chemical properties.  In the above examples, we used Tanimoto similar-\\n\\nity96
         of ECFP4 fingreprints97 as distance, although this should be explored in the
-        future.\n\nCounterfactual explanations are useful because they are represented
-        as chemical structures\n\n(familiar to domain experts), sparse, and are actionable.
-        A few other popular examples of\n\ncounterfactual on graph methods are GNNExplainer,
-        MEG and CF-GNNExplainer.69,104,105\n\n   The descriptor explanation method developed
-        by Gandhi and White 10 fits a self-explaining\n\n\n\n                                       21surrogate
-        model to explain the black-box model. This is similar to the GraphLIME87 method,\n\nalthough
-        we have the flexibility to use explanation features other than subgraphs. Futher-\n\nmore,
+        future.\\n\\nCounterfactual explanations are useful because they are represented
+        as chemical structures\\n\\n(familiar to domain experts), sparse, and are actionable.
+        A few other popular examples of\\n\\ncounterfactual on graph methods are GNNExplainer,
+        MEG and CF-GNNExplainer.69,104,105\\n\\n   The descriptor explanation method
+        developed by Gandhi and White 10 fits a self-explaining\\n\\n\\n\\n                                       21surrogate
+        model to explain the black-box model. This is similar to the GraphLIME87 method,\\n\\nalthough
+        we have the flexibility to use explanation features other than subgraphs. Futher-\\n\\nmore,
         we show that natural language combined with chemical descriptor attributions
-        can\n\ncreate explanations useful for chemists, thus enhancing the accessibility
-        of DL in chemistry.\n\nLastly, we examined if XAI can be used beyond interpretation.
-        Work by Seshadri et al. 31 use\n\nMMACE and surrogate model explanations to
-        analyze the structure-property relationships\n\nof scent. They recovered known
-        structure-property relationships for molecular scent purely\n\nfrom explanations,
-        demonstrating the usefulness of a two step process: fit an accurate model\n\nand
-        then explain it.\n\n   Choosing among the plethora of XAI methods described
-        here is still an open question.\n\nIt remains to be seen if there will ever
-        be a consensus benchmark, since this field sits on\n\nthe intersection of human-machine
-        interaction, machine learning, and philosophy (i.e., what\n\nconstitutes an
-        explanation?). Our current advice is to consider first the audience \u2013 domain\n\nexperts
-        or ML experts or non-experts \u2013 and what the explanations should accomplish.
-        Are\n\nthey meant to inform data selection or model building, how a prediction
-        is used, or how the\n\nfeatures can be changed to affect the outcome. The second
-        consideration is what access you\n\nhave to the underlying model. The ability
-        to have model derivatives or propagate gradients\n\nto the input to models informs
-        the XAI method.\n\n\nConclusion and outlook\n\n\nWe should seek to explain molecular
-        property prediction models because users are more\n\nlikely to trus", "lying
-        model. The ability to have model derivatives or propagate gradients\n\nto the
-        input to models informs the XAI method.\n\n\nConclusion and outlook\n\n\nWe
+        can\\n\\ncreate explanations useful for chemists, thus enhancing the accessibility
+        of DL in chemistry.\\n\\nLastly, we examined if XAI can be used beyond interpretation.
+        Work by Seshadri et al. 31 use\\n\\nMMACE and surrogate model explanations to
+        analyze the structure-property relationships\\n\\nof scent. They recovered known
+        structure-property relationships for molecular scent purely\\n\\nfrom explanations,
+        demonstrating the usefulness of a two step process: fit an accurate model\\n\\nand
+        then explain it.\\n\\n   Choosing among the plethora of XAI methods described
+        here is still an open question.\\n\\nIt remains to be seen if there will ever
+        be a consensus benchmark, since this field sits on\\n\\nthe intersection of
+        human-machine interaction, machine learning, and philosophy (i.e., what\\n\\nconstitutes
+        an explanation?). Our current advice is to consider first the audience \u2013
+        domain\\n\\nexperts or ML experts or non-experts \u2013 and what the explanations
+        should accomplish. Are\\n\\nthey meant to inform data selection or model building,
+        how a prediction is used, or how the\\n\\nfeatures can be changed to affect
+        the outcome. The second consideration is what access you\\n\\nhave to the underlying
+        model. The ability to have model derivatives or propagate gradients\\n\\nto
+        the input to models informs the XAI method.\\n\\n\\nConclusion and outlook\\n\\n\\nWe
         should seek to explain molecular property prediction models because users are
-        more\n\nlikely to trust explained predictions, and explanations can help assess
-        if the model is learning\n\nthe correct underlying chemical principles. We also
-        showed that black-box modeling first,\n\nfollowed by XAI, is a path to structure-property
-        relationships without needing to trade\n\nbetween accuracy and interpretability.
-        However, XAI in chemistry has some major open\n\nquestions, that are also related
-        to the black-box nature of the deep learning. Some are\n\n\n\n                                       22highlighted
-        below:\n\n   \u2022 Explanation representation: How is an explanation presented
-        \u2013 text, a molecule, attri-\n\n      butions, a concept, etc?\n\n   \u2022
-        Molecular distance:  in XAI approaches such as counterfactual generation, the
-        \u201cdis-\n\n     tance\u201d between two molecules is minimized. Molecular
-        distance is subjective. Possibil-\n\n       ities are distance based on molecular
-        properties, synthesis routes, and direct structure\n\n     comparisons.\n\n   \u2022
-        Regulations: As black-box models move from research to industry, healthcare,
-        and\n\n     environmental settings, we expect XAI to become more important to
-        explain decisions\n\n      to chemists or non-experts and possibly be legally
-        required. Explanations may need\n\n      to be tuned for be for doctors instead
-        of chemists or to satisfy a legal requirement.\n\n   \u2022 Chemical space:
-        Chemical space is the set of molecules that are realizable; \u201crealiz-\n\n     able\u201d
+        more\\n\\nlikely to trus\",\"lying model. The ability to have model derivatives
+        or propagate gradients\\n\\nto the input to models informs the XAI method.\\n\\n\\nConclusion
+        and outlook\\n\\n\\nWe should seek to explain molecular property prediction
+        models because users are more\\n\\nlikely to trust explained predictions, and
+        explanations can help assess if the model is learning\\n\\nthe correct underlying
+        chemical principles. We also showed that black-box modeling first,\\n\\nfollowed
+        by XAI, is a path to structure-property relationships without needing to trade\\n\\nbetween
+        accuracy and interpretability. However, XAI in chemistry has some major open\\n\\nquestions,
+        that are also related to the black-box nature of the deep learning. Some are\\n\\n\\n\\n
+        \                                      22highlighted below:\\n\\n   \u2022 Explanation
+        representation: How is an explanation presented \u2013 text, a molecule, attri-\\n\\n
+        \     butions, a concept, etc?\\n\\n   \u2022 Molecular distance:  in XAI approaches
+        such as counterfactual generation, the \u201Cdis-\\n\\n     tance\u201D between
+        two molecules is minimized. Molecular distance is subjective. Possibil-\\n\\n
+        \      ities are distance based on molecular properties, synthesis routes, and
+        direct structure\\n\\n     comparisons.\\n\\n   \u2022 Regulations: As black-box
+        models move from research to industry, healthcare, and\\n\\n     environmental
+        settings, we expect XAI to become more important to explain decisions\\n\\n
+        \     to chemists or non-experts and possibly be legally required. Explanations
+        may need\\n\\n      to be tuned for be for doctors instead of chemists or to
+        satisfy a legal requirement.\\n\\n   \u2022 Chemical space: Chemical space is
+        the set of molecules that are realizable; \u201Crealiz-\\n\\n     able\u201D
         can be defined from purchasable to synthesizable to satisfied valences. What
-        is\n\n     most useful? Can an explanation consider nearby impossible molecules?
-        How can we\n\n     generate local chemical spaces centered around a specific
-        molecule for finding counter-\n\n      factuals or other instance explanations?  Similarly,
-        can \u201cactivity cliffs\u201d be connected\n\n      to explanations and the
-        local chemical space.149\n\n   \u2022 Evaluating XAI : there is a lack of a
-        systematic framework (quantitative or qualitative)\n\n      to evaluate correctness
-        and applicability of an explanation. Can there be a universal\n\n     framework,
-        or should explanations be chosen and evaluated based on the audience and\n\n     domain?
-        For example, work by Rasmussen et al. 58 attempts to focus on comparing\n\n      feature
-        attribution XAI methods via Crippen\u2019s logP scores.\n\n\n\n\n\n                                       23Acknowledgements\n\n\nResearch
-        reported in this work was supported by the National Institute of General Medical\n\nSciences
-        of the National Institutes of Health under award number R35GM137966. This work\n\nwas
-        supported by the NSF under awards 1751471 and 1764415. We thank the Center for\n\nIntegrated
-        Research Computing at the University of Rochester for providing computational\n\nresources.\n\n\nReferences\n\n\n  (1)
-        Choudhary, K.; DeCost, B.; Chen, C.; Jain, A.; Tavazza, F.; Cohn, R.; Park,
-        C. W.;\n\n     Choudhary, A.; Agrawal, A.; Billinge, S. J.; Holm, E.; Ong, S.
-        P.; Wolverton, C.\n\n      Recent advances and applications of deep learning
-        methods in materials science. npj\n\n      Computational Materials 2022, 8.\n\n\n  (2)
-        Keith, J. A.; Vassilev-Galindo, V.; Cheng, B.; Chmiela, S.; Gastegger, M.; M\u00a8uller,
-        K.-\n\n      R.; Tkatchenko, A. Combining Machine Learning and Computational
-        Chemistry for\n\n      Predictive Insights Into Chemical Systems. Chemical Reviews
-        2021, 121, 9816\u20139872,\n\n     PMID: 34232033.\n\n\n  (3) Goh, G. B.; Hodas,
-        N. O.; Vishnu, A. Deep learning for computational chemistry.\n\n      Journal
-        of Computational Chemistry 2017, 38, 1291\u20131307.\n\n\n  (4) Deringer, V.
-        L.; Caro, M. A.; Cs\u00b4anyi, G. Machine Learning Interatomic Potentials as\n\n     Emerging
-        Tools for Materials Science. Advanced Materials 2019, 31, 1902765.\n\n\n  (5)
-        Faber, F. A.; Hutchison, L.; Huang, B.; Gilmer, J.; Schoenholz, S. S.; Dahl,
-        G. E.;\n\n      Vinyals, O.; Kearnes, S.; Riley, P. F.; von Lilienfeld, O. A.
-        Prediction Errors of Molec-\n\n      ular Machine Learning Models Lower than
-        Hybrid DFT Error. Journal of Chemical\n\n     Theory and Computation 2017, 13,
-        5255\u20135264, PMID: 28926232.\n\n\n\n                                       24
-        (6) Duch, W.; Swaminathan, K.; Meller, J. Artificial Intelligence Approaches
-        for Rational\n\n    Drug Design and Discovery. Current Pharmaceutical Design
-        2007, 13, 1497\u20131508.\n\n\n (7) Dara, S.; Dhamercherla, S.; Jadav, S. S.;
-        Babu, C. M.; Ahsan, M. J.; darasuresh, S. D.;\n\n     Dara, S. Machine Learning
-        in Drug Discovery: A Review. Artificial Intelligence Review\n\n     123, 55,
-        1947\u20131999.\n\n\n (8) Gupta, R.; Srivastava, D.; Sahu, M.; Tiwari, S.; Ambasta,
-        R. K.; Kumar, P. Artifi-\n\n      cial intelligence to deep learning: machine
-        intelligence approach for drug discovery.\n\n     Molecular diversity 2021,
-        25, 1315\u20131360.\n\n\n (9) Wellawatte, G. P.; Seshadri, A.; White, A. D.
-        Model agnostic generation of counter-\n\n     factual explanations for molecules.
-        Chemical Science", "ng: machine intelligence approach for drug discovery.\n\n     Molecular
-        diversity 2021, 25, 1315\u20131360.\n\n\n (9) Wellawatte, G. P.; Seshadri, A.;
-        White, A. D. Model agnostic generation of counter-\n\n     factual explanations
-        for molecules. Chemical Science 2022, 13, 3697\u20133705.\n\n\n(10) Gandhi,
-        H. A.; White, A. D. Explaining structure-activity relationships using locally\n\n      faithful
-        surrogate models. chemrxiv 2022,\n\n\n(11) Gormley, A. J.; Webb, M. A. Machine
-        learning in combinatorial polymer chemistry.\n\n     Nature Reviews Materials
-        2021,\n\n\n(12) Gomes, C. P.; Fink, D.; Dover, R. B. V.; Gregoire, J. M. Computational
-        sustainability\n\n     meets materials science. Nature Reviews Materials 2021,\n\n\n(13)
-        On scientific understanding with artificial intelligence. Nature Reviews Physics
-        2022\n\n     4:12 2022, 4, 761\u2013769.\n\n\n(14) Arrieta, A. B.; D\u00b4\u0131az-Rodr\u00b4\u0131guez,
-        N.; Ser, J. D.; Bennetot, A.; Tabik, S.; Barbado, A.;\n\n     Garcia, S.; Gil-Lopez,
-        S.; Molina, D.; Benjamins, R.; Chatila, R.; Herrera, F. Explain-\n\n     able
-        Artificial Intelligence (XAI): Concepts, Taxonomies, Opportunities and Chal-\n\n     lenges
-        toward Responsible AI. Information Fusion 2019, 58, 82\u2013115.\n\n\n(15) Murdoch,
-        W. J.; Singh, C.; Kumbier, K.; Abbasi-Asl, R.; Yu, B. Interpretable machine\n\n     learning:
-        definitions, methods, and applications. ArXiv 2019, abs/1901.04592.\n\n                                      25(16)
+        is\\n\\n     most useful? Can an explanation consider nearby impossible molecules?
+        How can we\\n\\n     generate local chemical spaces centered around a specific
+        molecule for finding counter-\\n\\n      factuals or other instance explanations?
+        \ Similarly, can \u201Cactivity cliffs\u201D be connected\\n\\n      to explanations
+        and the local chemical space.149\\n\\n   \u2022 Evaluating XAI : there is a
+        lack of a systematic framework (quantitative or qualitative)\\n\\n      to evaluate
+        correctness and applicability of an explanation. Can there be a universal\\n\\n
+        \    framework, or should explanations be chosen and evaluated based on the
+        audience and\\n\\n     domain? For example, work by Rasmussen et al. 58 attempts
+        to focus on comparing\\n\\n      feature attribution XAI methods via Crippen\u2019s
+        logP scores.\\n\\n\\n\\n\\n\\n                                       23Acknowledgements\\n\\n\\nResearch
+        reported in this work was supported by the National Institute of General Medical\\n\\nSciences
+        of the National Institutes of Health under award number R35GM137966. This work\\n\\nwas
+        supported by the NSF under awards 1751471 and 1764415. We thank the Center for\\n\\nIntegrated
+        Research Computing at the University of Rochester for providing computational\\n\\nresources.\\n\\n\\nReferences\\n\\n\\n
+        \ (1) Choudhary, K.; DeCost, B.; Chen, C.; Jain, A.; Tavazza, F.; Cohn, R.;
+        Park, C. W.;\\n\\n     Choudhary, A.; Agrawal, A.; Billinge, S. J.; Holm, E.;
+        Ong, S. P.; Wolverton, C.\\n\\n      Recent advances and applications of deep
+        learning methods in materials science. npj\\n\\n      Computational Materials
+        2022, 8.\\n\\n\\n  (2) Keith, J. A.; Vassilev-Galindo, V.; Cheng, B.; Chmiela,
+        S.; Gastegger, M.; M\xA8uller, K.-\\n\\n      R.; Tkatchenko, A. Combining Machine
+        Learning and Computational Chemistry for\\n\\n      Predictive Insights Into
+        Chemical Systems. Chemical Reviews 2021, 121, 9816\u20139872,\\n\\n     PMID:
+        34232033.\\n\\n\\n  (3) Goh, G. B.; Hodas, N. O.; Vishnu, A. Deep learning for
+        computational chemistry.\\n\\n      Journal of Computational Chemistry 2017,
+        38, 1291\u20131307.\\n\\n\\n  (4) Deringer, V. L.; Caro, M. A.; Cs\xB4anyi,
+        G. Machine Learning Interatomic Potentials as\\n\\n     Emerging Tools for Materials
+        Science. Advanced Materials 2019, 31, 1902765.\\n\\n\\n  (5) Faber, F. A.; Hutchison,
+        L.; Huang, B.; Gilmer, J.; Schoenholz, S. S.; Dahl, G. E.;\\n\\n      Vinyals,
+        O.; Kearnes, S.; Riley, P. F.; von Lilienfeld, O. A. Prediction Errors of Molec-\\n\\n
+        \     ular Machine Learning Models Lower than Hybrid DFT Error. Journal of Chemical\\n\\n
+        \    Theory and Computation 2017, 13, 5255\u20135264, PMID: 28926232.\\n\\n\\n\\n
+        \                                      24 (6) Duch, W.; Swaminathan, K.; Meller,
+        J. Artificial Intelligence Approaches for Rational\\n\\n    Drug Design and
+        Discovery. Current Pharmaceutical Design 2007, 13, 1497\u20131508.\\n\\n\\n
+        (7) Dara, S.; Dhamercherla, S.; Jadav, S. S.; Babu, C. M.; Ahsan, M. J.; darasuresh,
+        S. D.;\\n\\n     Dara, S. Machine Learning in Drug Discovery: A Review. Artificial
+        Intelligence Review\\n\\n     123, 55, 1947\u20131999.\\n\\n\\n (8) Gupta, R.;
+        Srivastava, D.; Sahu, M.; Tiwari, S.; Ambasta, R. K.; Kumar, P. Artifi-\\n\\n
+        \     cial intelligence to deep learning: machine intelligence approach for
+        drug discovery.\\n\\n     Molecular diversity 2021, 25, 1315\u20131360.\\n\\n\\n
+        (9) Wellawatte, G. P.; Seshadri, A.; White, A. D. Model agnostic generation
+        of counter-\\n\\n     factual explanations for molecules. Chemical Science\",\"ng:
+        machine intelligence approach for drug discovery.\\n\\n     Molecular diversity
+        2021, 25, 1315\u20131360.\\n\\n\\n (9) Wellawatte, G. P.; Seshadri, A.; White,
+        A. D. Model agnostic generation of counter-\\n\\n     factual explanations for
+        molecules. Chemical Science 2022, 13, 3697\u20133705.\\n\\n\\n(10) Gandhi, H.
+        A.; White, A. D. Explaining structure-activity relationships using locally\\n\\n
+        \     faithful surrogate models. chemrxiv 2022,\\n\\n\\n(11) Gormley, A. J.;
+        Webb, M. A. Machine learning in combinatorial polymer chemistry.\\n\\n     Nature
+        Reviews Materials 2021,\\n\\n\\n(12) Gomes, C. P.; Fink, D.; Dover, R. B. V.;
+        Gregoire, J. M. Computational sustainability\\n\\n     meets materials science.
+        Nature Reviews Materials 2021,\\n\\n\\n(13) On scientific understanding with
+        artificial intelligence. Nature Reviews Physics 2022\\n\\n     4:12 2022, 4,
+        761\u2013769.\\n\\n\\n(14) Arrieta, A. B.; D\xB4\u0131az-Rodr\xB4\u0131guez,
+        N.; Ser, J. D.; Bennetot, A.; Tabik, S.; Barbado, A.;\\n\\n     Garcia, S.;
+        Gil-Lopez, S.; Molina, D.; Benjamins, R.; Chatila, R.; Herrera, F. Explain-\\n\\n
+        \    able Artificial Intelligence (XAI): Concepts, Taxonomies, Opportunities
+        and Chal-\\n\\n     lenges toward Responsible AI. Information Fusion 2019, 58,
+        82\u2013115.\\n\\n\\n(15) Murdoch, W. J.; Singh, C.; Kumbier, K.; Abbasi-Asl,
+        R.; Yu, B. Interpretable machine\\n\\n     learning: definitions, methods, and
+        applications. ArXiv 2019, abs/1901.04592.\\n\\n                                      25(16)
         Boobier, S.; Osbourn, A.; Mitchell, J. B. Can human experts predict solubility
-        better\n\n     than computers? Journal of cheminformatics 2017, 9, 1\u201314.\n\n\n(17)
+        better\\n\\n     than computers? Journal of cheminformatics 2017, 9, 1\u201314.\\n\\n\\n(17)
         Lee, J. D.; See, K. A. Trust in automation: Designing for appropriate reliance.
-        Human\n\n     Factors 2004, 46, 50\u201380.\n\n\n(18) Bolukbasi, T.; Chang,
-        K.-W.; Zou, J. Y.; Saligrama, V.; Kalai, A. T. Man is to com-\n\n     puter
-        programmer as woman is to homemaker? debiasing word embeddings. Advances\n\n     in
-        neural information processing systems 2016, 29.\n\n\n(19) Buolamwini, J.; Gebru,
-        T. Gender Shades:  Intersectional Accuracy Disparities in\n\n    Commercial
-        Gender Classification. Proceedings of the 1st Conference on Fairness,\n\n     Accountability
-        and Transparency. 2018; pp 77\u201391.\n\n\n(20) Lapuschkin, S.; W\u00a8aldchen,
-        S.; Binder, A.; Montavon, G.; Samek, W.; M\u00a8uller, K.-R.\n\n    Unmasking
-        Clever Hans predictors and assessing what machines really learn. Nature\n\n     communications
-        2019, 10, 1\u20138.\n\n\n(21) DeGrave, A. J.; Janizek, J. D.; Lee, S.-I. AI
-        for radiographic COVID-19 detection\n\n      selects shortcuts over signal.
-        Nature Machine Intelligence 2021, 3, 610\u2013619.\n\n\n(22) Goodman, B.; Flaxman,
-        S. European Union regulations on algorithmic decision-\n\n    making and a \u201cright
-        to explanation\u201d. AI Magazine 2017, 38, 50\u201357.\n\n\n(23) ACT, A. I.
-        European Commission. On Artificial Intelligence: A European Approach\n\n     to
-        Excellence and Trust. 2021, COM/2021/206.\n\n\n(24) Blueprint for an AI Bill
-        of Rights, The White House. 2022; https://www.whitehouse.\n\n    gov/ostp/ai-bill-of-rights/.\n\n\n(25)
+        Human\\n\\n     Factors 2004, 46, 50\u201380.\\n\\n\\n(18) Bolukbasi, T.; Chang,
+        K.-W.; Zou, J. Y.; Saligrama, V.; Kalai, A. T. Man is to com-\\n\\n     puter
+        programmer as woman is to homemaker? debiasing word embeddings. Advances\\n\\n
+        \    in neural information processing systems 2016, 29.\\n\\n\\n(19) Buolamwini,
+        J.; Gebru, T. Gender Shades:  Intersectional Accuracy Disparities in\\n\\n    Commercial
+        Gender Classification. Proceedings of the 1st Conference on Fairness,\\n\\n
+        \    Accountability and Transparency. 2018; pp 77\u201391.\\n\\n\\n(20) Lapuschkin,
+        S.; W\xA8aldchen, S.; Binder, A.; Montavon, G.; Samek, W.; M\xA8uller, K.-R.\\n\\n
+        \   Unmasking Clever Hans predictors and assessing what machines really learn.
+        Nature\\n\\n     communications 2019, 10, 1\u20138.\\n\\n\\n(21) DeGrave, A.
+        J.; Janizek, J. D.; Lee, S.-I. AI for radiographic COVID-19 detection\\n\\n
+        \     selects shortcuts over signal. Nature Machine Intelligence 2021, 3, 610\u2013619.\\n\\n\\n(22)
+        Goodman, B.; Flaxman, S. European Union regulations on algorithmic decision-\\n\\n
+        \   making and a \u201Cright to explanation\u201D. AI Magazine 2017, 38, 50\u201357.\\n\\n\\n(23)
+        ACT, A. I. European Commission. On Artificial Intelligence: A European Approach\\n\\n
+        \    to Excellence and Trust. 2021, COM/2021/206.\\n\\n\\n(24) Blueprint for
+        an AI Bill of Rights, The White House. 2022; https://www.whitehouse.\\n\\n    gov/ostp/ai-bill-of-rights/.\\n\\n\\n(25)
         Miller, T. Explanation in artificial intelligence: Insights from the social
-        sciences. Ar-\n\n       tificial intelligence 2019, 267, 1\u201338.\n\n\n\n                                      26(26)
-        Murdoch, W. J.; Singh, C.; Kumbier, K.; Abbasi-Asl, R.; Yu, B. Definitions,
-        meth-\n\n     ods, and applications in interpretable machine learning. Proceedings
-        of the National\n\n    Academy of Sciences of the United States of America 2019,
-        116, 22071\u201322080.\n\n\n(27) Gunning, D.; Aha, D. DARPA\u2019s Explainable
-        Artificial Intelligence (XAI) Program.\n\n    AI Magazine 2019, 40, 44\u201358.\n\n\n(28)
-        Biran, O.; Cotton, C. Explanation and justification in machine learning: A survey.\n\n     IJCAI-17
-        workshop on explainable AI (XAI). 2017; pp 8\u201313.\n\n\n(29) Palacio, S.;
-        Lucieri, A.; Munir, M.; Ahmed, S.; Hees, J.; Dengel, A. Xai handbook:\n\n    Towards
-        a unified framework for explainable ai. Proceedings of the IEEE/CVF Inter-\n\n     national
-        Conference on Computer Vision. 2021; pp 3766\u20133775.\n\n\n(30) Kuhn, D. R.;
-        Kacker, R. N.; Lei, Y.; Simos, D. E. Combinatorial Methods for Ex-\n\n     plainable
-        AI. 2020 IEEE International Conference on Software Testing, Verification\n\n    and
-        Validation Workshops (ICSTW) 2020, 167\u2013170.\n\n\n(31) Seshadri, A.; Gandhi,
-        H. A.; Wellawatte, G. P.; White, A. D. Why does that molecule\n\n     smell?
-        ChemRxiv 2022,\n\n\n(32) Das, A.; Rad, P. Opportunities and challenges in explainable
-        artificial intelligence\n\n      (xai): A survey. arXiv preprint arXiv:2006.11371
-        2020,\n\n\n(33) Machlev, R.; Heistrene, L.; Perl, M.; Levy, K. Y.; Belikov,
-        J.; Mannor, S.; Levron, Y.\n\n     Explainable Artificial Intelligence (XAI)
-        techniques for energy and power systems:\n\n     Review, challenges and opportunities.
-        Energy and AI 2022, 9, 100169.\n\n\n(34) Koh, P. W.; Liang, P. Understanding
-        black-box predictions via influence functions.\n\n     International Conference
-        on Machine Learning. 2017; pp 1885\u20131894.\n\n\n(35) Ribeiro, M. T.; Singh,
-        S.; Guestrin, C. \u201d Why should  i trust you?\u201d Explaining the\n\n     predictions
-        of any classifier. Proceedings of the 22nd ACM SIGKDD international\n\n         ",
-        "ternational Conference on Machine Learning. 2017; pp 1885\u20131894.\n\n\n(35)
-        Ribeiro, M. T.; Singh, S.; Guestrin, C. \u201d Why should  i trust you?\u201d
-        Explaining the\n\n     predictions of any classifier. Proceedings of the 22nd
-        ACM SIGKDD international\n\n                                      27     conference
-        on knowledge discovery and data mining. San Diego, CA, USA, 2016; pp\n\n     1135\u20131144.\n\n\n(36)
-        Dhurandhar, A.; Chen, P.-Y.; Luss, R.; Tu, C.-C.; Ting, P.; Shanmugam, K.; Das,
-        P.\n\n     Explanations based on the missing: Towards contrastive explanations
-        with pertinent\n\n     negatives. Advances in neural information processing
-        systems 2018, 31.\n\n\n(37) Jin, W.; Li, X.; Hamarneh, G. Evaluating Explainable
-        AI on a Multi-Modal Medical\n\n     Imaging Task: Can Existing Algorithms Fulfill
-        Clinical Requirements? Proceedings of\n\n     the AAAI Conference on Artificial
-        Intelligence 2022, 36, 11945\u201311953.\n\n\n(38) Zhang, Y.; Xu, F.; Zou, J.;
-        Petrosian, O. L.; Krinkin, K. V. XAI Evaluation: Evalu-\n\n     ating Black-Box
-        Model Explanations for Prediction. 2021 II International Conference\n\n    on
-        Neural Networks and Neurotechnologies (NeuroNT). 2021; pp 13\u201316.\n\n\n(39)
-        Oviedo, F.; Ferres, J. L.; Buonassisi, T.; Butler, K. T. Interpretable and Explain-\n\n     able
-        Machine Learning for Materials Science and Chemistry. Accounts of Materials\n\n     Research
-        2022, 3, 597\u2013607.\n\n\n(40) Yalcin, O.; Fan, X.; Liu, S. Evaluating the
-        correctness of explainable AI algorithms\n\n      for classification. arXiv
-        preprint arXiv:2105.09740 2021,\n\n\n(41) Hoffman, R. R.; Mueller, S. T.; Klein,
-        G.; Litman, J. Metrics for Explainable AI:\n\n     Challenges and Prospects.
-        2018,\n\n\n(42) Mohseni, S.; Zarei, N.; Ragan, E. D. A Multidisciplinary Survey
-        and Framework for\n\n     Design and Evaluation of Explainable AI Systems. ACM
-        Transactions on Interactive\n\n      Intelligent Systems 2018, 11, 46.\n\n\n(43)
-        Humer, C.; Heberle, H.; Montanari, F.; Wolf, T.; Huber, F.; Henderson, R.; Hein-\n\n      rich,
-        J.; Streit, M. ChemInformatics Model Explorer (CIME): exploratory analysis of\n\n     chemical
-        model explanations. Journal of Cheminformatics 2022, 14, 1\u201314.\n\n\n                                      28(44)
-        Lundberg, S. M.; Lee, S.-I. In Advances in Neural Information Processing Systems\n\n     30;
-        Guyon, I., Luxburg, U. V., Bengio, S., Wallach, H., Fergus, R., Vishwanathan,
-        S.,\n\n     Garnett, R., Eds.; Curran Associates, Inc., 2017; pp 4765\u20134774.\n\n(45)
-        \u02c7Strumbelj, E.; Kononenko, I. Explaining prediction models and individual
-        predictions\n\n     with feature contributions. Knowledge and information systems
-        2014, 41, 647\u2013665.\n\n\n(46) Shapley, L. S. A Value for N-Person Games;
-        RAND Corporation: Santa Monica, CA,\n\n     1952.\n\n\n(47) Molnar, C.; Casalicchio,
-        G.; Bischl, B. Interpretable machine learning\u2013a brief history,\n\n      state-of-the-art
-        and challenges. Joint European Conference on Machine Learning and\n\n    Knowledge
-        Discovery in Databases. 2020; pp 417\u2013431.\n\n\n(48) Lou, Y.; Caruana, R.;
-        Gehrke, J. Intelligible models for classification and regression.\n\n     Proceedings
-        of the 18th ACM SIGKDD international conference on Knowledge dis-\n\n     covery
-        and data mining. 2012; pp 150\u2013158.\n\n\n(49) Bastani, O.; Kim, C.; Bastani,
-        H. Interpreting blackbox models via model extraction.\n\n     arXiv preprint
-        arXiv:1705.08504 2017,\n\n\n(50) Gajewicz, A.; Puzyn, T.; Odziomek, K.; Urbaszek,
-        P.; Haase, A.; Riebeling, C.;\n\n     Luch, A.; Irfan, M. A.; Landsiedel, R.;
-        van der Zande, M.; Bouwmeester, H. Deci-\n\n     sion tree models to classify
-        nanomaterials according to the DF4nanoGrouping scheme.\n\n     Nanotoxicology
-        2018, 12, 1\u201317.\n\n\n(51) Han, L.; Wang, Y.; Bryant, S. H. Developing and
-        validating predictive decision tree\n\n     models from mining chemical structural
-        fingerprints and high\u2013throughput screening\n\n     data in PubChem. BMC
-        Bioinformatics 2008, 9, 401.\n\n(52) Plumb, G.; Al-Shedivat, M.; Cabrera, \u00b4A.
-        A.; Perer, A.; Xing, E.; Talwalkar, A. Regu-\n\n\n\n\n                                      29      larizing
-        black-box models for improved interpretability. Advances in Neural Informa-\n\n     tion
-        Processing Systems 2020, 33, 10526\u201310536.\n\n\n(53) Shao, X.; Skryagin,
-        A.; Stammer, W.; Schramowski, P.; Kersting, K. Right for bet-\n\n      ter reasons:
-        Training differentiable models by constraining their influence functions.\n\n     Proceedings
-        of the AAAI Conference on Artificial Intelligence. 2021; pp 9533\u20139540.\n\n\n(54)
-        Ouyang, R.; Curtarolo, S.; Ahmetcik, E.; Scheffler, M.; Ghiringhelli, L. M.
-        SISSO: A\n\n     compressed-sensing method for identifying the best low-dimensional
-        descriptor in an\n\n     immensity of offered candidates. Physical Review Materials
-        2018, 2, 083802.\n\n\n(55) Lipton, Z. C. The mythos of model interpretability:
-        In machine learning, the concept\n\n      of interpretability is both important
-        and slippery. Queue 2018, 16, 31\u201357.\n\n\n(56) Harren, T.; Matter, H.;
-        Hessler, G.; Rarey, M.; Grebner, C. Interpretation of structure\u2013\n\n      activity
-        relationships in real-world drug design data sets using explainable artific",
-        "ability is both important and slippery. Queue 2018, 16, 31\u201357.\n\n\n(56)
-        Harren, T.; Matter, H.; Hessler, G.; Rarey, M.; Grebner, C. Interpretation of
-        structure\u2013\n\n      activity relationships in real-world drug design data
-        sets using explainable artificial\n\n      intelligence. Journal of Chemical
-        Information and Modeling 2022, 62, 447\u2013462.\n\n\n(57) Sheridan, R. P. Interpretation
-        of QSAR Models by Coloring Atoms According to\n\n    Changes in Predicted Activity:
-        How Robust Is It? Journal of Chemical Information\n\n    and Modeling 2019,
-        59, 1324\u20131337.\n\n\n(58) Rasmussen, M. H.; Christensen, D. S.; Jensen,
-        J. H. Do machines dream of atoms?\n\n     Crippen\u2019s logP as a quantitative
-        molecular benchmark for explainable AI heatmaps.\n\n    2022,\n\n\n(59) Smilkov,
-        D.; Thorat, N.; Kim, B.; Vi\u00b4egas, F.; Wattenberg, M. SmoothGrad: removing\n\n     noise
-        by adding noise. 2017; https://arxiv.org/abs/1706.03825.\n\n\n(60) McCloskey,
-        K.; Taly, A.; Monti, F.; Brenner, M. P.; Colwell, L. Using Attribution\n\n     to
-        Decode Dataset Bias in Neural Network Models for Chemistry. Proceedings of the\n\n\n\n\n                                      30     National
-        Academy of Sciences of the United States of America 2018, 116, 11624\u2013\n\n     11629.\n\n\n(61)
-        Bach, S.; Binder, A.; Montavon, G.; Klauschen, F.; M\u00a8uller, K.-R.; Samek,
-        W. On\n\n     pixel-wise explanations for non-linear classifier decisions by
-        layer-wise relevance prop-\n\n     agation. PloS one 2015, 10, e0130140.\n\n\n(62)
+        sciences. Ar-\\n\\n       tificial intelligence 2019, 267, 1\u201338.\\n\\n\\n\\n
+        \                                     26(26) Murdoch, W. J.; Singh, C.; Kumbier,
+        K.; Abbasi-Asl, R.; Yu, B. Definitions, meth-\\n\\n     ods, and applications
+        in interpretable machine learning. Proceedings of the National\\n\\n    Academy
+        of Sciences of the United States of America 2019, 116, 22071\u201322080.\\n\\n\\n(27)
+        Gunning, D.; Aha, D. DARPA\u2019s Explainable Artificial Intelligence (XAI)
+        Program.\\n\\n    AI Magazine 2019, 40, 44\u201358.\\n\\n\\n(28) Biran, O.;
+        Cotton, C. Explanation and justification in machine learning: A survey.\\n\\n
+        \    IJCAI-17 workshop on explainable AI (XAI). 2017; pp 8\u201313.\\n\\n\\n(29)
+        Palacio, S.; Lucieri, A.; Munir, M.; Ahmed, S.; Hees, J.; Dengel, A. Xai handbook:\\n\\n
+        \   Towards a unified framework for explainable ai. Proceedings of the IEEE/CVF
+        Inter-\\n\\n     national Conference on Computer Vision. 2021; pp 3766\u20133775.\\n\\n\\n(30)
+        Kuhn, D. R.; Kacker, R. N.; Lei, Y.; Simos, D. E. Combinatorial Methods for
+        Ex-\\n\\n     plainable AI. 2020 IEEE International Conference on Software Testing,
+        Verification\\n\\n    and Validation Workshops (ICSTW) 2020, 167\u2013170.\\n\\n\\n(31)
+        Seshadri, A.; Gandhi, H. A.; Wellawatte, G. P.; White, A. D. Why does that molecule\\n\\n
+        \    smell? ChemRxiv 2022,\\n\\n\\n(32) Das, A.; Rad, P. Opportunities and challenges
+        in explainable artificial intelligence\\n\\n      (xai): A survey. arXiv preprint
+        arXiv:2006.11371 2020,\\n\\n\\n(33) Machlev, R.; Heistrene, L.; Perl, M.; Levy,
+        K. Y.; Belikov, J.; Mannor, S.; Levron, Y.\\n\\n     Explainable Artificial
+        Intelligence (XAI) techniques for energy and power systems:\\n\\n     Review,
+        challenges and opportunities. Energy and AI 2022, 9, 100169.\\n\\n\\n(34) Koh,
+        P. W.; Liang, P. Understanding black-box predictions via influence functions.\\n\\n
+        \    International Conference on Machine Learning. 2017; pp 1885\u20131894.\\n\\n\\n(35)
+        Ribeiro, M. T.; Singh, S.; Guestrin, C. \u201D Why should  i trust you?\u201D
+        Explaining the\\n\\n     predictions of any classifier. Proceedings of the 22nd
+        ACM SIGKDD international\\n\\n         \",\"ternational Conference on Machine
+        Learning. 2017; pp 1885\u20131894.\\n\\n\\n(35) Ribeiro, M. T.; Singh, S.; Guestrin,
+        C. \u201D Why should  i trust you?\u201D Explaining the\\n\\n     predictions
+        of any classifier. Proceedings of the 22nd ACM SIGKDD international\\n\\n                                      27
+        \    conference on knowledge discovery and data mining. San Diego, CA, USA,
+        2016; pp\\n\\n     1135\u20131144.\\n\\n\\n(36) Dhurandhar, A.; Chen, P.-Y.;
+        Luss, R.; Tu, C.-C.; Ting, P.; Shanmugam, K.; Das, P.\\n\\n     Explanations
+        based on the missing: Towards contrastive explanations with pertinent\\n\\n
+        \    negatives. Advances in neural information processing systems 2018, 31.\\n\\n\\n(37)
+        Jin, W.; Li, X.; Hamarneh, G. Evaluating Explainable AI on a Multi-Modal Medical\\n\\n
+        \    Imaging Task: Can Existing Algorithms Fulfill Clinical Requirements? Proceedings
+        of\\n\\n     the AAAI Conference on Artificial Intelligence 2022, 36, 11945\u201311953.\\n\\n\\n(38)
+        Zhang, Y.; Xu, F.; Zou, J.; Petrosian, O. L.; Krinkin, K. V. XAI Evaluation:
+        Evalu-\\n\\n     ating Black-Box Model Explanations for Prediction. 2021 II
+        International Conference\\n\\n    on Neural Networks and Neurotechnologies (NeuroNT).
+        2021; pp 13\u201316.\\n\\n\\n(39) Oviedo, F.; Ferres, J. L.; Buonassisi, T.;
+        Butler, K. T. Interpretable and Explain-\\n\\n     able Machine Learning for
+        Materials Science and Chemistry. Accounts of Materials\\n\\n     Research 2022,
+        3, 597\u2013607.\\n\\n\\n(40) Yalcin, O.; Fan, X.; Liu, S. Evaluating the correctness
+        of explainable AI algorithms\\n\\n      for classification. arXiv preprint arXiv:2105.09740
+        2021,\\n\\n\\n(41) Hoffman, R. R.; Mueller, S. T.; Klein, G.; Litman, J. Metrics
+        for Explainable AI:\\n\\n     Challenges and Prospects. 2018,\\n\\n\\n(42) Mohseni,
+        S.; Zarei, N.; Ragan, E. D. A Multidisciplinary Survey and Framework for\\n\\n
+        \    Design and Evaluation of Explainable AI Systems. ACM Transactions on Interactive\\n\\n
+        \     Intelligent Systems 2018, 11, 46.\\n\\n\\n(43) Humer, C.; Heberle, H.;
+        Montanari, F.; Wolf, T.; Huber, F.; Henderson, R.; Hein-\\n\\n      rich, J.;
+        Streit, M. ChemInformatics Model Explorer (CIME): exploratory analysis of\\n\\n
+        \    chemical model explanations. Journal of Cheminformatics 2022, 14, 1\u201314.\\n\\n\\n
+        \                                     28(44) Lundberg, S. M.; Lee, S.-I. In
+        Advances in Neural Information Processing Systems\\n\\n     30; Guyon, I., Luxburg,
+        U. V., Bengio, S., Wallach, H., Fergus, R., Vishwanathan, S.,\\n\\n     Garnett,
+        R., Eds.; Curran Associates, Inc., 2017; pp 4765\u20134774.\\n\\n(45) \u02C7Strumbelj,
+        E.; Kononenko, I. Explaining prediction models and individual predictions\\n\\n
+        \    with feature contributions. Knowledge and information systems 2014, 41,
+        647\u2013665.\\n\\n\\n(46) Shapley, L. S. A Value for N-Person Games; RAND Corporation:
+        Santa Monica, CA,\\n\\n     1952.\\n\\n\\n(47) Molnar, C.; Casalicchio, G.;
+        Bischl, B. Interpretable machine learning\u2013a brief history,\\n\\n      state-of-the-art
+        and challenges. Joint European Conference on Machine Learning and\\n\\n    Knowledge
+        Discovery in Databases. 2020; pp 417\u2013431.\\n\\n\\n(48) Lou, Y.; Caruana,
+        R.; Gehrke, J. Intelligible models for classification and regression.\\n\\n
+        \    Proceedings of the 18th ACM SIGKDD international conference on Knowledge
+        dis-\\n\\n     covery and data mining. 2012; pp 150\u2013158.\\n\\n\\n(49) Bastani,
+        O.; Kim, C.; Bastani, H. Interpreting blackbox models via model extraction.\\n\\n
+        \    arXiv preprint arXiv:1705.08504 2017,\\n\\n\\n(50) Gajewicz, A.; Puzyn,
+        T.; Odziomek, K.; Urbaszek, P.; Haase, A.; Riebeling, C.;\\n\\n     Luch, A.;
+        Irfan, M. A.; Landsiedel, R.; van der Zande, M.; Bouwmeester, H. Deci-\\n\\n
+        \    sion tree models to classify nanomaterials according to the DF4nanoGrouping
+        scheme.\\n\\n     Nanotoxicology 2018, 12, 1\u201317.\\n\\n\\n(51) Han, L.;
+        Wang, Y.; Bryant, S. H. Developing and validating predictive decision tree\\n\\n
+        \    models from mining chemical structural fingerprints and high\u2013throughput
+        screening\\n\\n     data in PubChem. BMC Bioinformatics 2008, 9, 401.\\n\\n(52)
+        Plumb, G.; Al-Shedivat, M.; Cabrera, \xB4A. A.; Perer, A.; Xing, E.; Talwalkar,
+        A. Regu-\\n\\n\\n\\n\\n                                      29      larizing
+        black-box models for improved interpretability. Advances in Neural Informa-\\n\\n
+        \    tion Processing Systems 2020, 33, 10526\u201310536.\\n\\n\\n(53) Shao,
+        X.; Skryagin, A.; Stammer, W.; Schramowski, P.; Kersting, K. Right for bet-\\n\\n
+        \     ter reasons: Training differentiable models by constraining their influence
+        functions.\\n\\n     Proceedings of the AAAI Conference on Artificial Intelligence.
+        2021; pp 9533\u20139540.\\n\\n\\n(54) Ouyang, R.; Curtarolo, S.; Ahmetcik, E.;
+        Scheffler, M.; Ghiringhelli, L. M. SISSO: A\\n\\n     compressed-sensing method
+        for identifying the best low-dimensional descriptor in an\\n\\n     immensity
+        of offered candidates. Physical Review Materials 2018, 2, 083802.\\n\\n\\n(55)
+        Lipton, Z. C. The mythos of model interpretability: In machine learning, the
+        concept\\n\\n      of interpretability is both important and slippery. Queue
+        2018, 16, 31\u201357.\\n\\n\\n(56) Harren, T.; Matter, H.; Hessler, G.; Rarey,
+        M.; Grebner, C. Interpretation of structure\u2013\\n\\n      activity relationships
+        in real-world drug design data sets using explainable artific\",\"ability is
+        both important and slippery. Queue 2018, 16, 31\u201357.\\n\\n\\n(56) Harren,
+        T.; Matter, H.; Hessler, G.; Rarey, M.; Grebner, C. Interpretation of structure\u2013\\n\\n
+        \     activity relationships in real-world drug design data sets using explainable
+        artificial\\n\\n      intelligence. Journal of Chemical Information and Modeling
+        2022, 62, 447\u2013462.\\n\\n\\n(57) Sheridan, R. P. Interpretation of QSAR
+        Models by Coloring Atoms According to\\n\\n    Changes in Predicted Activity:
+        How Robust Is It? Journal of Chemical Information\\n\\n    and Modeling 2019,
+        59, 1324\u20131337.\\n\\n\\n(58) Rasmussen, M. H.; Christensen, D. S.; Jensen,
+        J. H. Do machines dream of atoms?\\n\\n     Crippen\u2019s logP as a quantitative
+        molecular benchmark for explainable AI heatmaps.\\n\\n    2022,\\n\\n\\n(59)
+        Smilkov, D.; Thorat, N.; Kim, B.; Vi\xB4egas, F.; Wattenberg, M. SmoothGrad:
+        removing\\n\\n     noise by adding noise. 2017; https://arxiv.org/abs/1706.03825.\\n\\n\\n(60)
+        McCloskey, K.; Taly, A.; Monti, F.; Brenner, M. P.; Colwell, L. Using Attribution\\n\\n
+        \    to Decode Dataset Bias in Neural Network Models for Chemistry. Proceedings
+        of the\\n\\n\\n\\n\\n                                      30     National Academy
+        of Sciences of the United States of America 2018, 116, 11624\u2013\\n\\n     11629.\\n\\n\\n(61)
+        Bach, S.; Binder, A.; Montavon, G.; Klauschen, F.; M\xA8uller, K.-R.; Samek,
+        W. On\\n\\n     pixel-wise explanations for non-linear classifier decisions
+        by layer-wise relevance prop-\\n\\n     agation. PloS one 2015, 10, e0130140.\\n\\n\\n(62)
         Sundararajan, M.; Taly, A.; Yan, Q. Axiomatic attribution for deep networks.
-        Inter-\n\n     national Conference on Machine Learning. 2017; pp 3319\u20133328.\n\n\n(63)
-        Zhou, B.; Khosla, A.; Lapedriza, A.; Oliva, A.; Torralba, A. Learning Deep Features\n\n      for
-        Discriminative Localization. 2015; https://arxiv.org/abs/1512.04150.\n\n\n(64)
+        Inter-\\n\\n     national Conference on Machine Learning. 2017; pp 3319\u20133328.\\n\\n\\n(63)
+        Zhou, B.; Khosla, A.; Lapedriza, A.; Oliva, A.; Torralba, A. Learning Deep Features\\n\\n
+        \     for Discriminative Localization. 2015; https://arxiv.org/abs/1512.04150.\\n\\n\\n(64)
         Selvaraju, R. R.; Cogswell, M.; Das, A.; Vedantam, R.; Parikh, D.; Batra, D.
-        Grad-\n\n   CAM: Visual Explanations from Deep Networks via Gradient-Based Localization.
-        In-\n\n     ternational Journal of Computer Vision 2019, 128, 336\u2013359.\n\n\n(65)
-        Smilkov, D.; Thorat, N.; Kim, B.; Vi\u00b4egas, F.; Wattenberg, M. Smoothgrad:
-        removing\n\n     noise by adding noise. arXiv preprint arXiv:1706.03825 2017,\n\n\n(66)
-        Pope, P.; Kolouri, S.; Rostrami, M.; Martin, C.; Hoffmann, H. Discovering Molec-\n\n     ular
-        Functional Groups Using Graph Convolutional Neural Networks. 2018; https:\n\n    //arxiv.org/abs/1812.00265.\n\n\n(67)
-        Jim\u00b4enez-Luna, J.; Skalic, M.; Weskamp, N.; Schneider, G. Coloring molecules
-        with ex-\n\n     plainable artificial intelligence for preclinical relevance
-        assessment. Journal of Chem-\n\n      ical Information and Modeling 2021, 61,
-        1083\u20131094.\n\n\n(68) Sanchez-Lengeling, B.; Wei, J.; Lee, B.; Reif, E.;
-        Wang, P. Y.; Qian, W. W.; Mc-\n\n     Closkey, K.; Colwell, L.; Wiltschko, A.
-        Evaluating Attribution for Graph Neural\n\n     Networks. Proceedings of the
-        34th International Conference on Neural Information\n\n     Processing Systems.
-        Red Hook, NY, USA, 2020.\n\n\n                                      31(69) Ying,
-        R.; Bourgeois, D.; You, J.; Zitnik, M.; Leskovec, J. GNNExplainer: Generating\n\n     Explanations
-        for Graph Neural Networks. Advances in neural information processing\n\n     systems
-        2019, 32, 9240\u20139251.\n\n\n(70) Rao, J.; Zheng, S.; Yang, Y. Quantitative
-        Evaluation of Explainable Graph Neural\n\n    Networks for Molecular Property
-        Prediction. arXiv preprint arXiv:2107.04119 2021,\n\n\n(71) Yuan, H.; Yu, H.;
-        Wang, J.; Li, K.; Ji, S. On Explainability of Graph Neural Net-\n\n     works
-        via Subgraph Explorations. Proceedings of the 38th International Conference\n\n    on
-        Machine Learning. 2021; pp 12241\u201312252.\n\n\n(72) Shrikumar, A.; Greenside,
-        P.; Kundaje, A. Learning Important Features Through\n\n     Propagating Activation
-        Differences. 2017,\n\n\n(73) Montavon, G.; Binder, A.; Lapuschkin, S.; Samek,
-        W.; M\u00a8uller, K. R. Layer-Wise\n\n     Relevance Propagation: An Overview.
-        Lecture Notes in Computer Science (including\n\n     subseries Lecture Notes
-        in Artificial Intelligence and Lecture Notes in Bioinformatics)\n\n    2019,
-        11700 LNCS, 193\u2013209.\n\n\n(74) Baldassarre, F.; Azizpour, H. Explainability
-        Techniques for Graph Convolutional Net-\n\n     works. 2019; https://arxiv.org/abs/1905.13686.\n\n\n(75)
-        Hochuli, J.; Helbling, A.; Skaist, T.; Ragoza, M.; Koes, D. R. Visualizing convolutional\n\n     neural
-        network protein-ligand scoring. Journal of Molecular Graphics and Modelling\n\n    2018,
-        84, 96\u2013108.\n\n\n(76) Rodr\u00b4\u0131guez-P\u00b4erez, R.; Bajorath, J.
-        Interpretation of Compound Activity Predictions\n\n    from Complex Machine
-        Learning Models Using Local Approximations and Shapley\n\n     Values. Journal
-        of Medicinal Chemistry 2020, 63, 8761\u20138777, PMID: 31512867.\n\n\n(77) Wojtuch,
-        A.; Jankowski, R.; Podlewska, S. How can SHAP values help to shape\n\n\n\n\n                                      32     metabolic
-        stability of chemical compounds? Journal of Cheminformatics 2021, 13,\n\n     1\u201320.\n\n\n(78)
-        Mastropietro, A.; Pasculli, G.; Feldmann, C.; Rodr\u00b4\u0131guez-P\u00b4erez,
-        R.; Bajorath, J. Edge-\n\n    SHAPer: Bond-Centric Shapley Value-Based Explanation
-        Me", "   metabolic stability of chemical compounds? Journal of Cheminformatics
-        2021, 13,\n\n     1\u201320.\n\n\n(78) Mastropietro, A.; Pasculli, G.; Feldmann,
-        C.; Rodr\u00b4\u0131guez-P\u00b4erez, R.; Bajorath, J. Edge-\n\n    SHAPer:
-        Bond-Centric Shapley Value-Based Explanation Method for Graph Neural\n\n     Networks.
-        iScience 2022, 25, 105043.\n\n\n(79) White, A. D. Deep learning for molecules
-        and materials. Living Journal of Computa-\n\n      tional Molecular Science
-        2022, 3.\n\n(80) \u02d8Strumbelj, E.; Kononenko, I. Explaining prediction models
-        and individual predictions\n\n     with feature contributions. Knowledge and
-        Information Systems 2014, 41, 647\u2013665.\n\n\n(81) Erhan, D.; Bengio, Y.;
-        Courville, A.; Vincent, P. Visualizing Higher-Layer Features of\n\n     a Deep
-        Network. Technical Report, Univerist\u00b4e de Montr\u00b4eal 2009,\n\n\n(82)
-        Weber, J. K.; Morrone, J. A.; Bagchi, S.; Pabon, J. D.; gu Kang, S.; Zhang,
-        L.;\n\n     Cornell, W. D. Simplified, interpretable graph convolutional neural
-        networks for small\n\n     molecule activity prediction. Journal of Computer-Aided
-        Molecular Design 2022, 36,\n\n     391\u2013404.\n\n\n(83) Riniker, S.; Landrum,
-        G. A. Similarity maps - A visualization strategy for molecular\n\n     fingerprints
-        and machine-learning methods. Journal of Cheminformatics 2013, 5, 1\u20137.\n\n\n(84)
-        Humer, C.; Heberle, H.; Montanari, F.; Wolf, T.; Huber, F.; Henderson, R.; Hein-\n\n      rich,
-        J.; Streit, M. ChemInformatics Model Explorer (CIME): exploratory analysis of\n\n     chemical
-        model explanations. Journal of Cheminformatics 2022, 14, 1\u201314.\n\n\n(85)
-        McGrath, T.; Kapishnikov, A.; Toma\u02c7sev, N.; Pearce, A.; Wattenberg, M.;
-        Hass-\n\n      abis, D.; Kim, B.; Paquet, U.; Kramnik, V. Acquisition of chess
-        knowledge in Al-\n\n     phaZero. Proceedings of the National Academy of Sciences
-        2022, 119, e2206625119.\n\n\n\n\n                                      33(86)
-        Bajusz, D.; R\u00b4acz, A.; H\u00b4eberger, K. Why is Tanimoto index an appropriate
-        choice for\n\n     fingerprint-based similarity calculations? Journal of Cheminformatics
-        2015, 7, 1\u201313.\n\n\n(87) Huang, Q.; Yamada, M.; Tian, Y.; Singh, D.; Yin,
-        D.; Chang, Y. GraphLIME:\n\n     Local Interpretable Model Explanations for
-        Graph Neural Networks. CoRR 2020,\n\n     abs/2001.06216.\n\n\n(88) Sokol, K.;
-        Flach, P. A. LIMEtree: Interactively Customisable Explanations Based on\n\n     Local
-        Surrogate Multi-output Regression Trees. CoRR 2020, abs/2005.01427.\n\n\n(89)
-        Whitmore, L. S.; George, A.; Hudson, C. M. Mapping chemical performance on molec-\n\n     ular
-        structures using locally interpretable explanations. 2016; https://arxiv.org/\n\n    abs/1611.07443.\n\n\n(90)
-        Mehdi, S.; Tiwary, P. Thermodynamics of Interpretation. 2022,\n\n\n(91) H\u00a8ofler,
-        M. Causal inference based on counterfactuals. BMC Medical Research Method-\n\n     ology
-        2005, 5, 1\u201312.\n\n\n(92) Woodward, J.; Hitchcock, C. Explanatory Generalizations,
-        Part I: A Counterfactual\n\n     Account. No\u02c6us 2003, 37, 1\u201324.\n\n\n(93)
-        Frisch, M. F. Theories, models, and explanation; University of California, Berkeley,\n\n     1998.\n\n\n(94)
-        Reutlinger, A. Is There A Monist Theory of Causal and Non-Causal Explanations?\n\n    The
+        Grad-\\n\\n   CAM: Visual Explanations from Deep Networks via Gradient-Based
+        Localization. In-\\n\\n     ternational Journal of Computer Vision 2019, 128,
+        336\u2013359.\\n\\n\\n(65) Smilkov, D.; Thorat, N.; Kim, B.; Vi\xB4egas, F.;
+        Wattenberg, M. Smoothgrad: removing\\n\\n     noise by adding noise. arXiv preprint
+        arXiv:1706.03825 2017,\\n\\n\\n(66) Pope, P.; Kolouri, S.; Rostrami, M.; Martin,
+        C.; Hoffmann, H. Discovering Molec-\\n\\n     ular Functional Groups Using Graph
+        Convolutional Neural Networks. 2018; https:\\n\\n    //arxiv.org/abs/1812.00265.\\n\\n\\n(67)
+        Jim\xB4enez-Luna, J.; Skalic, M.; Weskamp, N.; Schneider, G. Coloring molecules
+        with ex-\\n\\n     plainable artificial intelligence for preclinical relevance
+        assessment. Journal of Chem-\\n\\n      ical Information and Modeling 2021,
+        61, 1083\u20131094.\\n\\n\\n(68) Sanchez-Lengeling, B.; Wei, J.; Lee, B.; Reif,
+        E.; Wang, P. Y.; Qian, W. W.; Mc-\\n\\n     Closkey, K.; Colwell, L.; Wiltschko,
+        A. Evaluating Attribution for Graph Neural\\n\\n     Networks. Proceedings of
+        the 34th International Conference on Neural Information\\n\\n     Processing
+        Systems. Red Hook, NY, USA, 2020.\\n\\n\\n                                      31(69)
+        Ying, R.; Bourgeois, D.; You, J.; Zitnik, M.; Leskovec, J. GNNExplainer: Generating\\n\\n
+        \    Explanations for Graph Neural Networks. Advances in neural information
+        processing\\n\\n     systems 2019, 32, 9240\u20139251.\\n\\n\\n(70) Rao, J.;
+        Zheng, S.; Yang, Y. Quantitative Evaluation of Explainable Graph Neural\\n\\n
+        \   Networks for Molecular Property Prediction. arXiv preprint arXiv:2107.04119
+        2021,\\n\\n\\n(71) Yuan, H.; Yu, H.; Wang, J.; Li, K.; Ji, S. On Explainability
+        of Graph Neural Net-\\n\\n     works via Subgraph Explorations. Proceedings
+        of the 38th International Conference\\n\\n    on Machine Learning. 2021; pp
+        12241\u201312252.\\n\\n\\n(72) Shrikumar, A.; Greenside, P.; Kundaje, A. Learning
+        Important Features Through\\n\\n     Propagating Activation Differences. 2017,\\n\\n\\n(73)
+        Montavon, G.; Binder, A.; Lapuschkin, S.; Samek, W.; M\xA8uller, K. R. Layer-Wise\\n\\n
+        \    Relevance Propagation: An Overview. Lecture Notes in Computer Science (including\\n\\n
+        \    subseries Lecture Notes in Artificial Intelligence and Lecture Notes in
+        Bioinformatics)\\n\\n    2019, 11700 LNCS, 193\u2013209.\\n\\n\\n(74) Baldassarre,
+        F.; Azizpour, H. Explainability Techniques for Graph Convolutional Net-\\n\\n
+        \    works. 2019; https://arxiv.org/abs/1905.13686.\\n\\n\\n(75) Hochuli, J.;
+        Helbling, A.; Skaist, T.; Ragoza, M.; Koes, D. R. Visualizing convolutional\\n\\n
+        \    neural network protein-ligand scoring. Journal of Molecular Graphics and
+        Modelling\\n\\n    2018, 84, 96\u2013108.\\n\\n\\n(76) Rodr\xB4\u0131guez-P\xB4erez,
+        R.; Bajorath, J. Interpretation of Compound Activity Predictions\\n\\n    from
+        Complex Machine Learning Models Using Local Approximations and Shapley\\n\\n
+        \    Values. Journal of Medicinal Chemistry 2020, 63, 8761\u20138777, PMID:
+        31512867.\\n\\n\\n(77) Wojtuch, A.; Jankowski, R.; Podlewska, S. How can SHAP
+        values help to shape\\n\\n\\n\\n\\n                                      32
+        \    metabolic stability of chemical compounds? Journal of Cheminformatics 2021,
+        13,\\n\\n     1\u201320.\\n\\n\\n(78) Mastropietro, A.; Pasculli, G.; Feldmann,
+        C.; Rodr\xB4\u0131guez-P\xB4erez, R.; Bajorath, J. Edge-\\n\\n    SHAPer: Bond-Centric
+        Shapley Value-Based Explanation Me\",\"   metabolic stability of chemical compounds?
+        Journal of Cheminformatics 2021, 13,\\n\\n     1\u201320.\\n\\n\\n(78) Mastropietro,
+        A.; Pasculli, G.; Feldmann, C.; Rodr\xB4\u0131guez-P\xB4erez, R.; Bajorath,
+        J. Edge-\\n\\n    SHAPer: Bond-Centric Shapley Value-Based Explanation Method
+        for Graph Neural\\n\\n     Networks. iScience 2022, 25, 105043.\\n\\n\\n(79)
+        White, A. D. Deep learning for molecules and materials. Living Journal of Computa-\\n\\n
+        \     tional Molecular Science 2022, 3.\\n\\n(80) \u02D8Strumbelj, E.; Kononenko,
+        I. Explaining prediction models and individual predictions\\n\\n     with feature
+        contributions. Knowledge and Information Systems 2014, 41, 647\u2013665.\\n\\n\\n(81)
+        Erhan, D.; Bengio, Y.; Courville, A.; Vincent, P. Visualizing Higher-Layer Features
+        of\\n\\n     a Deep Network. Technical Report, Univerist\xB4e de Montr\xB4eal
+        2009,\\n\\n\\n(82) Weber, J. K.; Morrone, J. A.; Bagchi, S.; Pabon, J. D.; gu
+        Kang, S.; Zhang, L.;\\n\\n     Cornell, W. D. Simplified, interpretable graph
+        convolutional neural networks for small\\n\\n     molecule activity prediction.
+        Journal of Computer-Aided Molecular Design 2022, 36,\\n\\n     391\u2013404.\\n\\n\\n(83)
+        Riniker, S.; Landrum, G. A. Similarity maps - A visualization strategy for molecular\\n\\n
+        \    fingerprints and machine-learning methods. Journal of Cheminformatics 2013,
+        5, 1\u20137.\\n\\n\\n(84) Humer, C.; Heberle, H.; Montanari, F.; Wolf, T.; Huber,
+        F.; Henderson, R.; Hein-\\n\\n      rich, J.; Streit, M. ChemInformatics Model
+        Explorer (CIME): exploratory analysis of\\n\\n     chemical model explanations.
+        Journal of Cheminformatics 2022, 14, 1\u201314.\\n\\n\\n(85) McGrath, T.; Kapishnikov,
+        A.; Toma\u02C7sev, N.; Pearce, A.; Wattenberg, M.; Hass-\\n\\n      abis, D.;
+        Kim, B.; Paquet, U.; Kramnik, V. Acquisition of chess knowledge in Al-\\n\\n
+        \    phaZero. Proceedings of the National Academy of Sciences 2022, 119, e2206625119.\\n\\n\\n\\n\\n
+        \                                     33(86) Bajusz, D.; R\xB4acz, A.; H\xB4eberger,
+        K. Why is Tanimoto index an appropriate choice for\\n\\n     fingerprint-based
+        similarity calculations? Journal of Cheminformatics 2015, 7, 1\u201313.\\n\\n\\n(87)
+        Huang, Q.; Yamada, M.; Tian, Y.; Singh, D.; Yin, D.; Chang, Y. GraphLIME:\\n\\n
+        \    Local Interpretable Model Explanations for Graph Neural Networks. CoRR
+        2020,\\n\\n     abs/2001.06216.\\n\\n\\n(88) Sokol, K.; Flach, P. A. LIMEtree:
+        Interactively Customisable Explanations Based on\\n\\n     Local Surrogate Multi-output
+        Regression Trees. CoRR 2020, abs/2005.01427.\\n\\n\\n(89) Whitmore, L. S.; George,
+        A.; Hudson, C. M. Mapping chemical performance on molec-\\n\\n     ular structures
+        using locally interpretable explanations. 2016; https://arxiv.org/\\n\\n    abs/1611.07443.\\n\\n\\n(90)
+        Mehdi, S.; Tiwary, P. Thermodynamics of Interpretation. 2022,\\n\\n\\n(91) H\xA8ofler,
+        M. Causal inference based on counterfactuals. BMC Medical Research Method-\\n\\n
+        \    ology 2005, 5, 1\u201312.\\n\\n\\n(92) Woodward, J.; Hitchcock, C. Explanatory
+        Generalizations, Part I: A Counterfactual\\n\\n     Account. No\u02C6us 2003,
+        37, 1\u201324.\\n\\n\\n(93) Frisch, M. F. Theories, models, and explanation;
+        University of California, Berkeley,\\n\\n     1998.\\n\\n\\n(94) Reutlinger,
+        A. Is There A Monist Theory of Causal and Non-Causal Explanations?\\n\\n    The
         Counterfactual Theory of Scientific Explanation. Philosophy of Science 2016,
-        83,\n\n     733\u2013745.\n\n\n(95) Lewis, D. Causation. The journal of philosophy
-        1974, 70, 556\u2013567.\n\n\n(96) Tanimoto, T. T. Elementary mathematical theory
-        of classification and prediction.\n\n     Internal IBM Technical Report 1958,\n\n\n                                      34
-        (97) Rogers, D.; Hahn, M. Extended-Connectivity Fingerprints. Journal of Chemical
-        In-\n\n      formation and Modeling 2010, 50, 742\u2013754, PMID: 20426451.\n\n\n
-        (98) Mohapatra, S.; An, J.; G\u00b4omez-Bombarelli, R. Chemistry-informed macromolecule\n\n      graph
-        representation for similarity computation, unsupervised and supervised learn-\n\n       ing.
-        Machine Learning: Science and Technology 2022, 3, 015028.\n\n\n (99) Doshi-Velez,
-        F.; Kortz, M.; Budish, R.; Bavitz, C.; Gershman, S.; O\u2019Brien, D.;\n\n       Scott,
-        K.; Schieber, S.; Waldo, J.; Weinberger, D.; Weller, A.; Wood, A. Account-\n\n       ability
-        of AI Under the Law: The Role of Explanation. SSRN Electronic Journal\n\n     2017,\n\n\n(100)
-        Wachter, S.; Mittelstadt, B.; Russell, C. Counterfactual explanations without
-        opening\n\n      the black box: Automated decisions and the GDPR. Harv. JL &
-        Tech. 2017, 31, 841.\n\n\n(101) Jim\u00b4enez-Luna, J.; Grisoni, F.; Schneider,
-        G. Drug discovery with explainable artificial\n\n       intelligence. Nature
-        Machine Intelligence 2020 2:10 2020, 2, 573\u2013584.\n\n\n(102) Fu, T.; Gao,
-        W.; Xiao, C.; Yasonik, J.; Coley, C. W.; Sun, J. Differentiable Scaffold-\n\n      ing
-        Tree for Molecule Optimization. International Conference on Learning Represen-\n\n       tations.
-        2022.\n\n\n(103) Shen, C.; Krenn, M.; Eppel, S.; Aspuru-Guzik, A. Deep molecular
-        dreaming: inverse\n\n     machine learning for de-novo molecular design and
-        interpretability with surjective\n\n      representations. Machine Learning:
-        Science and Technology 2021, 2, 03LT02.\n\n\n(104) Lucic,  A.;   ter  Hoeve,  M.;   Tolomei,  G.;   Rijke,  M.;   Silvestri,  F.  CF-\n\n
-        ", "learning for de-novo molecular design and interpretability with surjective\n\n      representations.
-        Machine Learning: Science and Technology 2021, 2, 03LT02.\n\n\n(104) Lucic,  A.;   ter  Hoeve,  M.;   Tolomei,  G.;   Rijke,  M.;   Silvestri,  F.  CF-\n\n     GNNExplainer:  Counterfactual
-        Explanations for Graph Neural Networks. arXiv\n\n      preprint arXiv:2102.03322
-        2021,\n\n\n(105) Numeroso, D.; Bacciu, D. Explaining Deep Graph Networks with
-        Molecular Counter-\n\n       factuals. arXiv preprint arXiv:2011.05134 2020,\n\n\n                                       35(106)
-        Krenn, M.; H\u00a8ase, F.; Nigam, A.; Friederich, P.; Aspuru-Guzik, A. Self-Referencing\n\n     Embedded
-        Strings (SELFIES): A 100% robust molecular string representation. Ma-\n\n      chine
-        Learning: Science and Technology 2020, 1, 045024.\n\n\n(107) Nigam, A.; Pollice,
-        R.; Krenn, M.; dos Passos Gomes, G.; Aspuru-Guzik, A. Beyond\n\n      generative
-        models: superfast traversal, optimization, novelty, exploration and discov-\n\n      ery
-        (STONED) algorithm for molecules using SELFIES. Chemical science 2021, 12,\n\n      7079\u20137090.\n\n\n(108)
-        Kim, S.; Chen, J.; Cheng, T.; Gindulyte, A.; He, J.; He, S.; Li, Q.; Shoemaker,
-        B. A.;\n\n      Thiessen, P. A.; Yu, B.; Zaslavsky, L.; Zhang, J.; Bolton, E.
-        E. PubChem in 2021:\n\n     new data content and improved web interfaces. Nucleic
-        Acids Research 2020, 49,\n\n     D1388\u2013D1395.\n\n\n(109) Tolomei, G.; Silvestri,
-        F.; Haines, A.; Lalmas, M. Interpretable predictions of tree-\n\n      based
-        ensembles via actionable feature tweaking. Proceedings of the 23rd ACM\n\n    SIGKDD
-        international conference on knowledge discovery and data mining. 2017;\n\n     pp
-        465\u2013474.\n\n\n(110) Freiesleben, T. The intriguing relation between counterfactual
-        explanations and ad-\n\n       versarial examples. Minds and Machines 2022,
-        32, 77\u2013109.\n\n\n(111) Grabocka, J.; Schilling, N.; Wistuba, M.; Schmidt-Thieme,
-        L. Learning time-series\n\n       shapelets. Proceedings of the 20th ACM SIGKDD
-        international conference on Knowl-\n\n      edge discovery and data mining.
-        2014; pp 392\u2013401.\n\n\n(112) Kenny, P. W.; Sadowski, J. Structure modification
-        in chemical databases. Chemoin-\n\n      formatics in drug discovery 2005, 271\u2013285.\n\n\n(113)
-        Tyrchan, C.; Evertsson, E. Matched Molecular Pair Analysis in Short: Algorithms,\n\n      Applications
-        and Limitations. Computational and Structural Biotechnology Journal\n\n     2017,
-        15, 86\u201390.\n\n                                       36(114) Griffen, E.;
-        Leach, A. G.; Robb, G. R.; Warner, D. J. Matched Molecular Pairs as\n\n      a
-        Medicinal Chemistry Tool. Journal of Medicinal Chemistry 2011, 54, 7739\u20137750,\n\n     PMID:
-        21936582.\n\n\n(115) He, J.; Nittinger, E.; Tyrchan, C.; Czechtizky, W.; Patronov,
-        A.; Bjerrum, E. J.;\n\n      Engkvist, O. Transformer-based molecular optimization
-        beyond matched molecular\n\n       pairs. Journal of cheminformatics 2022, 14,
-        1\u201314.\n\n\n(116) Park, J.; Sung, G.; Lee, S.; Kang, S.; Park, C. ACGCN:
-        Graph Convolutional Networks\n\n       for Activity Cliff Prediction between
-        Matched Molecular Pairs. Journal of Chemical\n\n      Information and Modeling
-        2022,\n\n\n(117) Langdon, S. R.; Ertl, P.; Brown, N. Bioisosteric Replacement
-        and Scaffold Hopping\n\n       in Lead Generation and Optimization. Molecular
-        Informatics 2010, 29, 366\u2013385.\n\n\n(118) Turk, S.; Merget, B.; Rippmann,
-        F.; Fulle, S. Coupling Matched Molecular Pairs\n\n      with Machine Learning
-        for Virtual Compound Optimization. Journal of Chemical\n\n      Information
-        and Modeling 2017, 57, 3079\u20133085, PMID: 29131617.\n\n\n(119) van Tilborg,
-        D.; Alenicheva, A.; Grisoni, F. Exposing the limitations of molecular\n\n     machine
-        learning with activity cliffs. 2022,\n\n\n(120) Fischer, H.; Gottschlich, R.;
-        Seelig, A. Blood-brain barrier permeation:  molecular\n\n      parameters governing
-        passive diffusion. The Journal of membrane biology 1998, 165,\n\n      201\u2013211.\n\n\n(121)
-        Liu, L.; Zhang, L.; Feng, H.; Li, S.; Liu, M.; Zhao, J.; Liu, H. Prediction
-        of the\n\n      Blood\u2013Brain Barrier (BBB) Permeability of Chemicals Based
-        on Machine-Learning\n\n     and Ensemble Methods. Chemical Research in Toxicology
-        2021, 34, 1456\u20131467, PMID:\n\n      34047182.\n\n\n\n\n\n                                       37(122)
-        Wu, Z.; Ramsundar, B.; Feinberg, E. N.; Gomes, J.; Geniesse, C.; Pappu, A. S.;\n\n      Leswing,
-        K.; Pande, V. MoleculeNet: a benchmark for molecular machine learning.\n\n      Chemical
-        science 2018, 9, 513\u2013530.\n\n\n(123) Ho, T. K. Random decision forests.
-        Proceedings of 3rd international conference on\n\n     document analysis and
-        recognition. 1995; pp 278\u2013282.\n\n\n(124) Martins, I. F.; Teixeira, A.
-        L.; Pinheiro, L.; Falcao, A. O. A Bayesian approach to in\n\n        silico
-        blood-brain barrier penetration modeling. Journal of chemical information and\n\n      modeling
-        2012, 52, 1686\u20131697.\n\n\n(125) Pedregosa, F. et al. Scikit-learn: Machine
-        Learning in Python. Journal of Machine\n\n      Learning Research 2011, 12,
-        2825\u20132830.\n\n\n(126) Moriwaki, H.; Tian, Y.-S.; Kawashita, N.; Takagi,
-        T. Mordred: a molecular descriptor\n\n       calculator. Journal", ") Pedregosa,
-        F. et al. Scikit-learn: Machine Learning in Python. Journal of Machine\n\n      Learning
-        Research 2011, 12, 2825\u20132830.\n\n\n(126) Moriwaki, H.; Tian, Y.-S.; Kawashita,
-        N.; Takagi, T. Mordred: a molecular descriptor\n\n       calculator. Journal
-        of cheminformatics 2018, 10, 1\u201314.\n\n\n(127) Chollet, F., et al. Keras.
-        https://keras.io, 2015.\n\n\n(128) Wager, T. T.; Chandrasekaran, R. Y.; Hou,
-        X.; Troutman, M. D.; Verhoest, P. R.; Vil-\n\n       lalobos, A.; Will, Y. Defining
-        Desirable Central Nervous System Drug Space through\n\n      the Alignment of
-        Molecular Properties, in Vitro ADME, and Safety Attributes. ACS\n\n      Chemical
-        Neuroscience 2010, 1, 420\u2013434.\n\n\n(129) Ghose, A. K.; Herbertz, T.; Hudkins,
-        R. L.; Dorsey, B. D.; Mallamo, J. P. Knowledge-\n\n      Based, Central Nervous
-        System (CNS) Lead Selection and Lead Optimization for CNS\n\n     Drug Discovery.
-        ACS Chemical Neuroscience 2012, 3, 50\u201368.\n\n\n(130) Polishchuk, P.; Tinkov,
-        O.; Khristova, T.; Ognichenko, L.; Kosinskaya, A.; Varnek, A.;\n\n      Kuz\u2019min,
-        V. Structural and Physico-Chemical Interpretation (SPCI) of QSAR Mod-\n\n       els
-        and Its Comparison with Matched Molecular Pair Analysis. Journal of Chemical\n\n      Information
-        and Modeling 2016, 56, 1455\u20131469.\n\n\n                                       38(131)
-        Hassan, M.; Brown, R. D.; Varma-O\u2019Brien, S.; Rogers, D. Cheminformatics
-        analysis\n\n     and learning in a data pipelining environment. Molecular diversity
-        2006, 10, 283\u2013299.\n\n\n(132) Schomburg, K.; Ehrlich, H. C.; Stierand,
-        K.; Rarey, M. From structure diagrams to\n\n       visual chemical patterns.
-        Journal of Chemical Information and Modeling 2010, 50,\n\n      1529\u20131535.\n\n\n(133)
+        83,\\n\\n     733\u2013745.\\n\\n\\n(95) Lewis, D. Causation. The journal of
+        philosophy 1974, 70, 556\u2013567.\\n\\n\\n(96) Tanimoto, T. T. Elementary mathematical
+        theory of classification and prediction.\\n\\n     Internal IBM Technical Report
+        1958,\\n\\n\\n                                      34 (97) Rogers, D.; Hahn,
+        M. Extended-Connectivity Fingerprints. Journal of Chemical In-\\n\\n      formation
+        and Modeling 2010, 50, 742\u2013754, PMID: 20426451.\\n\\n\\n (98) Mohapatra,
+        S.; An, J.; G\xB4omez-Bombarelli, R. Chemistry-informed macromolecule\\n\\n
+        \     graph representation for similarity computation, unsupervised and supervised
+        learn-\\n\\n       ing. Machine Learning: Science and Technology 2022, 3, 015028.\\n\\n\\n
+        (99) Doshi-Velez, F.; Kortz, M.; Budish, R.; Bavitz, C.; Gershman, S.; O\u2019Brien,
+        D.;\\n\\n       Scott, K.; Schieber, S.; Waldo, J.; Weinberger, D.; Weller,
+        A.; Wood, A. Account-\\n\\n       ability of AI Under the Law: The Role of Explanation.
+        SSRN Electronic Journal\\n\\n     2017,\\n\\n\\n(100) Wachter, S.; Mittelstadt,
+        B.; Russell, C. Counterfactual explanations without opening\\n\\n      the black
+        box: Automated decisions and the GDPR. Harv. JL & Tech. 2017, 31, 841.\\n\\n\\n(101)
+        Jim\xB4enez-Luna, J.; Grisoni, F.; Schneider, G. Drug discovery with explainable
+        artificial\\n\\n       intelligence. Nature Machine Intelligence 2020 2:10 2020,
+        2, 573\u2013584.\\n\\n\\n(102) Fu, T.; Gao, W.; Xiao, C.; Yasonik, J.; Coley,
+        C. W.; Sun, J. Differentiable Scaffold-\\n\\n      ing Tree for Molecule Optimization.
+        International Conference on Learning Represen-\\n\\n       tations. 2022.\\n\\n\\n(103)
+        Shen, C.; Krenn, M.; Eppel, S.; Aspuru-Guzik, A. Deep molecular dreaming: inverse\\n\\n
+        \    machine learning for de-novo molecular design and interpretability with
+        surjective\\n\\n      representations. Machine Learning: Science and Technology
+        2021, 2, 03LT02.\\n\\n\\n(104) Lucic,  A.;   ter  Hoeve,  M.;   Tolomei,  G.;
+        \  Rijke,  M.;   Silvestri,  F.  CF-\\n\\n \",\"learning for de-novo molecular
+        design and interpretability with surjective\\n\\n      representations. Machine
+        Learning: Science and Technology 2021, 2, 03LT02.\\n\\n\\n(104) Lucic,  A.;
+        \  ter  Hoeve,  M.;   Tolomei,  G.;   Rijke,  M.;   Silvestri,  F.  CF-\\n\\n
+        \    GNNExplainer:  Counterfactual Explanations for Graph Neural Networks. arXiv\\n\\n
+        \     preprint arXiv:2102.03322 2021,\\n\\n\\n(105) Numeroso, D.; Bacciu, D.
+        Explaining Deep Graph Networks with Molecular Counter-\\n\\n       factuals.
+        arXiv preprint arXiv:2011.05134 2020,\\n\\n\\n                                       35(106)
+        Krenn, M.; H\xA8ase, F.; Nigam, A.; Friederich, P.; Aspuru-Guzik, A. Self-Referencing\\n\\n
+        \    Embedded Strings (SELFIES): A 100% robust molecular string representation.
+        Ma-\\n\\n      chine Learning: Science and Technology 2020, 1, 045024.\\n\\n\\n(107)
+        Nigam, A.; Pollice, R.; Krenn, M.; dos Passos Gomes, G.; Aspuru-Guzik, A. Beyond\\n\\n
+        \     generative models: superfast traversal, optimization, novelty, exploration
+        and discov-\\n\\n      ery (STONED) algorithm for molecules using SELFIES. Chemical
+        science 2021, 12,\\n\\n      7079\u20137090.\\n\\n\\n(108) Kim, S.; Chen, J.;
+        Cheng, T.; Gindulyte, A.; He, J.; He, S.; Li, Q.; Shoemaker, B. A.;\\n\\n      Thiessen,
+        P. A.; Yu, B.; Zaslavsky, L.; Zhang, J.; Bolton, E. E. PubChem in 2021:\\n\\n
+        \    new data content and improved web interfaces. Nucleic Acids Research 2020,
+        49,\\n\\n     D1388\u2013D1395.\\n\\n\\n(109) Tolomei, G.; Silvestri, F.; Haines,
+        A.; Lalmas, M. Interpretable predictions of tree-\\n\\n      based ensembles
+        via actionable feature tweaking. Proceedings of the 23rd ACM\\n\\n    SIGKDD
+        international conference on knowledge discovery and data mining. 2017;\\n\\n
+        \    pp 465\u2013474.\\n\\n\\n(110) Freiesleben, T. The intriguing relation
+        between counterfactual explanations and ad-\\n\\n       versarial examples.
+        Minds and Machines 2022, 32, 77\u2013109.\\n\\n\\n(111) Grabocka, J.; Schilling,
+        N.; Wistuba, M.; Schmidt-Thieme, L. Learning time-series\\n\\n       shapelets.
+        Proceedings of the 20th ACM SIGKDD international conference on Knowl-\\n\\n
+        \     edge discovery and data mining. 2014; pp 392\u2013401.\\n\\n\\n(112) Kenny,
+        P. W.; Sadowski, J. Structure modification in chemical databases. Chemoin-\\n\\n
+        \     formatics in drug discovery 2005, 271\u2013285.\\n\\n\\n(113) Tyrchan,
+        C.; Evertsson, E. Matched Molecular Pair Analysis in Short: Algorithms,\\n\\n
+        \     Applications and Limitations. Computational and Structural Biotechnology
+        Journal\\n\\n     2017, 15, 86\u201390.\\n\\n                                       36(114)
+        Griffen, E.; Leach, A. G.; Robb, G. R.; Warner, D. J. Matched Molecular Pairs
+        as\\n\\n      a Medicinal Chemistry Tool. Journal of Medicinal Chemistry 2011,
+        54, 7739\u20137750,\\n\\n     PMID: 21936582.\\n\\n\\n(115) He, J.; Nittinger,
+        E.; Tyrchan, C.; Czechtizky, W.; Patronov, A.; Bjerrum, E. J.;\\n\\n      Engkvist,
+        O. Transformer-based molecular optimization beyond matched molecular\\n\\n       pairs.
+        Journal of cheminformatics 2022, 14, 1\u201314.\\n\\n\\n(116) Park, J.; Sung,
+        G.; Lee, S.; Kang, S.; Park, C. ACGCN: Graph Convolutional Networks\\n\\n       for
+        Activity Cliff Prediction between Matched Molecular Pairs. Journal of Chemical\\n\\n
+        \     Information and Modeling 2022,\\n\\n\\n(117) Langdon, S. R.; Ertl, P.;
+        Brown, N. Bioisosteric Replacement and Scaffold Hopping\\n\\n       in Lead
+        Generation and Optimization. Molecular Informatics 2010, 29, 366\u2013385.\\n\\n\\n(118)
+        Turk, S.; Merget, B.; Rippmann, F.; Fulle, S. Coupling Matched Molecular Pairs\\n\\n
+        \     with Machine Learning for Virtual Compound Optimization. Journal of Chemical\\n\\n
+        \     Information and Modeling 2017, 57, 3079\u20133085, PMID: 29131617.\\n\\n\\n(119)
+        van Tilborg, D.; Alenicheva, A.; Grisoni, F. Exposing the limitations of molecular\\n\\n
+        \    machine learning with activity cliffs. 2022,\\n\\n\\n(120) Fischer, H.;
+        Gottschlich, R.; Seelig, A. Blood-brain barrier permeation:  molecular\\n\\n
+        \     parameters governing passive diffusion. The Journal of membrane biology
+        1998, 165,\\n\\n      201\u2013211.\\n\\n\\n(121) Liu, L.; Zhang, L.; Feng,
+        H.; Li, S.; Liu, M.; Zhao, J.; Liu, H. Prediction of the\\n\\n      Blood\u2013Brain
+        Barrier (BBB) Permeability of Chemicals Based on Machine-Learning\\n\\n     and
+        Ensemble Methods. Chemical Research in Toxicology 2021, 34, 1456\u20131467,
+        PMID:\\n\\n      34047182.\\n\\n\\n\\n\\n\\n                                       37(122)
+        Wu, Z.; Ramsundar, B.; Feinberg, E. N.; Gomes, J.; Geniesse, C.; Pappu, A. S.;\\n\\n
+        \     Leswing, K.; Pande, V. MoleculeNet: a benchmark for molecular machine
+        learning.\\n\\n      Chemical science 2018, 9, 513\u2013530.\\n\\n\\n(123) Ho,
+        T. K. Random decision forests. Proceedings of 3rd international conference on\\n\\n
+        \    document analysis and recognition. 1995; pp 278\u2013282.\\n\\n\\n(124)
+        Martins, I. F.; Teixeira, A. L.; Pinheiro, L.; Falcao, A. O. A Bayesian approach
+        to in\\n\\n        silico blood-brain barrier penetration modeling. Journal
+        of chemical information and\\n\\n      modeling 2012, 52, 1686\u20131697.\\n\\n\\n(125)
+        Pedregosa, F. et al. Scikit-learn: Machine Learning in Python. Journal of Machine\\n\\n
+        \     Learning Research 2011, 12, 2825\u20132830.\\n\\n\\n(126) Moriwaki, H.;
+        Tian, Y.-S.; Kawashita, N.; Takagi, T. Mordred: a molecular descriptor\\n\\n
+        \      calculator. Journal\",\") Pedregosa, F. et al. Scikit-learn: Machine
+        Learning in Python. Journal of Machine\\n\\n      Learning Research 2011, 12,
+        2825\u20132830.\\n\\n\\n(126) Moriwaki, H.; Tian, Y.-S.; Kawashita, N.; Takagi,
+        T. Mordred: a molecular descriptor\\n\\n       calculator. Journal of cheminformatics
+        2018, 10, 1\u201314.\\n\\n\\n(127) Chollet, F., et al. Keras. https://keras.io,
+        2015.\\n\\n\\n(128) Wager, T. T.; Chandrasekaran, R. Y.; Hou, X.; Troutman,
+        M. D.; Verhoest, P. R.; Vil-\\n\\n       lalobos, A.; Will, Y. Defining Desirable
+        Central Nervous System Drug Space through\\n\\n      the Alignment of Molecular
+        Properties, in Vitro ADME, and Safety Attributes. ACS\\n\\n      Chemical Neuroscience
+        2010, 1, 420\u2013434.\\n\\n\\n(129) Ghose, A. K.; Herbertz, T.; Hudkins, R.
+        L.; Dorsey, B. D.; Mallamo, J. P. Knowledge-\\n\\n      Based, Central Nervous
+        System (CNS) Lead Selection and Lead Optimization for CNS\\n\\n     Drug Discovery.
+        ACS Chemical Neuroscience 2012, 3, 50\u201368.\\n\\n\\n(130) Polishchuk, P.;
+        Tinkov, O.; Khristova, T.; Ognichenko, L.; Kosinskaya, A.; Varnek, A.;\\n\\n
+        \     Kuz\u2019min, V. Structural and Physico-Chemical Interpretation (SPCI)
+        of QSAR Mod-\\n\\n       els and Its Comparison with Matched Molecular Pair
+        Analysis. Journal of Chemical\\n\\n      Information and Modeling 2016, 56,
+        1455\u20131469.\\n\\n\\n                                       38(131) Hassan,
+        M.; Brown, R. D.; Varma-O\u2019Brien, S.; Rogers, D. Cheminformatics analysis\\n\\n
+        \    and learning in a data pipelining environment. Molecular diversity 2006,
+        10, 283\u2013299.\\n\\n\\n(132) Schomburg, K.; Ehrlich, H. C.; Stierand, K.;
+        Rarey, M. From structure diagrams to\\n\\n       visual chemical patterns. Journal
+        of Chemical Information and Modeling 2010, 50,\\n\\n      1529\u20131535.\\n\\n\\n(133)
         Sheikholeslamzadeh, E.; Rohani, S. Solubility prediction of pharmaceutical and
-        chem-\n\n       ical compounds in pure and mixed solvents using predictive models.
-        Industrial &\n\n      engineering chemistry research 2012, 51, 464\u2013473.\n\n\n(134)
+        chem-\\n\\n       ical compounds in pure and mixed solvents using predictive
+        models. Industrial &\\n\\n      engineering chemistry research 2012, 51, 464\u2013473.\\n\\n\\n(134)
         Boobier, S.; Hose, D. R.; Blacker, A. J.; Nguyen, B. N. Machine learning with
-        physic-\n\n      ochemical relationships:  solubility prediction in organic
-        solvents and water. Nature\n\n     Communications 2020 11:1 2020, 11, 1\u201310.\n\n\n(135)
+        physic-\\n\\n      ochemical relationships:  solubility prediction in organic
+        solvents and water. Nature\\n\\n     Communications 2020 11:1 2020, 11, 1\u201310.\\n\\n\\n(135)
         Loschen, C.; Klamt, A. Solubility prediction, solvate and cocrystal screening
-        as tools\n\n       for rational crystal engineering. Journal of Pharmacy and
-        Pharmacology 2015, 67,\n\n      803\u2013811.\n\n\n(136) Diorazio, L. J.; Hose,
-        D. R.; Adlington, N. K. Toward a more holistic framework for\n\n      solvent
-        selection. Organic Process Research & Development 2016, 20, 760\u2013773.\n\n\n(137)
+        as tools\\n\\n       for rational crystal engineering. Journal of Pharmacy and
+        Pharmacology 2015, 67,\\n\\n      803\u2013811.\\n\\n\\n(136) Diorazio, L. J.;
+        Hose, D. R.; Adlington, N. K. Toward a more holistic framework for\\n\\n      solvent
+        selection. Organic Process Research & Development 2016, 20, 760\u2013773.\\n\\n\\n(137)
         Sorkun, M. C.; Khetan, A.; Er, S. AqSolDB, a curated reference set of aqueous
-        sol-\n\n       ubility and 2D descriptors for a diverse set of compounds. Scientific
-        data 2019, 6,\n\n      1\u20138.\n\n\n(138) Durant, J. L.; Leland, B. A.; Henry,
-        D. R.; Nourse, J. G. Reoptimization of MDL\n\n      keys for use in drug discovery.
-        Journal of chemical information and computer sciences\n\n     2002, 42, 1273\u20131280.\n\n\n(139)
-        National Center for Biotechnology Information, PubChem Compound Summary for\n\n\n\n\n                                       39     CID
-        1549018, Jasmone. https://pubchem.ncbi.nlm.nih.gov/compound/Jasmone,\n\n      Accessed
-        September 26, 2022.\n\n\n(140) Sell, C. S. On the unpredictability of odor.
-        Angewandte Chemie International Edition\n\n     2006, 45, 6254\u20136261.\n\n\n(141)
-        Genva, M.; Kenne Kemene, T.; Deleu, M.; Lins, L.; Fauconnier, M.-L. Is It Possible\n\n      to
-        Predict the Odor of a Molecule on the Basis of its Structure? International
-        journal\n\n       of molecular sciences 2019, 20, 3018.\n\n\n(142) Rowe, D.
-        Aroma chemicals for savory flavors. Perfumer and Flavorist 1998, 23, 9\u201318.\n\n\n(143)
+        sol-\\n\\n       ubility and 2D descriptors for a diverse set of compounds.
+        Scientific data 2019, 6,\\n\\n      1\u20138.\\n\\n\\n(138) Durant, J. L.; Leland,
+        B. A.; Henry, D. R.; Nourse, J. G. Reoptimization of MDL\\n\\n      keys for
+        use in drug discovery. Journal of chemical information and computer sciences\\n\\n
+        \    2002, 42, 1273\u20131280.\\n\\n\\n(139) National Center for Biotechnology
+        Information, PubChem Compound Summary for\\n\\n\\n\\n\\n                                       39
+        \    CID 1549018, Jasmone. https://pubchem.ncbi.nlm.nih.gov/compound/Jasmone,\\n\\n
+        \     Accessed September 26, 2022.\\n\\n\\n(140) Sell, C. S. On the unpredictability
+        of odor. Angewandte Chemie International Edition\\n\\n     2006, 45, 6254\u20136261.\\n\\n\\n(141)
+        Genva, M.; Kenne Kemene, T.; Deleu, M.; Lins, L.; Fauconnier, M.-L. Is It Possible\\n\\n
+        \     to Predict the Odor of a Molecule on the Basis of its Structure? International
+        journal\\n\\n       of molecular sciences 2019, 20, 3018.\\n\\n\\n(142) Rowe,
+        D. Aroma chemicals for savory flavors. Perfumer and Flavorist 1998, 23, 9\u201318.\\n\\n\\n(143)
         Mallia, S.; Escher, F.; Schlichtherle-Cerny, H. Aroma-active compounds of butter:
-        a\n\n      review. European Food Research and Technology 2008, 226, 315\u2013325.\n\n\n(144)
-        Jelen, H.; Gracka, A. Characterization of aroma compounds:  Structure, physico-\n\n      chemical
-        and sensory properties. Flavour: From food to perception 2016, 126\u2013153.\n\n\n(145)
-        Licon, C.  C.;  Bosc,  G.;  Sabri, M.;  Mantel, M.;  Fournel,  A.;  Bushdid,  C.;\n\n      Golebiowski,
-        J.; Robardet, C.; Plantevit, M.; Kaytoue, M., et al. Chemical features\n\n      mining
-        provides new descriptive structure-odor relationships. PLoS computational bi-\n\n      ology
-        2019, 15, e1006945.\n\n\n(146) Mostafa, S.; Wang, Y.; Zeng, W.; Jin, B. Floral
-        Scents and Fruit Aromas: Functions,\n\n      Compositions, Biosynthesis, and
-        Regulation. Frontiers in plant science 2022, 13.\n\n\n(147) Tokitomo, Y.; Steinhaus,
-        M.; B\u00a8uttner, A.; Schieberle, P. Odor-active constituents in\n\n       fresh
-        pineapple (Ananas comosus [L.] Merr.) by quantitative and sensory evaluation.\n\n      Bioscience,
-        Biotechnology, and Biochemistry 2005, 69, 1323\u20131330.\n\n\n(148) Wei, C.-B.;
-        Liu, S.-H.; Liu, Y.-G.; Lv, L.-L.; Yang, W.-X.; Sun, G.-M. Characteristic\n\n     aroma
-        compounds from different pineapple parts. Molecules 2011, 16, 5104\u20135112.\n\n\n\n                                       40(149)
+        a\\n\\n      review. European Food Research and Technology 2008, 226, 315\u2013325.\\n\\n\\n(144)
+        Jelen, H.; Gracka, A. Characterization of aroma compounds:  Structure, physico-\\n\\n
+        \     chemical and sensory properties. Flavour: From food to perception 2016,
+        126\u2013153.\\n\\n\\n(145) Licon, C.  C.;  Bosc,  G.;  Sabri, M.;  Mantel,
+        M.;  Fournel,  A.;  Bushdid,  C.;\\n\\n      Golebiowski, J.; Robardet, C.;
+        Plantevit, M.; Kaytoue, M., et al. Chemical features\\n\\n      mining provides
+        new descriptive structure-odor relationships. PLoS computational bi-\\n\\n      ology
+        2019, 15, e1006945.\\n\\n\\n(146) Mostafa, S.; Wang, Y.; Zeng, W.; Jin, B. Floral
+        Scents and Fruit Aromas: Functions,\\n\\n      Compositions, Biosynthesis, and
+        Regulation. Frontiers in plant science 2022, 13.\\n\\n\\n(147) Tokitomo, Y.;
+        Steinhaus, M.; B\xA8uttner, A.; Schieberle, P. Odor-active constituents in\\n\\n
+        \      fresh pineapple (Ananas comosus [L.] Merr.) by quantitative and sensory
+        evaluation.\\n\\n      Bioscience, Biotechnology, and Biochemistry 2005, 69,
+        1323\u20131330.\\n\\n\\n(148) Wei, C.-B.; Liu, S.-H.; Liu, Y.-G.; Lv, L.-L.;
+        Yang, W.-X.; Sun, G.-M. Characteristic\\n\\n     aroma compounds from different
+        pineapple parts. Molecules 2011, 16, 5104\u20135112.\\n\\n\\n\\n                                       40(149)
         Stumpfe, D.; Bajorath, J. Exploring Activity Cliffs in Medicinal Chemistry.
-        Journal\n\n       of Med"], "model": "text-embedding-3-small", "encoding_format":
-        "base64"}'
+        Journal\\n\\n       of Med\"],\"model\":\"text-embedding-3-small\",\"encoding_format\":\"base64\"}"
       headers:
         accept:
           - application/json
@@ -1172,13 +1215,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "84324"
+          - "83025"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -1188,7 +1231,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -1202,1695 +1245,1695 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA1SWSc+rSg6G9/dXfDpbWgpzVZ0dAQKEqQgEQnoFYQhkIBRQDPfPt3Ku1K3e1MK2
-          bJX8+LX//uvn51eXt+Vt/PX759ezGcZf//raimzMfv3++fdfPz8/P3//ef8vsnzlZVE07/pP+B9n
-          8y7K5dfvH/a/lv8F/f75dS6B5aPP8iYzKjQoR4y8YDcXDhrvvT0GtvbDpfk+CNv1mQIZXnZjh43E
-          irY5So8NilyxoLE+zWC2H6sK3/lVo/5cXtqN9jILp7U3sDFw7sbRuq6hzEkpNvVY0gjwXQu6I0GT
-          fA/2OS/tbgG8pi2e0Pv0jMarARpZ3fwPdvwgAdv4nl7wSs82PZN7TBYjyG9wj3zNn9NXRGgzFDxU
-          +oxga3e7OfNkTAY8QAVR3WNBtF7DyoBv6Jo4e7Q8mLM2KNEuOWtTyMm8tnh5kyGGa3bYrGkNFqhQ
-          BZQsvNDM1j7OoF1bAx4zofYRfxrI8n6efJSu7X4iLtJznnuYNpCJhPFZujP5Vt/OK+KHU0d9pVRa
-          YW6AChFoKurHpd2ymIUN/KQ+wIojoWh+vu4qaoTFoen6aTWK7qmCTr7RUXOH/Xw6XfAKdF5NsWVT
-          dtuiq7oi9eBimnntB3yEeShlWQAxNgdqEKE2Oxt1Qi5Qa4QhWJnw04OU0h1WY1nf+GtY6XB5fW74
-          MOZrtNa1yMJdkmhYT9iKsB+j9dH3/7hMGSdfL2qpQKNndYw58Qzm9b65MCFU8XuHz7aV1f0S9oUS
-          0EQFOeGbWg6g+nZbWprlHbCOK7+QWbM9VmyJAevhve9QRs5vej3cKq1ncMLCqJbpJO0Sblt3cmOj
-          hIwKLndlSfiH9+bhkXYl1se72K5tKt9A89ksaoXw+c2/vtClqSNa7Q56tEXxDoIP4x1p0ncMmes8
-          qhGopyf9U3/UEa6hNxcJDXPZJNM42N0/fB7MKXTmF3MX0bcercBTIyNU3gq4HeKSqtGYtPQQiysC
-          cOhxOhzvGqeLWQ3ZY9FQNRjjaJni8w25xq2iWCdTvsBttVFQ6iccxrIOOHZuVfTg3wo9MJ1J2Ok4
-          y+iZPU+T4Da2M1vXkZHZMMiptfuY0TAZkw5qC+5oVYs2mNWlaZCl84CqX363tWdDsE3BkeYuekTb
-          s2pK9Kcfl30stC/ufYWAqeoZ7z+jSuaw21vI2joVB5XBtbN3Az18WU/ynZc84l8WGwBz1hBWdAk6
-          k77b6yi8yQb2vEu1/cO/eDJjqqSvqGXfoNLhseEGeuSTE+EP72OP7j56+MzoqI4wZsuM/KFYsW+X
-          bS7c9SKBE9tp1JRVZpu7pGehlB9YfPJqw9kkxlHgcNzr+GyzElh8rWcQcx7BJJWJoQneCBvYRKuM
-          bSlwwUbCuUZ8ZYQTMxAVsMVsTKjYxwBrzL122Jf/eYHqASfs6va4rQfC93Ann89Y7yc14ktxDlEf
-          ejk+8cotmtdlZWFYihq15/ZGWMpPqTxwvI/Np3reuJM2ZLBNXxhbBlSclQnvPdxL7pFeevzIZ+bg
-          NvDZZjbdi17frnLWqejS0pbiL59DGZg3aFc9N41PXYjm6MwMIO1rDvv6wpLFbrsVBYZh4BNROGcL
-          nrwNhYvBTWIPl5yL/LlEx0sXYZPHtsaeFdVAnKTr+MLjXhuLTOGhLZA9Pm93kM+8Z6kQewGPy4gx
-          AFu0JxlhFHnTziSY8HWwuNB8sA96nu+ZNjG45OEfXo2dWpPl2bszfB3SEme7AJP1q3eQ5aoddkTb
-          0tbiOaRgu1Q+PVR+mXdJ4FgyuwYrdVXbBrNY7HX0fDwzqlyNcFuqdT8hYa+/cbj3JrAMKGrQmQUX
-          atezqnHjmMvgqtx1esz5FsxBoIToKiUR1SXfjmbldOeRCVlKo+3stdt1b7jgq89Y7++CNm7xJYFV
-          xjyndjuP7VKXQgAXqSx8saIlWG/cQ0VfPzV4jrZzlzQ8fN/zEFtfP5e2bwZuXnGg1SN12u0BExG+
-          hjfE1vBR8pW7ZGdolZyGb6IQa1yzajaQPyCcBF19OvMbVAYkWHng4+OItuWQRiHS7lijLvPQwIgB
-          0aWsSu7UDYV6G4ra1CHP6XdcusyBbMZBskDrPwyfT7l7vrAzUaCwOyjYiLqFUFZGiajw6ULzHJF8
-          jjv1hWjanydetbp8+e5bdGcQoG4sqJGgj7OL9BFX/sxvo7NRkybQZNiBGlUnRLO5H3XQlX5OjZEj
-          +SITUYSSJ5fUGewm57WL9YL3+/rC3n3ZA/6k5ha0DQ75ghcX0YpooqPe8kLshMh0WLlQGyTFYo99
-          Um7OKGlzCtk+eOHLV99WLJgKpHLfUU880XYtno8U3QbrSiPPnKJZGJUJHWpF9NnNf+fLjUE6rLoj
-          wMk9fkX8RU0U1MqvFnujXjgbXpQVuuHtSQuiZ9oELrGL5FFy8YWoF8IfqiMPn493Rsux5J15V6cu
-          Gp+aiK3qZgPuLXu8LOHDRM/cdGyFB20M9IxTkxbbyXG41nZ1MHr8lWrEhGRekreNYDkwNNPbQ7tO
-          Z81HZQdP9CR5H+0fva/DnYXdqr+CJ9cRFxaJJeF4AJuzQrmbYJFaPM7VYHHmyNqLqBv8EpsMxdr6
-          1VtQMQzv+6SMtPWItR5FjLhgJyneYBvWxYenPGIm+d7G+YYXa4aRL2c05gG3bdntKiPaCiPdc2MX
-          rXW6KAiyo0cVMZq31QtPZ5SdkoqaevOIVgd7Bowyc5vYh19HC9AkFl5yepnWYOSiD6v0EyxLaGGH
-          R2LUS7tziM7vYY+rq3N11moWS6iXqov9lCERJdWYyI/ywVJ3vgSaUA23FH55xoerD8jCKs2AGNLw
-          9ChqdbumXqMjDWHLL7cy3ch3X0C9VFyq3F8XMJcBvkH5NRywOamSsyAin+GSfq54vxuJNh63OoUX
-          uzYnGNhbu4Kw9uGVuRfTTnyq0bf/LLzxVoOVL/9rLzIqOMZdQoPvPbDNIUihvqol9u1FiIY33+go
-          fkgTNSPVddhcO7koBtOHevxCwHe+deDyJY+9bbHzcQ46EdqHfsT2O9CdmX6WB0g26lKcpk+wFsXw
-          gI/ugXD5KJdtLmpswL73XhNMBQ1wIJh6+L0XsT74hsNf1aoEbkzWCTHLQlYQdj60zb6nmKTDtj5m
-          kACxEE2qcSzeSH43ZHk4aQE1SIecEQRTB+IUdBSLYpLPyunDw65371R/T8rGvozPCvuPklDPv5T5
-          lp9D48/97DODo5Gt1CNRjlKxpReO9ttiKDkPX4esxEr/umlbNZwzOZamgR6r4zXapnCBMKCnOz2N
-          SupwW1wlsuMRPEnvxI4WrfBZKAqHltrc7Dp0WBcXXS60mJ6qP5HhlScpxKKu0ewzG/m4I2CG7omI
-          U319rdryzQd4MZom9rvPxoSRfQjDSZq8UUfOIO15Hg4HzcYO0/fOtKeKCuOb1ODb+0LIypvZAPjC
-          iKkpYdIuan365z7B1+RzjqauYxmgee5Ci6+eLK/wcIa8dbpM/E5VyMBKrA7tT8dgk6hCu71pW0OS
-          eYjaW1uAro1i+w9v1LzjWpvtYeHhrj67OD4CJeeY+j3AhKNHf91l13a0Sf2AcKUBNZouBet8c0tA
-          kMJQRTUO/wEAAP//nJrJsoJMEoXfpbd0hExSyZIZZCoUVNyBIoIDMhVQEf+7d+DtZa96eSO8gRaZ
-          J79zsihrwaTIK7+GrKu+68VGwogGVf1g5UNNSq1gAnhkm5boo814862QeYRmxBEcdIducr6vJ/Du
-          PsHrPPX+9OFY9wWOTu+pm5vW8sH9tkzI2DNHZ6dJEvDSq0ny+PaOKbNL3wDFyBC8zj++bfgMvqeQ
-          GWcvFtDy4yXJRGqIeNf0uIfrNtDlWovVQHmjJVvuk/QgSxMu1SCjzuAmBZmMJhHMiFtvUXUYIetO
-          n3CrXW9d577QAW6K25HoHiuIC/I2Rdf98TnKKx+R0i5dGeOIhtI26tHMR90iiZ15w3fVCzqh00QJ
-          tH14DB/LYKGeVSnIO9zaJOy9uptPlmSAfKk8jF1vptPr/dXgsZ1mUhTMqM8JIy6yjv3xTy9naRok
-          2NbSQAxVreJpa+5aWA7dNtyiWvUmMHUL4cfewcrlffAE4e06P30hBn3k+UITyxAbOy+J/ayO3dxK
-          9gE9d5T/098JHbUehllnsHoq3Zis8xk2SWLhSN1K3fKZ2AXC7+FFzEfu18tdfh0gQJFHTgYq6pFP
-          cIlWPV/9OEWTcxUXJCskxqHNqN6SVqcequlpkF3KV/X8qz85JQXRU7bUqZN9QoCG2KM01dAt0SFb
-          YBk7JpT6yKkJOunMT7/Cbct7+o8PwEsKD+NTWqFlL+WHrdiJ7ripvFvcnxSvQhf5FBD9aaO8z7ro
-          IL/g8yLKI64R+ZC6ki1WL8muPXXo7/ut84vYhmZ6ZGtpInwrbKz1WnlTF/aFnL/ONnGKqx/zZ+7h
-          QHvXAmx8wkc3xoerv31GzwUnYujRmfGoJWfCaQhpYI85Le3GAf3iC/gan0t9/gwXDUq6+GQ38H43
-          H+qXsX0uLwv7p5brFsvbZHA1nJCYQf7wlt/zHtWGX/tTRNXQCCx0L41iV+VTfdqqDA/LrRhDia/v
-          +dp/LFr9LSmmQqiHtxuUKPwcGuxcCHhDc7w8peybtPj8JS+PyoXp//h9BPHM0ZlwR1fmv1ZOdvfT
-          s57uXeyCf/wuxF3zh4kJ/ARmdM3wxf2G3Y8v//IAI1Abb/GlKJXXesE2T77x0jsbF3487jPPGk3D
-          e0hAa/OJKO0b9FnqJkneXOoIOz0kOXesxwqdmTIljk3imF72AQ8/HlFyquiCeRPfsEPtE3v2TanZ
-          IsIF7ILGxWHrlTWVi8AH/Iq1tf5RvATZ3oWV17HiWl3d3/LM+Js/irqV6uVQxaycy8cD1nppplS+
-          RCG0tqYRc8opnb/mBdCBFQ84vn94fTamQ4/8/jrgO2+W+kT39A2iaWKif1nXY0+Ol0BP+T35zYPp
-          VtoWagw/xoXNqDqb1dFVTg5IJ3ZQNfV0oakBYPUUu0ZtdvMGoRRQOl5+vI7ohjFFWPMFrI4K3/34
-          FlXT2xjrwd7Ui/ZRfCiLTTCSR+p67G0KR9i9uTcxDLVGPd3RCbUuxiE9fWb0HW7JAdb/x+qx7Ohc
-          HtwCJcXWGeuVdwc+6iY4l+UJqy9lyZdqIAYKqluMra656UvbMBk8yNTgnbrzdLr5XiK0GZMQew85
-          jOdsZBW5iS/vsfXrLp67Y67A9ix+SBHMKZ316KDIDbl02AmuVTzMzsOSzRvmsbU97invuZEBt5O7
-          DTcvj0HDczHecM/ghb1vW3qUt9QCGRzuQtHFXNdfFSsD+Vjt1/eheH9+KPxEzbgNdhOdg+buw/3E
-          dFjXMuQ1a/4C9YXesdLGzZ8+yc/jDCO7+s3fvECyXF7x/fd8MhwT8Mrrnmhthut5Nk8ROkRmEqJr
-          tKnnoKs0SUfYI6FdqIjfbXRAR7l/h5UX7LtJHvQ3/PLMwDDsmsUAJ7BLvg1Hu3jQhfSGJX9KXxt7
-          UeD06R1+n/Kq19htpydqf3rLHu8NtqNjgaZEdENw9y0dRR9qj2c3+/X3l3t88tAGzVFe88CYZRNO
-          j7imi99Gk3xt3SvRmI8VT8zRd1CoR+eQFmxFl8MSX+FtpznBsajU05VeKsToVbf6yzLvzn1kyEPN
-          N1jh4wBN+r47wMG1TeKr8n3NY6ko833cYLNAbs558cOVOWSoJJj2XzScKXmCOEuXP16fDSXLoHH8
-          ACd0tGqBKxwRkma7Dy/Grq/nPerLH3+OfMqp+ZTV6RU063InN/MsecO1Va4gT0NLdh/+W8/dMdbk
-          0WQBX0thV49NAwBRF39Grs0jym73TAEJ1xvkbFevetLG84je9/SN/a69d98tncZfPonVcyzXfzw3
-          NZ1GrOfxg6aHF4u/90ECcQ7p6qccub1p0TgH5VsfLgxt5Tp9YqxwNOwGL/66qOJouPLFxZuq+jrB
-          o55qrPIK5HSp2OsfH2orj6zzwQXv1eVEN7NrR8Vqk6AuxAKxvWOWU+7t9LDHsRjK6vMVTz+9y0XX
-          Ibjybjk1OFGRLFHPiH63eUrCQI7gSMYae4XsUyrxegiVvbDh9nNqY6ocOmP7y4+lZ6TRwadfHgXM
-          PcXumt+u+XMKh9E+EctwvJj78cfv/C3xGOcD8uYGfnmQ+9J5bx7NKwtCYPUkUJ9mPF2VMIPzqQp+
-          f+fC3mRE9PNLgWc0lJuiRkI/P7jmG5RsvpeDtOZv+EgbJReo5Whgh+yR/PxJP+0l98+v7keFr4df
-          PwvY+hK8+j0+OOxPiMsimWhFtkNTNpkRrLxG9J7t6mXTVisPJAHZR/E1Hgptl6E1/8J2S+pu5S8F
-          Vh7Cv3xozfOL7crDYc8ZSsweUw3gl7/7vUDiSXgpIuwrSyLr+aL5pw/B46CPTDyj+tu0YShFvHXD
-          nn8zdXY9D7TWVzirpZILF3afgLb3j8QOjwiR5t6J4ESCOiLefXlzxlMeHSzbG4nr7Smbl0ED56SM
-          MBZN3WOb7nz9zV+SrDw+V8wG/vTVFw0V/eY5LG43ENeuLbpYuaD993nG8aJPF8ef4J5CE/Inh9KJ
-          e0ALl2Oi4WsuvPRpVLeWhDexOz5oYHnc6k/A2OIXsdXjuevzyNKgv6uHkNkxT49mc1hBypYMDlzD
-          zenWckVY9Osbnyn50OlQ7k7S8/Ak5OeHeu1RSeAFX4zjgtUoZbaRBEXLhOHW+Hpomh7bBSS2d7DZ
-          5hMls0YXWT/7Ejm72gd9g+bsw71iZqwbWeH1b+sxIcPSVIwND+t9JgYGKPFrWudT5y3vCKxfPkus
-          1T+NuM1CpJAPR6z7UY+/yJtbmUoHjP3pPHlDc9unoFhpRlRBkSiJX5s3vFB6xO5nqmN6u+YnidTc
-          gNV+eHrk158UIp8ch/yQT13xNGD1y+Fsl7U+jafXCEd5fJPdg7fo7IsFj/zmSknoMlo9ud+PBuNd
-          MLCr1k9vEc/xJFN800iYFr4+UKctkXnBMMZt8s3nHx+t+TPxN2fBo7NLn6Ddw3M4VMYRLV2iTshL
-          rh6OmYeiLzOYrtxzbIj9QRjQeGjjFvzi2pIdU2sde550Vma52wb/9I6m17SAcz3UODwyXzR9rc5H
-          6NRf8e54UimnBsECdx8qfE/FlzfFT+YE9HL3sBrEGZ3d5rZItDoYZOU1j9UvnYVWfSS/vG5Jg9ZA
-          wjXeYEMcO32O6rqRisi7jGIPSbzcm6mRjW3wIso9LhFldtETjEhxyWnDxXTyfOkJcjoUPz7tlkew
-          5uE71Qj54ej//CcrXQ03xFbbMHVnVq83Kr+LPqIo2qLX1nmlwHdWOo5BYSA+v3Uukh/lmfz4e2xK
-          2UGccuBC8Xkl8ezFXwc9l4/1m790WvNkxEf7GnvH2y6eGQ8ZaHN+xNiuNBqP+a1zkNWwNvHv7RbN
-          9HhO/vIxOLssmtvhcJXNSuNGfjoO9fRBZwsy91HjzKhf9bLmLTDc1B4b3YPr+jhSxz9ewx+x9zor
-          EBn4qBkaESdv0a8e4Le/Cqonpy8W1nzwm4L+6W93h6sC6/wP2TXPoa9z24AfFQ1xuJ0Zj9XwseB+
-          3XHEXfefbBf2V2C3ty3+7YP6ON2VUD9oh817vqvZHTu3MN4549f/+nh8NRas5xHOXcnGs1uXi2wq
-          2oNo4kfvGmlwXdDVsMe4ED+UjtqSyOv5//E8f2yPhsw6h8PYudNJXw5t3MhKk41YK6Sv3h2+Wgoq
-          Cq1Vn1s0acz9hKwrq4apSqaaxHsXoH7NL5wbE40XK98osFesN/E27i5emkRJZDG2D+v+BLpXb8Yp
-          WI6qh9vVjxKzej0hB1fDqkE5Or26QpGkptfwrji9veWsnTTg2ZglZpF3OleOjAQ1876NG8Mj+hJV
-          WQrZ+GCJKg47SpcWIvTjsXNP3t34jsBACy1kog1SlC/cZw9y/2E9nAyPtG5tQRsh6o0Ee0bEelWX
-          7Ba4wc4maz3lJDxyhqzZoY+1dT84o3h7BfMSALbXfdpYlhMPxhDciZfKrT5UlV6BcDa4Xz6DhPwR
-          isgfvjL213xPCE2u+OVD4XfVI3J7xo4sX0oPF/bMoSl40uIvP44ZtUTzUn4BDEMzsLvuV2dGpxH4
-          0bUJ0SmCbtLG+wiFswtwuOl2iKz5ydZO1Xntb8/jR19PZSpFmGA/VfRf3oj6rZoT7TJcuvlqAcC/
-          frcC/vn3/3GjgPvfNwpq18rDqelFfVk87wBfyHgcBK1T89+ADVFvo4VY5wvNl0k5K7DwgTJOQtbE
-          U0oyS3Y80SF3Q1A9Vn5hHsJ2/hKj78KarTr1CvFutsb36aLo3GY/RxLkB4v4zqh0NGu5VI6YyCUJ
-          Y5w6zm96A06KZ4yvUtvri8pYLET5y8L3lzh60264Vdvu9g6J9RSznF4/jAIHqQRidUvjzZsHb6GT
-          1LrEfQoRmul2NsC9v1RyLMwon7y2cEHfCT12h0bppmfKL+DEvUeuYOr6XG4yBjLffmAfhUncnoyJ
-          gbgU4hFOlydtWLFbYGEymWjnDNBgvmUGdpp/J/nNVBErv0mJOvHb4IvNRh478FwL2+PBINr4UahQ
-          1CcG9BJtSej2OGYD046A7E8EG7hVY6HZ8C6UFTTkerjXHXXw5ypffc8hLn8SaqK7TgEnqXFx9EKP
-          mrJn/iQf9+1EzHHdUC2+fILc8geCcXPOOY47aHLseirxNw5Xz2CbCrhLq2I1fihUuH54BbyGOYdf
-          Wxpp12wYB7LaGzFmzFe+1FuVl1+uo+HT8G31/vXSerk8n6dQvHpzN18/jwjUgOHCyiGveLQro5K9
-          fRUR3ZZaj5O58iq3temQooS3xz+F1pUXHish4TI2p0sm91BIRA8nNpH1RfOkErhjOWMjLmpKnel8
-          kMUKEL5NldDRE6UVbG+FOqInfdWLs2EBkvx0IXrhlkhwpvsB7B1IBN+NAtE4qxxIdOlATnPd5XO8
-          q1LoAmZHrI0z0T75DD5kjpGQQ1zm9fx5iABoyk3sjc+mm/x0buTd8cYT62oY3eLcTUcwG1oR/8X1
-          +aIU/Cj3mLBYH995zfWfO8BGTI5knxx5Ojxu+lXePuxk5J+ilI+5e2egK7k3TnfklrO7WzTKSVye
-          ybGdHjnLJ/AG1IBMDi9+9ianTC2oPvoVh5dQi3mlYHr0Zp7z+nk1n8ZkdOEeTBqJ5tqqOdfPT3Dc
-          NxNx3+w+HnybPciab4bkZAuDTkkJV0iJtV37Y0IDfpiNXOENxjq9tfrkbMoQzGPpkbMYnWq+6gof
-          OfEpwmqtf7w5ZCdFbisSYF9TIp3/1UcZjwXBcZXWvNa5DRzydiBaHt5z/lGki7wL1ZFYNWN2vOc+
-          IthZuMf6JT7k/O3Uiaibbh3Wv4tJBeYZ9RDeR4yveZB1k1CVPpjP6YiPsNt1vF35lXyZogO+2dSq
-          uaSRKriw+zu2ZC/KBfloZnCxPAuHzeR0QrfTFtk/X7tRws9PLtB2p8CJ2V/XfizpzCdtCIHY6DjU
-          mK6enUmr5PvxaWJHPLT6nEuvK0xLaWM1eiQ5OylahKY3wuHCpk9dmG+cJTtSdh3Tz5bzZs33JXjr
-          ZCI7UyDd8h2ME3ry52Ctn2c9/fSxdOx32OeBVA9K1AG6T/FzFLZBTadLWEXobjIKsbL4kQ+vd6rJ
-          DRPd8H147+kSWG4IwpOtsHvbDZ5QsDsGNqUUYiP4aLqwuJMkW3H0JYqqX/7qEzaDneJsaJRasPfY
-          hV0jTRhbrNrRxY/eMuStOj4V2Htr/0Qw77MT8cJ6pH1EvBa+kPJrfymUvOshhc8x1sfGW6D7Jo42
-          SqJNGOzPt33en56v9QZZUY788G29htdTCxYdCSOdbnI3XcI2gpwlavhZ7jSeoLFDuWPbfARxX3bz
-          dqBvmTFshthTdaDCjnFFGBXvTLDT6R31sniUXb4LCUZ7Xl8O1ySU6fHmkmvXj/q4IEFEt+fSYIWW
-          tjdv5l0KsSob4eMtfOuJYXMHGqZJxw9jp/ksm68T0B7tiTpdcU41ibOkQTwn2CTtEfFKecpgjJ97
-          cnU7VefehlOCeTsF2Hlopb4YDnXk+BGE+HyzvFjYh4UPx/2BGzfnU+5Nz5RZwDEsCwf0asZ0F9qL
-          vHVVmxxOiYt4PRUAalUsiOYQMyYXWTHkyqYH7JSg5qwhoATc88Ug9thNqNclaUQRXzhYlYIln71d
-          DHKWD29yie6PfFI2+wWq5XDBVq2m+eSf9yCfS3iQa63K3iDsK1aeTVpgS8gGbz74j0WqagXjZH3/
-          s9azPajs3ieByVsel+W3BM47McFmVLZIQCL7lgXNK4iuKDt9obv6jexGWDfdvRRPW0YEOeEvFLvO
-          lOb8mKiZXF/GMlziEnWjEu3fsA9EjM/NGOX8dvj6MDx7bXxMVxxzt/fuKYct/RKMPCGecfU6Adbw
-          jI0kFbupdveNnDCvCafVpqx5ojI9ZEsuYls4PRAddUNDmfThiHk+39HMnh9PebOPdjgfn07H0e3W
-          AvacpeTyFq9136Kkl+MhVPAhqm3EFvX1Ka3zlWTmVteFW7LlIXqzOjmKuMmnUP88f/VDLm1/96iX
-          sprctluXpE9eq8eR7iuZYfCOrHcMvckXdwuEMbmN03z7oEYpdw3cB8XHsSm0aLlrjgamePng0/lC
-          4883eLCy45gxUd4ooQtR+R44NlewX6lfugiP2wH597YZWf60oEXZvCskXHA7ymDcEGUWmQVJX1KS
-          bWw75q6f70HeHiODZPRexZRhj6WsLfmL4F13otPx5PRg7smJqEl+7OboPjDAx193vOy6g7646CjK
-          4bk64OBmRfrS23KBXoNa4N2Tk2OyoFclB2Lk4LshPLypcxsLlfbQEdsbam/Ot8GC1NtbGvlmyWvW
-          yy4JCOpch4vov7sJSXtR9lTRI7nCfGPKP7VITh1lwGG9ETsaHNkWMFtJRA+6IP/jQeEY3sYP/jzz
-          eb41CYgVg8JFPLziuWs2DerPD2F89t1YU2EvvCGALsL68bLXJ/llsyC17JO41pbP6U+/kfjSyKVd
-          ZLTQNs6QVCsVdlqqe0toVKUcEU0hYf/0PL5grwmw+qYY2bVfluOrXKQo/1jhfEw1RO/ax4GqZffj
-          JHtdPUzTswTmnkhEY1NDHyUIE5jNucDKi6sQHSw9k/XLbSYqe4o69vbOGVjOyYzN/lPnnXw0U4h7
-          1iSOqr7z+XAd33/nxzZzEC9J07iQYfGE/ehq5NPBS67gSOl1lJ5CRKfmrgM0imOSGO397mvy6gFW
-          fQ1Z2dV0znxzDHA9iIGwjauOhkbqAii6O0r5wfPoszEKSQ7mD8mlQx8v2bVqZU98X0dJDC71Wr+K
-          dL7V71FuO66ete6oSG9vO5B0R+R1/jA9TEtlj4/zsY5bcRP06BgGXMhUm1f+nTDbAx/vMXZLmXSj
-          5F162B/7wwhvbtON5ssT0crn43xMK0q1dopQQ7SYqPfdi46JPZ1kWo42dtWNiuj1vA1/8xeb5Cl4
-          n7tqF/ASmxNOasX12BYggxHPOfHvNqJz8sl4aKshwAfxYMZL8lEKePLHgPz4bO23CB5auBA/D7L6
-          cxnYCTo2Ktf5G+h8Baovr/Oc6LIz1kuflgU6a9YhZO9WQ0em1lMw+IOKdx3pvKWCnQ+J9KyJL2Qz
-          +hbPr4gK6egQU2Ge3ex2dQGGDiLRTtmu5uvLtofXoBch99jMHYkvWiHJt7zHOIu++sBT6QT5rWUJ
-          PlSv/DPqhoLUXjCIOT8ERJAIT9jfqgSbjOV69DyB8+c3HPHgerzR6BFK71eW7LgM1/Q/AAAA//+k
-          XbnasjAWviAK2SRJyS6bBAERO0BEQUS2ALn6efj+Kaeb0kaF5LzbOYEOKxUabHonfnts6wVaBxPq
-          nsOR86632PPnYALhcu9m9pYaLn8sHxLY/SKxkmzOt+caQ9hFeYHP7nQC64LhDG62FJPdb4B/epYf
-          Thei25MM2LKBIWyf89tHfCQNa+amb/jHZ7exWwd6mdoYxre6IdqLqfNVOY8t/FR8TNQdP2jvORYE
-          irjiUMIG4Hx2UdHLkVl/fSMrH5ycpqh0WZbkfDpoG6OBQBI6gWDL+w3R7j/mf/o5asAtX3d+QB3T
-          p7O4vVpKpWLgIRL7H8Ev5VBPv6mcYbD9Iqy+1XlYozvxpT/+cQ0RgVWTqhjufomoheuBtapUFmb9
-          YZmn9dnQKVhSCA3VuOwT/C9t4ZI4+Fe/oarEYDPr0QP7+mPMxmo+ZfDsgOvPFGYmieOIPlenhd8G
-          WMS5pTalZRRasPv6F+wr4DmsHz7mYdsuBP/5QX66vnQ4R+3FZzKfG7r3+LKgpmo9sX6LoC1RP7bw
-          r3606I3dNRZuPfyIYY5lPDh0y9xDDwS2/GIs3Fg6Rja7IP99+Pp/+PdvvZbn80TsnQ8XQVmyv3om
-          3j2QXJJlYgvv90Ymuf8711sqXySE7umTPH6Dmm97fUNhGTbiHS8RWFN5DMG0vEKseF/qrqe19xG6
-          eG//4H10ymdF38Ph4UU415RuWLTMEcGz4wp8Y05iPtvMNfzje//Yjwd3EeVgRA4fRdiH5iWafr7f
-          wvOkuUS/Xj9gy0ZSgC7/3v0/f7AKW9ZLuS0ciIkHMmxa9uyB4FuBf4iKO6DvsX4D3EgctivlW29D
-          JjtQlr3Ub9NAdVeOC2Ww/z+Skq/49/0luH+0K8a6oGjr5j56cP/5Bnau135YQo+1kHWbUqyl5yri
-          l+fXQY5Uav5n+ib18potHlKxsrF6vzBg9rrLCHL2ZmLloFegt+e0hG/mUWP9ln7chdcCHQW15vvi
-          S63cbeg9Bs6Rvxf8qkZ977DsH36R6zV7RrSqbi2MLl8bq87WDPRzlQOY8U2H7aeead1W5Cqk4tv2
-          xfiGNbrrcaB9zB82Tty9XrRjpKI9r8GOcay1Tfv1DEgG2SDeC7gad5mPIdyiGvqiwUFt0qRu509U
-          EsMlGd3O7SYj8LKAPyKDj+h9ghtodWMg2vJ41NSnHx3u14PVsa+i7aYcG/gefA8r8mHWtt0PQjW/
-          pcTXufPAGcnRAq6jW8QkrTNsoP/xwNTVJ/7z99RgmRjseY7PtPRLqVKOMfjLN/59f4XPBdSWmsH2
-          vn822oER9hrLYA8atUuByDZwZaPNp7vepaIc6fC6VId//paVD/cN3iccYjtJaneqKoeHsCX5fARu
-          ONDi5PtgY1KEH+70BdMbRi3a/eG8drNbLy39stC+PnmsTk0Mlh9TmGAdhR7b4+8JVtXTJQQUafWX
-          PMJ0WJ7FBmqxJfh8OhrRdkStjIzrPjFlre+I/uU7ERucyVUXP3RlrST40xuzxOh5tLTxbYYfGHXY
-          3Uqb8rs+kXY/7LNeH4NlZd5vqV6yDTuy+srp2IUS3Pe/HzeC526106Zgz9dwSF9ctDS3pw7vSxjO
-          a8P20Wafuw5QgzN8uus3enhdEqki7obl7QHctbDuFvq7f9pJcrTZzVodIse5YpwHMBrlw30B1o2k
-          RNm/b87GbwHgc/Cxda6fdCYvnwfVm+lmyThqrrDnYfCtWzL+xw9/ednuZ/EZnWzKNqIpAf9WhT6S
-          D8IwXRPCw1qRSiIbrK1R5aF36HKdQ3w69xrgxlvuQAH2jQ9q9Z3v+pqHVYs4ormzN3C7nkIvR2Xx
-          iY84sOXODcK7WGJfsqkeDWovBjCO3reZ+xxDsKIkiKE2igPxNLTU2yI/ZagS67zzc+9SqwoLMBib
-          h236mCkdW+qh9hl/523q6UCfLyGEex5AQmf80On2inWkRq8E387Nx90iyeshc5LozB8vRJvHtCpQ
-          +0y+xI6K616/qgR3/YXt3+bUwnusK3hV5QHv+qOe4hRXYPeb/uyMOCe1BWPY9VxNrjKjD//yuSy/
-          Dj7C35+2uXczQ3/5bPHQYb04wLb+6dU//8Ki5D2j70gcsvNT3cvBvQFqPkX+dHBsbXsPpQ/v91bG
-          jgbfeWc/0hlW7YEjVnt8gaWNnyO0Hz86R3xWuvTKRR7qnplP5IqJc9oPWQgF3wnwCZ0MlwbLZ5SE
-          83L1ud2/b3seBZ73T/jf/IraHAO7r3fBj11vjJnbS//4C3+5eVjG26eCan94EBlaz2G9o4YH8Za1
-          +AwdWNOqFCQoucyVeOJFHjgmXnppw+KPeC13qHe+8oDBZhk+ufRFqVzpKvzLJ5RzU0VUF9AMl9vP
-          8N/n3x2MicarUL6FDXYYJ3O3hTkEwNk6hdxP7LLzxbWH9DGciEZ+p7q3IWpBJmHJZ8RwBkvZwAC2
-          Lpj+rS8xjFcG//Kf00v2Bh5++wL8TL3Cei33Gr/nFeA9cyXB6dmmawiYGRi+ruGbkChAaPVH+C9f
-          3P1C/eff4OveHXGWe2NE2O4Xw/oef0j2sM+ucFoZCP76AePzBMCuTwv4p59exT5hzEfPACI48ATv
-          /nC2DpABalQnWK6ZCux+w4IHm1fwOXr10Xw/3xLg+sZ1PkJL1gSOazfw15/IGEfS1uNZW6BhHyOi
-          rdVvmFnLFWHQ8toMrHHSpqeaZaDgO4y9N2CiJRZTH96X/owd8lHcNe+7DoxbdiSnY6TWxMlBKhXS
-          UMxDy+tgvUz3Fux5oX+4n5G23qdKhnt+iU9+L7jbBg6ipOfpgaSm2GnbQc0b6H3NZRZ1cBoW2GFP
-          2vnQP0RvsV582s8we68UW8HjTMe5PhaQ/aqP3Z/cNII+S4bWj9Jh/RjIVHgY7RuZUd/43zc6u1xz
-          02d4GbeSaPczHWZTj3W47zec8nnnzpVcJWivT6zEOTeMWMUiuN2rO77Roqo31DoLUJ+VRbyje3UX
-          C39M+Lyfb/giBhe6/vm/+yXVfG7PV2cr6FT4lwft+DR0H/7rw5SvFWKNTRvR5lT0x30/YuehzflI
-          3pdFeokvC8ukNcCqQllGVb/12D5/aL7qacCjCBYOCd5Kla/D8d0D7dG9yNUe82F+rjGDWMvycYx0
-          Lac8i3VQuVJOsHRRKWuygIF7PoDNwqmj7c5IDjAe8Rn7ijK45BtaInyyRUwycG7dtawdDxZS9JoF
-          FdJoRe3VgWcDHki2+9W5ei4FnE+H+yzs678O/TM5/ssLeyLk45ULWLT3R3wWnF/R+LkeUvDqjtrM
-          Z5GS8+PXaOAHXjoiq7I5LDYjv//6OzPXTaq2PFfZg8dJN/GDTSSNwFTf0PXxPGCjhptG/vDAf6Pv
-          P33GIk5i4VdM1F1PHQfKaJUE//LnhxiAfHm7xwSK21f20fFs1dTCpITi9pHx4+7NYDmbLQMDJnSw
-          jIyRjq2eSf/1Z3f8dbc9HwPbaZ/45zIyUFO3R1jwPcZ2WCiU7Z4uAze+BdgZP2y9ZcNpgfXL6oiu
-          HoKcCoq0SL0nA5LkUTxst5cywlg2HuR0cPR8CyoaAoNNM+w7I8mn0cI8+OMz+QNewzqmEg8Ol07H
-          ujOx7vwNaAP++kG+xjB73pJnf/w3t8i41OQRrzya4Fv3K3f91dvCCAEcztDG+kuz63kryAb2fNb/
-          01Nbt7gz8Ae38SXct9rWD00Hzbc0Ezf1aU79kAsgfI8+3vN+sOexC1z6Uf/D45yij5iB/Xpxtr4V
-          ytHjasL7zzOw/7C0QWCizwiRAtN/em69vWITdrJj+El2fg9rJN1keKuYFznx0RX84G2R4fh1IdGD
-          Uojm+GsVIBp5Y+YuVal1bzhBmBAtnLe3OtdTdP/68GEfW2KEteOyz4uow8VS5Fnc9Q0B96ZAfDvb
-          2M3ciLLw9MwAO/NPH4SPwN37Vz58XUqI/V3Prnu/BwZRbvujO7A54bWshHt/FT+RJWrLn//b+zc+
-          nVtQL1DcO4bMpfCnc9/Vq4XDEe31Ph8uz2NO//Cc/5q6L7TCnG+zVmbgdQ8Z//3hV434dRWgne9x
-          dv6a4F9/6GKaZ+LfblU073wG80fHkjJ3VTDajFWBXZ/u/FkNnZeuPbCXmWJTiOdoeQ92CRfmlviS
-          EOlgUcofA3Ej/uUPbc2tTOrAg6l5/mvvX65ftWPhlt8YojeCpy1QyCqIHOuKQz6vc+KmUIXmW5zJ
-          fdfPtPKpjo6XJ8a6GEX1nz6XfmfpPaP1qQNiGL8Mtky7EvPh8ANBZhegpPa0vZ4zbW6EtwM2z2Cx
-          Hb7lWrDKbfvTz0Tf857Rj7MWZtKHw9re79iu3KcFu17a+4nWIFy5yIdfMVbx6ZabdPGbZ/rPr6fQ
-          9AZu7z8enx/fIViWw4Hiy6OBu9/Gfury0SKSqQcy5os5OFij+yu1zfzL7/71V//4XLqJabfjb5Rz
-          9vxm0YktlZndinUYl2eYwe/jIc+CAittW55f6/+ZKOD/90TBbKYmsR6PWVsfl7YAj6LS8Ck8rZRu
-          ybmEJi5/5OT1eT7yvpJBt3WE+Wh96nqxpcBBAx6d+WC3x2FB3TKj7TlLxFyKuGaPRPKBN/It8YTJ
-          izh9zDJIJzMi+vsw02351ilKHpOA5a+g53wXXFUoGG/qS/HHdbfOzh3wu8tXfC1k3RUE/eeAwP8W
-          xONaZ1jqwg1AcHisRH+ZCyB3NkvgKFF3bqaYdwfhvfSwfdojub2GAZD7cszgSHGE8VeL3OWGbwna
-          wltHfOauRaznohCORxFi31dzl+SNyUA2dX3i5c9PvSrd0ZSyW9PODJ64nErthUFMFdjEO6YmEL5h
-          nUL13gk4GfYzAaL0UGGJHZ6cdZurt/B4NmF9FGVSbneFct5LjAF5XxNcVtU72ory1kF8WXQS2eYX
-          rF4nech7dwopzq3pLugkB+h+TxiM3QulmxZJPhzw7BDZ8U7uetNeDCoc/CROZMU5J5aRhE6/X05O
-          p6al66k4yRAtgea/imjT6DX8VRCJs0NMc+WG1S/wAstTwxDN6uWczwbVRNunuuJS/b60ztC3DlVM
-          cCSGc6A5bcJBlrBxkbFGhWO08E5VIuUmRT7a1NTlrDFb4OWyBOQyd3dXIAvoUZ6MD1zmIBvW22st
-          kA3ZGMvILbWJhYMMHwotfUaGJuV+8CUhVnl8sAyRlC9ifUrhYFkhSY/4HC3vHstA1Lue5KrausKF
-          vbRIPCrAX4sodCdMYAH1k5yQ282S6cTCWgXZlMnECUcP0Ga6N/Df/dJvBuWWDkEwONsBq1iYwVaU
-          zw7KkXAhvpLOeYdD4Q2TSvr47OOd5my0njKEVivEzy40NWGYwhgOKN+IqphVtPC+sk/MfN7EjMWj
-          uyonuUdyFV9xUL0I4IHBmuh+WU1y7YrJ5bG3luhx5TMSL36db/fjmYfX1j7ilD8VkSD9Ngk28+VC
-          YizAfNzG4I2UUD+SRxiklK6PUwKLZJ+R9gM3omTKZvh4ZCGRl2iq/9YfWa9zRhTEkGhNxjhAUueK
-          2EvtVdsWZlXRAOua4Pxyjfjhdgvg6/tJiPzmr9Esz10KX5pnYEM9qZQn8xTCCqU9uT63/QzL4DdQ
-          yJMz8ZIyGYS6mjcYj1zhrz5/BMt2dUSYLGqC5ah6upwmlRaY5KaducOmaey7nXUobWKJU5w4dSdK
-          V1WSY1Jhj7VZl1DLnpHylXVcnlNMeX6eVTgJwRVbxLIBG/XnCpbnNMUlAGiggiL7yCYPhahD7uTc
-          2KEGOPStY6M/8BFlnkGJBltc8Hkun/WSF84b7t05os+HIKIOuyvMJov8I1+2LvUTe5bSqC79npGu
-          mjDqlQrt94kQ43KsBnqdAhM51e1G3Ff7GhZWSVpQ6fCBzbxRc5o3JgT5rRmJvLwuOd0EToQ2FxT+
-          DOefu1E7DsGRkH4+Xo9g2H5Vt8F7OFyxlW+0Hjmy8sj6HrUZsrcb4IWHnQBGYBUsG66oUWIpCdzx
-          bD7qcuHOhCMO7G2px3e/VGrhFFYqYpJ88yuz8+sxWnEKsHzjfE6WFVcIGoOF8bp0JCwPr2hLvM1H
-          W4SFWcSWSQUeuxCQogbz7Q9PEl/foA2gge/2Yxu2IeITmNR1SMzf8AE99ZAPNe/SE1u0q2HT52qB
-          c3NAxO4+5rCpWluiXVbM5+oG83ZU7z2UkKH509VpNe7OCwX8XcoHOakrqMebErWIjzZMyvlr1EJg
-          P0NYnbOGqA5/AAvk2RKG4KDgv/peZl/uUPO0K2K4v3L4yUSCQA6Ris37sXNpE9YqClyGEPv6YLXu
-          LAVvaOmZ4gsGfuWs0esqqirwJSZ/mgG9goiFoR37+CqdLMoZWqcjFblHLH+YNlrOaaVDIY/PRHt7
-          j2Huvu/u2IxvivUoZ8EkjM8eTmYmk0QXhWFbql8FpM4WidEVk7Z8LxWLFj5L9+t5Atrfpw4yb/mL
-          lYIc6/aaISgeQhFiW5ehu00P2UMRdylJfIkjl+77EYWuOeLz7enWG3goI1pm9kn+6mWZ07pAFaxy
-          rGtnMqzPTEzg7eB4OEp7BfB/fBwqSzKDTBLdNTu5ARxtid/57pqzXGE4yLkPkx/RH1cvPb13MP3F
-          IvYD2EXr7ROmaP1Ue8OLzkCofkuIjPNoEBm5jEsLEDfw9buy+MZcJZfyv61CsN6OvggSrAmSYjV/
-          /ECyCR8jcrwTB5LOWYic8BGgWiI36KWbMS5YO9a4zGk89Ll9Z6xdF3ZYM1pW8HcpHqS8OJ67uUEm
-          w1/Q+DjT6Tnnk2+37fOlJYmaXouo8BY7VO8DNgHVpWHJlQii82MGxJ+/n1pIDUGH5qEkxJhPp5xb
-          ZK2D9Ry5f3iYczBI3wibNiY3NMxglS9D+YePJGwzkC8zDWX4PLiqL034Hm3Ct7GgNeQHjDtdzbln
-          tiRoUIofzgno6u3BfQL0Nbhid3Qu5UL6WOCR7XmfGefvMGHfUyEueJHY6yABeglfDkKrE061bZ7A
-          WPNHFpaxqZKrXw90kyKBR9tduxBXkoA2Wb4WoHsld+R+PYJ6VZxXA35MxPmg+8TuBtTIQW2/vWbB
-          E5/aZHVHFj05dsSpZhnREtRuAN+sWfnd0Fzy+ZBYPjLPo4uv3/wB1tPzy0BruB+I6nTQncryHkI/
-          ce35azw+2rY0aoEex1tBLJw4gwCegY7sudnIqZLXevU+lwCFiDyxTnIBbLonxrDtlxd5enM/bMw8
-          b0C5eP3M7/W4tkerBX/65XRL9FowQRZDmRQGcbQmy9c7fyhAzwmsf/ikKV31q75ID/uWEO/X/txt
-          aZwSqcYHkHslP102TX8+jBfpPgvl9ebOIgjYP31Cwr0e1+ykBTBU+w9RQe6CFZRxAN3QAP5xPZbD
-          cnh+fWlgTwVWjPcLdJPOb+DT6NsMh0udb+DeLZD09IFP0ea5i/H8+YjP4xN2yVNx//Hlu9Ian/Tf
-          YRiDwk7hxdXbGRnt6NLj/evAPz5xD5OZ7+vXQuOkFkSpf229ePszZJIHEWae9Re6PK+2CuR7NxAv
-          kRhtipyhBC+W+RG3owKlx/ATgJDNbXyegxzseqyExnk2iFJEm7tykThC3rIzkm1SVFPbE0r4Sx2T
-          nK+O6W7Egyygo6/P4KeAen1cTync64lcRgODTQ4CEcXzR/KzL3hpMwB3XwJSURCb/XQuvbIXiKZT
-          gOc3t1yG+e5JjfRiggOx+7IZ5nBQYmRsh3YWPZnXZoE5bvDwMF7kPJeHenwimiAtiL/49FHkgf3V
-          Z+lvvTG+p0I+XzPEQJqkPb5FjZXz4r3KgH86frH/Y6WIVmHfw6cObzh0sjRaIfcSQSk+I4Lt9j5M
-          K3x34CSIiJw+SlX3AnNcoFwlV+wloxRtITda8NaVNdHqX6yNux6F1m94zYdcu9Qr0x0K6U8vnV8t
-          cZezEhaQVx4rcedgzv/uF9jxgfgwfA20crsN5tprIe4BOBrbS1EFnU/wJrjnSD6ibj9LMn8kbHLH
-          QSNV4rbwUAWYXN2z4G4/9R7CO7FSEr+vWt31hSfDQVoNrDNXs6ZXLDcoGQwH49vz7vL83Mqg+QgO
-          kV8u0La7tzWwLCqb3PZ6Wg+3cEMEQYfk5RhHbEWDCu5ThfO6vs2c7759D/b7QRTVm9xF6sREtKvr
-          ZUZU+2rLNgYVVNWDT9zcyun25doM7vxC8n3/cn12LAH2PwlWQs8f1lPamnBlO5lkjf1xtyYoOuiG
-          J0BOryMeNnCvNvSIGXdm40J3hWv4qtB2edxxodMMCPwC9472gon7w4eIEr1KUeCxDHn2bqMt6FKb
-          8CEfMfaPzlJvWgZN2Ebej5TaM3BHjhx5dI9eDbaw1VLihFUGBzUWSRyI7kDz71eCUWtP2IdwBOv7
-          KPswlMUTjo9vkM+Lmqng/mHVeZ27ozs7shnCkItSbJ+21F0V59dAOGJ55ln5rK3KJ7BgqOcaVgWB
-          Rtvj+6uk5P3TsMNInDvu+AArFtbEP2h+TQf3J8KXrsf+pechnbjN8sB0PKrYzZPDQIuqVeEgNxk+
-          x1DN2Vutq0B36hA7l4ek1Xx7aaU/P3DW7WvNSt2SII0loo+gndf0yD5mEEEu+ecPtu7bd+DPH5wr
-          O63n++2aIjbJFp/nHtog7HpTUoI496e5fA60ZZgektfjRKyAKjlV7ccGtLK1iK6YE5jw597DcNeQ
-          sbIctfF4ec/QPEkrOdXNb5/ISkQ42PILR2pW5ms5PlTkh/3573oioX6ceXjjRwNHa7y482n+Wcdd
-          r+JzWMJh8k7KhkQ+9+dVfKVgvcmKjG6VXOCcTDrYXnaYISYeYmJZ/hH84SH8mUTwRxcMw653QpgH
-          KktcAqxBuCcqj0LyQNjMN9Plm1v5htfB0LHZyG69+mnLwz9+WcuM0u79bDwgSWVC3MNTrdckJS3g
-          5c8bB5/lXS9ToWfADg/MfJXqIBcuICoQ+jV3/BS0uOZehE9QvSUWNj9Hux6hckugelMd7J6VdE98
-          VRNO053B58AWtM3PkCdVuumTk3oKchouSwf+/JAPQ2VYV67bYLlo3jwh9kpp3eBRurbukchm1lPS
-          /VYVep9w/of/1JhJBSJlK7A7tZpGkTtsIO3Kn/9VD8+cmAwNYftTNew1dlj3B0Hs0cie3n96VFuV
-          bjXR+aaE+KTWN8r7ZenAE289sXYTkmiJVpxJchGlRE1fORW2sKnQvDQbUdko17Y/fM/CIfff2vnt
-          UlstOsmQY4rV4WzWLFecLYian49dKSB/+VGG9M24ELlCt5wfB42Bu7+dXy9mzOeL9mXgI4YuTvJG
-          jfiREXvw9CpM9PAwReNb53b8N605TCNRIzNzSGF0TDJsO+MnX+X0E8O5Pj+xIfoOnbvgIQNUctQX
-          XoNLOZiBGLbF+zBL73HOKfNMS0j4NMSnU1K7Gx4sBuCwi2b19x7zFW4WhM/jrcNm0ydgubUN809P
-          v1DcaFOfHQu450n4UgtOvkDpkUHwqS9YvjINoH/7UeJeLvZ4ddMmP515sOMJNvU+AtuVayo02uoX
-          69tJiXgfTh00t9ODmIsItUUJeRmp914gxnTUan5ULz3o1WTz10iwqIDYRAeiU+pYf9fffDsklgcO
-          j9PLL9/cCbCrFIeo8qqrzz7PW70RO5Lge28NSq2qacv0/MQQzNyX4F1vzb/GHuGLY8U/fvuHH+Dw
-          QAv+82vrn77d9xdRz+YLrHp3LCRSvABWVO+sLRVNK9g0EGCfXBawKmMmw86PfjN/H/R8SwZ7ht/4
-          cMb67n8Eu2qcv/wMZwdLBGv+OvLwRT0XZ7r9duklUXU4CeEVa9d4cid3zB0Yb53go5ZT6LTrezRa
-          VoqdUFqGZUXIh3a3pn98km/OUU/A95HHez5W5cKOpwge28h/iS8RkEs1SrCgL+ijhKtyCsENwnl9
-          KBhnX8cVVPu6gCz85QSLek3XRRtb8CjeGpbjqB+WVLr3gBzmDqvcstbT5+SlMD4mFVHbDESDNOU8
-          xDn8kdi8ysO2qJkMx6M84YyRru5S6lwIq9fKEz2sP5RKitygZugakvweqtvpIt6AanwBtv/ygO53
-          lOFfflD2aulOOawycChwiF2FfedTQpAHf85C//yURgqBdtIlkBTiFreZrllHZxTcYxU/Py3c9UK2
-          QCVEFvbBdKcs5GH59/9I6Qcl2PXTBryb4mGtr185NQa/hVt47fD5e7HzGdvpGzZH0SRRttbDuudx
-          cNgSBruSOrp0WEAAdfXk+pTmK9iAsITw+on6Wfhaar6R4LEBiW7TLKjXeH9GwdmRDL+Jic5c22F2
-          59cbucHtgS3Lv9M5GxwTltbzTMyt5nOiPtQS7Pke8fiAo/Mpklp4TlwNY7Eaoi20Awk2T7ea0Wk6
-          A9ZQ7jP83D6zP+z4vIbSrfvzA1jLVq3m998D//T4kMgavTw0BmEB0Bkg1sr7Pz75Ww83Ap96fg0q
-          D98fliGX/WDB1s3jG7LPySQ+8/1q27AZPNz5Cytzds0XLh092P5kjcRL34P5x4gBWPg0JVn8GdxN
-          vHcpTA6Wics/Pzuwsf+3/vNBuKT5ZpbXDBz5PMY2h2lOY4bdoOZFPbHgR9WE/mG2kFeeK/Yc9Vxv
-          jH3NoHP/TcRIxchdkK9a8Jst331/99rszr8Kaoml7PmPQZegUNK/fIG4gf0bdv9igZPHq9iVbUuj
-          nMDsJ1iekQ/6kaO96x3Nv7zHp3uevL6zZUafsTpiu5IP2hJNbQF3/0+sx3ABtBZgBkJZOuG9PxF1
-          OZIgON+0cObbOqbTq2NLkLw2Fnv59IuW+qqkkI27kIS5sESEZ68JNE7SQGxOIfUoPucSED4LyV8+
-          uF1krAJh+cyzcEuaYQlcroePRxqSEjx57V9+vecfBEv3Xz6mSGrB0+Bb/NdP4HQCErj3P3z2ZQZg
-          DWQ5QONacBj3rq5R8AxMtP+ezw+NRnnn6CVw/h0tfK5BPAjD75hJf3mXoZ7eYAl0sIEjOnj7fjHq
-          Za9nCId49Znw+x6oN5xiaOLih8sAWtFcqqkFU+KExNrzu+3v8+SzJ5yT50tblxerwxGPwczAysjJ
-          ji9Azu/2DBuK6GQ5fQJDlwHEO7etRpFwUKXeFntcvu9yThhFhvAW37/+Er/mfHlKYYoix6uxCs6d
-          RurEZeCeD5AQ5C7dqqPZgkRofWInp2dOG/fnQM2pPSwrd0Bn9l7JqEsdmZisPGnLDT+Tv7wQ//HJ
-          JhhgBJri8fPRbeJolQs/ANqzvM0L1bNhOx01iG7fNp7RrldXTSoduOsvUv7YLBrOD7cFM8NHWNn1
-          2ojI1sJW1qCfQmrQ74bdBlYcv/mSliT19jGO/D981MkPDIs1fWJoCTJLvKNTa9Mfn+9461O2eGnL
-          U4njPz2J/SkNQWfUqoP2fgs5rcM52pjhzP/lZXs/wc/5hVlluPtnn9/xmfV6b4OoLzp826TK3Zpb
-          8obnxNaw4RWORv7yzj9+MFfzuevZLIPXU6NiW/cP9N/6jLb8JeqPoWCaXnSEh75gSRnMzUBahulA
-          exUSnw0P54j3gywDr0opMU4hobSvSAXr8T35B8n9DJt/K0JJTZeO3C36zZcnfyzAD91b4uXg7C7G
-          1DBwUMofNtwfM8zJYI/SUjXM7r9v0RZuricp3qXEanlQotnJIC+NclNhjf64YalpIEFG4BX8l4ev
-          P1mVYPuOs1l6l3299LzUwPkwvmd0urQRuU9pCeMmv87g1SoDP0R8DIsrG2PnkMCa5o0PocZOIjkd
-          Gg8s3KWPQeGcn9gVP9yw5/sVzOZwP7M99/WIaP6G3aW44dyjLN32fBUoXlRi21YGd+GdroB5WoK9
-          P3AYFsXKfUgvj+eerwRgMdAyIrt1Br+7H681DbHsIS9xELE/iu+Syu0WGJInmv/6UX0YZAuMJZ8Q
-          9Xn+aNtY/Zy/vIdgrzLBPh3ZARxVb7LznbZa3cqimnq3GZ7Td7RGstzBE+88ia9p1rC91OANmV/7
-          3PsfP0q3sHnDpt+u2F4fgjY+0x8Dsna84fBn6nTtuUpGpcFW2E6pRfm/fPhxZTNiO5LtbvJmx5AZ
-          EvQvP9vIZnrw1hU1/utvrOCFfAibn4UVTThFqyw9Frg1nYl3P+eS3T/Av/wQWrco6ptbUiHW1h7E
-          V9rQ3eToyMIjXf70oQhWbpM9SIbfODey2GtjQQPnDw+xajPLv/WT/vIMrRFPGpvyy4zeW6ySXa9o
-          +8k7D27B1yHOJkXDUvBHHQpnKOHgJrzp3r/r//p1RDev1TBL9lVG//zA3p/4y5fA3k/DZ6p93c5y
-          oQR5n9NmYZNkd1FcaEHRzK0ZNh9JqxT80EF/V/MdzxdKNwFJAIqzTvT9/8/hYMd//Rtf2p+js8T8
-          EsPz83GfDzy3gL88Do5KQfBp9w9b6B1ZaFCOw2bsnwH7h0fn5/NONIPhwYY2PELzpL6xXvV2xIEX
-          8uAJjTei4rNWL7OUSxBuYk8umvCNZvodNviQ8OB3VvEY6K7nJbSEGvELaNMJOKSFYJOvpCzgj9JY
-          vS7g/5goEP73RAE8EdY/WsZMN728NvCpBSo2t62PFsvHLcSVUBOrOVfueIWXEoXNbBLPtHJKAX5t
-          SF2kCzk90wUsv4ftQLFbKpK+sq+2dZcmhFcdjP6KgaWx/ZPy8HD+8LNYvCdttC02RudL0s37Q8Fc
-          AShDCIbvzcDKMlzcpUi3BeazbOHwdyA5hWFcQpszSoIB7Ic13LwYZu9FIyU9XGu6ffs3FGZs4BN7
-          GPJZKhcZbuYvJpdlWLWFM8I3as2t8UUTbMOWpa/5v9fD+07NCbznw4nlX1hWwZxvV+XDAwe6ATHu
-          ukiXwmFDKU7jjdhX3s2XFNYtvDgbS7SgF1x6AqiC1hnZ2FRiG3DNem9hyTY8Kb3TSWN/D8WB7LdP
-          yclrSL2AL5bB3X4VOFMvX3etaouBQqS9iZe8zIH2ZS6j0RwhicPx7G6uxaXoffTbecCFWwvbvVHR
-          BXURefJHA3CyZ5fw3/U0YZ3zLSMnqKJ30wfXm1N/W/acwOUk6Ngqbu9o/RHNQr2e61gefX0/w331
-          YKUrGJtNXA5bfrglKH5wR6wORMsFl1VGhL+ONUuGLrvsp4EMePAvOktHbo22eGFbGHmpQq6em+T8
-          lkYe+hzWiDjg88nZJLd99LYdHXvxug0re+d0dCgilfjxA9bbaIsFrE6V4K/Hu0VZJX/xKL0XEs4G
-          Txo2NwEiuMfqlajb9HWH14AZSdbJb96ex8/A11ufQQXFJlFjoLrC5/S0IPTVO7mtsRjN9HxKYXvg
-          OHK+avEw8beigmBRjsQ+lLO2RB8yS2wwWNiqJgFQ+3GD0BeWC7kprUvX21OfwYOvKcFFdhm4n3Hq
-          UX4aFKxnt/0ZHOvDg4zH/4h6Nz26ddMrQHHOZtjMgK41EIkbnKre32cQZQDCsVLRlxVtkhl65bJb
-          rvNI1/iQhIjnhuV+Lni4XVgRJ90oUyEhDQ/rq86R+Ltk0cp/IhUZykkg9l6/NIm+LGgOqolPly+b
-          T7wSmFB4vDOiEmnWtrLdYpRQ7eIfnLLX6FR+LBTgasZhJNca3e8nvIKAkkfOTxHX1LkO1zmcMOY9
-          fli7MS1gFDRXnJywVbM55GYkZPJGci3XNC5+TQG8htKZ+OEbDRs9nzJ4DYwAY5fPwVYnU7rvZcmn
-          Pq5y4fQ56uByQwKxTYfQbcIPFjyHrsNX0xiHzcyRCp1bEOJbZ1p0s7VURTJYc6wwxbkWYBUy6JPM
-          KsbDvt6Zy8pomqwPTsWGcVdiHTd4cRZ27u4kdvn7aamgpRSbLzZnWWNnBvVQeMm7YnOTiH5DZALY
-          5vLM7Z+XKj80ELwdl2hlHg2r+RFVGIriHXsWYOnmxIoP+29Yz0xnpy6VwSVEbu9FxCU2GSi4kRHs
-          14vPTfPJf/BsWXB+5bmPTqEARhluOmq+sUssl471OA73DYJFO/6tj0s/12sPOlsvcFlEWTQOWdUi
-          NvhZ5PwdXVco7KgEJxSWfqXz54iVoWQCQygZv5n9NtrKfH5DvtxGHL3bMtrIfH7DeyxfsW7Qvh6H
-          rGshk6pnoi233OWhHJbwe32HxEPeHE37fkdUDF7Y+GzLQE421EGmmwLGAOfRUov+DMIV2NjAUeEK
-          NE63f/imeU8v39ZhhCCIiOpPt0GttwjKKTTGS0bkpbkDItKwRek0nPHJa/Cw2d+QQcEXXH2enX4R
-          F7GCDIpXGxHZWT2ts5s1QTjqKvJUOy9i1aBU4aEOInKD3M+lqsyPUJ7bFPtC3w3E4AML3YP3hM1R
-          cOsVr5IP9vrBltiU7vKSSAiluZWJ6jx4tzfuTgIbUeWxFoUfl3e3RUKuJDHEfaVUI3fgLHDrWAvH
-          30CtOTvVOuS16xln4GNENL2cQrh8/f0tJJXs0tLcROC244DzNhfounx/Jfz294A86leVT7fJ9SUZ
-          ey9yvdm7pUIFC1EFc7+9yp98CsqqAKx41Xyg1ra22qzcwbSAb6wYFskpf1k8dBGuM0nDdcnpZw17
-          VNNFwblMOW063uYOsl7JErwpw/77rwK5T5XMbWwN+xlit4STEtxwKN+8gf3GDxF2wZLO8PuhgOqg
-          TpGv+yfiNGvj8i9NeaNjVTHE9B5pNNmO4YC0tz84//kB2A4NqeBf/eXOvQXsp2EZRN6M6a9TKuec
-          7RgWdA69iJXh8cpXIVQCdMvvws43TE3viCvQYUQT0afEi7rbcZHQbMss8dWkzzfR8gOoKu8MBzC7
-          1WzkiQ2Ss8zA92z+5H/4B/uTOJJ4yKd8bdZL84+/ks0A7mJbMD4KkfImafb13e2oUhnN9+mJT36s
-          DezD+Mnw678Uki/HmnLfc7fAOm0epPD5aBDOx68OVcaI9usXczq4SogaUJXkws0cWB7Gb5+IZJ/k
-          wS7isG7mfX+KrzT6Q5vfKL2Om4UUM4j3epbyFadEgvZXzHGGqiZarNiykHr3r8R7El7b9dWC2IbL
-          iUrODP1JfJLA5n7t5yNBj5wK71eGdn2CLeZZ0H/7nyGzRQJWf2vj6R5l6D6M+1uIRlDP9jeEqOKl
-          mWhWrNT8RzwtAFVMTk4CFrTuD18G/LPno4U6uqxpZiHrZ0043co42qausiTty2izGLyagcSyxiAv
-          Md/4VNf5sPFsn0CAUUJM533M52NwfMP2Ai2idcqn3hYPBTBP4vMsYcceuGx6xNCBAvD5uxu4mxIe
-          OljFRMJY7cZ8cbWfDv3jusxTOp8GvsfaCF9+8/PFarqB0U4kFg6RsxFVpAvd0GR1ULbOF+xbRaxt
-          lVUsUEpEY2Z+Sqitd/HlwMPyTMjZ2ao/vfZGqWiZ5P79fgEbD10AZQtfiPOgVb69o21EzbPDpGz4
-          U87v/AWUT+eS+Og57oYmuYNL+iL4fBvew8K27wVwgr7u+y13R2jwGzw9pC+2fXka6B9+vJLgg6+v
-          7wcMM4p5xLqLjcO76QGud2UfnY4bj88qVHMhDAYZitl6IG5vOkAIx079w2+fMtZtmLz0scHuTk8z
-          P5FPvZqfRUaGYgjEIm5dT6fH/hKs5OVgY5hIPuJ3L0qv+3YmSv/5Rqvm5S2giHbEENcCbPgreBIW
-          65JocwHd9S7uE7zv1Cc5B616GyaQwdmrCnIK8HtY+VtcgRMf+QSfL5q2z7MU8IFeGil43/nTYylM
-          Zh75r8QrhvWCAgu6muDteKK77A2jFPL6hSXuovzAfD+Jb7gHYsQx9EqbKZt60EoLlch8fKbbUxje
-          f3hF5PXyc3+qXUnojy/BfOEG+vB8Bz6LQ4GNkCEuGYjnwwv5bfv9NgBrxbID1SnrZtHj15q62SGD
-          wnw28JM/fuh2ksYZXAXqEuPEyQP/lEofomI5YRsmXU6Yg9NBhU94rDguq21W8lugXR1dEnWKUW9F
-          iXU42ypLlKq36k237hawh1QjZmy5+f6mMAjznIvn7eZOgH4OF0dK2b6cmfhRDKvElwmwyoH1m/qD
-          a0F6gwryOSIEq52XrzKjiiBMZGk+TGVJt+753uBn+MgkTQXJpZ6+MTA+uz4xGikZKEflArGNtWDj
-          4ufaVNpNBYIhQ1hJlAtYgs+jgaDs3lg9G3rE/Qzcg/l4Soi7HGtAFUZj0NfV7mR/Pr7GNrG7wLDH
-          Z186xS5gO3pugHQIh7k3iwtYplSWkfgJRf8Qxl+6HI2mB/ANUiJXqVlvWGMDyT0lLNFJK7rL+cs4
-          MPIyBZ9VTDVa0Z8JVV9eyU3jhYGe15eFEhUSkmHnNyyWafcw359yrR7a37Cy3KajNzcy+Dbc77mQ
-          kJGHJWhMgrWqjbaXplToD7+fQUP3/zN28O/+fQP8rtfy83tDe7q/SfwbjtF4JJ2D/urjtOuJiYxw
-          hmumZySUan1P7MMSdg0z+EcubYb1SIcOMHIc4rivo5zs+hlw5ez49XID7tQFeQmvIKREe7fMHz93
-          QD/M1Z8/AKTULQ9O0rXDfmenf/obgvChOtjSguf+1hHZh5AzPWJMnR/RGi8BbNLugJUL/9VmR9Qt
-          +DSil89sXw0I8XZOwTQ5n3/+aimtaIRD0mXYujZ23rh9OUt/evOS60m9HN5nCe58gC3DZerfKP10
-          qX33lGgvTaH8yRpCMAMxwpcDe8inSOUaRPLA8fMsI/kff0I/PHH+Xk/D0lGjhfahScipMzvw568k
-          uLbNrif9aD6Nsw+xCxtSWIAFJLtLFUjeSUus3Y8vZ6pA+GCrGF+3IXLH/f+i+YFP/nH+uDXLsq8Q
-          Co8qw8b7INSzvwSx9JqYCntNqEUsjpsMxWfbJz6czoNAzSz451fCy/68rfP7wqPnrbgS/Itid7O/
-          GQOvTVT70LQAWPNbKoHT/An9Wb/YuTD+RAayjZDP0o/tAC3svITnmA1wHvf7U/3jPJF+gqcQN4gN
-          QJfCa2BLXIfYUstq9A7UDbBRYeB7dXrS5dNAKF2L79dnf64yCJP0ttDDZo743JFAEyz+HSLFDGOf
-          2iPNpzxzG1BOn4/fSl2nTbPsvyXNMBsstxRp1OrqBa6GePKnhFr1amajB/YZUnze/Rs1mNKEh+tl
-          8z8lO4KZOGoLqeIR8qeHSCqm+rGpEoDNgtdcbucPcDK9caZHY6OTInM9FNxb64vWYNLNSl4LrHL1
-          6S+srmprPK7mHz5gz+ejevMuXQ/Ha2rNa8o6lD/uZyCZJWOxo16+2lbLHSMF78wnp3Nh14IMLgFy
-          Ccl8cfG7eoVX3wQDqNM5V2vb5V43zoJQOA0YM0SrBdb2IByHr4TP9jmh458+7J/Nl3i3uzywrPPZ
-          oKq9juR0Db/5n98B0SWSsaFIL7rGr094NJ9CQ+S68vLpzx/Kxb0hlhRvGjnqLgspux2x0fb9sGjk
-          PEIjNU6zmECgTT9kd3D3W9hR7pNGzYfBwsvp4vnAuZtg7Q8wgcqwn0Q+FJm7Tm6YQJBb0u43K5cm
-          +0TQn/9eSedp733/wKbma6w1L5R3h+k+woh3GWz/3i2Y5TzY4BlWLrZ98TvQ2FdL9GoPwdx5/GVY
-          IBIXqEqfAXsf7kl/nFnHSPwE/yHtTLYWxIEo/EAsRKYkSyaRSYKAijtARAZFpgB5+j7497J3vfZ4
-          TjSVyr1fkiphipKty0fI7mRYH5wbcXRmR9f3lS8QBtd0kjJghCtlfQ8pSfaZgo7/hgvCEguTdF4n
-          VH6NlJYWP0hTDTTsePW539dVaKD11NZYJZKncU/p6gHsmwK+v1WmWnL35sKafXnEdtXtgnvS+PDw
-          nkNsoFRxliP3ctHrGUb4GB/kzf8vOtrmm7h3lg9fW7xLSD1j4hgTpXS5ihE8VEHvAZlenCJsPgMU
-          5u1G4lH90qE4ABtynqFgN7/pKYexrMM73t48c8XQ07JSVXRb9Ag/MnFNhzpyVunCrOmfPpiwYr2h
-          w8RvfLgvrTYKAieg+LILsG0fdbDAyn3/+Tfvw4zOYr1VG17L6E3se5o7nCKZOQzeY4PVbX8g1uPJ
-          QLk+FtNeC2g/uzcdwtnjIqz89I8bP2bACjeN2G9rT2fmHE3g5x8OYHuW6VwqAxblkGJ3f52rtdbS
-          9sczic5aTfoRdY2D0VAdpqv+SfpZWhMWzh8X4NvGX6fBEnKYsNadbPFDaSqULpo+g0zOObH6b3XJ
-          3kAzaxdnhgl+emeAqdedsSWl35AMXwGCyS0zbKfyMd2/p61LmiffyVOOi4rAImGkGdy9rYq6HHJ+
-          NOaQsrOIz814Cv/0OwZRimXyiuheKKUcuvfaJs/cbqoO1I8YbPHo9dZrAIQaQYDCNvB/+b2f9bsV
-          wIifvsTrv7I2lJ9HAcvH9Yat12Bt+crXEYl8ySMb7+T2F6mDxyu4eXN/7ZyxP62SVJ0S0ZuzkfaL
-          pHQuHN/OxfuWteaMuTWUMDwZA/7xuyXjzDc8NzAm94hZ0tWjjgrurdcSuzmndIwRm0BR7wg+CX5B
-          qTwm8y9eSLTbqWD/yx8Jx1z/+MTyiIQIit9q9IRrpoX7RyRcQSuaDFF85qQtNgeuMCHoMEmp/AmH
-          OtJm6ecX4vokOxx/SLdVLx9IvH2fHUQ/QHafNcR0jEc4/PRPlxk7bDhJGJJt/UDiLwFRpHMJ1pkT
-          VjGKeJuYViUDVraFFqopZj1BGSttX/SGACsR0WnIPnM6CbUTwIekpDjhSrnng/AybWVK1m28o7b+
-          PkfL18ABLiQ6Wm/bhkE9GN5etkdA562LZFSok0flXKPfu9e0Pz0y8T++/SmzGGKG08jJFywwnwv1
-          KsifxsTu5etWy4jSGV662sRWw1OwrnHqwe/sLh5bt1HF3+5tAlgTuT9/WS0cuGUwv4COGKpbgSUm
-          SAAOn143/Qwr0vlRAW9lunUZJJzTqbHgShvfwk5saxWVor0sxcGzIxr+rNr60qxC3PQL8VL/ElJ/
-          ob5UJR9I8MIpGjvGpgzSQmmJ5+iqw1V1JUHbpXfi9jNTrfl3lGFRTunEP1oIhlbRTfhR1W7a/Axd
-          fzxaeC0+9rrl7azf8pHB0d4t3p7GZUhE7hRAJck/+GjedcpXyrIi9tNuNXfOVsoJphGAjoE5OR2D
-          G1hO/CmHj0UdPEl3DWfjOTlirJsy7Wofp7OeAghdaVdgA4GYzvoJZaBVDy458NWojTfL9GEPXjHW
-          8pRWo8XKHdzy4bRLSz4cXqHYQZONzh6iY1gttJEl1B5qlhi5x4Lh9GFMWKr8E2/jofOJWhAK4tP5
-          7WfOrCyTD+d36Xt76frWFkec1D+94XPPuBqQ18nQ90/JprdSMLXnIYBT5MVYTtAzJazlMgDmRCdH
-          5d3TJVT3bzjaaMFH0eY0Mpwo88uHnjTuwr4/LV8T5vc0IO5gKg4bF9N2I9rFxC48Xpsf35758QIS
-          7N7fauE51wVOUMTYvGZVOO261oAj2vtYrxrSLw+B+si/eR0+JpdBo9+0vcJRCW7ePmddsDJoYVHH
-          Pt/ksPn3YZp5E/54kvIVBG219uccCme9wZesfmnr6FY2Ei+3ZOpuxVMbJ0Eu//SKfu9msGTebgY3
-          jcCJC5H8r3/Z1hM+FukekLTrB7D5kalOpaxavAvy/nh1+NIUwHW9PCF0WPmJCdSGrhxbXqXPkryI
-          V3p3Z6W8KkB2F4Xk9tE0sCqSmQG7zxtP3OWexvVgkeCTmD4+fYZeo5B7xnAO5ZZo93gCa8rfY+Ch
-          MCYKBq0zJtuLKiJ1CtG0hU1Xs24DcCvvJlYczXOWlzIPcG05c2qMg1vNFztWYT9dL16/8cAFXgwd
-          trB7Y/tyaPvlUzUe2M47PGYYGmdA9TuH7jg/iOLSMpyVbxvBx8V8TMWZYLDshXr+nV95dTCMzozn
-          VwJh4I5T8xzedMuvEfy8QfvTD+Dn78As71lst3oE6OqMxc9vTqwzWeF8vKfJn16+K7tGo9IsqdCC
-          xoRPlmQ4g7K8A/DTu6KcpIDGgm+gUbhaE3rpD22Y5p0JD/Nz8vjz+tTWw0dmkewMIvHPdeN8w3yt
-          4SoWdNNDFVh1KajRlg/IuSnLDTDCDoat7xP/HTbpYl58CGcnGojGBSKdPnviwh+//umhzrOOpbTx
-          oIlhHq9+2e3CQXqpRoDN8GuHS37r/3g49rJQCifjxJRgjiuC8eUj9KRH9gBplgRYPtcHjRVfrxZx
-          6Y4QZRd9eoou2IRPLVC386qtq4rDynDIEx57m7/sHHOfSBQtLfbAnoarnMbzHx+5mwePbvkpg+dv
-          LhNVqmr69dUqQ+N5p5KjaF+d+ftQTOQyDxMfr7aSrue5zKDjXXVsfxRCl2uWqD8+jj0/WMB8E2cB
-          Xp1d7sFz/qKs8CXvH+8iGL8mOqt5VkBD7crtPLYPB6teIrg21wJr1hCGa/P0O2Qpr4jYiXlKh3J9
-          RUgd4xbffvzqx+M9fj1j6/M5bvE1rPBZ97H3fUIWkG7r8m7t3lf8O0+l2XhNYFjPLf79HvLjrXVm
-          f37nJWnnzXEEeefyngDgj+kSXPEV/PY/o7w/+5mrbQ+aM/fFG1/QhnNhRz+9ePJRsPSzNewCWBcR
-          ICnTySm/e0gxVAy4w1b21UNeYoQC7kshJ3bJHZxp51XGn5+Ni5Gn8w74HqhkqfTY5XVzNh4tgx+/
-          cB/PLv1+TltXjKCWf/xMm7HRCP+nRoHw3zcKynRdif2NbtXcrQ8OKNM6eftCHCsSmhID44tREHWf
-          fqoxKAIOEYvx8eGAw2q0aWyg/CU9iaomsJ/fpZPBRpRVEuPvSudUN7YqobHsLYlxD/fJnZYSvSjm
-          1F3pvidtP2fowLQVOSihDfaPB4FgMTo0JTf7QgeRCjPU3/ID5/w561d1ZFZ4DooHub+3PpF0iiOY
-          p98CY2PQAbkNZxt2lxLg01XTHbYdqze8PaSEyOuuCVeVrTs0EsnERmgW/RRXagRo7xtEzXWuWsJg
-          Z0CDfLppOCo5WPn+KsGcqUqiO66h0TmmHnp9MoLNhjzCHjfZBKUsMb3F7YR0tV8kBouEZJza5cvZ
-          n1/+1hdXu5NDUY7has4ygw7XXe3xw97U5vRcFvBVflesVucDpW1jv2Ep8jwxnrcgpI3EZeh9jGpy
-          lpDac158z6Auy9DrFDkK2a7hJXifWYPchdFJScANEmCU59MT72KRsm5nBSg4OOpEqbgR+us+A7tA
-          VnF2DrHGydlUw0T1jxO33jRneWoWC3cO1fBhmt8O3/ZCjrTZv+MbaeOe1nsjRnX/ZrCsOF8w+7Kz
-          QvlTf6eyat/aMjTCCjST5UgQ1XnKIv9rQveV6SSkeQRY8so8ZH+fjPcVTRWwl5TxoS/tH0RJDDHt
-          NewM0JRtb1qkY1jtudu4wsMcqTioWsPhxdiB8JBci2nPnW/hak+HCHr3xicPl9FStnI0D83ZAWCd
-          1HK/h6FqwMtOuZDEttxtfj4JT77PK3G4dKBUsc8ZUvXZJ9EcKOGcWQwLIYA8vm/j45mT4EIq3hyi
-          ve+RwzPScAU3ck2Jzb8/PQ1xyyFD1ht89RY5ZE9fJ4NWW/LEy+5SNS+y7CJycELiXhXSz94ESli5
-          RMTGLh56Lin1ElpBKBJZvgcOP5gFhzAvR+RyQqxDk/lQAzEsG3y67wa6LEp/Be9U0slTMffhcHeF
-          ACQX2yKaY58rumebAapX74xta2LpoJNyRfF5pxA15FDVK3DfgYBfPpNgPlVn7hpeQHnaF9hzMlNj
-          fdqsSLLhkaj6vaL8+hgzWLwY01vx8xGukvp04RA8DsTCPqGztK4M4j0xJbmwd8N9oeoycr1aIdqr
-          D3v2Num+OB6Onbfu009PPgGsYas2/vbGwgJ8zyUr9BnvTqxHblJ+BCcZni7rEaffRev3jiibKLg2
-          Gs6sm5HO+YuV0Mcrv9iDy15bQRoa6BWImGConAFl4TlGeXFSsCNCxpkX2fRQfNELbE1c0PP13kuA
-          +RRm7DJzF9LTx78iCYgeUUCk0rkd+zcUsujpPVc404XnzgMy3oZBbEWOUvZZ7AzovnJ9aqcH2gQK
-          LiSYzCH2yshO2Yrnr3/5xrT51Fn7yVqByWZnjOmtDWlgzSuMrt1A8Msi1feqiTo87+Onxw007CcU
-          fhJY0NjC2oPYgGW0Q4I+dengx1AbDnXS2UPnuSmJbOUrYHvhJEH+vORYyw1H21/qYwA18Eyxjm7b
-          /K4XDl4PQYQDR4rAohSghNbeAfiYu3w/S2LBAfN1XTFuCgx4WX/FKB1nTGI37cAAhF6FWqck3sjc
-          PimVu08LD0lUYPMz1ZsDkzo4B/UNG7J0BDyoagMej0E3sW9OdhY/bd/weZRkonDvMqXX91eHYSG1
-          0+ciTv2yb6wSWTeDw9oHa856Ej4dDCLQkBPLY42t9MsVlu2dI16Tp+HYbFUOz3RUyD335Yr9pI9a
-          Gr/pSLQ321cTIyourDTvgvUbh8N11zcZfD0pmZarPVdjbFYR2uVSiU/nQQNTMpU5qkgDiDE2TsgN
-          xaRKAnpp2LwXfc+5YpPDI0dnYt1FOaTGILLwt94T2LfV/Cx4Hb1vxyN28jGtlhgcSyCHikVO5Mb1
-          c3lIbTg/ljtO63br2/3cT+iSOSHRdwQ4lFESH4iF9SWHGOvhuuIhBt9ddZ+ksb/RpW5KF6SoXInH
-          5q6zAg+Zv3yHtbe69U3eIROmx3ki+eBUDg0vvoSeze6A3UowHd4b5RgZyqxND01UQ/5jXFtUsVY2
-          RRTIYD/2LQe2/Oatmt/3JDoiUzpVe5coJXsH3Dg6EIJGxcQMm7Rnax8E8NI99uTQ7rl0/u3Pz/r8
-          wTd2FKtlBtRFA+2/WNEaPp0fmc6htRgPROe6JF0t8NIhY/gZTttdD1pfvLDo5V0mb4sfyj3cuEXT
-          pT2R0+U8pNMhF9Zf/E5z8LEBW8iFgCLYnXAWHN6U2zGLj7zYwjg93L/OeD82BYp6zyU44Z/pcrAV
-          Fh0vjYszJ945VLXSFvz+/6A6H8DsEjFCKh/v8fO0Mj1VrbCFQnevifVmXhqnh3EHHpqWEHN6PAA/
-          mC0HH8KSE/fzmPu19cMOqUq7kPSzZiGxrc6DaRZ5JHh9d9qQnssSfadjjE2bB85yTsoZJu/axiF+
-          nQHLlUUN7e+Dwam2F9OF5+4DGtHuRJTz9uYlyp8u3M3H48T0agc+jBIEsE5MhE3dVOiI8tKDPQL1
-          RCZvTofL1XDRrrjWJOMeSkrIXVQRHYYj8Tf9Q/8BAAD//6RdybaCOBD9IBcySZIlk8hkgoCIO0FE
-          UWQOkK/vg6+XvevlOz4Rkqq6Q4Vk2n8T1F8CjRogkdnchq8JIf+VjOC8BW4fU80A71RIiX7ANejf
-          +qVA46Jy43xifjpt4pMHB/j08NYYEPggN74htciP4wbUGVgeF2mBiw9fGKz1e9rzNwGGqrP/409C
-          raMepodlJNbZ7lLWQ4eDiONSqippVU5DvJNgve8piTIwhb1XhgnsRlcl3rtV3F/8Qvl7GTFa6+Fi
-          vgsOvocgo/aTb3Rm67IFC3azx830KsP52FYVWISNTr25s0sxDu8B4BaPUmd7SFgjTk2LNO4U07Q0
-          UiAijvPhafq+xqdQvcJlQnGEfvmP22+Yck1BOLBen7qXrwpm5xrffnyA2OhRusOteCYQfuiO7D/+
-          kQ32UChoIUVBDltdYa2SVe91H9kjuQ2dyGhJ4xit9e2v/nGlcY9hauce3klDl7LZveTyqyvPlCRC
-          1c3BkWgQmpjRg+K8y4mo9hvYdSGSvcVl+rLmDzS4aEvd9XmY6JUC9Mb4PXKhbHbLco4y0K/nktua
-          S3WWLCqG5qz2P34B5gXbARy6vTuCTZinrBX9N4zKcKJ7xUzLxU7FGN6qyiHad1ultDoaL7DcRW0U
-          eWvWF+OqjPIZ7ASavdvCXfmzBH545whXKZwfMJWg0o7WCI594Ir40dc/PjSKOvXAgAXcy3Pn3bEs
-          uv6KH8UbSYD/YHH2rHCKQa1B+2IIWKgzlg6bCxdDi5cCPKz1YmJSlsNA3plkf3RhSgfu4sDoOrkk
-          yB/Y5dZ8h7/rBflj1HsoDhjeL2+Z5OdW1Vd+VkCuWMaVL907uj1oETCW7jlKp+OrWyT0lmBbindy
-          POQt641G7qE8jR5VSzKHbF+kEnwq+pHiqnNKJjAqA6cF23E5z8dOXPUODKpzRS3LaLsFYN6CfNOe
-          qJudX9380FUOms+T/fu75Nb5he7noY78eN2z2ToKPtwP+DVylVGnS3vey3DVY3T/1vOOJYuNd8xK
-          DBqEAupmLuneML1JR3KZN4q+XGv5BtDdTYkrL0eX9zaSBzw3e42768EqOUPwawjuh4WaIFtXpj38
-          G9rO02fVT/tQpObggdwhj1F6Mq6bZtZ6gAQ5R3Cire80OLIFd8LtS1TjQlKWgaEHwd7WqDVyuc6k
-          PdqAKIkcenoz1RVMY2vCEqcXohQ3L5xPh3wD740C6P0V8GAsucYEuZ/lNEdfYz1H/DrCbBxianya
-          iQ3o4xtwmq5bkuxMnIqz+8ihOnnTOD5Rq8+6tHvD/vx+05C+ep0WDxeC1M48stpL4bzpLAfCKJSo
-          kWy/5eLf3REBogxYvPOXkBVvToPJrlbWevoMZ5nLzR9ej3frq7u5Lmej7C3SnvziZQqd0QB4Y00Y
-          OC/V5W/md4SkYPE4Pl9BN6sFe/3q/Vitemu5+FwMUzkNya/+sa404S6Idp9RRKnsss1xwuAFQmnc
-          jtgPl3wDBSgK8WbkzUxjy2e3nnKGDUywhQt3um3iFmrfNsA780XTGRwDBb665xmL11zUp++4OnBq
-          KuDNXkpKxtdkgcj6gDEKH9Sd3vrjJdvBaTdu1bIH9Be/9rnlieVfWNknjItQ0T16PKmuDVgGPj10
-          jsaFHHTag8UGjQkGN66pWmQFa4zNs4U1yNkvftL3S+IdxN2ljp7SsdDp/cgWoEDLpvf6uGcL/xAm
-          +A1Nh3gyp3ZLxrIRWemBEYKwqvNEe/cwEUKD7OX6Uv7wDQ7NdSDaPdiwaXwFGvqebj31eD9wxSkB
-          Hlzxi5yyfVFOnXtd4KMx37hrYs+d7k3xhs32eSXmcWt1CxfltfxQ0w9VBdcBvEl2MkA92GB04F13
-          ip9VBOvzPcCIy8SS5R6/gbIdNGOn3pW0l3frhhLfIqGZoDVszoWSgy+4jYmRLom74ulLnjZbRP70
-          o1npEDWn7Lzqk6VkWyXLocHF21Funybjazy9IETtmSpZrv/pKaiyiJDAte76VL30HFwnwSQkMUbW
-          DF3BIWEJEtz3qHHrId7Jf/z1cHJHfcZTXkOPTp/f/YE2TgoNHSOjISR4C+kabx6UHCknqrFUrF71
-          B1S7jhA3O2vddA2KCE5DCXEnKOfwj2/++LZyObvpPMyJDA18uY87/2rpgn/XR/DTYya+KTpXDHcF
-          Pg3BoU4Kj6UQ8OqEQj638B/eFs5dA9kbnik+7L+M9VbBoV1cGyRc9Y3wWYYMbr53hfjYb8vJ390F
-          uN+JFdWmhoIpP+cQylPv0XStn0so7ziQEy0j9n4SS+amkvdXLzVrMvQlD5QRHoPUxcuzeegN/1EL
-          9POTnIZSl72a0YffPPTIyh86do5CA+Bs440llGOd6WDLwef74hNMmJUKIeduYJ4vW+qq9yLt00tQ
-          QVvhJaKo1TPtJ65WIPlUIbFOR63koRdhGNXGQFTUZ/qiH+s33BVuQ5xtfnWn3kkhpOY3IkeJXdjC
-          ccoNPStl/OnxdDbJToJWqfjUtUrZ7VwS+OiHr90mzMP5vLEg3JaZTi/CWQl5PMU1eqoP/McfBvup
-          mWjlo2M3N7zOPtHkIfgZdtQzmg9Yzp5mgp//ds/jwWWqeKwgBBsRSyO3cXvev1XgYjwRiYu3ypbk
-          fvNBeGsajLr0yBjpnQq49bsYhfkZuRORwxqOdzoRQhXL5d2HmSGq33l6RE7ifgfuYQGzMkwSuh9b
-          n3fjqEA0fjO8kXSuHLVhM8G31UOKRw+A0f0+chg+soq63yVL13jrd59QeRKDlFXKqsKPkWN+INFO
-          vMHek5wYYN4Yj5VPmeU0cYWG5ANXk9MXndjqF3hojW+CE25xp7rix58eHYttM3YMTI4CIsFdRm6n
-          PAG/LaMc9AKziOUrLF3UV9zCkIw63uJjrE/y1peQ4HA83nxykE6Xb5zI1kgCckQfUs4TvQc7ujvu
-          yOG8G8sfXoOV/xGy+jtMMZoEOomOqHbYePqzieoKCrdvsvKp9VQ7OkfoAN7Dn35ZJNTLQKbrKbKs
-          sMP5iJYEdWj3HkX51Og/PgxzomTkoqGzzv3ypeTcjBDI7JJV4XKDzuxsMPjc9FWvNQb8+UFRcqSg
-          PzZuDle9hAVeisJJPBsCWvGYnPPNvWTNXBR/422sfprYtHILaXURKYkeVfrFVfAC6bAQYt6aE+jN
-          sd/AB8Q6cb8p1Ac/WkYYYyZRr0mUji9730Du565S7FQ7fRyq3IC7nH7HOglhypp2aRHHRxjvlM2W
-          /fTXeq7RndqkO6TicOgUuB8lBYvG8w0Wl6HbH9/d3773lEEtMWEQf/XV79LBlPn9CL1F3lML+o+w
-          D53KAMfPqyXHTonDSSDRAgv/daBrPIHFHQ6vPz2oX5O2HPVjUUEtNBfiOEVfLp6p5394vPn5VYu1
-          ecFVr47iOt/UtfoEjEExkjuZQ8CKJDfkix3J9DHZSigWSWyATGmDcene+M8fBvGzAcS9xWnaX7dZ
-          BsKh7Kh3UDesc6337ac/6O/ztb71aN6Yj7F4em9doKdagWhz2VJlPBmM5R7agNmKUnLZGTuwqLU5
-          giwwQ+poR71rEbs68Ha2bHKOu6ibts85hllZRNRb+T1r77EkyZevS4irf9w5Oau+LN06FVPQzuGf
-          vz5KBRmZF9pggbd7AAdZHImS5WXZWk1qypHI+2T130B/fN3fQN2UJ2qma0f/8s0TwJsLIWT/OJdL
-          +2pq8PO7/af3dhd86t6gXlfMm5Ywdf0Pr2KBpMTWqqqchNipITptrgSjr+EODvMNWN98Qh/sYqWz
-          ZWEP/vJZbp8VGLyNhGXBdi9U3eQh41f/D2YjjfF51RPM0bgYVqlkUF+tnuECvzsF9i9S08NcWt30
-          /a764aS4f/cv0FOhofNdmOn+Ge3d+av7CZqmdEvW+sUGdTjl6Np+D0RNR0Xnw07e/PoPuOnOair8
-          +F54Z9a4ySYZDP1HmuQPvivE5uJO75o8G2HM9pBau+cH1KXrevA3nwEtxLIHUqn89B91ADow9g1g
-          BTgva9d+w4cxMTyNuzU/8VxHS9ioVVfBE7WLcZvibTm4Hy5Gfr8k1D3VMuhTA09ydOIp8azPWI5j
-          b1oQcUJKrO/l7c6vm2NApn8PePGPuT746ihD+QwGuv/VB/4wV4BtLIteulOSzqYebv78I/2ALcCm
-          z8kCq39IdZPN4TLfFQc5/edOnE+C2ahAP4LDHDs/v9rtE+UWwVr7+tTIwJQO7gdG8GonJVE3uy5c
-          jNBv0doPoQfDHMKZAGGCV/SwsbTi79x5nARXvw+DOYjA1O70HoHxyfCi3bKS+ZukgrV0icbno60B
-          u85uAidBvlF11S9zjk49QCd4JboeFPqSu8F6quLjSNzPrQyncyoE6OSF+YgkJjLKyvvrr1+jzcYh
-          5XxzV0PjJW3IWt/chSu4Cv7m92xx0G2AbDogjvszFoVzES6rP/nH/25O4XULeCkbJJ5Y/vNb9Tl8
-          nDV4OXTZOBzPesc3ajTB050+qOYfNy5TIV9DaMcBUa2Rlktm1hVct+kc+cwd9EV0lR4dDNsdF9dC
-          7nw4NxAeDn5L82y6gfmqiC349fvU/H7tmBSEEtBi70SttR6v/iv+6WE82fnCKpehBKDydsN8ynl/
-          ehGufh/Z9/PDnZgU5ZC7r3uEPG9z1z2uoQTVCU/4VKhNOP3i99EYb2qz2knnJqrfkFswxRIlfDm9
-          Nh8MyHEX4vkG65DK76cEr/eN/ue/zkcnSeRV3xGNPFA68dlUoJU/Ure2MzY1/bDAZvYkcgLRi7FK
-          qSp4pYlB7hK7AObdlhs0X/BLlOSgp7xvZQs4Hz6MkEsgAHZXzxxsXlL8m89waWK3h/rIXeh9xYvF
-          lUsf7jhq423bHNiwhHOEVv634tM3nIiqVmj1T+jaH0hXPTYB5Jyu1BbfTF9CTodIXPfIcouTG/Lh
-          466B0Rd9zLjvoLdv1vnwtWm5EX7UIvzzP1RX6im+dFdAPZzlwOLlgCif8h1Sa+MokFe3wZ/eWDaP
-          Q4GKg9tQNx9AN8xqF0Fwkqa/ejKpSVuA6oYrzKIqAMLKTwGr7jaxcuy57KXXCozK00SIJBagZ24R
-          IUC0YZSQdtF/9RadvFNOsyYpumXz4ROAr18fS6QJQN+fbA6u9Z64VnnTl2ejQNAahkwNtR/A8ko/
-          Hlj16jiv8bD6bwLUuDCmP799AntVgTmLCup6spxSuT1B+IyqgZjZUS1ZfHMdaKj9jWYDVVjz6QIf
-          aqGxkNPHUVPq2C8MOWf2Rt6uGKBg0jQo7vI7te5qBkbzvkC01jcMSiNl0zWoI/jr5zitU3Vz/9Bk
-          OHQHl5IAxGUTdguEfhpfxuVW7lMBWIcAhDapsXz5DOk6XhqcvEuCi0z3dNZp0wTJ5x2Sn78xM/Nc
-          ofZcAJoa3hWwX//xh/eade7Lv/FOoTGP3NrfpI9rKv/6tVStqQ1qfaor+OWhh6V7FqXCfSvX8HC7
-          2dQj9JHOvlrJgGZCsPKrohv65Kz8nxUFu/9eUYA9z6Epd/qy5n0cLbjXtQ5vs08DpqI4yvBY+ieC
-          +2Ri00wkB+Zh7hClFd9sSl/cBhVw+xjn/ATS6bi55uBg5huqbpqpnARD0RD6OtnIWdAqhYhvY3g9
-          ZW9imDUfDu041pC37QN1qubTzY9r7AN7jGpy9jaf8C2KlwgeTo1NcigM3TSTyUGmRAlVneqpzwZY
-          JnRiiUH82SzTaTneJ4C4t0Quef12l14bKijPpU6d9gH12vwYAnq/cEpwHI1l37/wRt6S/YnacQ3K
-          SV00Bz5d7Tn2OXml07jRapBKtKZH962zmb6EF0JfKxs3jF7KPhZHB3LFEdPj3veBmB89D8Lv8Uui
-          qw/ADL6nDXw50TS+3KkKJ+9UCGjsNzd8XD5LOO8f7U2m/uwRD3O7kG2a4wJn4/igWi7CcIkTY0Js
-          nz5HYcMxd5KmqUavKWV4GQW75Dea9QKJVLSYKxu9Wz9vUXB9mPSwPr/Abh8Nfa/LQo8p6tiiC0kE
-          w7T2SLb+3sQ/dA8ZvU5HRHGX9p4f1qieaU3MjXtz+du3XpB8PHREr5taH07NJUJPK0eY6o3vCkS9
-          vWCkDoQqytnUeR8BDgrPPaKpYmAgDLt3BoM3fNMre59dsRZ2Juq1447oj/s9XcDl6YNPpXtUb4Kn
-          OwrlNYG/+Dl+alMXPh0I4NhfOGI6s94J+0SeYMi2BdUfr0WfDLcrYFNZW3rZ3jj9QwdjQdKbL4lm
-          EcGd27GqgTSpI/XF3R6wN73KsP0ODxrBbaIzxd1ZcB7shIZBMesfQjYKpLKWENskrFu2DyVDfeNx
-          9DRyHuDpJ5HgPGQd1ZNWBiwcPi+0340h0bfyIeRsQfYhOT4u9Cj5Xjl/jMEA9TzUVCdLqc8Kl1bw
-          F6/3s9OkPGvvI1AF2lDzMhLAR/vUhEk7Aeq3YdFx8TgYkIW2T5zv0WaLuS9XBnq7/93P3KePGKz3
-          j6fp7oTTL1+Ojm4Qrf666SjekhjtA5rQQ4RadyrrJYD2AYb0aOlh1+NOs9DQmV9iVeqBiVusVci/
-          bGeqn8VE5zxiZlCA8kDU9feWwxIZyGcupC7nhfp0eeeCXC8aoNZ+P4YsKh8+lCZ9JEZ8v7ois6kj
-          b7PnQOyrqncLv31OaDAOPd41u9Tl1/iHk9+r1LmEp1BIjWKC67u05BIhxxWujxIirctCoogUpv3Z
-          4V/IQbVILKZbbJSb8obGk9ticQPeq4MevuFdLnzqmPHHnWfyxehqaBY5PA5hJ16Ek7xbzH1A3adS
-          h/OCBg1KngfJUaJQH24ffAOmcZLW7+9dcZv4HPqsCs22ShMI3vjggN7aEINBejDB3HcZJAnkqVtc
-          aDo9PaGC0usT4MbLF50tmZBDeJ1d/LaLnk3FMzWgFZJmnGercJdPB3zoWdmbOkeD6XTXQQEGS6qM
-          cKzbdFYYvsHDCWYkD6562McSiyHb99yaH5UrcPZkIq9sKRa7dq8LCWfl0BxKYx3/nTsQstFg0g87
-          cr4c9W6KxcqBnpO+iDp/aTe5t6cMB8FfiHY+XVxhqZQMrf9PH3Fa6P1+qgPoxA0kNpGPHd0fOAk6
-          cQexbNeXsF/2jQxjBYbjLlg+7hR5zgiJs2OYMqHRF856yehwugijcKsO6RL4wxvezcQjKncLUv6+
-          hTI6ZwLGTWx77jyOVwi3gnmkjj14utgh3USl+0FjE9u9PonaIsBLrvj01N33jLMsmIPP7TnSXHs4
-          YLk2i4c6ZdMTLPQlmzfbyoCbRiH09P6MHdWk54TmUwcwmOQCzPGdYngYrGpEkt+XUydONUxUXqNa
-          rX9dccTTG0bZ7rrm+w0s8vLOQc2FHlGGT8BErMUTYvBgE28uVMbfBSBAsq3vxN0UprsM8txC7b7f
-          kPNVgIDubc1EwbIf6H44wHS67x+JPDxCgR7f20Fnx6PswZZfnpjTT2M4Zf4i/MaTWntHd8Wk1N7I
-          GlM2QsxdU+GC1ALtdaWjyededpMzzBglPDLJzV4UIBxgG0EBfm/ExPqZLUQ0PCSehS819Fh3uRVP
-          4W4GT2LHxiVkW49PoL3Rz9RK0lfHn9jwhpFKyci3V5yKQ8MW1IlnlerC+hpcxLcRRGm9IVEzSiXT
-          BxzBQctVclLAweV+8dHW0Z5e1C8Plg+jFrzm8paYeXZn0+NV++icvQBRR98q+e/3kKHZfEx/+Tzy
-          6HADgjN8iZbYY8dsjCXIF45OLsb7pQvdGUp/+eE7byOcrzSqkRONm1F8aDlg18vXAei4I8S2ygp8
-          itMrAZksjzTyQtqNt7iVEEhwh7dhaXXieH4EoCFLQ3FSPxkv6FsDPg4BIOpNjlIhD4EAuXMUE+V4
-          +brTcAo0dN/PFQ1XPGIv5+7AOtW31FoeRsmGYhkR+Fy4cbpda5eWWuNDhZgm/iD66hYinRKodbZC
-          Tqdryeh3K1vo5dQ6xX3is0XyHQPIVSxRp90/Uyratxw0qX8goRUfugUBX4A/PrCJI9yxm7l4yIbm
-          hWaLYerT9FwCVMQnkZ6vYC6nrSVZyHe4+pcvjC65XqM84N9Ee3J1OaTZMYJX/foiP/7A5LcFkc7D
-          YRSpWYA/flgvMaa4TN9pvbUmB1WTsMPok2cdSzlJAUm7gHHT3z8lrflShn1339NraUrhtOjkBdZ6
-          TYyVH02Naynomktb6jqw0qdgXUNcvk4VuS8q1pcdlPtfvcIS7VWw2A9jkl3bOY9sGSFYStuX0DX/
-          9lTdOE99Zl0rQa+sKbFcaWLLxXTqP75gi4rPePsDbyD1Dxq1pAank0dwjo6vpqPhWUxccQlRAtf5
-          InaMCzbJYWggyzQKmvCC2wkPZ5lgabdbsl/rKX+5KC8I3ygmrjjoIavXXddiMa6JnplxN+EGQnjJ
-          NR+L0XXPWPSZa5j6tzPRXvdnx6K0vKFEFTViBZrcTdx8jGERtR6xXLTvxmHqbvCiBC/MSl3rxKR0
-          Knjbh2fqqfYjnOMcJjv7nFCyv1gjW5DuTaB8hRVeDHYLB0EXTXj0TudfvoZzO9sKnA9mTL3obYWc
-          dv/U8GB4A7FLM0mXPIMyjG6bdNzBznVZjk8J6JTuSgmbo3Cmb32E5Di11O77Oxiq+TyCE26uI/oY
-          KuOA4k5yX4Mn1aLl2y2vNFWgIRKZYlIppdhtEh9eJccjxn6bpcv10UHwQLAk2pMyVm8P7UZOjEM4
-          Lh/fCBccZn/zN24978kWoxhb8P0eMTE746337q2RYZ9rDcWPrdVN5LJwQFef8V8+TDnqcvAoME/M
-          t9cDNjw+BXwc3ph6Y8l3NNAcE54uUkXC3eHNJnE3j3C/uyq/+Ain+uvfwJqvdL/m6/R4FQH8vjeI
-          uNMkhq3cSm/wALctNQfRZIJ22EfQMRGhWddt9KFaXhIE3nCkivMg3WzJiQw3aVCMrH6zdABTqkCq
-          63dKKs5y1/HSwL7rTtTWL5kuojbYwDYro3G3n97u3FLAAb6wdKpMdyedPD9tgWfZpxHmzOymOdlh
-          sLsoDU036ZyyolrfyUhb7w/vh0Zdz+2tNYUcg+Pd5TPXT+ATyhF172+vFLvD9QYO5nSi151Uh8u1
-          HjTYZs8ISwl/D3/5CjM6luPXvRid4FUdhJv7MV/j99YtTXtKoNqER0LE4A0m2TY4CJdhT9f6XbLv
-          dnEgF9wf1BEPWsq7VixAejIfeCxPMutt/mMieBGO9BBJfMrul1sG/XJ60Zy5LGSl1gTwaS0+1U7b
-          N/tMgfr+F+9ubg1W/In/4tu2D66+0Chdt2XljvQR5gxQTWomiF1JJEntV+FimlOLPnPR0kcs03LZ
-          fr4O8s6fgRxTSXQHH44teMKvSu1+Xso1XjdwZ7+P1KK9yqYkbGSoSd8MA8XWy5l7RjV8X4MnltsH
-          dGfd+y7wqqcvvIVSG44DjT3oHILXuIHWFgwXT175+CYkVk15xjjhMQFwyyGe3x9c9lNvvaDCu/YI
-          cstnzHtwMRyE935dxKSE8+FYBJADY0ew5+xdLmjqAKK03eDecIt0yUMmgMn4oFW/WTovr+eII+y9
-          6OGh5Yy9nLPzNz4n19mH86v3pd11N4tUQe/CncJs24KP60SrPr2Gv+dD5Hi//D7XB5j7MqC7dFnx
-          2uj60fI3qHiZNTUaNqRD1TQCfJZnnjrDJSyfvslt0GuTcfQanrhyPnihAfOd8Bi56VCUDS73EUw6
-          A5Mw+HxAk7iDiS5awX71suRHqfYgttuKGPbn2VExSF9Adp0B87pIw8UFSo7W+kUxyS4uO7zKG7jc
-          R0T0fl8yVnPxCJ/OgKl5YUbHe2LDwU+lepgvyBsM3+8hh3hLa/qnN41S1ZCuz1/iTKRzmRItHtx+
-          qTR+Z25kzLiK2q9eU3W2Cn05Zvce4kmDdD/wjj5upE0OLEvPyWHmRtBVFgigfOxP5GprQjoNWKyR
-          EL8Ssi9GLm24Z9TCRCIXvKz6nz2W1WHLhC/98XP2AJqycyP9SHR24VljRnizi8jkE82tIJhE6V2g
-          mfaQGLCoyzVfNdjUY0n3orxhNBSqCvTKG9OcVEX3yy8gJ/LaUZTalKnKuQf8a68S64H3+vTj/0cn
-          uuBs89LYnDk63gXKUSYH3j0DdnJ1B631gFgJj8LJrAINXeqdNW4qA5XTEWxNuOoloi3rO9Hnssag
-          bU86fsunduW7i4fk+anTVa/oQ/CaWiRubJkewEYK20Gea+g99y654EZgS7IwH/F2fiPmhb3LZVur
-          L/TDF016lmCxL76EtncrpP7x8tXZ0IBJHtubgLetrzOh14Y37IXOp3YW8qA+bk453LZhNtZJPLD1
-          VIcJndXaoDqxW70ZxxNEXPB4EFzDs7sMNPfkB9qUWMSNACjwdzUMCZ8Sl/OYOxPLceDmWMx/fkh9
-          E08ZyAupIvsfy1jrMVCapsP8t1PS9zo+MpWVhETxVytnT50cELGvRvDuUa16uZkAg3ubeCerLxfO
-          zxdYzZZHglfSA5b0eg0tuFjUkt67bgxR7kHEnT7j8uSsUjCKqoYrf6bHpNrrfKPrHtoP4EWPizrq
-          wzqfKB/Vkfz4EyN13cNBeuqUxPG6h9n7JcHrjonj21rfIWbpglF06ywMT/OnY3h3r3/8gtyGzAqn
-          63Yfwa75Bpj2Dy3kHq86AOIz2q/4VrtsN2gabNX6TtS5N1JegLqFysshpaaqcqxf8WuXj/pIdFgq
-          3RySlQ+6a/3iO9ul0taw0CKTmBqr3zXjmxdAngqUHjZz6vJHnuRw1VPk+JrGbmHBzoGhkmnEH9pv
-          17x95fXTx1R92gtj15v6QolxqwjmN7E7O7lSoJuYpSRd9dsIj6EGOdQ043y66kBQb1kNeBAdafKo
-          H0AY82cA1ZSbqYvgE7C6fwlQ5aYOo5zXw4+3vfdQf1SXsbhoqivWw6SAmx5d1ueN2HSS7xh8PsNu
-          1as6mxsjSUDMmxeq0duRzciGCVxO72nFy1f4y0ew+nG/8QJzfbxmsE7PAckALdy58O8YnvCmp5ju
-          nuvquIRD5+xYj+CQ8uVU3zUHjg/cEW+rBuGffrvD6Uni90nt2I7jJegVTCIaXvcks5pUgde+HmnU
-          d8ZaX/oXXK9H7OYcs764eMIff0oCz3CHrbh4SCxP+o//lVNR7GXYa2RHidC4YNpungLYkFnD4Hbc
-          d3/1upziGgPOYzptXtkb4jc30yMWYpeRb1ggaWqjsWH7fSmM3zaCz81zSzF5dqC2uYsMJxB+8HS7
-          Wnp/G5Mb5G33QLVuE7ii97QLGOA3Jgc8diWVX2CBtPcbYj+4SmfbJBFg3EgeDZZgH46fQcnRjy+f
-          0efqzschfMtcaK77944Zm0PSxNC1Svrn96x8vv3zl/VzYnXDAi8CZGM9kJj7cOyPj5HqeqKuf4/Z
-          Qs8FRrXiWtQIWyEcwBRqf/xpxaOSzo9EkFe/jdpmZIX8B84O/NVnwwtJ1wSvqYbXdu8Q3Yq/3ZDe
-          bwVMOhPTY316hAvNsCxPe6+kt+IcdMtm1t7wCaWIeJHy1sXnvc/Az58k/eMV/vQVuPW+Ty6833ZL
-          23j45z+vfn6aTlclqOByCu8EV/jrDpaybUFYlQZmZCndUW66G7ztqxrzJq3AfGa+DLIhC8jv+uMw
-          T9UfX7O2z0851HHwArqRHEm4L9+gx51jAUPvM4q1m6DP32L1/1a+HHzah86WkL+Be1ie8WfgHXc+
-          s0SC0a2xaMy1djd9vEYCq99LHa/AgHqJsu6hvHnjXXPrymm7aQTwSaoJc4MTpXR4DAXcZuVANbeb
-          y7aLvj2YtE0wboSXHI6nEsrQ3Ckvev4+Y8aZH4+Dhe2MRLloT5c5svgCcRNWVJkSvvzzqxVimDQP
-          rmVI+UpS4KeKHkR9f8ZyXv353/it8y8wNi21BbgxIGRfoaBkVCMb2NbagofF1BjnH/sKOC/3hrei
-          labiuxdfULRuLiXeYdDbVA/fkPrMI3awfHSacpP2h4d6QmlHl7PzhuADbyR494o+779xINtjXFNn
-          J3/0afe5Y7DqPQxus81Yh1wDgokP8JzmSTdNLYh3naiOVPGddcVoEb6QKkaE4vJ0Y3/+lH6PTGKd
-          8ziduWsxwbMaz3i6T9Rl24tewxXfiPsdY33i7xsNxtxjpoeu3buj8pkMWNjWSO8f4wlY9Nm1cDCS
-          9ZRh7+XO2z5foBtSeQRD/tHH6jloUFUuEXH0UgsXzbq9wO20rjhrjl5IK4sFsMnAQt22GsrBU14Q
-          4Y9jEDLoZvnze+FkfBG1r2keTiejK8D6fMRb+XFbqHMPRVgQskefnVs3NzpBdB2VcVd9Lcafut0I
-          3y63x/Nt27hzYeIN+Pm5SPK9bj5PQgFTk+epJ2ECxlPJSfC2G3viOjgJWWca+Nc/wKDI3m7zw6uX
-          o96pWfB7IJbSDQLxtZ2wHMI2ncTdboR4O9TkkpAsXP3QDQwypSUOOnk6s0lmwrtp7siB+5665cO+
-          Dnq/3euf3pnUidvATyLpRG8C1RVXvQtM4+tStd2p5dQquwkYemqTQ1ek5bzyc/DDX8NbHvp84uQJ
-          LiOVxvd5Y5e14FQ9WPklzSQbuLMUzz1syCPGXP8E6TI5xgTXftO4I9vX2iePTOgfzR2eVn1AbTNV
-          QH5ornTVg2zVE7XsuZo17mJcgD4dXAzJ4mmrf1KGVAjrXmYnHIzb8q7q887NfekinN+UmFnA6P2B
-          I7CpR0jUPDXYrCU6hpWXPjELitldJi2RoLnuseyB1k357VDCP/8Tr3prJifdQ6W9CajdPJSUHr1B
-          g9tadckl5Z/hmh/eDw+IU86ju+i8a4G13hPFeRspZ29ZBFf+i5ePSzpebG0NaPfraayDjnXLLY+n
-          nz6gjo6Q+4GVMYGFxvlIdafofv4V2rlCTn/90/kq3UdI3NeVqsbxmo7ed2f9/JFxywRbn+OcS1Cc
-          JyNRn0vHZoWZibz2Z0ZhECvQJ1kL4eo/YI5dg5Kp2mQiM6iPZO0fpj8/UsZTvMZ3OzDa3OoeTkG9
-          JQp6uCE3+Ab362dSxVEKd5H2gIN9tyR/48dWPwyg6/5GTOXud9zlLjmybtyO4+VU6e7Mk6BA51q7
-          Ymi0BLDvoTJ+/T0sLbtHOnzkfIInZsz08vDqsN2TuYfPZ++MyNLD8o9fZoO1JWQ6J4BOS+0ALlgW
-          qjfWpfvhMXSjqCDr/elc+f2YEC16RJXRFnUmX5dRfkT0Qh17UdbTFIxAFqx7TMximvXBkD8VnAzg
-          Ux1eL3ojxbtxlwW+RW6In9JeMbwYZuGO4ffKbzr7UGB4CMENiy6oGav5Uvr5EUQ/w56N24eV/fzF
-          sY/eVrrikQw2t+2RevjcMJayFwfk421DnLK/pr/5hiseYqZVUjdZqlKhpsoD8tPP3TTtJ3nnHiUS
-          f2srpJWj5CjmjQt9xFsjnT7ReYLJQ/rX755++eicldOKR6q+vNJQQ1WCA3o4ZddyMZ5MQOgtu3TV
-          f52Aw6gFqo5duuZXOin7ayH/8PLwlIV0NI+X6P+sKJD/e0XB9hUc6WH3tUu2HJ890tItJWqVh2B6
-          baIcPkVVoe6+Beu5yZOA/KNDsXwRl7A/+XyOovCq0dOuYl1dZJUPTi8joH5D/ZIrZsOC2XKPCcae
-          rwvzca7RW7tD4r4vc9pLYV9ATW/R2JijCIavQSKYCqaFt3JD2ELyewsmnZNIsnkt6fQRnxuY0UAd
-          eUOYypEKtwgWRnckql+7YPYOOIaY4YJ4pfoFTLcaDY7LMaXW0y7KJb9fMXIyPiOBPngp1zrIhJfa
-          qtdzcgx9josthosoWHje93M3R+auhTlTp3E3K2W3eOsuPrrHCQTbFwwm9zDHqBIeHj1EziPl28yu
-          ofxazzWHop+KZelpUOndjqqXpAgHtSgctNkZIb2bz6Wcv4O+nqMUCsTJdEmfBkOrkHvsSxqHJE6X
-          4CkbyIZ7k8ab6OKy7VkwgLnE666UONDFfsdeaIs3B7rn3keXvdz3tFufF8seend88HFvSAcOpraQ
-          RSkLu1iDm3yvEG1zKXXWG04BT9d6HHm3+rizs+MhPG4tg1xV/wZ4xzA26JQvHtk7qEnZIVl6dPYq
-          QPZ98i3ppFxv0A2rhGLvUJbjtowj+PlecxqGb5JO734L4ZQFKbXpq0qFaHeNUfhtrsRDOt9N5HWC
-          6FBvELWzygunkqvfcFxIOvLr9ZlC0hf056NL/PP5mgoM3k0g3Ek4bt+OpzOnMW7gZgbGuCPlzp3n
-          k7ZBwX2wMS8od8CUa5vDqvgmlFyWAkwT8tddAPWOep1g61xFVB8Zz+VKL65rlBRU2wJaL0ckh3Ne
-          urPdDzWMxfC53l+fsk7/ZrCJ3jVmyXU9F6tPNghl95Ikdd+GPNieesRl7Y4eBULcSay1BHGvYhwX
-          es3KPr2vu0S+PJ5krpgCzsKdAKZccOihr16Ac1LOgftj6lOy0ZRUyO8njBrjLlLXOZcdzUZthEko
-          nWiwd5uS9obzgq3At9SkWO8aOzlMEBPWjDsVaGxRN88N2r78I83jhC+nOS8x3NpCM4qRs03bQown
-          5FZzT26k69n04vYvNCddQz1NeoY81Zca9b7UUbPOqT6kpiqhetMzepiWOhz2wV5DaZnW1IGdqovo
-          7tY7EEsZPg63IxC5j7WBi4lUEm8iUV/y+8lD6u2uU2NDL50gQ+WGLGTZ9NHHp5LzdzsPcqclIUmJ
-          j+70FrEEh5aTyc2wynCY4UdD+72RExNKZjiBce8glD1KjNiz6iZ9VidUCzcVo7umgQXFpoaO7oCJ
-          +p3clE/vpgHiqylT53GD+iRtcQVbQWwx259mffoaciT/6ontHKxwCUcawQ+3KagTXM8pH9AgBmI+
-          bMf7F07lxC7nFlRsd6cqeJpA5GGB0R0sCnGpfANTkVUBtKIvj7/1Oy4XqjxjdOdMRonB3To2Qij9
-          5nvsvNuULmRhLzjcTxKxd/wbDNJcxcgQnxkJDzHqxuApm3/5ddgbHRAcBbRQy8scL4/2GP7uB2lu
-          7BBV8Qs2eFCMAbjmLjlBdAFLf0gFOJ4ee+INSHNHcjjlUC6CgOoPe5/yrlH/mx+HUxaDvn0EG8QE
-          tl/r9+QurexmsvrJY3JMxw3ouZGToZ9YGsmV11BO8dGLQZ2eEHWf36xc9uXpDXbqno1bDFg6+M8R
-          wpcnc1g4oQ1gllzL6LR9vYi66Db43Nv4BvnGkmjM6R9d/MhlgEYx3mGm84rO+O83AHMX2fRxOUiM
-          1atjfb0bDk396gzmvrlC+HmLlKhtUbg03AIZfiLsUC8a7ZIJ4Tv71QdqRuuuiMfD84ZuzdumuqXu
-          mSjaUiUrVVKTOxelQGyU0fytVKQuPewZ8+Ejk4/YRyS/3VQmQO4xQSM6XshFLKaSrt+H3qs2x82m
-          rNP5uQ8s2A0Pjnh6F6f9wX3l6OqkLd271d4V9pPJgXLmLjSasmtKlXK+oeus88RYLl4pUmfvQ7PV
-          lHFcx38Kl7KGCgyyX/y6TNIIhFUSfKjqsjYddt8lR8PhxRP301iAt9yg+MOTw+a2KZkTWB5aTmJJ
-          tEt+ACJJjUhe6xVRnOvDpZ5S9nA/cQeqH+9xx0dL2sNWgCn1TpsICCU5WTB72D7Zvz3N5ebtJoL8
-          6Mfk5NcdW96nbQbz7BUTYh1dl1fOgoNCb31nqN7RcvTt7QSWx4mRGGdqKIp8UCPQHqZxd1KFcL7q
-          SoHcedlS8sP/+tVjSMzXB4PXjnPHcT2X2naPW5KkXRlyPj146Kb3Z3Jd85V5l68E3eNYUuc0XTta
-          bLIEbtLnifzwk7+3+Q066gbQ7HzZp7P/rCCyNzVPTGE+ptwcZQEMl7qn2SU7MWHFX9iWdUzj9fQs
-          XjieBFim8EWj7nsBnDaNI7wWiU9v0z8AAAD//6RdybayvBZ8IAbSJxnSSQ9BQMUZIKKgIl2APP1d
-          nG/6z+74rCOE7NSuqp3s3ElCpDkwZDH/3EjQvv1m1YT2ggAJQnwszmyxvs8NDxndmrE1D6RY314p
-          Q3dkApwK/gTWwPplaO2WnBSi7dMtCUofelUlzQOXifr0ZrP+b/6xdZy+w6JoXgyrLfPwjr8etQto
-          QKdZUnI9GgMdnmz3QpfnbSKPXlaG2XkcM5Tyk0UKR9/vaXuIGZqJZs4y1k76JlwzVt75AnbVbG5I
-          R8UFkS5UCL4JwbDmmFsgep2zcJNGoK+EpDOsRVPHgTA8wHb5Qh5u7UsnYdUCffCfDA8VpWaJc9a1
-          hmu+dgoXpKwkANPo/R4qN0L/bBnzrVh70D5jOYOMjX3sX8sV/PzFNSCLjwIOmIId1gRaLWTRDc+T
-          eLG9BY+1CO0bb4Qkr51ksijwwTXTBeyhFjWb9kA2fDBrRsK77SasF9sxlKfxRa73vhtWM+5MVHN1
-          SoLI44q1M/oMqndtw6r+bSkh1FHQyxdZUiRUGbjTFRiwZxMwk6slAnrHZxmEeP1hTIwb2Pr3u4WD
-          kY3Y+Dg5GHrVsWERhSlWPgcAZiVuWfhtlxbfweR79DJvFYj3E1VG+hCL1X8DW3bRewslf7937Vvw
-          Lzif7keiKKsN+IoZL/C3UUyOf1fZzdvEQElOxlkOPnVCurMOwR/fU5/KBUz1rWRAFR5S4u75k6bX
-          xAe1ZlUE38IT5Z+TxUOzXVfiguvdo451CUHRNWaY9uwLbLq3XYAyOgPxwGOhy6CqIcrNyMC2Pd31
-          cecL0LhdOOJ953OyFHfJlHd+Tc7zPfVoXj9SYHiUksAoP/qe32qUpNVxHq4p49GOLgu80W8b3l9V
-          MmzvOK5Bt0YNwcnCNhvnKjVChr3O7AP7lFrykYdADp8hMc3YW+81rsCOt0TB0wuQ4HWT4WEDG9bQ
-          0RvYrG0+8FlkNo7vJPeoa60x+huvhmOt2C5JxcD3t6iw3faMTg9nxoTpwL+JJ+u1t/g0yaDs5ve5
-          3udvegHPBtIKZRwouUQ3qf3ZIPjMTxKyJWno25BjWDC5TPz2ntHlh9oRbCRvsRmWaiH4T56H1ucW
-          hnI9196mMj8IFvmhkVBljx4rdG4G8DcCRNMnPxGy+x1CMiGdBPhCwed7TkS467N5stywmPf/h9rp
-          GBJ80sZkO4Z0BEQU3sQNPkrBastnlBBKe+x3j6M+uwrtofZ7rdisvKWh2f3MQDzmt/1WjEMyCXlv
-          QzAODxKoxyddwNVm9i7TISlO4pTQ2h5ymI1Yx245UrAlIh/DPf7JUQCrt1acncHgyHih8F2fxVqA
-          TYT3OWRmdimlYuK0Lw94B4RhPaidRxvhJ0P29ZrDdc8fxLGqEH6/e5fOdxAX9OARW9r5BlHk5Zos
-          2ue6wcK9PGZR6Npk/Fv/Az4FuMincGDJKZbhjm8hnNBLn5WSLqgdlIhEHNIK+lLPrBDGpbvPfkrX
-          xk5quHHRjezrUaca4hlUb/CNA+6TFNtJ8WR4nL0P8RJaNyt2XxtgH373L1+R+sfX4EDGO/FFYfHo
-          kNUZTNT1TQIlv4GlFUwZ/r3//r3oz+FhC1bawbClFBVk58vwMzykWd7xltJ2kuVdD4XMkamK7V3+
-          KoDH7Eau4jnW//Q5iI6P187P1WS8+2ULfs77HApV0haU+5JIdqTmOn+OX8Vj12rwoTb3OGRd/0aX
-          Bz4zUK6jGPuPTkgo+BxeMBqul1BK3u+iT1tQ/ekDoobPGNA+2yv8iXzCXuK2oFsPfArbSGOwlVxd
-          b531R/uHT/hPf2zag3OBPM0vYuzP+75qt4e9Peh/+ouu/qKZ6FeCnNj6rBXb8LE7mHoGJtE18gd6
-          2oYWzqnGYu2hnppZvB1cJFv8PMN9vPzVGQy5tkKIj9raUBq7riyJd9vGuab2yUqy6IXql8CG06w7
-          A2s3zgh192ThOINHXThZ6gs9ikcSMik0AB8/NwPmXy3HjjlfAS21uofXdyvNBxAPw+oXbYjw4TuF
-          9LDfQsE4Ngu0lTnjo3QLExbm2gUGRE2wzzvf5ndJHUY+1tOFXI+T1SzMN+9g/lVyHJzuI/ge6tqU
-          +eV5w+rXwsPmZ7GIEqfcdrwQ6cK1E/OPf+Wn5dYQuP5qEBA9IfiZCwXVmViBnH4ycDLjjG4Nvrlw
-          /RzlmbGPQvL7hlUEYyWSsCafeTr9+RmfenaIZdblQI/nNUWPRhYIru0HJX/6jEUFxvi6KYBbO2zD
-          V349zqwk8wn1x2CDt+j0wLv/M8zEXWK4PZl0fhdnNtnu36OJ0jNccWC5c0JHMn4ASC/TvOH4lSwM
-          EGt5909Ckb+MdLlrxw7ufg7B5feVrNdnHiH96Pywzl5WSvqAz+GYlDkpNfFZrPf+koGzOuY4lZtY
-          50iW1dCDQ43/4olG5qeCBvF/5CxrvbfU5RzBPZ/OsHu89eF1BjMYUPvGnp9HiXCF7gI/kgZ2/SU3
-          43tKFCBaUUoMPR7o7LjfGrqWcSOWtbHeHl8iWLPfD9uf95rMKdFykAn+ZfeTlIYH376Gndtl+Lb7
-          KwKVvA3mUAxJfj+ThvBJW4HbOUPYdzZcbLl2rqEizRMO1KNKuej5YaAEhQIfbfzU/54Ha/+SY9cG
-          WbEV4q+FQ623Ox8xwL/897PUD9YbmBfbL7tHAIy/xyzryZP+pO9WoqIWJOLrA5/QE5RfIDElnVzl
-          6J1sjKb7yJGe1/BADIkugdJs6LBJ2yzdRZ1yVS+V8M/PMkLhSad1qwzgWuYNh394dGguF2TLbY7V
-          nw//8Vc5jCsXV/bxmowpNymgPaoD9o7qg/6L793vICbE/bDufATG2XfAavGShsXyXiW6WnlMjG+x
-          Jd1kaO3f/OEQdmdvMT2cwVhjO5zP2atZRPbQAf5aRcSUHhxd2Wsww0U9OSRaAe+tzLF8yZlXTvie
-          x7NHCy34QIdHHfY9oaCr+L3mkIHJlxhjrOjCdIp51P9utz/9oy8H5sL+6SVc3p7VsPVGXKFMX3dH
-          +3bwKAe7EFrB5Rgeyu+r4GvhsoEX8H2cd/KxWdjrMqPywldYPY6nZpmjAwttP9Fmfnt/wbimZSTr
-          8Thg42yz+qLdXjX8pj9K/EWb6ThlXQWrG/PFtlb2O98JWPg2B3vmFUf31lhfYtRpyAs7yeCSmd2e
-          PlJBcMMPEHsDLwSqjHb+SNTkQGiv9YaBhlptsXUqebpJYLoAVh2+2EynpGEjgn3IVJaCjXrq9dVW
-          vRY6UYWJYWpKs1XfzobyIgnkErg/Sn/Kx4R5qVuzIEuqLrBvhUEtverYOfWxPv75fTZynRk445cu
-          z3jL4e5v/uFXMiU5W4E/vsfveqq9aFyOBpwEWJ/Khk7S5mRAUHqXqPpbHBYB1hGKQGkRR66URtiu
-          S4ccDx/CzYt4bxLa1URUsQG29veZ2zLMQRpxCfGM0AUCnSELuedjmLmoMIfxh9oZ3kC8hojHWCep
-          hi7wIgkRMWV7HSiypw3CJitIELGrt3UjsKF/L/jwql2agshz7ULAWTqxCPqAqTYEE7RnuyTpuz7o
-          /Y2rfRjmG8ROKKNk1TLh9edvYxWiK91Ue2GgcUs5HLqKO4xZO7SQ8CceH02787bLfRJlYTypxFXM
-          q86BepRlIzy/iHYnub74P7+CTNQteI9/sM3u3YcTDrX5gFusbxxn1fDmoxs5Jps7LOCqQGQUYju/
-          uNeT8tr54/8bX9x/rOanMJII/vhgeLf7Yvc3Kni81yp5yD8CyOLWKdzxAme/s6mT4jKUYMff3c9J
-          CmpOWQuStDziTKXEW7RbX0P22/n7RY5L0v/hpfDManIvb19vqrVogxL7+mFlBRdvPnFQhJOBTIyn
-          7uf9xHXe/aMEzUi8dPqy81f4kRQwy0M3gWHVhBF+XyFH9BjQYdVUevnTXzN7vBlg/b5YFwoSr2Or
-          zlZ92f2BPz79z4+bL0kFgXcIMHaS9ztZm7gv4a7P5y38mQ2pf8wL7Ov/X/2BFwJHBL/0083sZ7sM
-          +/cLYas9IPGtSfvzU314tLqAJDpX65RUjQ3OYtoSf1uuOkve4gZ3/ULM/qYlW5qPL3AQXXVf/6m+
-          FXhiwXRPxFDY/We+e7W+pG7ilzhiExQcTf0LvLBmQIzn5U0X5u7N8j6/+M+Pnq7DM0S0uStzydUD
-          2BgB+v/0skXSQf+XPxrTmIny4rSGsjCwQeUIPHaMn1csbPDcYLaZYrgXw4vtONUv+AGf/o/P6luu
-          iZ8/PvXP35yAbylw939x8Fg8fSqALMJMxSv2xZAtum/B1ABhPd47J1z0lWmdC3x9RYtclKQsljOv
-          GGjPJ8RtSrsgu//3Vx8I38FwAuvun4NFTRyiNwnT9CrzY/74DQ5m/dds3UhdsEapgIN5fCfb7emm
-          UNRcngS9ei9o8sTGn1+FH99npK/+4ppwyOOaaKHS042pRQWGQSDvfDscutTVGGi2dMWhfbwW1EGW
-          jy4zh0jY4Obv/VP421aMw1/NFaSc3REAuER/fsbAHlndBk/2cZrZm6sUS6ueZcjA0xfvfj5drnpU
-          oe2R0PAvvlY363koH6MDwegqFktwdjo4m4+//NvsfvEcw7943VuLNtuDvefQuqOe+Iev0VB7OTFQ
-          pu0V//klG8fhF6yovpA//Uad09uFsMkLrMX0Ada1OMlg5w8k3M6XvT6AFxgfsytObPVNl6+xpdAq
-          boCo2/hu6BVqC/rjl0f+dxsooaoCDdjJJIvZM1huUb3JnW38dn4vgZUXqQxPJ/QkeD4ZYJPy2JdM
-          oTwRQ/st+m+FbwU0bG7O9LHtPcU30wV/+PMvXxRJ74Kd/+76u9IXqWZ56a9+ogoPuaFMfdTALMkd
-          +fMbqf9k2L962s63rWHh344GlN8bhpBhOrq4S64A+cWrcxQWQ7H9+ZV8d+SwbxkfsLrZi0XYrN/z
-          L8s/dNE+jw1cG93F2it/6Yvixz7MydWfRyzZ3rbXm/78caw8G08neT/HUJj5JUQ5cIDwly+Sk3gJ
-          v687albyPi7wL/9c6+yk/9VP//yYcMTRWHR3P20Re2AYYl5Pr4YMWZdDeH99iOnmZ51WWIRwepMy
-          XBR70vvdX/j3/ko5O5TdBvCC5O7vPdlI7v3Dr+yUvkLBfXV03fEV7fXPsNv1FXXRK/7Dz73+MSTL
-          dymzP/8T+/ymJ39+7j9/0Kxjp1mr+lWjVx3K4VtctmH3R6D8rN4lNg4ZLdaPkCvwr14c9P1NnyUw
-          pTDO3gO+MGijy0zaDr2MViPJITrs/LpQIGWDyyz65JcQW65FNF5+Mza395fSMNh7AF4qBbur6el0
-          1yPSp35nxP01z4Lq9lOD2q9eZ7D7ldzzGLuImyVAtHOTNjw8OAvc9dm8gqdJ17Wz7H9+aJQrz2S0
-          G2cGhqrpu3/W0ZYNngvS43nA5tKnw5qYlw/07zc+lPb1/K9+HMDPmYT8VaP0jR0f6lfWwbbQtQW5
-          H0MI8MzY2JD2ijyqSwjLXN+IFz8dXRjf9w5UD/OI//BNwOTlA3fjtVDmwFisD5Xbd5D0+nytEiNZ
-          32zUQdNxpb94ouu7V2fUvsWNnP/qqyDXIrj7dXs9RwHbVjjwL15CsRFssKG+kVGF4pHol1ig03xF
-          Fawf3QN7JWsNvK8jBe71F+Lu+mDM75UCyPlZE/x9Rt7UyUX2/+woAP+9o4D5LNWcPclSzOBx9tGv
-          HlKsSs8XWH8K9cFVOk/YV/Yu80fN+sCqkeZwYdZPMsfzi0fzQ2RJqtwnfdZ5UMFAxjoxLI9rtu+h
-          r2FUTpcQpH5Ht8B5RWgWzC4sG/PhrSkBpSwZqoTxJRabmfl+WnCTtANW758w4UbHaKFZsiquckP2
-          lsZRWzgT1yFBpjOA5p4UQYhBFoJlQAO1QhoilOVCKJ8Pr2E7argFn1I4E4vaDf0l4lNDMv/DocAl
-          fLFO7GeExffUYPdw6ZLlkysvdAA/bpYT8+YtSoNNmDJ2hK0Oy8P6GNQZvcRoxFcuuRTLK5V44ILi
-          ER7c9FfwrxObwRPVS+wsx8+wdk63QaSUt5DaeG4Wmh/2DNkLxCgXQd/eQy0j5+VcsBHhUzOb/COG
-          PopcUhibRBc83loUWJlG7m9LHrbUyw14COCJeIYu0i1Q2BnlQvbByhYptMukcwXTdjWwI1zehQBH
-          m0fK2dKIfkr6os8sEEKUf6JZe0SMvnTdI4YnJSyIy7L9sM2AlAAe9D6Ub9Fz4MNf6qLTPb5gZ1K2
-          YqGc3UGXuTbYOEC3INstNiG6efuZF/kwzOpVbRF4r08SHU9Rs5yltUOFclyI9Tt/PdYF3Yze+tvH
-          /ugCj54LJUP30ohJkra/ZMmfEALVbk1swGFotg3RCnoXeMQnOWqAsJXpBgXiPudDokrN9M2KGYqn
-          UJxl5gDB8rHfOUqvxCbHi6F57G2aQmB9TI/425jR9cppNsTCCMlVZ1Sd+6GlRL/mnZGbZV681ayb
-          FsafusZZsdgDB8eLgSqfyORv/ql7NVp4Gw76LM5fNWFLjv8g13IWjJPsqHNt5Kbw7vOI4DE8DpSk
-          XgZd7/XCPrSUYpLxLAN+fj/xeT2mgDcu7wx+SqMnN6ifgdA5swbO79Qg+fmgDfS1nHuEmlNOsHJW
-          AVdJbAdHsNjktNwtnTQZsqWr+Rrn7fF1GsENHwow+74jQUgzfbVRvKFMv78JtvQ+2eLuAEFUyQQf
-          9+fTfrQNxD37H745LEM38LZNlK7GmcSSUic8JXaNrHW6zXz90b159ecSfu/Zmdj7+NfnQb+gtXwd
-          iP1QrYZbtEEDrZY8iVkZR4+vKpuH43Sq8Ck/42RT3rCGAwhsrMvVu+Am+fSBniM6JPeBSen21i6Q
-          umuD/+J/foiYhR8+fOFL/Wn0RTvwMXL8LCIue3/otI6aDSlteiX4IbkDf9KVEZ2zyMZnRzEL/g+P
-          7Mx+kvt68AZOj7/pXuHmiIKjzJu933KBT/m3YDeW52Rj836ElT/J+PQNlGQJP/O436m2Et2rg0Ko
-          y1ID7dBNBDthCRYWWyP8W5/Y+igDN7/phrbbQ5wPZCDeJtmRCFEYHWZJAQ1dtaKU4Vb8TkS90rXY
-          np/YR1fjnMwS/IzehoxNgw/Pes5MjZphFN7rC+HHcg+ZEcRglXWmhztezutXewxczr4hCBI9CqVv
-          wCUU1dkHFd14wsWp7wGNllKGz3iK8b0QKFhqcIxh3J4t7FFYJiN45T0sFGsJWWsewLoOWolqCH1y
-          Fug9WYbpzSCiIo9ot6MHhOtmzOBIKw6b9+cMVrXHPLA+hocfytNv6JXDGfwhgolxTd/NdnlVGXgr
-          gz2zo7ufCVDcGs79esWOJOoF6yRqjMxPwmNfer+Kf3hIy/BEYif5JvwUBReYWfx1zvVB0bnTxWQg
-          6O2EqOFV0VnHOmnolUTxjjfLQFapc2F27Bh8vSljsYWcn8PD/JaIta93Gt6yFqF1MebtnX+a7kYj
-          E0U/5Rt+Dz8n4QQjZ+V9/Lg4WenARc9DCHlZ3LCXZnTok9O1go15THDqUkXfYiHKkFWODD5nH0Un
-          bdVpSKqcZV5Y3A2runE5LNjrA6ujWTQUjgqP7HA/U+u1PhB8+LvA75YvxLig3KOj7lfS/RO6WH92
-          +5ki8diCZ9RIxDW1e7JNUZBCrmE1khyfb0C/hWojbXrciasLLqCefeoRzTURh1OfAPakJBF6Seo1
-          hMpxbLYo//lIHhQVJzkBw+K4yQz/xqvMHV/Mvj8y8LTFa/gczWJgvf7YwuTdbcSEUuDxH22KgXEH
-          Ofb278P27poBIIQYn2f5lWxMwafwAAYu5DZPLdjUHns4E9shITJedIuc0ARttHn4JlyOxY+FTgaL
-          PPjOeSbx+paG5QK3bD/T6x1u+hLhMITJYfthzUmsgqhMlCPzc+Jx+blWOnfxXyN6f1mADVq0gEzs
-          rYR/+FWEUPPomxsvsmimZ1yFv6fHJm9RQ0fj0pBCrvJiOzx/PjJENSbh0wkLoYK9CS3qWiSS85yO
-          19fJhsmX94jbPTAQ2qpToFnyKjGizQL8APUeCbJqkPPr/f2L/xw+3As/0+r60SnQfzlUmL0ixyad
-          N96Wrwzh1/Kx8TVdbwoD9AF/+eNkqIE3P3+liBqrVkkJeTVhYQBZ+DL9C97zmT61xfb54wP48jwb
-          Hr/6nwpGeMhxcD7z3vbwp1EquC0gl5Of6mvaeiF6JndETDVswWKUUw2b/qzt+dZJ9u+hoMNlKOYh
-          vA10+ULOlLnEO4RLKvTJ9rUjG809vWL7HPaArgMega6LH6zC7UmX4aCaKEjUaM9vdUGPmwdBl3kc
-          Ce9nSZ83WdygKOYD0Vl7S1aU1yWCV07AnvEhOk24poXMIl7I8TxdmvmEzguQ7/CI0z88iiZSgvX3
-          AVh5ZhiQ2HUq0L3xStxsGpLxRjNDkvGjCL9JgAtazBMrXfnbDx/ZF9MsDzzYsNASJxTyWG84OFYm
-          lMYuJyfPVL35c/VM5FnjQixTTAfOSmmK9vnH/jaKdLLlzEDzcUHk/OY/w/aXr9eOj0jwgp03immV
-          wXKbTBzueL1lh/2WIj0Jw+WZETrs+RneZrskR7Pqkr10mwHJ6hR8CcDZW5+aaULjkdq48ISJEv5M
-          Q/h4Jed5vdJTsWSu2MML8wlCuPOljX5yBtxmtyR6uPoJd2w+MSzUVxXK2loVNHadEn5u4IRNYwib
-          1ekglEfTGgg+IgTW6Hnw4e+9raQI33xD62jY4OvEtURjynVYgQIg1OyHPv+Q8yqG0ZM1+RFEclhP
-          EpdswvDsERGzBLtb7DfL53DYpDj8qMSnhQTmr53ZctLcbyQGMh1muukhrOpDT8ziZXl//BL6jlbM
-          rLV3hZ/fYIFtL2szcq4fsFxfJxfNApeQ3SgD28N/j+hxzbZQ2Pn7YIUghOOzP2EjcFFB+yavgf0O
-          7zPKkDKwJTO68HkcLtglrQ646CmEYEj187/1tvwifoNauqSkakNtmBjneIGpdxOwN6dKwhZuWkHb
-          EyLifzyajGMFNJD3aY8VzS93/sK+gCBFNxwafJsM1OIhaMXxR9ydv2xVpfBS+uSUWXw272YaTrIN
-          +FqJ8PUTxYB/D50M0XK9hFy2uWC5kzUEi3LZiOari7e++Pvyp39CKXJjnT9koAM7f8AhiqaB+DxT
-          wuFc6fgPH8fPKYdQis4uCeb9Hi/tdCqhxF3bf3x7yTTPkHd+iI/2ffHIpDjb3/fGOk61hpX5pYQv
-          uTpiZ2q6Zk3Ep4LOzlrNhyR76xuzlC6MCjiQ+PVE+njfgAzxyN6wL4UXQAuhyGWze+Bw/STMsLTo
-          FsHj8LoQ9cOzgKpMtndt/lQkFO7LsPYNWUBzTDvs54Hh/Vha8LDo5lPIaRaktLweL/B6XtRwDU7J
-          QA3zx8sn5WASJ7pAOpWnewgPr1CdBWrrYFXJNoIhVc+4tC5ewX1bj4Fdfg1n9vYQvVGCHIsqh/Kz
-          OEdnOl8vHxsO9eWz81+Wbrt+hVd7PpIHr2oJ4TNORuEpE7ASO89hiQeUw52fEfvZvIc1q8cLUM7c
-          FApJgJORX58L/OVyiPVeHIYleS8aPOnuA3vqMwf0sUgspDQ/kmCP7wEb8iJf5KAIl9PGe0TGp/5P
-          HxAn9PqELod3DRlmhtjn1sATmj6L4fV0w0Rhwkhf9+t+ganNLjnGVPem/pd3cFGPdxxsLxWs6JON
-          sHe1GgdYMob3SkUFqpdsmmtsBMmcWTSEviloWK1tP+GCV5LDSRbzUGi8qtmm8+6VvQ8i0eexBuPn
-          ICxwTLwvdg71odiQpI7w8GLG8KBvQ7ENS5Kh0KxTvPMrjxZD40r7/BE/yq1ihePFhDAgB6L3otes
-          intn4HDxZ3I/j+pAGROL/8ZXPZ0wWcCg+EghhxYH1bscfoOP43/47MCNp5umNRtsdA9jnLSEjkId
-          9jBB3wg799XQ2fFbf2RTPZXEOgPRW07C1IHvtw7wOY5GSqMllWEj5AzWg+Gw14pPMjTD63Vmze5Q
-          rPM99GVDiL7hwoSRtzybcYM7foaMtQjDVKYPUd7Hg7Xy4tK1O5801AWnGB9j2uir07EQauO4kZv0
-          vFKafsQOLo/WxEdGXIfRjycDXM16xJVt6QVrTW2JRMm7EOw/CroUe5dg9O18kt6TICHWtd7Qwfk+
-          iGpxL2+DrpCBJ1Fe+Kp/uWH2s3MI7x/Ihah6w2bSxkUBCow4bATPjq56Focopm1JDLdkm+lxm1vI
-          vqsi5OxfTpd/67n/KdhS3NFbz8W9A0z7PpLzdvX13V+J4VFsY+zz9eytKpFHyC4XhugRrOg2WdcN
-          7Y2JQ55vJEpx0KWyXZhvrF6NKFn5SDdhaL5SjKHi6qQ9y+UfHwgLof3QMUolA524kMO6Fn3AZPnB
-          BqgPIbnVjxFsY8G10LlVfsjt+XO9298ObptwxLYmd8n6uM0fcLVOVxJv1atYRTWy0RQtDbHPWq2v
-          1knsoTT2ObafvqxTHz5TOclanpSjW3j0+5EyuON7CAbs6+s6BzbMJHHCf+uLO5LLCzRx3mLjcEv1
-          Je9fLwju5nVGhZBQ7unSHrz77YDVOr16fBZ1Gxyt1424zKGkY4tOMQofwf2PHzRb/EYR7FOg42OX
-          Gc2GoJ9DIuYJdvIR022NTyn8XZoS47cYF8tZkjqw4x/W3rk58HZi1kCxVRPb67n31mJtYvhK4nhe
-          rYpvJnVDGWQaNifpeFnoJPtjCF3m3BB72ShdmwpF8CpvxQyj/Psvn8GkFS1iRLpJBSXQM3iYvxKx
-          T2igq5u7CgRs5GF3q4Ri4dm2Qp1ff/ExLq/Dsiki86ePcfzcSq9z3GSE4fH4wXZ/uIBJeroKjNZp
-          JUrsqAPrO4f9jPLvhLPzqnr//BLBYmbi6kOt00jSSrTnr5AiYiTLQ5fF3SHOcHw+8c10S6Hx5weR
-          P71F12X7gCLHX6LIuUy3LOoWMD67Ez4DoyzodTNGID3aCrvZ5CXLBkINynfmuO/QC5Oxm10XliVU
-          yFHjERhrcIyQE9gAe8tjA9NfPulbNwtfXMaB6cg5Odz5Z0hbyfB45bXycPebcPi1OdqV1m2DUd4g
-          vPMhuu1+GJTuxXFG+BIWS4RNHxCuwvOqQBG8lqyaAV9rEXETU/II18422P0a7JoaSrb30Inwjx+Y
-          k9U1M9tkMTxkhoOdnZ+V/THcd9hMLr6pvQH436Os4B4fJIiNqzdKx6ZEhk4b4l/gUWe72bWBVcAE
-          W9s7aPiri0SYP0oLJ8HwoNtNsn14OWOVHEX3580NutTQuzBH8mgubLKddGWGuigpxPpQR58b03DR
-          AZkNDriob7rdn0Uob6OZ1i+xWRlT6yDRCE+Ut//W9/Xagp9/a7E+GHwxd4Mxo0mW852fRPoebxqI
-          b1X752+CWQ1TBe36jdi4CCi3HLoINmNdYO8ZtcMy0oyHp/4Sh4fGdZr1DcYS6MZwwsaPjYGQNacF
-          ypHszqyq6Amh0OwBP3+fM3+dVzq7BM2wwFeDaJ0QFZx7SiuoIL0OmdB0AR93AoSHek1CuPuHS8Bg
-          H7yGQ0H++BgVt1cO3XOXk9Sltd4Xkd/CPz9316vJzncreFTzB3Z/2kdfnk27wQcs/FASLu+Eetpn
-          gSsn+vg66gSs82s10JBlFvY046TzS+W0//STI4lNQh5v9QNzLfcJ7pA5sHEnz5BzKw4bN77Z88vb
-          APAqCPPcQ88bp0tQQu6ymcQubnedJUSCYNEjnhTFLy7W3U8B26Vhw96x1mF6vEpb3vkZOe76nTTF
-          gQW7f4CTXb9NPr+G8OBpQcg6UpV0f/74nx6473785rXHEp50+0GsbRWTKXxEsxz+rmeixU0A6DmO
-          +T//NoQKOw30SNQIXOWlwCbf3ADN8jGUTTUpiXVTxmTJjsECo5Wsc59NQzHdjyOEgZVrRA3YH9jY
-          +5TLr5MhYeuqtsN4ry4GaH+PFPuC3ia7/k/BMnYa3vENrNx3+MBO7Y/YiSSqU3VEEZQHTQ0lh63A
-          dPr2JjxnsR2ml/CmU6yKBly+rzfxcvlUCHxVb3//TxRBhHQbJBsCzhld8sBL3mzQYmdgxFEQLrsf
-          zynumYG/K+POwrZmxZhXcgwhdqdwrfcTVq6aifA5Cs7M5u+2+asXyGXJKDNtXd3j9vwGp2hr9p4s
-          9T//B2QCSUN1/K10U14SD18nU5oPUqwW/M7HBD4ZD8RV8meyJuJPAw2pHuRPvyyhqLIgCSvmH1/j
-          3w+xk3wRZGELHzVYLT9YgNcqKjlVTtvseBCi3a8hfpldhkmrru2/eDsewaaPbP1iITq0PTb79VxQ
-          +DnDf/pIL7hOn98veoFAgzXR9vywBoMCUfSjMcHgVxV7feMDX8baEa91RW/t67cB/vybip9JQxf+
-          AMHuz4ab35rJGj6yEZ4WK5sXY84T0la1IvvAXIm5+9OcjfIF4p94xrfcuTXLybF5aIXilThB+Uto
-          RWEN2Cx7YKdONH173sf+n56ppurnTXt9AOVs+SKqElzpgEKuBB+83vDOd8Dud6d/eimsd79x/WbF
-          CBL0johf+wOg8Vma4ePSW8RbNUfn4zue//QF1m08/+m3CoZ8cQqFmy94S5VFI4pxOs7P5f71FrLB
-          Hua6LeDTL9voquOxh5c4RkQrLz2d/vnl6TLi0/0TFkt+wznU4g8g2sHbmr98DP786n94fO/DFLzV
-          gu7rH3mr+LUyCLb91r6OHHVhHx88PJ8MsQ4cq1NqsBEy341HnAbyyRxyRg7dukYksfWG7nqGh6PU
-          kr98C9bdf4O7H4+1JJ7pGtwmFuz+JbEc1NHlla78P/8Ql+XTWy9Op4H60hghL3tGssJfkf/p9VDc
-          6wd8qo0vIMTmhxjORJvVecsRzKOQEmXXS5P2DWy4xye+/B6VR39618M93xNvP3UnMN62AVMbXRK0
-          2W1Yf2ip4P48rNGgKbbx+2ZhoFOAFfzVG868dzI0i9sfflV0/YtvehUeMxDaD1hOShKjYujO2OJ6
-          lW7vPNigXI0L9lATDuz+MCgNwYiVQQ4avpZFDTyf8Evy8qk0uz/rAlsJdYwPJxtMw/2VofTC3InD
-          U+Jt3lPb4K6f93j56duGQAm7VzLNHCi+lLBLlcFQ814YZ+yl4btO0+Bk8wbWZv4KRovPFZje5CdR
-          4vOYUKA/c/TnR1jvqRym+nGrYHZiMFY0ZW22a3lT4JHPJKwj0iZ7eY2Fe/yRnLvWdPxKW4b0iHn9
-          yydU5N4GZLP8EcKbJQxbK9xsKHWn7i/e9n4fio84vwtxengzdAXOr4aTSNS9/vVu1lvKGkjitzhc
-          lSX01ti9jH/1R6IRaCQCowchdA74hC0R1HSpRbeFj1vrEc/O22LM3KWDq9rf5x/Uz5S9HZQLOjwb
-          Zp7D+Nyw8dpF8I9vwM+V0ed46GwQHq3PXj+ei3dWtylw6xcinmas+vdc6QZymOqDlcz+FduvvG3Q
-          KmdmrqfLwZvhwTL/8R29aiIw3vh4AeRzeIeyk+w9NZe8gx/Vt/d6sV1sTSiNcG/LT9zL3DRUcZUR
-          DnX6CVeXcMNyEt492McbCnt9dGvQ5QXd13zBllW4dEEHh4XfBV/D6vtQi5kLtwr8+VPl7vd9/vjX
-          X37MxVOa/HvedHqGOLyLOCGPZeURGS5XgsXsMayqkX3gn3/LSKVYbPp+Ykc71oe/9a8TrdIuEK7Y
-          ID6f6sV6D/P6/9lRAP97R4HA7l1HAPok6/i2PvCwtgFxJ/uXUOF4N+FdKFVyio23vpbkrUH1mVGM
-          gb8k2035MXtX3JbcOc0AnC5LLmSwP5Frphz2vz8hXNYfi039lSabkzw/MD6nIrYdTi2EIoojdKph
-          GgJ+31MqQpmXYt3+4MDOz812dJ81LOucw9a6zd72LlYTqc+cEps/e95q7l3XzjC8zY3QnQoOelEI
-          z9G9nr9texgm7v5zgeBpMXFC2dKJwhkM+nu++7amYU7caIR+nvrkyJdDsljP3IS27WYhO45FQ3Tm
-          qMH4+3SJNTNH7+tYpQnV/Rqf1FLkYTL9pIIStqYZJrujFax1hB7b3cNpFDqFcGV+GhzQmGLb6OZm
-          qxyRgXx37YnPWFKzAtGrQKEEHcHhaDZ8P71i9ErlGzmlYuhtpdMrKA27IzmPI+utAvFySA63DTvi
-          t6F0vKkvdE6MG3l0UjpMx8fJl3W1VbC+Na3H+mamoWYrp/1MZajT3yBe4OF53C/Yvkl0GQNDQRJS
-          JGLqytBMz3tgQyo+Pvj4yRPAzkHMILiODj5ZuC5m46OWiJGfCva/4FtQywpsYCcZJMq75MCnjnsT
-          xo1/Jmm0xJ4QoCqF6HR6kcL5FAM7Gb+9ovZdMPbR4NEKDRlMytwgx9KmdBNenAiZ8dfM673YmvVR
-          8iHi+cDCumdbA3f/uqxcV6GBQxzydHkGzQLT72YS5WL4A3deXj1636yYqL/DBtahvJSQnS41iaLz
-          6pHv8MyQhI8TqeCtB6P0ECEMHJSSLPCotyXzbwGeHN9D8OHVgXuJrILckB3J+cbTgTa3JYTHmRbE
-          vKVN0WNH5pG83gPsgUTUaUJJC53klRNbObo6rcxjh7bg5RGT1FxB82fVQ5FyLr7dl+/AszfEw0bK
-          ChJN99PAdVLNI+ljecS5BY1HG1z20PLPZB55E9HP43BO5RGLHxI7t6TZuEl7wfCkPeep8uxGWGgq
-          QynnvwRT7gXoHr+oQ2xEqkl9NoSEUATbxeNn8LY++qJnsYKeGBEchXpEBYzeMbLn34PonVM1vMiM
-          CzTPi4Tt50K88bo1NQqYqzgLbXtoFiNgKhi7Zko873zVeeZwahHD0XZeb6gohDduPmjUdHeeIUgG
-          zjYUHxUD88ReHj8L4YRgCGUSyTis72rCG+qSwe/tEuLiM5feeu7sErbBFOHq9tzANsW3GL2HpA0v
-          jFg16+XeyijgTt+Qw2oIeJYbR2gfnw+sOzff409zzKNHXJRz29F3Idi8PUN3TF7EbB1b39bidEEw
-          nwdsdeNb37pWcsHPC67YfXFTMlv2wYA0uwnEIMdjIdBB7cBdqdpwVZJY5watY4B8NzrsV97iLWQ/
-          hfZLrxkxjjdjEDQuEaFJxyM50hrSNX4oOVrE74uEDd3AH74htfx+Q3Cc3slyzDoG/s0Pj07dsH0m
-          I0c3Vvj8+/0t5D8mfCqlic3W6Tzhyjw19OAMI0ST6uhsaaQbiudKDA9sZg3bMAg89K5fDl9JPYHt
-          ygk51Ol1CFFyacCKv0mPlIO7zmNZ7hW1R20jsN996CeXoRirOv4g8dmLs4zvhrf8DA9C278H2C4b
-          WBABLz24K2WLs+SeePTFONHe9asmXuUJw5xN5xAkMXefhetb0b+/yCnhdWAO2ESnrpmui/RBe3zj
-          v3jd5kNRQakbDRLFn3PC+makQWjXN5KtdpYs/Rq6MKOKT5yeX5otn1oXJXN7IedVMsEUarQDlaXn
-          IWPAC1hvq13DsyJbBBeRSYUnl9nQ008KVpREGlbPC2X4uZoBUURoDAT1OZS3w+Lj5Pu5AS5ORx72
-          r0tCDEl2dapxiSxb9BzgU36sKc2flw6BtR3wLaYoofrr4kIpESUcBl8F7Ou/h3qzxTjUBafoLVsw
-          kXoeJOIIUBqo19xkmCrLj6TXsS5oytUQOe9xxJVy25LvCbEhFC4RT1zk1mA7vZcO+RF9Y5X472G7
-          tUCB4fl8IZX0VgFrbe8cpqXuY5s+NY9nFSVFTGC4xDgjg27mJ8vQ9Gl8bB1e72LlC36GGseZWFsv
-          Gf2+h7iCB1F/E5US1+N/Sm3sPUtOf+vbE6Jo05DKkS6EsNYHTkjSGvA9bPBlY8Zms2zBQIrOP7BT
-          qqO3/eUzQ+dV4tXts5nuXsGAbLklOF3cDWyveFVQDTp55nXFazjebTJ0XhpMrE67UEoHtYfjp5hD
-          oW0fw1a8VYhcUSv/fX9h6AMR9mnJ4+s+ni3IBR+drmxCLt04DkQ7uSyUP+EPu6+kHQQn++ZwxwNS
-          vuZ0WJf3u0TWWbzie09swF2XtYXFbcEkdvUn5bY3m4PeJnAWz34I2Km6phAeQU20w48dFiKfXaRk
-          TkoKCvtm9avkg6hhaTOr3S/68g2jD2L8NzszowQ9ClE2wsxXZhzt8Sb0z3QBa5BN+A/Pp5/AZyi7
-          yd4s5DdH524uY8Dco+n+e7y+kbgOUXb86zHUWgWviksE7+l6C8G+3lZG1Vs048EnuxbSqcH1PGKy
-          dCbxs/zsPUo+C2ovwolgpv82q7qYHeyHrCUlHzbJWBtbD5Xn6Yzxr9HAViiLiMRkLcJpx4u+KV4u
-          sEr2SDQ7/SREbe3P3++F3KV+gr/8BxxZfxL1WBuU+lHqQtYdRKL3LzvhkQVYWLKkx0fwFBtyi/QU
-          UU9biHUPNn31AyVC5e9h7vg9ekv2eC/Q9h8B0elxBCMMNBu+b8d4hgTqHp1YMYPuas7YnfpNX1Gq
-          pvJDCdzwsK93blHTDGytmhBl642E/eML3HNjiTP10kAu8NujgjNe5BGO5sAJxMtg9Ru1sK/bn/6P
-          7+zzQULrrAz86S12UCJOOfNn/w6owb1YuDYSh4M5qL3tqhQKOIXJMGPN/hSEoYYBo7MFCVYrUR+y
-          YYggJ44vXFTetRnu7Bajq3F4YcXmGW/nywwykiLH/tRIxURK9gLjjc4zs/OVRR0UHgJ8+REt/HyS
-          rWtXF6Y1n2HlEBrDBvm6Auf5AomBB2P4449yc0vHPX5nsMjdywQhc7+QKIn0hp3qaIbBew5D2tER
-          TFSwZrB/nz3/BcXqavcNCMkPEaeKo0RoYcXDSxnbM9m/7xaWYis/FOyG47aMOtXtuof4+r6SBMnr
-          sNqayYIZ//z5cJleCXXzboHt4XAKOcXvi7GCTgkDhg0xbpy7R6OevIDSyGHYx/QMpt9nMOBzksHM
-          Pc/mMFrIhnJxdS746MDnQBjjWu0NAzzs3hfF4/7w7CZUjz2fH73tdPi4sHf8GJ+OtQEEcJQhEEtu
-          JFox4mTNpbVH51uz4iC56HRd714E8msdkpQ5CMXnY9MUbp/e3/lV15Dv8MuByfEdVr/ej9LTrbGh
-          N94UYkRLrM+s/XpBK0mqWRYfPB1PVDThSZHf+Ogv/bAOZVVKHD2YxKjtotiYqIVwJMyZqAZ/GdZX
-          2jPgb74lU/IS4WBGLOrJdMMu0opk0+5RCnUoxzj00dbMTGG/JMnuz8TdAr758W6TQ9MCJQlj7QDm
-          wBlEWL2WFKvBrdCXw0XzgUS8EptHlh223a+GS3DC8/uq9Q2NOM+A2VIkRA2edbPgqxzDSNhaYuZA
-          SjYynmdIRJgT5cHqgD81hxhGP8n6hxec3Z0i6AlDGxLgR8X2PLQx/MMLx8R3fbkHRxk+KnPfTXT0
-          AXUHaEKjZNSwj0+Tt5RGuf1bL8rBPHg7vtrQfkY3Ur5f92ZhvMcM4anLw81898PGtrcMDp3k4Mt7
-          Ybz1neAKVgX/DvmdbzfUXFp00lX7nz7dVsH24SoSJURZGewOzoGBii8uJNcknS6Md50RIHmGreu7
-          1tc0pRtU8i0gO99JxvQ3VIBPNQ57Oz+lLltFcnqTf/OVEQVvuV9/1f9Iu5ZtZXkl+EAM5KKkGXK/
-          QxAQcSaICqgISIA8/b/Y3/TMzty1NjvpVFdVJ92i5Z/J9G3VD6LT+ayLzSd0CA7VPBlF9d4jwKVF
-          1OY3eBNvLxWwuv8IGf6bJJNffjs4fzoXm1PReSuzu7whLZWtC6aXNsuqDBm8D9GdKNjmG2oeHyNK
-          wvoTSnjvD//06/KrSqzbhC/opq+hl1o+lBSt01YriTs4Hl7MRF8nrqFLv44oXPSIYB1IsTotK8K2
-          XlN7fXwLwj04FX4oO2MzteZmTAK2lTY+OSW6fylWkb/UKGBOe6wT41Usza00QbWQSFw3Ohatr2c9
-          qNrHIEG5Oza9eosyCV1fAbnGlEO/VOvKf/sdcGpLx/TpxOK82i7Or5fnQLmHpEq+w/HErOGkcbVr
-          5f/w03knvkcojmdUyicTb/tLFyrgCeY2+hEDfBWxu2rM4VmMX3zt00cyfCOnArcJjkTNPrW3/vg+
-          Ezd9HfaGxgz073xbRD0T+W3qHldWlxHeAfgkC88Xb94m7YHflAG++F+VcvENq398MkQ0huInLwcd
-          cVkdEf/5/SRLmTCuuOlN7GVuQecSifWff4Bxub14OMuJLPEK34R7rxQS2kLGSz82/4Zgrp62oES8
-          QmZk14nWz3GYL+tagig2FZZ3c1As+iGc0MYPsSuNzrDlW1u6htcA+yiJmmlnuyu8pDtPNCWPClrk
-          UEJx3m4wZK+SrtnPjBC36yOs6f6hWMT37EI+mreQ3fT7d1tPhCgJsSWe1mY9NkKE8HitsW4c79rK
-          X/VVknnzMQ2BHv/x4R72fKlhJQ93dM6NfQyd3j+xWh7UZK0soQXBvlwITvCgzeWSgdTd1me4Jk5P
-          KUvXFf746k1cHskSVv0DhmwU8GllUm2OxQ8LdcFa+Dbf5eSfXhgJnLbfy4XAUF8Hu/MtknQOM0w7
-          W11h04f4/F3WZNn4ncQwHEfUw5ltqBzRPdzeuyEc29tcTIeByFB/9AHb74QOCy9bLAjkymPzFhwG
-          wudXFt3TZhcOx4+QzHWWbvi6phOXLmbBb3gMmVVJW8+JqBiFw7mGoFrvxCvO4bAa0/oGdlevG36A
-          9iPp1QW16diND+UNjcZuD8fpfMWK+4q9ObtnPAJcWTiUL3GxbP6WpH6kL5a1cPTo6aqowJC43Pwa
-          SueNn0ok8BaiaosyLL+PDUhVqppgRj4ki/fmZmnTbyHPlw2lZzaoYPMbsNyJgSZkQHpE3qs9LULw
-          LAh9TDpyRXeH//CeHQNdhR5/e2w4LHhj3jvZYb6oDi5UPGnzQzzLEDTWKSye35CuF97MxF8+kH9+
-          3D+/wstND2NzcBF3UnhZ4jMvnwSDDbSZVFMEtaUCNi580rSZ8U1B3mMt3PnSoK2q8i3Fa3o4YVkI
-          Orps+gyFrr4SbfP/2EwjDDo81wy7hlYNC3eIVLTLKz88WEw+DKd6CNFffvvbnyU/9BM4SmZjNYDc
-          +6UHnZVSef1ihW+ot3hvaYUds0vClju/hukwfGRxypeAGE6cFHxqv2NAJM/xDe/HYV2KSypWSEzD
-          T27rdDnNfQfDL2CIvd/eSB6SpoLlXU//8H4RiJbDldFOoRgfA4+4keGD608Olte+TdZds3QSz+ot
-          Mbb4oreQ8OjTvleinSQ/mePHmkrsNn45GY+6x5tywPzh//Z9NPlxh1yWksviTUI3Ghp3V6wMykfO
-          bfmy0vjPcSwhuVAP2xv+vFfuNqM/Psg+1u+wfnm/hOdvj0gcnVSP9pLWo9Qwqkma749khkB1pXul
-          v/FN7Stt+e3LCBhG4CZ+81fY1z1l4CjsVVIlB5nS7hnw6DWbM3YdT/doB+wkre4hxmFeGgM9PGMR
-          fEfgiWItjsfnjm5Le1Knf34WpVs8/vlF0xK/A7T8Ui+Eza/CCssKzRS84hWZfauTP3yds6+Yg3tU
-          d1h/RA+06L6/8cvLHvsZqw4dm30Z+GY3RCwjbotZyTUTZa/cIRfhOqPVS+YHXKKbiu0qFuhSEcSA
-          6T5O5OJ4w7A+poiB7XyQAPG/ZiWFe0WLnpb/9G8PUabCfL89J3YcUbO4ld7DZLaImDr5JKvlzqXY
-          3xoLe97uVSxhGgLawnHTY1rC8e84hjHFJVG/N7VZC/4WoejUxti1nxyabUO00cV3fYIf+z39WSf/
-          DUzziqdXlkMxM6r0+NM74eFEBsqtrlGjot5HpGAWXPxqF1//9ByOh8lEvMjQEdWTeiH2rHnenKO0
-          F0+l3eMLf2qaaW5Qvf/zy72frSDesncmMp7XE1awnQ3zOYxLuH3f7bT5S3SBVzCiUsgaIm9647v5
-          dUDes43vzj1BVDNJhLh7+8R+6OQNsa9HFrZ8Tvx//787bC9U7vnEdo6gLYdkKP/5d85raYpZgdKG
-          JvtRbMA0NJOqfCt0t9w9tvidTPmVO62iz4wzlo2HX8yd/7b/8RMvY3uPPsyyhTw6t1O7+S///LH3
-          jggTSwwjYW+BsYfrIGjTGr7NghW7WodspRFxkfSj69/5We/TLayFbo/GevVmeKI5x7rV25TT5tMb
-          TKXSibXXw+RPz6D37fnC+lQI2sodix7eh/iOg+BjJ4I2Hiao4oQJl4u0dZXf1bmITyVLzG70h7/z
-          hTb+goONv9LlcXcBcmsNpVOne7Me8CWsrZZgLb5z2no4Lg/Y/HPidK+xoE6jwh//xCeshHQWUCSC
-          wf1cHP4UZeB3Y8GjPq34f/7tXz6XdNvliT3xe21cs0KGqOoafKKPEtGo/zxgtGEfupxjePPwUGb4
-          zmYcPv/0w/y5XyE7TAxxxb08bPWKB9r8W2JbjeItm16RzmHtYFXJz4gidM/Qpmc3vf1oZlSFNezG
-          RcHhPQqTkfHOIzhGL2HZ2jrZLY+ze9CgAKKIilss38rew1OuTLzxP8oqULroOneYnD/3VaOKfRlB
-          VwIbY6mKGqqNywR//i+GS5OMfvcZJePuq8QAXSp+Wz0MiTezm/YHWhdL73kuCn18Ih6Ny2I+6K6O
-          TDoZ03SPwmIahh2/3/gn1pnb1CzOol4l3y9JyHvKJ5mEmhMhiJAWMt/GLfiQn3TAzJvFf+sjqEeX
-          /8dX4+hUax2qzBoSqz2Eh00/raM1rcAG0YJTKX8Wo22srjS9+37ileOstb3PmcDveXkapdeM1iF2
-          U6RVO5OEAzsNCz0o+r96VDpJO0rv/VbxJDaDHTG80PUR1/qf/0LCWhcScoueIWz+NjnVAM2U/cxY
-          PIIvTDvearz1tjPzPz4cHqTxqJEnl7twvXRLSL6NSmllBp0o8Nkr3H8tGOZkNTqQ8iDCxvP0HuaC
-          Olf41BXGenz/DWOmfRho47qcDuLe1rZRvnsQ8MnCwalrtUW4zTps9QQc7HO++U3eV0Z/fESW7l+N
-          yruuFof0nZI//5V7egcWuLynWDtJY0GKJpKlkT16m16tUa+4Xg+NZV9xZDzGZO2Yqf9Xr1S/J8lb
-          j66yinwqc9g8Jp9hvvZRjCpGFrCVoQUtZqdmcKK2Pb2+WZ0sxZvukXMtbZK0UZcszuLmIsLpl4Rt
-          JjSDKCmzxO2nejoU1ScZd2ISS4HR36c1X0pE5/Nbhlw4K9Nnr4fFqu94kGJ5mxq9rS8n7a9XVKq3
-          L1Yfa94sl/fIoE0/Y2fznxd1lVUIzuxCcJrmw1COjguBID42PStrfHMMW3jVOMFy3Y10vV25VLqq
-          RCPqazcU0yrtAMxy/GC5y/WCfoc5hYlMKFxLnHprKlxFpGdqEtK+tosZ1KmFrf7wz8+iFlPvpXwK
-          ZOLjPev9q58sZrkjhf0Mk7WaXBnanXQMhfn3oPP6mTKkBGr4z//vIpzr6OY8OIIH1vLo1fq60PFi
-          Pe3dc6+xVz3g//BgAkf3kuX2UVnY+PE2aEjV5u6sTNCirsS3XaqjxUC2CfUlCEke5wZaQ0UZpWCG
-          FSfkwzWjJckMWnbdNK0zO2vD1/iJ4lZ/IvJaM5SUUlmCQd8frKqqqS1tuuzhYUUZzt9J0iyip0Rw
-          esUDwcmS0GWv5u7f92ObFyiiQ2+ISMIGxnrxygbuW+IaRNY0setGSzKdChFAEov6n5/wp6f+1Rfl
-          +fLw5mufR+D5pyOWn0zV/NVrYUT+diNEXJpf8UYiUP6kEe2101BvC2IPdXx8YPVSeB637EUb2vuh
-          3uqVWrLS4hHDV1Bl4lKIvfkh3uX/50aB9L9vFFwt9jmJHPtqlo/O+MCRsAwLf7lpVKzrK4BPf8TM
-          HRuN76icQHeYfHpYny6ZjfTASEVdM8RbxaRYMxey/fh7xMRvnEMzI1HYA3LOOGRQiprl+O0YeCJ5
-          wlpbWWglI0phfqzO9BGbk8d3jdKC2wv2xPbHwJut+LAHVn/IuNA/P29u8LxKy3yxiMwO5sDlNB4l
-          /zxpBCPeRmuQsRMEVSVPn4lyTUen3oVlFxvYy7GfsO9x30v16e1jDSLBo7+1F4HI1hRKWjZrK67V
-          N+Sx/iYWyke0YsVtkaxdNJL/jjWdO6hbFHI8M10+7xytPo16iZpfjWBjUBFX+dcHsGy3w3dGv3gc
-          9FwmZS88kLBhoemWufbhQBZKQsfhGtLbNx2uPH8P6SEg2louqgoiPq7kYsEXjd3D7KR3eGhJFNez
-          t46MksNDeEeh1L/Dhh2MfSX1KXMgzl6btVYzZBkZx1OGPSavB/7S5K7E5a+K2E+aND+mIBloVo+w
-          Yp4NKjhzlQLDCibW++ZWrJUMMvxOhxhfOdYY2DfT9xC3fYrtyGKLqfn9WPi1UYRNL356s9LJppTW
-          NiYO60XJguudC8/iQUjl+7eBP9l5CmNcsiRu1r4QjEisJPkqK/j+9BQkVOtSwiEuE3L+MhKl2r5q
-          oUlbl8iPEDesrTWiNDVxiO+r8PQ4hz5jyS1OzrSrrr222nnOwiOQ10l8PauB5/mXCUFhP8nRPL/o
-          Sy2/LfjptSW3/dYFT2/HB5QVLgnWiIpm7rCXpWja56TQD1Lx/VDdhuDty/hsTvdiVY+eDhHf5aTw
-          7yNaROeSQ4WCjNgtj4YuFoZKanzWxafFuzaszi0g9ZklEhw0ajPH+lJKp7nzCR5NZ6DBmIXgXLQR
-          Kx/aDrxzBR6u8V4mx0FiB3pvhq0LPRMRLaCPgdbx7Yr0+pxP4g8MujJjOwNYvk8uzXTw5mdWijBX
-          nz6U2Os293d7s/PEGcZ69dxuzCjvWnq08UJCcJKmM9IDIO2hIRzqqUTp08AlZK3e4wJKlfKFzrqS
-          KLmE+Jf9s+HdAzvD+xbV+NT52xv5OylBfq7KdKhOD/r7Rr4J7XzpiNqsbjJ/xf4BR+aZkXAJPcTv
-          LHmSpPfZwQruJDQf3s+9xDFjgTU2Pxec7iW19LU+ElGDI00mx3FZlF6vGB/Ns4HYlqYrmhnri8MC
-          SrTcfnEtPU6ITnCI5GT5qrwLl4DqWJZbeRCysGElXbry0041kmI+7a2rpLnMNaTNlyDhPh9yVC/r
-          GPKdlifLUFwYaOboi/1KXZrlnMarJKiLiNP8FdDF4jZH46oqxD2MRsG3FzqDrEYqTj+PU8LtvUsF
-          WWv2WFYGe+CYsxeDrMYqKW+zUgjw20fQEV8izpUsydyFaS9tv5/o+TAnZOLMPRSTfiOy09gJl+ZX
-          EfasdcKBdOG1z1zuV0muyicukkhPupy1YuhIKBHrBqEnNMwQg6h+YhIkyEo45qzFEk8ThDc8okId
-          n64g9fSL89BLC5pflkkiy+zhYmToQENzdaXmsfbEIVU+sOY2F9ltDIecHFR6c/usV0larh2WpT4s
-          1mCJWsASAWxKNyuZhdA0ofF5FwdHFQ9TWro5jCrDEf2eGcV8Mm45OmW/iZg8c0dzqi65VH4jRBTt
-          PWnjfbRU2ImVit2A4IJ/3qgofa+oJDqseiLMz5L/F09/6zvMNOSh7VkTY1X0NGGqZl4SxulMbo8V
-          e9PLdEbQ90yGdVvepkxE9xxZrxJj48fXCeXT/QMkNe8nunMmtB616Q0cnm7EshpBW75MLKOWEgsb
-          jzTx2G+3r6FBrE0UZgaN3pKlPtz26IANAWJvzaR3KpmBxmL7ddE0fm/eTdH4PTniYPY7LLgqdCAh
-          jDhs2HLLR7UrbfFM3HMzIfpSrAyp8p4h5W89eiMb9DYsn4eJi4c1auuIaQmdf7kTf/rYaPGipy/V
-          N97H8hjdkzlncQSjO7LkDEGLqGa0b+m5u4fh58tIaBFm6YEUdqywe1nu2uzpFivx+lHCvvUVh/Wr
-          Km+Q+uWL7Zz16Dh+0wqOmXsmzqNZvDn6HB7gyO447c7fuOBZVjGls056rL4b1RPEj1lCu7YmvrNU
-          0ehuSn1pWucAOyjMvWVNjpNkFVu76NuXoe/noLCgPhsGWzeYPJIuzV4Kw3YXrly3vXETWl3a4ovY
-          EYxej2v3DfuPyIWH4/wdVn51ZLDn/ofTYj5R7tLqozSgbU66/nSGVU+2wCmt1xZfoce/y/sMh+SV
-          4ivdvwZ+y1/IwucjSftGKhah+bQSzvsSY50fvGVkOAb8x0cnSs2MdA5R84a//KAwlYeEV3iKIHez
-          9x++DwJK0qvU+cWd2KaiJ0QkcyY5Q+hOnMb52lydZkY6N3qHteGJB5L7zSx9Kx/hop+1Qujtkwnx
-          r0lxwD35YpUNzpfaXfQm1kRPDfWmKoKbg9DEakrYfPeMV4H8OdchresPnSZQMvBfWovd6ztDi3xM
-          Rrj/akqixRC0b3+7qhLvioiEwk5L+Mth8oHIxjRxxuJrizoVLaD5ExLbs/2Edu7NhbOtOFgP+rdG
-          pWHvw8tS38Tf+bK24eMs/uGx/A3OyXpVI1f62//03p2GlYhOJFI1bKblbgaeEOajC490Xqc5riON
-          i6udDLhlAZtJuXj0oPUlnLq9T5LlhBOaV7cZbAo+vtuTS2frfAOYtBVjt674gf6EECA/XQ2iELls
-          RjYOfRCV8ojlmb7pup4VH3kRmFiGxkxYPp9VwKpWTXziPuha6OCieyWzRDvaOaLBoXX/9mvrCpgg
-          IX5XMhTJ5kDeO65Z1pc2Sty5vJHEUm3EfeTYlv6+N8iYrQKHWBZ26cmYjNLVtOWaMiNyvMnDnjr8
-          tC/5aiwMTcmHC1wH1Km3yj785dOqAKDU0MYamaCtWOEWtpjf49xLkdVfsRLdOPTHT9HbqJtpDXNU
-          zLvdtzu4aumQ0/b3aBo1IpjRKSXa3rS0tbWdGUkm55JcLVhE0mjYg57Ze2KfdxStjYjWw6+21nAX
-          9m7DT4WTgUP6nmg75j3Q8tO8/50XVY+9YdUVzoTLbNbELSOz4dxul0EJ7yvWE61K5ue6Z2FgLX7a
-          6bynCfxgtrA14CHHVDMKVu1bE4LPWcHqp+818pSHHCaKQuJs/Pb3t57z1XGxcvkPAAD//6Rdydqy
-          sNK8IBYyScKSSUTABAERd4CIgIpMCeTqz8P7/f/u7M4FIJLuVFdVZ3DP0drx7POXL8TuzDRftfru
-          QPfFOdg+o5dJmuCRwDInN8QuKh1WYJQQQLAMs4Lao0dY3/cg3SctdoarARYbHkrI0fSDg2t0BIL0
-          9CrwobZOTuoOs+UeZiPY8BqH+itii8bvRqC+fYcUu5LmFJ8fPZAvFwn7O78yx8dv0AD/e1eIkTuJ
-          /vAWfH5Pg1iv8JAvb1o5MBrSCzkcltEkFd5n8JJPMvYzdwELz6sd3NWzudU7Es36jfigrOOExNvz
-          PDR/IvBTwZq5d+lH4q4fR6Agd8EWUMd8+o2VoWz8gJwv8ZPRO9w7UMs9gxwy1Hjr58ZmkMgvl9jZ
-          oRuWS5FrUGgZh91bg9jn85tGkNcVhy+7qBlW0WQWXEXNxLoTvdnKdc4ItnpF7ovjRFIClxWyt6ET
-          JxLM7dTcrwOOVxjMIifuBuZnI4IsPzb47/uFXuMsaFjogY9JUg5UymMDSnx5Qys86htkDzEwqlRF
-          BEFl28O/ZOp+7laie+UEpp9XGeoLGDMp4/3VW2+pEUB95MqZk9yhodt8VhPN8ea11pRhQbvcgvbT
-          D/GtEGxP2viyspLcmvcAyV5/mA2owsEZyGUXmc1Cfh4Pv+f7C0laRSKWXrAIK6cNSWoGY0N34m79
-          02PYzy93NvMH5v7xe/KMnnX0l0/gmGUUb/ptoA9R5uCvv+dYg4I40NIZNNjo4YCA9T17PH+u3a0b
-          45PHVTrmtC/RB+h7lyOesjKT/dpFU81IyrEeeO9mvSz8xjdEB1vP5J0v9+d2Cj8jHTG75Nj8q0/T
-          NFzI2b2n5qIb51F2beWHROP9GxZDO/cADu6ANz6dL6lWbbcYSVf0S4clonNNYxgvPfrTq0wYlYsC
-          a9s+E+P36b31/oUIdNwMEbdeI7Z+s9sIqhOJsP60J5MphMbqn77VW2UENNtdHeBd0w/WWdN6dP4W
-          Kbi/TZNoHfh67LPDCE7xeiH2LaZs/E3xRzUWUyW+b9UeNVLFAiXRRGK/1C7qnd7lgbaEGj68OWNg
-          r9eQqV54OM5NXR+ZSBQ9kPlgrvC57WewdItlgzoMJhxu+oPvYP1R++SgYIs/jGA9eoYMz7uDhp91
-          m5kzCW7ZP/3qY+x6UswtPNxl0MQ3/nrwGGW2qIh2mSPVvcseC0LHgKFLRLLVn2aYJBvC4pAU2DA6
-          wOhk0kxFr6zEmq7KYLjLSweX6fgldiVqkbjmUwj+4nkWXkm04fMKf5cqx49LvAOTmf0q1TjcSrTz
-          vkYjOMc8g9Vpioj/VpZ8CktJgxJf3MhBg3y+NO8s+Jdv3qbX3mT6KqB65ys+2J8GzGatWvC8O2pY
-          e12lZhZub/eP3yFR7vCwLAPh//QF0YehjVh2W3q1dbQO3xbxMUiPaF9BIf2W8/77kRnVTpqr5gSX
-          CGpx3dDViAOIS6xiJO2aiD55WYF7dojQbjZO0fLzKg1e/POemLevZtJgP9R/+hs70OqjyRXPwR+e
-          zEvwuDKS5AtVC3XKsddeCpP6l+sK3e/rR8yWyt6UdJYIQphGONpxn2aJ7EqGf+O96e9m9k8zBReU
-          3ebPbpByIiS0VS0ZJuRBR27Y+K4IP7pl4mi5kojKSgTVq2CPBMuDxjY8EAH4jueNP/7+8Rd4yVoJ
-          b+OTL1er4qHHK29sDmwH2OaIgXjp0MaPLyaNFFyAjf8jAYLME+VK4SAJQx8bSQDMVfsICBZ8nCGG
-          iZazuZRF+Oc/2VxLcuInjgub+OMiFohOQ8fCrv79XnP7Vt5yD8MRDrcgQYxW0lAfVV6B6bk7YM/6
-          TiY5ojVVXqWI0NKLfkPpTvbVP3+guG0r7iiQR3hEfkCuGWpMNl9qWX2ZK0V8+ToPxNS1Wu28oEQv
-          YYkjdn0sIrgYvIzohmfrVn+U3lnv2O5h4LHvfXDgSXNG7N6fiK3exx3BYTdHG58p2GpSbzuFuNbw
-          xpeZJAi0gr0MUnxc2nO+EEUVwYbveOPXYE0lw1cdi0PzXtvX5rrpR3C3MhM7wqlu+jm8FXDAVYK3
-          fDDpu0VUedxzBSmtY0c0avbZH/8iVvI7sz89BoH+DbAuPC1v3O4u/hf/+J69myULwh7aTxTOe2Y5
-          5lqErg2/zk5HK/9aAAlCR1Mfpz0gJ5ak+UofUwI3vMaaXWm5ePvx4R/fnoXm7AK+zB4GzHJH21YY
-          6QNvSoqh3Jdzg9GJm6L3z+AciBezmPevtAP9+3uagSS8U2x4ZmMux1EqwK09/zY+gSPiukoAjvh6
-          wZ7bjGy6/CqoJnfTw67N3Ro6ZXYJT4PvErT5qUwcUAt9zJn4vDMPgyhXK6eGbReTdE579r5UkqU+
-          xumOj7EzN2v2Cmx4NtMaX7MqiiRayBRufBDj52s16fW1j+Gml9H1OuTDNj4W3J4nxcXrvakqrBKQ
-          wfPnCXgHtum/UlW4iOIz8N5s45cUKnc/IFs9bNizaUq4xYv4WmwMzfe4d+E2voi15ReQKGw4NRf4
-          B9b3v9gb6U5G8HG/K2SL/7Astkehv+3fL6RYi6TzfnTgps83/BDA5q+VahYqGt74r0f5TLbApn9n
-          ga21RxMRx394jF6iXETjAzw0EIxEQcBtfEDD06MG7149kMjXA0arHkFlHowzOexqfRi1bHXgk4oR
-          sUeZmivwtjM33Zkn59f3A5ggyDUAu8InySgH5lotEwdiLp6x93Uj8MtJ+IEH3uGJ1/FmIy7omfz5
-          RQj6SRhRFy0rFNkF4NO1O+UsfC0QJhXztg5F2Aha+erVxOcH4g0GG5bQqbh/fNoMRGeQOhU7yhbP
-          eVeHP0Cctczg3e/NeafpLF/i3pIh93gfieXNH1OCuzqAF4AlcsS5yLrd7tf/8XvsRYGVi5mROsA+
-          FhF5tugElksRGX/+JC5vq89o9e5lkHvB7g/fPamTBwtY+pgSIz+sf36gBUmvedhf+oCJ8e6TKlW8
-          ruQst1xEjX60leJSQXx957m3FHlXgfk7z/gYlhwjupL0wP02v7n6uCRiu5/sgjXjWgRbdorWX/rs
-          wMZniY+c2ltuRkehuu87tG7zaS2EjwVP7bZCqgxJwyYr5mCkyAGiL/ObU/FRWP/4DpKKfPMzvwVs
-          v/WXYHd1wbLYJoUhFfmZSc0zEtJXN8LP26iR5AcICK0VBnAvpis5OHXDFrfNgz8/lRy03vJWoK48
-          bGPsEBe1X/Mf/3Hchsxc1rTNMpEvhGoe9VjPUzVa+Q9w4ebfb+NF2SKuQgvcT9oR3XmL3jq9phIW
-          rZgjzranZnytsggV1SHY09uDJ55bo1cFPD4Iklxv4/uRpp5Z88L2obs0on9wRxB/WjKDexLni528
-          MijrTMYbPzPXXwQ+f3wCvbQpyVezvBv/6q/tDPeGybe4Vrd+DbkIz9accws60DKkO3a+j8ak2nn0
-          IfSXCTsO5oeBajEPxeO7IBplNvs/fObkmhRy7jRTk1ox/PV5Pu+iZ5334RBkKugkhKCcOwNRyz6E
-          7ifriHO3C5NhphkqO6/GvOZKP8x1dZPhbXtZGe8Fb8TZ0P7pbeLpopDTpaQIULlyEPMkrRHetHOh
-          2Rd3tD/JJyZ8LdGHYomyWSpRmc/0rofwr79gvcJ3PgMjgWqjBwM5qrHP6NjSFG5+G/nzZ163o8X/
-          6a0ZwKIGY+4PrvJqAoJkT229+Za64T++Eg/p1ZylmhlqO+yOCHx3XkM3PaC+a3Igh8JtvI0fVX/9
-          DoyUMxso+u0/cMNXbFtsD6Yhv3Cgae3TPIbhalJSySH0Tr6Ni7usD+ItNUL19SUY0ZV8muWJuApM
-          9WH98z9y3rk+FOVRGXvijHMe/Z5yl8LvOX9h/RJOzXr78QHY8ntePFqaW33m4Ue3TaKdhHSgxscx
-          oLzCmFwvL6+hVjdq8DlVDHvBD4JfE1UBnC8Hit1PkuQrxyUr3PplaNnfGjYlTbdCXz8e0LL5p1NO
-          slbZRb6FYGksw8J1agi2+YDU1/5mLm/BR0AXhCfxzh+ebfqngzv50hL0HYtocuJXrG78eMv/t7nx
-          cw0yw2+w3h6u5tY/KcDqvz+bvyOzaSIEQgjYgIanZoIlcH8aFHJFxd44mtE//3irp/g+RrRhEpNL
-          KIY9QB8GJDDmFDsAXI4Ya9HtCJbumdmQC5QvEnlK/t+/beZift8eQ0RB+xOVoDIzct6+h7T94kP1
-          Jf8I0orSG4Gyk//pzczpvtGSCNkKzdW/k/z8iQHbBzSFW79vVnWn8lZ0/IywFrdbQGnjMPH1AMqf
-          v4694OYP//ild0L2TLJRiRafPyMIim6el/YgmOtJClZVv+w17OzwGi3fubLUW4t/GL9NvRFryHj1
-          r95pflyZRPmiAoI2m7F/NX/gL95Abt8J9v1kzZkDnBDqe4fD/pPfVr5MRftPX13+3rf5A+qfX6TL
-          tW8yX3IcyAdjRRwxcAeWwD2FlbadKQREhy21K6ZwKYovLpRf2hAxlmvg04OJT4uqeWL3nTo4vfPL
-          1i+9NuJ6OyEonZQ90TY/UWTXkwM3vJv3efsz18zmERTFb4ad57vJf63DJbBMc5n89ZtWCBQK72/d
-          xEma770xp0cHPN+UJxv/b5bHlNXQNP2cHOfXIVrZkfkqnAsXZUH19ZbDvKsAcp0njsttd1KYDAWU
-          IErIwTaL6M9Pgp3IqTM4f3iw/l6nGmz95H/8TOiJr4HOC0vsvzvdW9q18tWp4hZsrZw1/POPP2fa
-          kMdazvk6h88CznmNsL/xHxEFaQuDZ3YnFjdbnnR3m1klUX6eZU41vBE7+w+sbeuMz8YrzXkg5jys
-          1/2E9qOuRaM/7HuYgztHrHCZvWW63+X/ZUWBwP/3JQXuDpzm3fKyG+bxsrb/VKWPxNctYJIecC58
-          CFJL7Ggk5vIgRg1sVPzwydkdIv5H5VptdeFDsFa92Pw2xgCopaeg2bkxc/HABMH9m52wfshUc2k7
-          awTy6+lj28DMY19ThyoaXntyLpXGY9HtTiEFXIpdXhHNwQUrhTPvRzipPH6gQuyI8JdcPHK/KNeB
-          XrOdD+Xz6hJcyrO3qN+6VrT3JcKn7th4U9s2iSq4d4YUNu+bcZ8Gq9ppjxy7lQTAMuPOUNusXGcq
-          ERCt87Fe1buEybzm27GJrXmyQc/PDinTbNpAZ0igeBUGfHqrGEz83i/hlL2Os6Jdi5wRuR/hEt89
-          fKWJ7/GwaUq1qeWEIDh/I3bkTyXYQ2Mi56fTNes1tzSVp+iKTxrmzcVktgUb7/Qk5a1Icmp0fqCa
-          6lkn18Q/eGKy3fKpHdEdW6Rao/m6tKWKuIojj2XRPSqoVQzN+C0gTzs/PT7QaKmW+GqTFFaatzyI
-          WwPjAWbsF4UR8e+xauGPIyq2WOgztsfcCOIQtjjkBJoz9gnR1qLt8cF6NQ3N40ZTyUAJolZSequp
-          zDVML+0dn4J5Hw21kWeqKbUKQatQeZJojRrsCUyI7n7uuSh7Uq9GZ4dhO/0+B2oiowQonyPihMYK
-          lt/7IqtXzXNm4W2apnBzrqK6g7TCSTRiT5zkswHJV+P+4t+IzLnE6jpzI+IDF+e8R1sHQkM7kjz/
-          OI047DCFClYcUtzGAEz7Jmuhfjt3xFOgB6T1x1r1OL1rEgpK5TGxnEQQiJE1S/f54PGfQYTwfZV7
-          ornVxZzF7WKWq3obEFwtNV/80l3V+sXfsFWdf40kB10MVzaWJOh62Zw+p50MPx/4w0Z9GKJJupUh
-          5MD4womhnwf6OFehestpRy6aqQM+Fe8I3oIqI+n3idic6K4PjyfNQ/LncDbp/BAzuPwcSC768DOJ
-          OaauOmoCJJ5+B9Gv91IbigxtlsxRjxY4v0PVvNcacW6IeDNzLgnI5q0jK8UvRvv7XEDd6C44ugbm
-          33yulLNa7Mh14aKIvyQkhK+T+cKn7uoMa5UmDixjS8bIMCqwPJWrD/vdAgleJwOwtzJDmPunEznN
-          08sTbGWXQaMeKux99svAsiCC6jLJE/Zkp8v5V0w46Dl1Qtw2p4yS7KpBuP80+DKP26Z6uHNgVAkC
-          1qfqMvCuOxtw+38IjuDYSOtUcFBodA2b2X3vsfj39VUVxTHWdlGQSx/XmtV9+SP4rIE855FXtHBA
-          +z+80sHouh8NvHd4xWiSftEaOz4H/VN7xWlJHsOqD2sBR1ieZ3gw00E6AB+Bx432+FxLRSNcFpqp
-          ybPIcLbGNzaLgdtDv0xsct+v1sD/tmP5v0AxZ5lxvMnqA7+q8W2+IorHKWftl8jy6xYI2PEmreEz
-          5zMDY9JTbMf9x5wbN+3VrikqXDyDA1v80qCw+1lfJFzQnItDSGs1970Tkpc0McUDa1a1/nwcfDj3
-          +2jq0VGEmD5jXKbZOaKHk1RCYpl77G/5u275oLpnqyR3jtOA8CBGpU72MBLXG4Zhi4ehhoQJ2Gkm
-          Pu/6+6dQPadK8BVbubeeXnkg/+V3MU61R/X008LbNfSIQeEvn098FsMOQoNcRpsAqtpOoN7DLiWJ
-          kHkms6VehNyJ+sRRJZCvSayH6tf99aQ8LDETxc9gQ/J45TPPBybgCRVK9WfcKaJTh5j4o9EMbVG3
-          SZxKmceWY8LLvfG+Y725t2z5i89rR77EP7/biGb5RGFgJQSpQiV4DP/qEG5Xws/ztnJObMSvAn9J
-          5GHjmlaD8IxvNnTYPSKP4+sezQ+x5qQ//Me6Yg6zAx4WGL4Vw1Eou42EP5oCTE0ryRWJwkBvH1ZB
-          Q+jfxCSiYL6PDPbQ5XtALPn8yFfp2cWKHj4l4hdFHbFIW2IVj18ZH1vWNevwC6Da3DNGznycgmXf
-          hK16X94dEh7g7q1I0BR48rUnSdc2zAWfHxA0nEJHnHOLPLFh1FHjxSyRLLi0YVXzhPDqNtq8XwvB
-          m3TpYqsHwylm4F07tlijFythf5qJK4XzMMtOGYJqDyTiuzrOReF2yFT+ccbY5Uc6bPkTw3Izd2uM
-          zvlwO+iBuuETglmIPZ6Y8AON1+JiR3snjB7DLIP3h/zByVb/57vAp6ql24+Zs95pwxOqFv/wL86H
-          R8O4Zkxgv7M14u77b75MmhvD61QfcHARtUYMqCpDxHs2Prwv3UDP4TMB3TzO5Ol+UURE55CqURE8
-          8B34n1wI6myETy23SfHZ7QEd3zVV5Y+v4nsU33Jxb/EK5F87nZxv690Unt/EBXkeMrTHNQRrd+Y4
-          0Aa2gjgIfSAuMOYg2zlXUiIyNCMrRw4iPc6JPitRtIZQQdBRmYcNr09zqh++lfo2TIyN53PyqAP2
-          Csz15YLDwG9zlq/yCM/2usf2JIrmWvSfHmzxIa5a6Izf6UIIX4oqYoMTglz8ypoNkrsYYW3xG0as
-          9FvA588ISQCfPuOfK7+q9HCUyfGclYyl086BaSF+iX7IHia9RXwBvtplJRs+Rt0kOCXwy9jGOVdp
-          TFTirIXK73xB8vc5MyIurQwvmfvExpvfRfPt6ySwg5yBo/dra2l2dQoTLVkQu4l6zrf0xEH15WlE
-          +5agYTWJQ1Ao+Tgr1U/MqYncAqKgOJBC6NacBhotVGMy0xmO4DvQ10X2Ib5UFnFOR2MQH80gw7MW
-          FNi/2iv7vchiqVO35tiqcmJOy7RQCHl+xfhR+lG3nxekapdcRjz3FtjyLUQOHCHxyd/8ps5LttXn
-          RE2SWHc7F0Y6toAXxAKfY05oVvP7LSDctw25/14tWPMhCFT+gTGKk7jOV/0aampF5nTebe+bubSv
-          YJR0CXalKvY+n1CH8FqmOYmaU5+vsEEdyLljiVE0GZF4xsYKv/HpjE9RLOWkuWYlNJvpieRmiqM1
-          O2Tuv3h610IYVn+cONBfJpNcWN82tBQTBwbSKSNH4ijNb0rqFcTi702cv3qzY4b2j48c0Qd4k3jQ
-          RMhZ7gG7wNoufqN4hd9HT7BFZglQMsU2JGF0RmAyW8BYlLtw98xrYqrRJRLn7CdC95N//wMAAP//
-          pF1Jl7K+0/1ALGSShCUyTxIERNwBKoIDMiSQfPr30M9v+d+9yz7d9sGk6ta9t0IKoSKJt0s40gUa
-          yHfIUWgEg9rXJ1QdOIckGWge8FN7KGHDjT1yK05LWddfG/jW92+ii9YuYF1/atS7N+0wfzfEauU/
-          Vgl1A8ck+jz3YBVC4wPrnXfDu/T9NjBffhag0IlHG5+u8CfxOIhJ/cQ0FDPw9zzAVdcAP8NlGqkp
-          WT48p+4RXdtrCehruzRGuHa3f/FE+RJTkLDfCT2sn9SRNJULOLioIRZ3K8aFvwwhnK43F/ll9jLm
-          bDA1+Pq9ahLdPr+O3hQzg6tUxBt/ezL6VSQelkgExBFMNxUPeskpHv9IEMpwFdD2SDX4JkVIgq9z
-          CajOrS0E3NbyZsNr/FePw/75JtFWr5lb7woFc68AmaJ4AEtpWfn+lPY6MYXhPRJgJR/o+rAhN1HJ
-          2cRZ9x5s+oVoXpaBNZ3n4l++nMlH6aY0DFwIbw5AUb9PRrE/ivAPv7D6RkI6ydZ1Ul7V2SXpwk8G
-          Nf0wAW0DD1s91DpRFY8YyopZIHNS+Ooffu3vI9n2w6l4SWBQfajf3x8fM/A36j/QMBeEHG3mA9y+
-          kjtINP5DNr1Qse/ii3sixAmxNj6Dt3qufi2jIxfuyAVUe3AuJE3zJNa6HNmShoavpicNoZA83yMJ
-          5FOh7qe9ga4nRRjpSasGKDm2SawlnwKWrOlLFWDTkkwyv9Vi1VwDeWOeo+/3ao9jslYf6MqeSbKN
-          v9N7o7fqZL23QZVO1rG1vCnwhOiHaPqu7VaDvDAMTfGFVf18C9bPrfnsI67lIlo+82pJNJuHW/5h
-          xZXcgNeIPMDYMxsSIeAwZujLABUY5lu9CDq68Qe4rS+xMmqkyx//N/wi/8eX6QprDszZXiPHz+9i
-          sIouGJ7uckwuMy7YejQ1DuhefomIEq3Veg4bUf29mgdKIKIVo3MGoR7ZbtR/T7+UHpPJhbx34cnR
-          di7dQsqbDvRvdcLKwLyKrIuYK8UlaqJnuITd8itjG15KOUF357rdboX7BXJr9kNhmZCA3sSBgy/7
-          fYnGhRaM5O4wgEtFe4K+jKvWj7dT4ItEHYnIKQjWXfdowUr7B4kVhw+W70l1waZviJXyU8WOy6yD
-          5DDB6JVnerVURViqXE9qYjRnm/HatQjBb/A/KBzOv2otLqCB3XdwUPkYdyn+2XykbvUK2YAa48aH
-          F7h40g8dnZQB/HkfdPUOuyGCZ5uCxfexBptX7aPzH19ezSSBujHFWz01wJJ8TA7WR+SS4++A2Iry
-          ewGvaYORlW/XeFddFMHSj3jc8zAIaLA4GVyWySe3h+uO2OHEO4x4z0aauo9GlrevO7QvjP7ph3Hx
-          pI+s4h9fYuGsuWzJh0xR5+B6Qw5VzgHVT3IPSm1OIgnUDZv829uErhyY+KN6j2CpCrOExgoZOrRH
-          d5xPbiFD7fBK0LUwXbYe5/4O3Z9RkmC/kPEVXwoZONGQENTWncEex58PycftUYUcoxLm9FCC+sAp
-          xFymiLFrKuRgZn6GQpI2BrOAGYHD8/tEKF6fHXlSYYB1nVGixYOZCt+a40DFfyHxvwfMFvom+O/3
-          SM9pW+FanbfJNz8L7+VPny7Hj6apTlqYyFfrJ9viwYfLJOJoXw4ftjA3bEGtXCf0QGzoluZ8fcH+
-          8TURUuqcUeV7HaDwpStuiB6PYiZYvPreL9Yf369WQRjNvSn3e3Srcmysl6qW/z6/6eNnSuL3Iwby
-          xdn8onPfkeApQ7iL03208dFxFCuzhmh6y+gQZ4dRCJKoVuTL7oeFn1Z361tqC8iU4oV0mgeBJH81
-          qqKaJtHC6JOtuvi9Q0+FPAn092Vka3lWoKHpd+TbD1S97g8Vw10PLLzcPG/ENFAmeSnUlBw49diN
-          iVliAIJMi8Slzqolo14Cj+WQ4QGVu26r5zz0he6E5fZZBGP/c0313uYhia48Mpap9QrYaexLtOyr
-          Mnz3WlNlp7XY9u8wfsMnyqH09jnk6I7AqGbxOeSV13GrL9bIt69jDzb/D4WQOwCeyniBetqJaMvX
-          lDVNE0JieB0q+tubbfhAFdvlW4SG4GKwx+vwUnv68qN1q8fDYCT8n96JZJv8wCq4bajeC/GHX5t+
-          +82zEUIrJwxFQ8qnn13vhv/0AkqCLv2XTyGsNJzbu1e6Nh1PoWmJEbHG39NgI58scEfLHivhTx9p
-          8bljeLSUDvn9MUglvalEeKbODe+ZKILPxr/ULhv1iEmh2W35VKi/cO2R9ycnQ6fNoYhrCTm25ASC
-          VEoDvAjWSrRA2S4ZvAU5TOz7Niajjw2ctEsJvcPwxfBw4oL5z8+6Phed3Db8mAzpySlP7/CMQEO4
-          bta+rID7hT4wULNXR6N7XwP7A2qkzX0E5iFCPKQOEpEv30eD+bvaB6uqX/DeDw4dOQXnWv3T85F+
-          3AG6Ox/8Pz5KnLVJKzrLlqY6nvLE+4C5THJuT101sHNBTv82DOE49zX8vdoH8s7TYlB/kSF8PFqC
-          1xs6bXzp2EORhT9Sb/n0255n/3bGnHgPtt1ysfmDm3+MNOV87aYxGScorElG0JoeDHHjq/Duf8/E
-          +3pTMDbdhfvjxxF3K8xAnPlx+C+fL9k+wO9zl8N1pR7xrKMPxLi81VC5CwXR6z0x8L3+udDXpw8J
-          RsmtVjnlFTUhq4BC/aZUEzH4DzTPI493RRIHbMd87Y8/I5/AR8AeJ79V6PnhI6/ZXTd+Yybw7PXD
-          f3w6/P1KAE/CTLS+TjqG4C+Dw47Bf3i1+j1W4KYPiPU4K2B5WExWpi+uib+6oJsvq5rLUZOOyDK6
-          sKN+WbRArkkZ9Tb5sb96AaLcDvHuqT/TJTZPIjQZcFHEuV7AGFQGpW6iiHgbfkvP+hZB4X6KkLHp
-          qRHBZw7/+Tv6Zan+6TnskJGgS8t1kwg5DJXHjIlR76RNT8k1yF8GjeTXfmH8n5+9+cfksAtSY2X5
-          FwPrLd3+/MuRfsDvDoyVYyS6DADgYn+jsMGijg6v96Farl6RgRKbiGTqdT8uoXaQwbndsSizjXak
-          X9k14V1a92TDl04CtKqVvdDE//EdL6rDv79HYd7w40jnGkLhnkYoal9aumhE7kEA0SVK5oJP6dkc
-          P/CaDAVW5Ngae8uTajiM0Zt4/vUbTBWeeLDhD9EO7JOydCh4kCV29IfX3cLWSYecCBcSDOMUMEH+
-          9lDxdypxr4VeMfvVLdC/pOqG53Bcf0DJwVPZiVhasoshXNW1V/06dLcxYcLIisLNIAgNiJfbhRir
-          iPsMfsap3PzlZfM/Pxzos1yMIFcYI5HVXwSlaqzwnXN/BpEuowm6b++g+5UnBrtUPwz7w3lFx5dx
-          3fQ+HsCWX5iqvyxYeTTB/ZRKByz/fm2wdiM2QdpIAjq8IRwXJ0lKtT9cVkx14gZrDLMGFkesooO6
-          nlKJtH4CUqeZiJfLU7Xy7aQD7oH2yBXzif35T0CEU3D8ZPI4/vHtP/1PsohLAKke25FDLmDEuUsK
-          I9/pV8OTNqiYxebXYOd9KMN1Vmb8LE7AmJxdFUMxRi9cVtgCbJoL/Y8vkuuriwxWiYkJh9oExJzd
-          PZj4Kvj86z/YL7C9MlcHyl8/J+JRWKRLhScRHrnLOdrdB3ccfOd0h5+mDlG++SPL5QMaOPmXOwlu
-          3KHiza2Ft/UPIvV4+xrsxPMcrN/8GcMdtdJ1eap3eGhIQMx30FQTRy8tAGpyjnaQR90cXTRNhc4Q
-          YW6WvFRUDlUL+5kv/ulPGgW/Ev7x281vCJY/v+SFsyOyNBWPf/4csAV3QeetX/Ltd02rNoN9itbV
-          /HRPd6kSBZ9QhJfuqQfr5jdAfVF4ZGMTjD9O0iLVH70Che61DxYJqeL+VrcViurwy9jWX4FOWprI
-          7tQI/PPn9Yi7I609W4xs/QyYcOCxpSwLWDFLLuivnErCUY03vC4jQNXtlUnHCjuKy6f4t34Rv9tJ
-          Het3TfPPL5wE8QKW/rbe1eFy9klyc/iRui/Yw7gIfWKg7Nytp0BJQFLmLnL3ygGIvEPwX/yi47oe
-          jM3vK0BndQWWKb2A9SRcKfjTt9rO8sHyOd9b6SperpGwcmm1YtToqrDGGfHTUDHWZ001mGT4QKKW
-          PFJmce8P+PN3QqGn6bz5P1AW8u+W789u2Y0Zhd/70yKOEr/G9ZE9TOCdGx0vjB6ApLTq8tc/2PoX
-          GpOkS2ergOwvqFZDJ5V2jc6pxl2dkb3xLRLwsg4AowwhxIat/3H34f0LU2Qae1LRP317ytoielvA
-          StfEIQmY4wCRv/4KHXfOAk152OPl8G4Ac/wfhC+cH4m53H8pbV/lHSrZoyFoCKRgWfdxoW76EYVS
-          fB1ZHIk89JWTjoqsDDqBe3k+nFo4IrMa1XH+OK4PF2DrES+KT8Z0u9Shi6YTsbd8no9zc1eV0vlG
-          4FEYhljsbwvc+pnIyAfLkEirx+qWf/i7ZJdgmgWtVt/H0w1p+jZ225vOJtxZoYmC8GlVNFd7Cuff
-          sKLoO4vBtOG/uvkX6HLFb2PaHYRY3fgpMZ3bK13CVIMwQ5aLvK1fxzjFpOBPX/3Hr/gxVIaj8EWI
-          eEewWN7uDjxO8pG/9VMX+VE1sOyeKglWjUvZXz5t+olY7v1mrCS5LPDPv3ts9W/BfC7CqpM1dHNP
-          PvjrJ/zxPeLG/RqsBU6h+udfPJwTB/pCPEVwysgl+gXvLqWnuW6hS1sVi9OwZ9Q9CS+V2y7d2vDY
-          WNFOkGEVa+8/vzZd9+K1h5vexsrV/TL6u4J4b3TkgcI//ocSQYOWrRxRlIlFJfzhb5vgGW1+6Iif
-          XB3/i6fLGQ4jC+RrCcGvUMj1e1nHNRtCDU6wPhLL6KaO/vUzvWFH8Pz5XYJ/fO+7NgHR6Mcat3zR
-          QW9bbSQImQ6k3dGQ1bycfsTCocxoK51a6Kx3jvjxBxqzPNxy8P85UiD87yMFett2xDj6C6Nk94uA
-          kmo28d+G3gmXSWkh5pKGRDwz2TKWVx/aYTGh4M17TKTip1WfIi8Te88djKlD2ymMaX1H5+SopeId
-          TKYi34CPDj2qOt5PiwV6YmEhf8eZgLUYaBBgjKI9WMyAqfGpgHKcGRFzyiRl2jLFMEBjjgxjN41L
-          h3oOTqpsk/PryYOlod8a9qfTjwSW9wuW3whL8BQ5B1nQeFfLZ+xbGEn1maDA2RvsyJYP1C/aB+Xw
-          ZBusSYtSNb1viUfy6o1FxB1VH+L9jsJ00ise+lIC88RKSants275IijChLgmQihoRjo7KgcFVOGo
-          vX0OlXjSmwQawSSiCxPOlVSd3liN423y27m3DSZEpQhTctTRUdpO+Q3TNQNdRc4RgD416LNwB8DZ
-          ZkdSpaoq+rTGRm3EfiTbelZ8eTzWSm98E4T4UurY/XXHcF8xTHwaJmC4/yIIguNljqRL6Fbivn63
-          6tnlD+R6SJ5g0d3mAz8n/Y702+eQSnmr2uAlVQ/cPKoFkD381PAzWC0ylBsKhJxTMJR5JiDjSAJj
-          yRStUb1PImL+JUfV6sMmUaVY/5JDZ48GXeafrurZGxO0qPdAOg2qDN9TdiSm83lUwmgEVFVwoyOr
-          aKyKws8kQy3LO0wVFFUCdFwZxvB+wLdURqkUWKmiOtyuQYdPZ47izaQY1mU8kuyY39h6QnMIxX5/
-          jzijvgOeTz0f0jXniHfbV8YaqVcTvq2jReqkUQKy5FUPjrwQE6+yjEraQ1zD4PYJSNFxD4N++NqE
-          RTCdkLaP7YrXOVWDyPInLLqjDtZxr/oKC+eR6EMYBBJ/+ZVq2ZlvdN4HH4N/qc2kQqW4ktP+7hjC
-          6RpPKrnc+UjyyryiHz6zIacsDJVtYFSSHtocxNdXTGJUHirpxD9L+FXaI7H79ZfibqgxrMJYRuHv
-          tqQ0+Vw+cJB/kDwOlV7RW3RI1NGVS2JGrR2snwOnw+KlvHEjj6FBXW9JVOzdDuQu/eIAP8EOgle1
-          b1EQlEowne/rov7F681gRcrjWfdhON4J8QItTP++HxTR7CP0fLqAzYY1wSp6PVHpFge2zU8e4Onk
-          JiT3ol9K62a71z5oTKJB1xqltr4pMG/DFqFHZLAt/nk4g1+F4bVugLjTpwacTn5CkJs+O2qJVgb2
-          d+uCrocYB+wvHpFOeGR8GxmsD23NVWlsOuSNrt2J01X0Ya/gEgXtJrG05RWr0W8gEWwyLeB392ME
-          zUuDkP1O6kA8yRCDOObF6P38Cd0gVBDD4iW/Ua6DV0o97YnVpfM5dLRtNR3vL9BDvLx8Yp/5NBDT
-          7/X+F68oeCPUCQcjLcEn3iNiFxOtWOaUd/iyNJk8yMkJxEdzy+FNNM2onc0hZV5jYfWnyF9Mf+9b
-          QDWuM2FUEQWD3XdM13R8URhQg4uocmqDtZ7HXD3e4BvdBuE90pMMJ2BdphqF7IhH6RLzilq9PxXS
-          XaVOBTMPSzh7CU+cvXbt1rTNI3iwiY8e2/pPtuaL8DB/eeQaylRRNkMFGpeIEffmMrCAW11A92P+
-          yBV4YsCk5qOo4vZW3x++rTwAEyRXekOH1PgyehDqVnmUUoK0JA4BncvKBMu7/hLXXrZTnse2gIZ3
-          4jC35kElNg2NVXuNQlLwlm/03DelKjkfIHGmEgFm3XccRNqzJBevzFPxGSn2/q29GW7V6QuWNNSo
-          SpbRJUZ55tm6fd99pJ2P5HYbDt369DgRXp1ARcYTOUzIrq8XyEH6wcuWX0vDzAIIPd9ENJ+iDV+7
-          Vu0tGZDrFk/C2XmVEFofBUWn+AUE/GgSlUsVj+TMjIxFTvcciHByQK69XABp/AOvDrvJRldtZIwG
-          dZjBv/p5buNu3PIFQzCVHzxQ1jB2206NklZoSfDYWpRB/Uz2j5fxIQf9mneUSU2hvn/gjAerabt1
-          Ab4Mt/UnDpqrYHHmuYdLdyBEq663gP6ubQy84haTW0n1SnJpK6peSffRW/CSStqjoAeJxbck4jrD
-          4M/3/QI3vCJhnYTVv3pG31yMhQr4bPoUGx6K9IHlsBErSj1jgumpuuHurx4Yj4RT2x96RDyIxGq6
-          /Y4a/NQpJD7/uDDyJpEMt/2NwONxCiTHjPyNQpdYFOCcrjJ8tfAwv3l0V7mejS//PKlj/lqRvh94
-          Yz0o5qIOhjqRkkb2OH2vTa4+f0ZCjFmyKqnPqKZ20jFB9/J6NvjciExIz4QiG57sYPF9P4QQTjq5
-          f1/XYNG6pFDRb57R9bavAumzaAvUTmAkeWj34zIJOa86DOuoDtEvoGLaa8D/3AxSOuSxvcVZ2lA8
-          Vk/8Fy/i33pkmd7i5XEzR+GwJyLcKdJK0HjcdbiFtQLnJnhEg5ljY9aVH94mdbmoqs1gnB/zLoTC
-          p+oj+SMnAZWJP8DzaZXQ9WvuApplfKYGY9wS63yQDYYVGULhMYSRqgbzX3zlcK/jASuHewR48xVE
-          8NKWBBkbX2D2sZ5gK/kZuWsf9i//VXyJv3jDQ2MaT/4LWuf0RXSR8oxCwmpQ9+aJmDw4jSyfmo+6
-          I68E3cIqNxbeoy+V9Xc7Wos1GZf3gHslfzUBOnX2GPTGBEW4ru6KSgKeIz0R7MPj75widz76QFIY
-          FGGgm4hEx1BNV5/yC+z0TieBLr6CxdZ8Hl7AgxF/q4e8+L6FsI4ojmjKb5JdjCf1q5QcFjd8paXC
-          YpgNq4os/rUd2csqF27xgnxtz494mZ/aP7w3R/o0VmbpucqjfEHa7imlG75AEE/HjljrVAAGx95X
-          cbu8SCmYNGBwbHzwx0eXiLGU+u9Shs2nq0mwzz7jMgtsUctgV2MuHoeRGqfVVN/Se0KHx+/U0S+/
-          avCDMY+MG40q1h92EAQHVSNBP/2C1aYBBBveI3c7Ns8/2TNXm9eRIfOV8gGV5GsEy0UJtnwHwfyQ
-          jhSMhJlYLBw5mNLQpdDh1IbU4tAb7HA+N1C5l4xEzj0ZJy/JZeWBLmcSuJ+2w64nx3Dj3/jSXLWK
-          hv7ThhnQKnRdrxJbVUEb1FfcCsiSPyNYz45zh4snVMSLbm+welHfwkx+dyTppCRln0WjqvQLFeSf
-          HvdqnPc7U5F+zkii1/LsljYi5h9/I3m/epUYkTIGG/4j3TYXNnDnQ6++71VBnHTVR8kFa6EesusT
-          RZlrBuLUmRMg8CCQ4836VixpfyFsEYBYNL9V+vc8IDK5R8T87J2SRnIwvF7KKoJn8ADrvDZ3Fdxv
-          Kznk93lkKwhFiCb3jW5f1a7477XP4ffk1ESbrDZdG1z70O1+K3rw5aVbbE3n4YZHJNkPWUBvpjLB
-          eUlw9APBD6zNu23Uo2asEWdaGhOYOReAX0lBLH96pPRZaD3Ul9zD8lbfNv6oA2tRlmj3pXtAuyGb
-          4K28y+Tv+7LjcLTl1T/0pF4uXbU0sOTgWWYLCSLhwViXTgl49NSJlFeddX/1A1alfSdaInyD4cuv
-          Opzb14WkN7411iFQS0BC2yYbf6mIwi4yxJfki/TlERuv3jFCePxdUhTNwBqFVChiaFybersncTVW
-          MUI8qOtXRnL269OV67Q7BGmUkpAdo05MPnwLNcI/iLetB3WSkIP+52FEA4o1wN/o0qj4bR+RniKe
-          YVGbOfjCWYnsdicFJHOSO/RH+0zMah4CtpppDclCL9HyXrxxdZsGqydZhySOWFrRoP7F8EnRZ6uX
-          JmCnMRFVzZ0vyGvYNpnRiRtVjnMDpbNwGnmzvGC48SH8MukXLHK6QvW6vAip8/bIsOOKBXTqyUXB
-          YQCMvfwbhvmiu+RSww9jtP9i9db9QqRZg2HwLtY/UJUDTLyv+QhwFrwp0OxWjXSmCOOKjUcPvN1F
-          QZF6UQCNM6P502OYLaMaMITkCJhOukbi47WmhNHFV4v2A4nR9HswY+PSwy/RYxQI8SMYPuoRw4Ul
-          R2TEb3HEij9noKpLZ+OXSbr+1aM1GhRi117AFnICJVSJ/UM+UNRqfZGQg0e9/iE74b7/1Ru2PgNi
-          6/lg0F8sD8olaE1i4qFJ2VumJTi7EyXhlj/fWE21vRsy+9//X9Xx5oM1Wjx0P7IxZfZFC1WxcmTk
-          KD4OVuORQHBtHg3m8eE+zgzcF3gaUE70jd8uh7Kh//RQVrmITQcHYxjdXUrS7fvTO/Q0qOyVBcvz
-          ctry/RnB4/cwkNAwX398tFSXMEnJ0XsP3fK5GgWkZZ2ikyUbgE3nlgceiiG6TLvBwJdeT9RbWcsE
-          maIbSGeuWVS3OBnofq9cgAXv8oFHyd1H0+/xClZ9TX2Q5/iNnPy3WYDtl0LGOAOvZMrYlAc7DBXt
-          tiPOVNTGiJWFA9WieghV65Cuv+/TVscgNP7qTUBLeujhfC0Mkm16d4kOqJE3/MDMmy8VVbJCBHEs
-          isgdzuO4+REv9W3lGR7zXGNCJ6et6h9kHeXu2AK6258VAITHiHenemX4sHM1kM3WB2mnkXb9xm9g
-          lGz36W/1nBgGTcCT7xAy/OxdTW413//0O0GPqGPr/nlbAH6bR3JrmtlgeG1L9U/f2wnnjNIvdAsY
-          SWebHNAHpzQiZQJjxS/Q0fdNwGrvqsMOu0e08duOPN7FB97XfoeHgH1T+uX3OqhXLyf2Fu+0erwa
-          MACTRwfxxRvvSlxlKP70GfeX0jOkJU97lfbbvdrPnO/YxcE5pGE/R7sX16ZLaYgK5Egsoo3fpoLK
-          jxO8ZrsOocM16oRnapWKN8gucX1kBdL3rr3UjU9Fw8ZHyHWCd5Ccsge6bPu30ovfwIM6G//wf3g0
-          5wy64ShFuORQyij4LfBRPH8Rz83bJNmiDKEinO7Ilo/3cVm12IValnUbPu8Y/ajHCeLmMm18Ia14
-          R7r68C1hQCyUzinehYUOv0YqYk69lGC60aUFZVRm6DCJv47W+Y0D71g8Rb9DHBnztBoNXMPLCfOv
-          s8PmYOhNQMuLicJ961Sr/8MRNJYmR+baBGw9omsG94J1IkF7iav1s80R2Pg3ZnN8SddN/8CPw/sk
-          48GpW2+1Zqrudn6Qa5wdY3uI75B2z4K4cTsYLOOFBI5kFDYVHFfSCkwRGN71iG7b/otffq/BkzWc
-          kbbrxoC5dOCVbb1QOpQjm5akyGA/sTc6zu7QsWGpezju5BSZTp8G2BKPGajftEfWoSMBrY+vTD3n
-          bYGF9+iltIlu7l/+o1AG15TJz2aBAp/fIpU7t+mS7qMBbH4D0twGd8vB+WBFc8kFq6mMqvX9kWPF
-          vLSIuOOjCVjhNpGaKC3d9EVm/OPL10ztSLTpUQr0eFBzT4siQfBoyoab1KjnLCQoAqMBVhskLYTW
-          S0F6c9dG/vwdS9DFWU/8R2oGoi/JunLaXmb0qGYBKniPD3jeunMkf29TupY7+6UaTSqT4x7zFb6u
-          zgJlfm/iZR9/0kW6ac0+FLkJjzoSDVbO1+IvXpBF5WeAjxKG//isd5SDjhjGLYdloNYYFPoF0O9o
-          NaoUa19UhE1e8XK6cmqc+g9ip92BvXk6u396OoJJoxgstGQRCp9GQqVueIYkNViGnYQSdLz2M1si
-          /26Con1BtPGBgPL4xP/Vb3IKg56N2vc2KVDaPYmTf7GxRIfXXf2ewhGlt2NmUKaVJjSv+Bcd45vH
-          hCN8RJCEpk1u0s0wqLv7LspW//HedOdqjYtchJu+Q36zA8a6O7kJJNzWIuwnL5CsPPovvq1ATBkt
-          HnEPiTdGmMshGJcatL6aEN/8q0cGfiGLA3/xuwvwN1hCDAqYqbmJx01vr5OS2HDnKzreHXdFtb5T
-          MYRhbOqkPhfXatFaoQbvKT8Sf9Pry7EGIZyvpbHNEQnYgl9xC/lSnInVxsYo/DKigfzVBps+fVf4
-          Mbg81FpdQUflVDK2Gy82nIPPDY8bXrB86j9QWME7ykZ6MFaH9gp46QQhVIVL8F4fjwhUX9kkV/zW
-          DB7c9jl8SS0m2mlMuqXnTi2ouqBDuhNtc/7kQIafqSnJLV+ike3Ghw2hhT2iua1esdRWG3Cy+vPm
-          3/WM9xK21csiINnh0hrzpg9BdsL7P38O8Nly04C73i7kkDfP//h+cNhpKHoth5F9b+MA9OyLiXEK
-          zVF6+cqwrzqvI/rt8A3+PU+q4B3eFfmL0d3i5KC51RdSGOk9xR2vhX/+FAq7+QQYf/lt8X61UP5o
-          1W66X35UydRIwJ+eCN3SoVCHPu+V5AD3IZvycxfC9T3wxGn720h3YaHB4Fb/848YnbpnDzf+ixwp
-          a7ut/rTwkt0UpL29qiPrsdXgE4kcMc3jPK67eMxApoCQ+OtXHtfWrxbF6UOLON3xwsSlExoo6q4R
-          qUdtqVao3jLgMhmR1E/W7g8voKLLEklLhQRr+Dw1sMjWPFJI/k0X4joKTIgmICPW6n+fh0Xw1ZE1
-          QiXd8HsbvXciSE9FnYnYLRWIlzvAlJ1Btb5vPwyWhXtF+2eejbQERQg+VpUgs7JhsJS5zME/v+2K
-          301Axu+owYnsTkgr3u+O8vgqwiEzQZSUWA8W2R9LKPDZDVU77ZYyFcEa+p8zT4JIYtuRR8EG7yni
-          iGVWOGWAP1G15qSJ6N3eDrAkn0K46Utk8mAdZx/2MfRH84xsppfVcD3GtapYUYPXepvLYwL384/P
-          3XMIuo3v6SA0Pxbe+1USbPWWwl8eXlDOdCV9J5yngNjK9+RgibHB3sRWoFcue2QJDtfNo9FjyB+G
-          cqv/uFvbtM3UeEIdsfrOHXllr5mQvoUDCtyP3vGr5LVA/BCTaI9qYat1TOg//+HAPJxie14GGNxe
-          AVYoa8Bie6dCvQbKPRJ1YKaiHkuRIh9XECmb3sWWaOXKwZ594r3i77iebPbZA2nNkD1FOvjnP7BD
-          fUT3rR+B15OQq1meB9EeBB5bSOVBJYxtnRy18jPOm96CnG136LD5KzRISwxb/W4iYxlvwVq8XAX8
-          8StFGDVDGhTXh5s+QwVojUpwj3iAJtNCdJlKwjY+zoFQj2vMU+sTMOvnFvDPT3pciNh9+abSwXIZ
-          D+jYAdrROOvvEOmSgVzPqNmCZGWBdoTP+HMWP4CO3FKC1+Rr5HpKT+l02OYWagAdiSuCc0rt12Ar
-          z7H2EaJYG0XMfXN4AFWJ3JlaxsxdayhP869HRvwdKub96gT86YtNL1d/8QiWziARhLsGbHpq+Nev
-          s/aBbfDD9ZIAEK8VcezXwNZK3CuK8OhDZPzxjVkAVJk9743Cc3FN13nt79AIsIipdEEB+atvW74i
-          g/f9Shxbsvzja+unMzsx2Z8G9agdVlTtM7sTwNWzoRb4CB1g/kknqR4/gPb+8M9fW7Xz0qpNz2Xo
-          eD3swJ9ehMLoe1G31b9lL3c+3PpvJFKhYGCy+4WQMWhE3JxJI5GfAQ+9m9lGnXnQOnGalgjGQiUR
-          J/8dAP9rZ/7Pv4v4sjt3kyApGTTa9xPVsEiY1NWKCJ/0+EGabJ8Ae7zjD4yqWcGFkXLV+Bcfwi3v
-          ImbHKiNbv1P1S9VGxrD7GJSKuIFb/wrpy9Ng0nGwTPVtIYs4olumf/1IaEfTOVp7BEbaDfUElvf9
-          i6w784PlfglF6KOH908fs8OX9urmP6AKro2Bu2Ht1QlcdiTSeielIycX8Iv3B4KEgzUuSD+UUN63
-          eWTceD1YmTmXIEoWCxXOxWKL7gY9gJL6RNEr+FbLc0gWOL9kjejhRWD0XezvUDiI300fmkz6w/N8
-          0VxS/x6mIf32UQyO4xKg+2jYKb5TWu+ju0+JzuCvWs5nO1bt0jJQ9qdX3zeTwk0vYn/jQ8unwHf4
-          hxfhoA/d+rsnjZqrbxSJeiameGd4Nbgs4RnVlrKki+x3JZja0id/eM4Utc+gi2yCXDUqK6rHuwhc
-          XlOBDmHgAjH9nmooHxmI9vitBSy/4gZu/h7SqPqsFjz7PtzZ8UKS8Pob//rhIJ5yGn07So1/fsef
-          H77hc0VFD7bwa30fJPiduorFULRhlmntnz4cGTlzE7xGoRMJgnPvWPRcyj+9SNDp/h6xJPHx/+tI
-          gfi/jxRowr0lLrpGqWTvIQ92n/MDaW/XSMXXkS+h8nM/xL80C5ssLWzhveMOxDuVHhMlveVgIhq7
-          iOuBZ6wS7Bd49j5OxD0tsVubJoghVj53FPJEZkxLNBkOF8iIrtQtYOfVjFWxWSjRZ/QG03mbrjUH
-          QktMaeeMqzc1LgweDUTlq9crcZem4t5XrgdicZYM6Fs2Q/iqCpec75lvLPjrYkj2XIzsulzT/izl
-          JcTCIyAOVOpuCT5Nqz6i9hPRUtiNBLHGV51vsCBzMr1xvYdcC4e2XRH6kbWiO078QJYMITmzZxX0
-          DHwVxVmLC+bIy61oMTo+LGiaYtm4fwJGgyOEfKt9UJzjWyBCzfzAkNtzJC1Ex2CO/JRhO/1Cctxf
-          f93aCKoMvx6/jeZkD2Mahp0OB6mfSKL6crC46s9U+enVkbw5WyPfrPYEv1x/IJ5gh2wJP52u5p0k
-          EpvujwHN8uEOXdALpCrQZZR+StlCWET7CD5aZ1z1ak/hceauyNAvB4Nf33SBw3F+Rfv94WngB1Ab
-          JUDSiNOZ0yvhpF51aJghxlr5O1W/1tMntTxkOSoqpAFpeA0lnMdnhSz2rAyanxNdfbquRGq/DCsJ
-          XmOoHgRvRMjj2pGXWu+u3s3Exa/FTMcFvW8mPNnqtK1nX61mJS5Q+Eg6Mh6v2pDCJ87hhe6fqC44
-          Plh226habn2OpHbWia3ySWvgQLvr3/MHfJ/XItiNtR8JH9SnvZdovAoKwSH3BdwMbIp3G9wG/YS5
-          ++WZrg+BFep+f7dI7r4GxnLrpUF64y8or9ykEnAx99DYa22kCnchJW67UuVmHWdi3qEcsCVwObU7
-          1FeUocObCcH0dqEHDESO6z1IxftpniBf7xPkxuMxXa+olvcm9ix01rt3JZE21CHtizMpnzsd8Mt7
-          SeAeKw65X612XGNu5KAlUXu7Z3Jly44qOUSXl07ytW1H/FB6G35/Lf6L96p3sg8GVG3jCOzEV0eQ
-          P1PoVeechIaIu4VXagiV30ONVORR0JfeLYa18nPQ7TzbnUTCVFG/3HAg8exeUuk2+S20btIH73yj
-          qBg3LwNAR91ElszKYE5PC1VPtfUleVF+U6YnlgxY0oekAiCuaIzBHTbuaqEcJQ+Av8+gh1WVWJEy
-          9XnF13WrA8PrF3J2BNPgv3mSwx2oKaonYgLeOGQQXoosRUWa6SPFt1oEyce4RDsKze0UrqmraRAo
-          0SKem4oBc41VBPEbGa+VVEsIz4Mq1CcTrz/4GHmb2zcwEXCPOweP3VTTxFd/0YUiUz19OqZUMIdm
-          910Q4qSwW8sOvmDsJB050qUJRHZ96qD7vCA68g7P2COvZTjCm4vMJpoDhsNTqWLldSfXzN0Fy8wF
-          FIbZ+bpRFIsJPyuVFZomJQov3181aRul4MQ+jyArsLFeO2rDjxK8kOs7ZMO/3lep2sR/eLK9FSXZ
-          Cn7XHalPxhlI1l7JoXiynhge3K4T0VUTVfhVfHII2jVdJ5wm8Ci3F5RP8Tb67RkMMOPvITLFmQKW
-          2iuEfWZBcpA8OjK33S8w2IUCiaLNwr+WdqQqmZGiIzf2FduvUw3rQRWRc/Nmxt5fl0LOOYXI6mUH
-          SKI720CdD+q/+KeL840UBjcJf9proE+fzxi+K+dE9BUR9lu1xFf/1udoRP7IK0KM1evXfJDKV1+d
-          9HurGRjctMWrHicjvex+IhyOxZHEb7dLhcPNxHBfWh1J80StlonzEvAZfIiC3soMyX7poTKNYoKQ
-          8D4CGl+NDM7CoqM/fOOtkSR/+IjFJdAN/uY6Odyd0AsFpZwDgc84EdaN4xPtmsSAqST4wB7nLUK2
-          gdOVZiuvOokhoEBIVuMldlkJGJR1UmZSNQru9SbDjK9DdLrcrt3iZBjDPl3e5PrdvGnObbS//SbB
-          +alXPFPKGlIKU7z/xUpKiTNNELZ3l/hV9TYWRYgn9Uf5OJLKxqxm+SP38PFzQhJFH2WkVcIGVUZi
-          /S++lpdhmDB49TJBzY126+VzgXB6JudosdkA/uHJsRDvuOcvcSUCTTdBZJhndOOWeyBt9UpdkBkQ
-          Mz0gwB9joVRdkNvECQ9wHEH5LIDqvAx0iMlrXN7zrYA3/iVFTN1nowTsCMNLijSkudaPjY+B2vAt
-          nF2UCP4r+I24WFTFu89Yee9CJmj3S69+3saP+K++raYsWH11q7eR+PualfT9Wgs8naIUJUxV2Jq/
-          NU31iVgh/dhNYLnw8lYPQp3EEfYCAZ2JCaPi+UVx/vtueDPokKnoSk4u/6nWPXwvauitFYo/r/24
-          OiYXKRs+k2uy+qmklrgAW72J5iPtq43PJFAUZIskje4C6Ww9GxD+Hhmxxuc3WKzxGwM+uZyJfuhf
-          HR74ogRhpuno7qGPwXaF8e95o0WaBrAEicX/4zfZeUAVLTP7pZ5/sRYV6stIpeG94+H+lfkkNNaW
-          LenRtOEcQxEZCD9G/jM/FJjE+xppP/dYsbRuTXVn9xwpgrti0LW2FbX8sP7f86zH82DC9hK1WH7K
-          WbqaSwWhmEdhJLQZH7APVBXFJ3yF0vzodBIkngkjt90h34/cAIuTHAP3acvoOAhPxizgUHgbLj3y
-          p64ZWXVYIhW4/AOhN/lWjDaiDeNVWFHYBl+DKOsHws/78CPBB/8qtoT3AkxiGUeyHVbVimedV//4
-          VyC+3oA1Gomh0SlfvJeIHkjG5/2CFyMsCNrwZP1VofYXT9FySxQwn+M+Ay87EdDhkbbB95AEJdzZ
-          OULRzZq6ZX0rFOIAZcRfFcGYtp/VVKhWvIzbKeJAP2dAf22j3HTjlS7xnl9UbroSUk69WJFBuWlQ
-          /3ESMfyLEOAsH2qoo/KEBUNBbNL1rwzFg71HxscwDRYc7QGio2ZGINDLdFjLtYaW7NxQUPsjo8fy
-          mkDnErjI44rzuEh7pMO31X/JsVWMbn7dhhLc/LxA0fc3BEtnbqNZPSiTC+u9Tnj48QAGBwYkc29J
-          OhalMam4VN4kCHSlWsNc0GCT6hkyD3wPljn5af/y4SYuviE0fHNXf/OUkfhQaxVd6rBU2HdxyMUm
-          bFxf7KZD476M5LFvWmP92q9chTpF+KHAIp3vz3SCVYyXiPPQJ5gR96wham8Xci4zLRDVn1fDZgZ9
-          RE9dDua3AxdoU+1NarvUKzGody78vqoq8jY8ZNVccvC9U27EGlBSLbd6auD+lftYcJQ9I4ptRtBy
-          S4jQkQtHLB9iHTbqZ4+Ven4FdOLPJbyZSo780lMqmo++D7d8Qq5zjwOh7PgXyPi1I4GQnIwle44L
-          2Oolyo3kyVaz4qjydHiXVG72rugzvlDITWZBLB6/KvbiogxgaxmQAb87xhivZWoju4ikrUsYuZSH
-          UP317x9xrp7BpK1+wqA0FWJ+qDauZ0V2IdLvDqa1w48bPtuwyz8Z0R5gCajlqyIExswTr5zcjlcC
-          TYZNsc4kuLPRmKPBo+APz09ydRo3/lpCsocxuXznQ0pLLpXBtt94L9ghWKlW93D1sgHVzT6paP1N
-          c/i42i/kkPlcLZlUyVAMdm9kyN8zW43lWisbnyJagpnBclvk4N3D/j+9IanEeP3x1Wh9FBKgsRFP
-          6hy0QbTsjcfI9OQowxe4FshFV5zO0XDYLkK+nbGknFJjfTbHBcikOZMaTWPAeiXW4XQALGIBPndr
-          rtDhXzxOwZqzST7iBSajPxB30xui5TWlahXmMaLPK6umeA8XeLx6Ajq5+zoQ0GDGYG/2J3L4pmKw
-          Pj0tVJVofyGZE6gVNvyF/+PzyFMPgSHad81W/9bvXuEnGF77i69WTXHA1883Zouw93UQO1+F2LKt
-          Vcsau67ysfQrcjlgAKkog0mpY7NFubjf3hrgxA+4PeoU1d+2Gv/0GXywkWKcyvuKiJSWkOzKhGzx
-          AwZkjj1Ub9so7dcsB1OzRpMCb1lINNd/jEvhxTEcaKQT/1Ehg+4naVGAuhvIsQ+njtpMDsGN1ADZ
-          wbEJmEqMD4T6gpD5bA5A2uJV2fQOcawbx36c4hTw+hxumL8crmw9cfgONz0XCf69697besGfcbMJ
-          usRCynKyZpD25RlZu8uxI394rHTTi9gi/6zWYJpd+JDp7Y+fBOsezssfP8J4wwOmLNcWCOGbEb+g
-          CKx8+ixV58NfyS2sHCBo7qwr7EsdzOEkHRnihY8Sr02J3HA00lVfp1L902Ph0QiY5KBv+4+/WvCn
-          j7NX+FD++Iwixyo8g39fWqoSMh8w5sVTxZc3WsNdsJzQTda9gPzVp8TWHHQqBh2w/c2J4c/9bBe7
-          cxHY6qUMhJE7b/gyjdh3H3dotUMQKXzHd7NbuHdw/Vbi9jwjow+lsdWXJgYo6n5asNZyTsGm50k6
-          GFHwxofe/ItfZPDfAEx/+1nmTENhvXcr/jDRSeWeTwMdjxJnMB3eMJQWL8TfU2SN7HRTWsDagY9k
-          c3kbSxRLCuSgo0Xqu5cZ7kUuBr0XfYkDOodRlwkhfLYlxiCRdUY9t+bAGrEMr9q+N2gfpA1UL6+R
-          PG78L/gi/03V+74ckav+rgH7ghaqW30i9ntaDDYqjxaM4fLFy8Z/1xnfFhgZ1YTQPLxHdrvM+f+R
-          di3dysJI8Ae5kHfCkpfISwKigDtAREBEHgmQXz+H+81ydrO/1wMhXV1VnXTD/naGCBnTTHv7Z2YQ
-          9pc3ltyP1fDldNIg+34oyEo7t5md9FLA/MPpGKLJ1fmoGAz4fJURsr/ip6Er1/kQNGbsi6/DN1+0
-          SfYAtxQ6eqZxoHOimlWwipQbev3lZ2VaPJG/gztx25Pjco9jx8i7/sXS78iB6WgfD7BsoIqK4nBw
-          25zOJvi3PhlV9WH/fnCElMf3DvX50g+bArNV4TFbyb9xy3scwOievf2eP+X5NlqCBftyDH2653dm
-          OpYT+OMrGosegPmoiwN/M74R5RBYzcTxYgexMiYYGI/QpV6VSuDXf3/IvQo1nedZieFv44J/+hM/
-          wVJBZUmQL84uHmdjyQ9AdEyATmjRcn7wpSt8ZncFXazPK9/gcEsBF2wOnrnFcelrOlfyvZw04j7e
-          U7TJB7EFdp7ExL7pv4iG9vMGV11QcPenB5Pjm5MTQfFI5kQyxfvfS4mQNMS4RQbgnt8nA6q0jJHT
-          zqnLFnXrwOopKihu76RZhAvewFH1ILrO6LRPu0+Vf/jhwY8abbuegAE0E6L65sldfko7wZ1vIUu4
-          GiPb2CdPTq5CSO66RAC5blcPaIxnYnK+6zp/SJUaOMO8+LL8iEbymlAF2/vBJMqpcHL6im8S9OUb
-          RVbRsc2W9c0GyWt6oJv3hDm9OP0Gw7cHUBnRplnk16eD+ZL+kJ8VF5c+dGWQWa6KkEVO5+jX0KyS
-          q744ENMGY47n8rvB8S00xD9Yi7vjrQ+v7NQTfcyEkV4tLYNlyZ2Q/8IupaPPbLD/XXjiRJ9i3Bzr
-          VcDiXrfEvL2ou7SpPIE5ziui88Gob2NZLxCzT5e4229tqMupCrwYquRH5O7RTR5KAXBx02AQ3MRo
-          nTShktKJUUiua2a+Ct3Sy3/7Se8nfWT//L04hW+SuZ9+xEB9VXDHR2J90YFS43PtoYHdE7KSm9dw
-          X24fVFC2/T8+s+rnxICm9st3PsCCdTIuEDbctyX/9icYHgLUbvWFnKWQ6vS2Jb4cAlqhy8be6aa+
-          xRTWxdAS7XM7Nwxknxiuov6nHwkd+MRywGmueB8cQZavEMkmHGQTIwW/eDq35+0Kg5B5k1vlX1wu
-          mucKVhcp9Zlo7/Lgf66d9BXfMWbvmpoz/e7MfQLv4y+XxBo3f3EFeGfsO7Hewi3fxOm4wIOXvvCH
-          L1BEESN3YN9vyA1uj2iLR82Cl2h2SYAzTV8b++TDx9TY/oe+gTsxvuSJSS2JeFNiRNcXC1IYBSFH
-          LmJ5zDdKouGfnv7h+qGTXkoVmHVrj04L7fQ93mIoT7jDQGoJXQIRbrBjJgmhUTX1/tLNNXi2LUJX
-          K/Td1Zu+A4iF40rcNSnon34GOhWRf+Bf3UiUHaB7AVg+v/PzRbalgwQaIybJa9PdpY9vHPzz0+Lo
-          cnNpc3A58OevQmySiMnsewBLe3KQ0nBGRKu7eoCMdptR/i6GcbF/fgpd4l+IA86WviYfp4ZWmH/3
-          K3asS08AbfAaK4Ro3Xh1lz+8+z74p89Bc8hpMT8LyExdQ86vTdfZ6XEwQHr9ZsR9Fkrz54eBnV+h
-          QrWacWCx7gvCizf8h3JNx0VJ90EUbGL57ePTNCtWK1Oe3sGdnGwP01+3eS04dMcTcfTByZf3CRdg
-          TOIP0Qcdu4XEphM89QaLiuBQ6U3Thx4woq+FTmZD8s+bGQ5//Iyk8Oo3//ze/f2IFWs8WNckmYBk
-          KCNxufZEOcPZBzP/+hUviuOOjHDpNvBR3jfi8Wmq73rcgOXLLciplaNx4xPLknb/C7+rj+rOQ27W
-          UMKfHd/jIt8IRQWc2U3zmcn4jdiy9q50Ox81d/+J87No+8Nnso8wHnlgrFeIM+FDLs85G+nu54MX
-          bjhkeM8in5KXksmn60Ha4+07ksnnA7gJqYzO6pOhe33Eh8d8ETFs6rChDyM2QZ5/C2R9nZ/e+5+s
-          hdFxSPxlyyZ9tC/qAB3lJeHjFH3cXqxEDR7jscPizzXG1ch+N+iVAkYJjge62FeLgcc45nEprJ8R
-          D45uyCjptF0vGfmM1d6EgBoH8rIPdbOyv0KBz7ZDyBPhG2zbyb6BRbxp6Goekb5xaWTC05PtiBfq
-          LF2gvZSQH9UAeT0TNH9+ANCI4aDS76RmZuXVk2/OeyKXX3Nx2VsIAphEF8VnMoj1VUKCAf749z9/
-          72D1Chjmx3OvZwV0KIPgCh+h7CGE7ry7viplkTkOFb7wEJSI2/UAXMTfg+g6fjckIYCBOx8jtgl4
-          QBlG48Df86IPOUdbceUcaPIvhPRpmsfV1e6xvOP5rsezaOnV4wD23/M3z6v3Hhv3FBKGkTEj9V93
-          Y9Ogg4nup0gz4r2LZgQOcFxFl5y50NZXe5Y7QK9yg/y34gC2odca/vmbPv/qmt3/qgF/kmbkaNGP
-          zqesYWAiFxxJoASbInshCRR3HqBLZJx1jhS2BPM8OKGw+qg68zRXQd7rORg4cjvSbE5LCJ+/hmRR
-          ZYJp6h8W2PGQoK8ZgvGpyr5wvzmnfb2qfAXgfgM/X8lRqWhPfWrmNAPL41j5zKdyAc+85h5+X+EL
-          w50fLO/MHeCZY1V02b2E5WCzpTx3xkoUH//0dUr7Hozn3434EW3GZa+PAB6oAvGywKJEB9oCDuG+
-          khMjNUtS3TnpebQ8ovzpUeLlgtQU99nfRtkE7ITz4B+/Jhtso+W53QY59IwjeoiqqrPrCCVwO94r
-          vOCsdtd7KG//+NpfvXGKXc6R5doNkfK8ZmCpM9+CKsGp/8z2ru35k4Egzz8FCYvB+6t3SmCz1X1e
-          r+nk64moivw8Oh45l5UfcZwuS7D9HDBRulcD1kIoF/j4mi+y70d9JfPlBlUpiFGx82XmdPthuPM5
-          dGlDId8+3ruACktFH9p7l8Q/Pykzl5TYj7ulr3H3LCH7JgQpwsGm2x6fUH/cVKQ2kadzS+GlMNnA
-          m5y0Pnc3aZwYWG3ThfgPR8jpn/+30u6N1B9vg5WodQeNJngg3++yZvvDxx2fUb777ZvJXnronL4X
-          LGpgpoTwhx5iJVawFNtBvuXfgIFrAwLk7P44OSNSA9cxrii0GDPapLHlQFkyJ2Tt9R6+mBRFPqX7
-          oJoheUV8auQdfGHvRW7bdmjoQW9u8JE8fHL12XezhCIfwPd00JG2vdtm8dFQApqaHHHfhTMu51s3
-          ybu+RlH0o2ARuXGAzdu6IuekHvUJw32Q8gfIeNvjb+wgK8jp9ZMhhIJ3tFVS3UJoeSFKXnxK53Vk
-          BHh1y5UogdLry8GWC4jOwupvj/KuT9Mxnv75/1b1tgEvrRiCi6FLCBV1mdPV1QuYK5OFlEtR5oNp
-          15L85z/eBYzzlSTZBPnKaTFntArl1aubwu3JJcScggvYjvLbkbfSxf/8JWq2mg8Jw8n+czpX+2Dn
-          3INfxpx8mEwvd/3D4z1fE+3zeEZLYXnM/3WkgP/fRwqY79kjtuIaEd+rLid+6831D62fN1t+iQ/Q
-          gGJMTmFZN2vS3juZ59HDn7BwoszdWSX5d5l8zOrpz92ay9LCZaAeFnTXibifWC0wcY0Ivcohogyo
-          FgFivl6In32f+RbJmyGr3t8p+ADnS5p0DPS74I1ZmDbuvBmnCf609YCCTuBGutxhBm39VZBzmIrj
-          MhzWSdbs77yfOi6jKaKfDM4ct6FLMlfuwoVmCS/PwEF2Jn30BedGLIu7Y+AzCIOfB2wfiLmj+Kun
-          VXsjV62T18ba/OM3AvsscOyAnHNacnuel3yGi4bhCT0ZZH6OT9B7yj7i1r4p/so9Ty7nPBoBfpRT
-          hEItfwN2YCpOvounBykC+6NPTJVcoZdHgc+e+TbCbuFDCGqpR+g+PaMuRhIHBfkXkqdqjeO22Kde
-          hkA4kFt/E/MVk7cEWeyyPqvvFkrLRJocyGlCUkk4NITNUQyeySvaO18lIx8nd06+vhIeM5rfuKt6
-          7GpYSsYBGVnjU2aDdQ9H8Rb4i2ffwRa0TgfMsCDI8eooZ9ZoiCH5DAFSql8bbbdTBWWQJB06jdhy
-          mfuvimXPGV5427t6L+nBMGXGqDB5vf17zv5exwLeKyfAgOPqkXOELJYz5ZAjLRzVnLHpI4UXvg7I
-          2Qo4sAApbyFLyhXpJnPTmZIopvw9RQW6bN0l53+W1EOIjIwEunqlW/ftDUi3j0pO5/qec7eXPkB6
-          Wp54yEolp/47n+BbCEvyrFjdXT+rAEE9rT+itnsfwu7CLXKJvDPJ2GRuNikSLUihd0fX0/3oUm9p
-          K3D/oCOxhakGW+siATLlQom/Of24bel4lZNjW6IifT4bJmzRAk32ZpMCuTiibI5ucG7FXcKpGV0R
-          zkvQKD8DZR5f50z5Y2JYGWlIwrhTc+YDbQ5KV28gL5WbAJXsPgBuUR0xDZZ3RNVz4MP8AVfySs2t
-          mUC1z7KMigdy8G2hGB8ohl7HXZF3CW7jOvh6Jx+el5nYBC102fKHBff3wdWiPMYtON0suRh6gtLK
-          lunWumdJrgSpIEY55zrH9JYEb04EfJrbL7Bun5cHeBwg/xn5Btgaa+LgM3lG5LGXudbfx/Xg+zMr
-          xN00IacX6ZACVwMj8g2O6utnXaAcWIKH7PxR5ezHzTFU8Pgjfm4Kzc+Q0wDi5hejUqKBy1xHrgWf
-          Bs6ofB//bhFPMTQZ9YIMdnX1JS2kDiqrEBHrPJyaJfsahZxmzzsWn2U3bi/MXuUt3BvrBsdzzloS
-          k4FXMf73/RZ2v6VZvNUceU18odvntV7lt9hlyBHf4r4/DgvcQJ0Q6yG5e5eQ3wbhI66Q4/FaxHNq
-          2wMrHgRk3EoLMMJZzWAuMy65Fg/k8p6Qx/D4vErIyitO3+7dVgJNa0NiYOzn+NyFPUyu58WXrPSs
-          b7y6lPKVqXz0QHyfr+8fG8vJIazRg6XX6AfjSoPRT3tgNtVal+U8NZZBLfT4uLFRxOQ/UsObd+nR
-          6fQk0TIFUgHNs/9Dd+ZduFt4PvpwxyOUwGvmbsuXMaTm4yLiBkEGODtRGDk9HCvihwcWLC05X2Ur
-          iX7++nrc3Q2ncQFZUqzomfNTtOMvliLx5yADqTHglWoToMaTi491oYjwlo7Bv+971tQ2p6uhVLJx
-          8K9EOeW9u10WIZbt37VBanf9jMtesIPvZ/olAXmXOvfQTyZEoZ3u64Vzml6CDb4cQohtZnHDqt7P
-          EqVDWpBSu4bjxsO2B0qpCMjdknPE2ctYQ+WOK/xz/Ypu70Tu4eC6DZ4ShgXbUw8l2bCns78O4KIz
-          yxYs0FgsBd3gKwVM99E8uIKnQ4L72YsmBek+rDpI/tZPHztuFeT9e6OrWql0JnyAQV9GG7mU+QUw
-          X9/pQMObEGnFg+jLH15/HtOX5I+9UfH02Uti+vlObObyHT+QFyvYv1qM0JQfou3Zjin0bsKHJP05
-          G6dRLRi4hJyO5WSu9MF975TjNgBy2vPvwnhKLGuHs+AzX/YJ2DdRDfnxuHSYIwVq+LZdPZl7tiE5
-          +dLb3VJQeqBRRgOLolyOy8G73eDtUrXIjzfF5ddPpsAW5TfMfY4yWB9ZUMsqxhyygq0fF8t5GLAz
-          Gxd5DWvrVJ8JA3lDc5DnTNSl/nnVZFkaEfJn76qvlsSkcMJPD4XZMjebskmtHAbfr39P/EfDmI+3
-          IP/h3y1rMOjeiTxAYA01cYcjGKmYFxa8nXwPhe8yj3gm3bsYGd4XvfTVbBa3tVoYviBLAneQ8nUL
-          lUDuFKdCIcn6nBWgUPzlT1JmXznfrrT35Ici+ig9D6exu536A3Di05lEM9q7/hbdJu545VNhDXO+
-          aJMO4pD8MOtVk7slyXuAglNqxCof5kjV/oehZRCX6KxZReupCwb5yUANvQ7JmNPcejCQSuDhsyCb
-          8i1bQwtyRXhH+fwIALOY30Ve4WYSl8qbvtLZVGQtQho5fX61i42eSFBvmxXZ46kdlz882vM/sgOV
-          AUs86aksRuWDRL/TrM8D03Py27EPRHMidhzsZawg5/Ytcfz9aMt3WhWZ1YMjMm/pkZJttjhQqwJF
-          t4h96ziSJQNevfVBzunyyTcuXUzgK68M2Tp317GmBVd5smUVIerU+XKUqkz+bbyLy2tkADY/nEyI
-          w/mHJZX5NLM/Lql8ML3QFw/g7pLqJ1jw/GBuRMe6Pm7nk2LJR+NQI+se6pSeZ6aXlzZ7/+EzYBcR
-          LDB5aorPjrjXl/yetlBoddlvxGAaf++/WbmMfvHZu03HH2fKHQiYnPHFy5NGS87VJqQeFclJjRod
-          16a9yeM6/DBErp8zctgbUFdvNbp4d6ZZ08lI5bAXjyRN1AxsTigbUD+WKpY+o53T5PSG8nLduxCJ
-          OG2GmAtMyH7YJ/rLRxuAaym8Vrf3mz1/Lpcz68HZUXwUX4ZNX5/3sJOD0Pug5FDXYLuMUwd5Q3F8
-          vMaHnCzw0QMXFxPRCmHYux64HHy0S0+e+mVtVg/YHtzkwiDn2NPp1kduBb3o+yOXTzk0pDogA2wo
-          bvEah1u+GoJRwfq+XFD8OcqU3vC9hMbiKJi62zCSk3wp4cu4G+RyAcecWGxTwnsBOqIk3hat0mfh
-          /uVHve1CQB/cwwDa1yz8bWpxM5kSSOF4syUSD6Xo0mP1NeHn4G3IeGmDS7ZZYeSxO3//5WO+eWqp
-          PHUOg0HpfcG2bacDcGd7IQZNWEB5IkywMrLQZ5pxbUj88gZ4TfQXcnrkgCW+3CAsgnTwZ5/8dj7W
-          XCE4PUSk+M0AtpR+MxhcjgAZzbiOW/pKC+kbcCUxL8NV3w7xTwPn2prR1enbZpui4CZ76giJbohS
-          jlMQ+zB5Koo/uarmrrN6Z+DNCQHy5csnovHL6+GwfguijJNCOe+8KLJuDxKm2nCm7Pj8+WDnD1hW
-          aDEu919/A+vAPXB547t8Y2rZgns8kIfBjGC1FMWH1saNf3wjYlx5DKCUfu+YmeitoVU7peCZLohE
-          eemDddtv9Q33x49opv2LyCOpe9hBWceT8DJcJuiWQg6Zp4qyt+frNHysGOI5GND1nXyacdbBBLJE
-          5pHBc6tOod9l0jkRvuQWSueI737HGFyDniFOGcnNAqSog0+T28fcvKRxcx6jAF5b2SKFayWwCUZe
-          wf58jXf+yYyYfB4K9Ig1+FztKM03/ypXOAr6jZybvetHrY8SHDYhRSci3KIJ5LMDH1bHkmehpnSS
-          R2cBNJkckgXTq9l87+BA8ZAgv838FyXhY53gqL9tFPzWs8twceZDQX2+iDYoF3eVqtmA4vSoSfiR
-          uZHEyZOBt01bkN2+m+gfn+yrS0XilAf6IhufWt716X6y503XcwhN+CR0JGaFOrpUYgjh9/1CPuj3
-          LgXf+6f90xsovfJ4JPMzToGZGzra9wNgV3UYoKq9DV8u4jPAMylN6LwHm/iP+D1u35ZP4fNNHriL
-          e6tZuU+rQa3gYmIlqgRWPlosCH9ySFTa3po148or7Hy+Id6uv9f79Sb94ScypcN53P5+P4RO7x/i
-          5+puRfaoQP/qMLmAtqH7epjgdJ1KYlXlRKlVWBtkE+eBmfCTRuuq1gPADvaIyh5+YP69jiVoxreE
-          zJTPdeIlNgN5/vJAaJHEkc6fkwfhZS194R7qgOWO5vSPn4Br1Yyb8OR8KKr1RE66Lun4efBNePtN
-          CSnlqRqXOdpLCHOnktPdjsYtPPM+iOdPi06WGtBNy6WDLAUA43oEJuWiomqh0xHBP37mYFyX/HQT
-          37pVo3vSWA3zeUaZ/JOqzZ+TNHS57WhVEKuGgBKPbDoORzGDgu2aSA8WNWcT3TBg8dZz5C5XNafD
-          usE/vbbP7o3GZXFp/Rd/xGWKeST327bA2dF8ZAytpnMgLnwov7YUH1dkjauGPA/M2u1LAlvSIxq+
-          qwoaEMT+Emmdu6414wD7e/wi1bbJSIm/lyLetw3P52miVDKKGsZxZ/lVIFc6sQplA3s+Is64oJzW
-          mAuAom8U6Vf2nNNSVCAMXmKP/EesjpONLz0U5DFEypGv8h3/Tdgeyzc5w+9P39ZY8YCnHQRy0etq
-          XPvDR5KBcnNQGG68u7VB3kO+uNVEOZmPnVJ9D/BNbjcUMvqi/3I9EKDqWSkyUHwCVEhXU4ZsHSEv
-          fcrjjpceYD/8kyiezdLl0b4z6Auej1ymuDS4sVpGhqFiEaNSFMoKISrgq/za6JLXz2g9VKIED6Yf
-          YtiXC+27wyQAQVty9JqWyx+fr+DbLSSUAHpoVn7OOHCyypS49di4tDqcDdkylTOxrvWxmXl/ysAe
-          v0g5uy99/r34UvS765tcAGLAF7t1DXf+goVj8gBUgnMPP2k+Yh6/0bjHvwHLyzVD5iAzOWXz8z89
-          T7Qo9HQaCJUlj66/oJN8uAD2hkQOvovzSDzjO+v79zkAy9TOSCc/P9qG+u2AgSgyOn/LjVLnbUoA
-          23mALJu4lARXR4BWKQc7/qhgcYDiySqeOHQqu1O+KvwRg/50+yGVis24Yd6TxD99f/r8NHebg28v
-          Z7lfkdPnRt35lvQ9nI5nmbh346NvHzGC8lUSRPxpTlWzeT+1lpm4zIlL6InSe/Hr4CU/+mR/HrDj
-          qQeNg3dFxa6XKE8WDKfsu6Hzrn+mP39NO5wEdGNcJWIfmBQAq6bgU+bK6SsjKS10cTnhXV+5y1kb
-          AuCuqovUHFmAn4cAynyud/iARDQOYTf3sOlKF5kUOJSeHMv440MoO73iZr0qNw/evttAlF+R6tiY
-          wQArb/phdro0zfqFGgMStTwit98Ho6YJ5qD8WlJ0Bd9Rp4b2uEI8XwcfFGeVLuEvr+Hl0EzonMOM
-          bhQmjNzIzy9yxax153ptHbhS2vig9M6A2/kDUITrgXgs0EZmrLsYxsWBIg07j3xdRLrBUVBv6PJ9
-          GBGZPxcPRokxEQRkzl1vSdXDMBQav/eiS04CekuhO7uLzycbbrbqaaegVr68f8yqc/Pnl8D464v7
-          ++kN8/1+AmgF1wtxn+lzXC74WvzTV2a23QDfrdiBJHhJRPEbB+DbS+/l6q5rmLZAoUyadBx8xcGK
-          yludRPx0Jy0cjiNGyufqUu7ebQXc9ap/vE/PnL4Kuf17XvJcFW1cbHzqoR9NOsmDz48uVhdz8klZ
-          VlTKk9JQ4Lk3yImbQbSStvric/sgw4ApSQDSk7vYNMzAeC+4f3qGOufJhzvfQsg/oGZ611kMmTS1
-          yOvbOzl/Rr4HucVaiNIJXDNPlRGIV8h0RHl055FlGIaT7ef8xhKR8qY5eoEDlsmwyGV6f/Ol1htB
-          ZiTYIX3XQ+NF4jI4aVGG3w9Ho4twVlPYg+VNQio2DfmmbglTzZF9JpS+EX6LyAKkwc3fekSbrB57
-          6cyYGfH2eJgyTK9w19fEUzEcZ7ZRIBhfpoO0ZDlHi4FSDRrXMfSl3S9ivIt1gIxRY8wMiOrk1Awb
-          UCOXRSc+qNxlz1//1vcP7/iqnTLQhkeKnz/5QzcfowFqomYjd8+v+PjwDEBU50RcoRNpK9pTCctf
-          cSGPy6bluz7toX9oRaJz06hzHMMy//S02eJa37s+lPBeejUKRAvmy7vOblDtspKco16LKCWjBHd9
-          hFwX1jops6yGu17Ha/8WXGqfbAf6lqsiy5+1nLmgSYHx8R3iNWUpXayxbsETxDPR8KuPFmmbFvCX
-          PwJd3cCvFq8HCLdo8LdvMTbzNxNjwEiHjhhG9Iv+/Hh4WInoC3u8zMQlE9j9MfIK+crd2C1bwNaH
-          mPitD5r5JZoWVHVGQXHtVM1mL00FhjL10CkstXFZTLIBkqcOyU96CNYxwD08j5tKXPNXjMuypQtM
-          Oy0h3ju/6XxJZe/PP/vzh1z2T1+2jVgRv7PZ6OcB1YcFbAty76T9PJgYQnCQpoIoy71v1jvtUsDp
-          N4+cD7UG6ONaCv/FU/0XR/+Nj1fz3vFU0ukQ/AoIrL4mZhyJIwnffQ3Durn529gldEGyYAJ2TV/o
-          +X0YOXfwJR+2cs385btxiqnkwT8/bY9/yidK6YOuxgdiXu05wvU3v/75YUjb9c46pfcCOkmq+7JP
-          fg3FE6NJQm5Sov3G0m1fa+PIKY4JcV/bNu56KoWHmNfQec+/O77ut67nNzpPwKC0OeQCPB2EgFh5
-          FbvLYPYdTO63B8ndL9V3P/MGg4sMfEE123yzE4UDbyEqkftoqv1WM5YAHmVMtH0/rB72B3gaFe5f
-          /tiG5z0Df3ziuh2aZlGWYvrnZwMBWID781etILig046XnOENDjTh/UNOW8HS9fUaCzFRiyNBorC4
-          35GJNUDCjUPucMxH+iG6IbdqovmL+ByjzWvkDWRoLP2/fNm/1saCf/9/tj4fQHxtvgp//PPkuU/9
-          l7TPVvIz8kLIOh0jrHj3WI5d1SQ+ElGzdPqCZV6o70T3ws5d2zq/gVvp3n1oXnhA4+TJwRW8nN1/
-          q9zJAYoPaTl3BN0nORpHptSAqFYTSvOKcxfzHWD5+H0rmB6Hd0PrADHSrOqjv+KudP/4C6DeKu71
-          sUM+OYmpgL/nfbXnD91aTpAgkJ35j89Rtqr9CtZddsAwuksjLQJlgIz4G8j14E7jChdtgu9ojYj+
-          FFp9InZawAXk+yCMRc357sfHcL+4gtRSeoDtdRk3QAOl8aGmjyPlhwn+1Xv8P760xuDpQ5zfZMxa
-          6kLHqDxywE5ijjipMUaUFeUNxF6sEesUBCOJSp4B9X27+BA3HF0S8FakHV/8T72szdK4GYaSLYTE
-          2PVh+6cfkVJ/0fnOM2ALxzWVRduPZmAe3Ib7Droj//nlkW7rOuuPSwYBt2jIDr+vXb+GmnyJBg75
-          7yFztwKMGlyC5owuez2J+7rFPqDTbNBpr8dtgbYaUPykJvmrd9IQuB5whWnbB33oI/V/WiV3aSng
-          Y6x6ER/e5sOfP4HZhXPdTZV+KTyCLMNVpHU6OVMllUOJn5BbxzedX+5MJpsjZtDuD7ortr0e2msH
-          yeW+ddFqy68ShhI7+QO/as0aK29NHu8lh5z78aRTUdJauPuJyHQ/LuXmO03lcr+bqeVS1Exuq7Qy
-          HIML8f78g92vgNFwMNGeD3Lm0f4yIIxzi86Sfm6Wo9Sn8NJGX6QluZB3evNe5LzpTExP/i+f+NJW
-          IDynlCh/9aaPmEMgh5OJzu+HR6fMihXAJtYDRQrB+rz71X/5EWlXKLvL18wX+OeH2ni5N6x/yp2/
-          ehdJwtlqWAEuBUx5aOzr2zT0fHscQPjoHOS6VvKPn0CIzGzXTyTHphwGMq/NPoqO962ZLOdhwrqw
-          BAyldtCX66rFsn/Nz8SAzJkufKkqsuXfXr4wvn/R+jOLBSa8wKOYFKTZf5/5t9/CWyw0W/2NAviL
-          fylyYObkVJGenfSn9y4+sUfWuzUQwPcg/qufbu06W/DPn9bPEYqWrxlt8vp7P0khtY4+f9x8gier
-          SP/yU0Pjl9H/4xsaW39ccmrqTW5UqJBg97uW+FIcgM49S2IlsQ34xzUWoKpzCtEOrjeufqt2UGzP
-          Djk9ohdd4wJv/9eRAuF/Hyk4R0dKTMUllK7V0sv0MXa+NH4CfQXBt4aOKljI55WuoZearWXB/wrI
-          5UDdrFNrZLJ3jVyivesJjJPJFDJ/H87ItH4cXbvqp0AINAZ5pefpnLpdCqgVPoclkRqAM2qm2G85
-          vPyrvEg5zQ9PAXy74xlXbPWhOFbMDnbODaJ4U7FLmXqI4WdcZKKUn25cmewJIZmGlBi2OdHlpHgl
-          dPL7hCz4ZdzVmUNTlgg3INMSsoiZ39wgP28oIEYtv10i2EsmR9GdRfrXWhus9W0th/P1hKxAaEbu
-          4S8OePKqRAIlcPP5eF8cSMzvgjS3YOj6C1MNmqttY+Y0LeMy64MFvzUukO6M1cgmCz5A9uCxpCwk
-          HyzWa8HQ4p0HuUSj4y7CM2Cg7o0hslfeb7DhWxJkt91kyuA+q+XxXeRh1BoS7b+3Wf1LAdm8tkTj
-          jwZlVcJjeaa3kSQme8xXxQw6sKWBjHy4Fi5zPne+HORHQFB419zZaxZHtsVX8O/5BvkIbuCVOxid
-          L9kt59nBM+EwmHc8mOMRUOPj+PAymSNm45YBeOldBkaVnvqSK3f5tq+P/JM6i5yMM6Rbr7EaTIVB
-          JynkkpG1DF2QR4Yx0OPnGC77CwNNxs1qIkN784Dy7U2B31gRSQ4e9kjnKVjk790c0UV5DJQ7bL8a
-          +j/vhwJXdACbPhgP2Kz3IeFT2eiyLJUH/Z//Q5fD2cu5kGo+tJubTez7T9UXDd0LmAv71ESuXcZF
-          m1MFXl3GIPbvcW5W59d78nbTrqQwL7U7jArLAXGIWKSfHpnLRKYYwPxxvPnyhmx9lgAV4MKnZ2KM
-          wzgukTM4sm7fGOSItKVs2Aw9FI8pIjflUUeb8OEtaP3qHqnX7aCvVnif4D0LIxRs94vL53PkwfII
-          PKL/Sl2fwEurZFt8BqTM2me0Kkl+hawkpQR1B2kkTiRpkN6KmTzzk5lzEjIyuIr4gNTpes375yxu
-          AFmYQ8p5+OY01ooYLnx2xls7f5rVTE4LvHFVTlAZBvqkHa6TjDz5jQq8inTZ/18eRYOQaD3XlLsx
-          VALs+x35R6Fzx4VIqgPqa90To+BovgQP6siR+nqQ8+PKjxhXtQk35+cRBUVfd8mNtgNZ0j9ROMdP
-          fTGEupc/0+z6whTagEkCD8N8ADXRXl4e4dZpr0BD7wgF/ec4Uu/l9eCgFSZKNfEarat7LUGamQZR
-          lUalTJ82vlw758U/Ou/fuDwR78k2pDNu9LDNPz3kYrn50JkYSxLn3Oua1wCc5I34f/E4B/Qg7/sB
-          lbeLETHXIPPh93GPUeBZeOwP2FdgIDUSceliA6Yq+0U6Hs0A2a+MizY1sAxQpdcJucf+4rJprMfQ
-          u397ojuS4XJa8mOA08tPYuSNQfkzf+ggumcPhLhAcvf43sTjQ++JJRZ5tPjyEcPlCJ7ojCUrp6Gj
-          d7KoexXK77nfUPHyu4KLfVWJMXQV4O+oc2RrptEefwXlxXI8wJwJenx7nzi6VJANoEK6EaWm4bqs
-          7BxLCHLDQ9eUrfP1yxYdZM/oSPQodd2//Qu+AaOQUn1bI8u7xkF+vg4tUkfGdekpWTLIitBBMd8c
-          wVqIfQkvX05Byr5eK3uUrjAFh4qolTvuLQDWSQ42pSUucEyXi7TLAsv7RyROwtrjNj+sGC5g2JDr
-          YcNlVccuYZZ2Izmd9ZDy7bF3YF05D2TY+61L9HlzsNmegQ/qpGjYc0lqqX55Dnm4A6HTeoo42LPy
-          2+eQ7zZMU7w7WRZPCjJg+dRnTakq2Ruw5q+l8RyXYT/CEUUJ6/OPa9LwW59lcH9edEVSDvgBvBdx
-          YwVMnvnNBrQkhgDn2zYhR+LR2N+7YwE/8vhA+ySgnJym5gDrTWHx9hh+I+2bVwB/Umuhqyo1+vZq
-          Yh/6zjAQTZV0fZnKywaseY1IdHpI+uTvjcaF2eV9eV41na+vgwGxcigwLyfVuHif/ApO1JSJ6uUn
-          d2QHw4D65fsiVtsP7taK71puIhD68zgw7gazRIHgdNzwcBNvDSO1Wyv3peAi72m98/35riBd7cyn
-          RnsF2+fqK6COCg4fd7xZTda6wcusiMRf8hVQQy83WIaJ72/cORup1F0mmAq9jq5GWETLEx09OJDQ
-          98c6KUa2ll0OlqB/oyt/bCk1X5kD4mzGKHU7SCm3fhgZAllDVnF0IrY6ugp0ef1Hzvv7bmUOS/E5
-          t3d/9L+xu9y7YynNQa2ivJ19nZu6zILN0dkQSibgTq9eneDpwITk3m72yFUndZLDx0lEz3mtXf5W
-          8Afw1CONpOD2GVn2zU/ypy8qFBj4mq9hMwxQalyL2KkiRQu6hqn81isf2TVzHenxkm8iMgoX7fsT
-          MKX2SeG0Qo3osv9rBvOR1+B21nw83K1UX+zm3cnGR1vR5XYQRtp6myKb5DohpYwbl54bVwH352dB
-          uVs8c166u4rMxLQl+tgJzXpkjF7eOAYS5OlgrMdyyeTj2fWQG52e7greQQDG3nqj19ygkUj1jZHv
-          NXbJY9XO+bJcP4NMKtEgKD2odBGeKQOVhk8wrYdhxH10nP7yFZY7q45ol3q9pBUeh4oojcbpyJIF
-          7niHwfJZ85/q7LfOiyZBxtAplN3zJzgk/RG9kil3lzUuaziZuNr53uRiz4U+DJI5IArgD7TfPLkF
-          1YtlyGmUNXfNdLWEV2+74mMfvPPNfOQVtLuhQ359kd2fze3rtfjAl2w1zDkTIwMqV9EmKvG/0XZj
-          gADz7/eEbCTSfJ2qqIbX8OghnZ9f0TLGrQIqjhuJesH/AQAA//+kfUmvg8yy5P7+iqdvi67MZKqq
-          d0wGzFQYMMZSqwXYxmBjzFRASf3fW/i87kXr7d7SOscDUBUZEZmVGUXrUH1DWD4EduNfnUN++Nms
-          oeLHunDMuVKlEMaFZ2LLX7h6vgHthZbHtSOPjT/NT/2iQ+/DysTuWdqvjdDFkGnfHsEVuWi0OAgD
-          EMP1gLEG2X7c1QoEAX/C2C/j3llezUmH8GqnWEu3U2f0Q2bpftMrnAfo06/qnvjw0yATKxs+rcfc
-          8yHKnspEHeLkAiWsDaEwXMhFicZ61exU3qM7HYjGaDMdlTuS4XufTuRG9kJPqcxLYBHXmfzwm9UO
-          bAlVje584E4vbbn43wYOhzUkpiOqOZ9+8xVeVbMlqv0Z+zEL8hD6nS34V1kJIqrzuoSEu3PDHvY0
-          bVyVfQnTuv6S40xrOrwiuUWa936Qi4xVwF7zSwKJFB4n/htr9XAgyoCUhy6ScCdYDkcqzwU8drRJ
-          +iRDPysmHUDunmvicd93PgSJHUBWB9bf/ZokRumQfGIANmp6zanTvl9Q7hN5Yk7CCih6GSU4V4OD
-          g/4Z9+t15iooRlOEfe3LOOtQPUNY2h2YxFdrawt4pgEcuz3Fp/d4i6jA3QdIhehCdObdgbWdlAy2
-          +4jxH9v+I8yxEyE3JFei6Os7osenwwOt7ixiPW+naE1WdoBBWF58XuSMmtM63IKxSm/+cm34fswN
-          KYYn3MZEg7vG2fB0BtE+vZHcYPh8478rYomfE3cHtJp9leEdGO5dxUco2XWT1fUEf3w/Hcoxn+JP
-          Z0DvGCgkKyo2Wt+KkwBkdW/i8WPg8HMPBxjql/ynv5zR668SBIWa4YMZctFEuFsLg0VPsErnZzSb
-          32snxabsk9NdR/VaX/jtVK/ukcycVMoeZ5DB/VmHOLrnpiOIPVql7tTf/bXDQr4CthzQInMD9gG2
-          ndn32xJufBJn3kPM13an6+Alqgfyw7/Z1T48HIV3QjwmIXQN5NhAv/ubpnNDp8u7E2E20hfZ8E6b
-          7NMQQi5PHWJ9aNVPWXIVYWZDCefZBMF6tO0SuJ5+mjhPsHNOVAYZbnhG8rPbayPPn2J0wImOLZZh
-          I/osHBU6WrCQa3CR6mU2nw0i+WRjY1ztnogX24fmGIvE1dRvNOti10LHfBY+ipm03/gjBI9wFLDH
-          34eevnatBe7X9eCLz9uSr/GB6X7xctqb+ZAPRROoSJq2kt3kdM8X1K4yeltM5FMis3TOzyQE83dN
-          JlZv34BynasDyZNlcvIemK7TCCTILExE9AOItdl9dimYDp6JzTV+9et6PjKwT8KDXz6yESzXjhHB
-          3rpeyUFlp2gGD7sEr9u0TLstHqxDE9pQhoFPQi6M8u8xFe7grTw6okw7jVJP/8pwXZsTNh2xiubL
-          00yh9LlSn2t60NOvMIvoZrwfvmgi9KdnkdzHMsG5IeTL5TGEsHelHVHBVXHGT6uuqCORT+z7V3U2
-          /ZLCBW2z6R9qDv74Ecuda+xcu1Ab3iIjoY0fT9QsTTp/4jWBEzvGGz/J+sGGvir607XC+ZCMdA41
-          OUMplKYJik+zZ21oyNCVU4IvBveIhjuXV9DvLAHnOi8Dfir2LrROhwX7oZHkyxAdB7g9n2nPn7l+
-          yJC6Im9U98T0MjZa69hzYT9cXWw/RpcKT3/xkWoyDvZ346JN1e76gj7UImK7uVcvddW64OnuVn/R
-          13c+6swzlH6vGfuW9FTS5RiZj9H0eeP51GgVdgZkXklFsD+PDq2SDMJpSQVfuFOlHrXO7GAJDonP
-          FnyU9/pbdSV5LqWJKeNeo8lyff3iET4kr5hSs6ESzC1d9KVP4vbf/cdKQKVLAnENT3Xo8RYyCPjp
-          F8fwjpxZP44plBV1JKrKjD997SOUhAk+nE9NvT5vjQWjBbDY7PoXHarGruCziUVsTzs3n9T9x4cv
-          UT6Q06D5YNnWEzxfzwesDu+WDi5/g7BFhY0PaV/R+f1hXZSLdYTdBa5124XAlmTkF8R/8DVY2h50
-          gBflBD9m5FAWXcMC9p7gYUX5DPXMDU8WPM9ZR4xvrPVUBSxEdn4ZyGHIj9FoS50Ek+9p9D/yvYno
-          4SKm8IbVhNi7c9L3drTK4PuIG6IwZQPIlYcWiHwLENfjn2CWz14Jv6tzwhjKH/DjJyCWFoP84h9H
-          k1GHhyCMsMmvTi/MO8+G4+mOf/dXozv5yEB6sgOf1dsDWO2qgXD3vJdbj8BrNH+owf7iM9bXrQpp
-          gFYM8fWr+yu4Pp1lix9QL2eDeBKk/RpKNQPXWA7/9GcHDnUBO30HJnR/bF0L/a5FHV4UEnPbqUGE
-          3o206T2SOCyO5mP9fcGT0Is+67f3eiGV58Ps0t2I65RBPjqLwsDP9ZIQfzeeHPbkfmMoiPcF28KQ
-          gMWWKgkMxlDiNMKwJ7/19S6VL77ewpLSt3Y14OYn+mL1LDR6aIEO//yDy207w2E0EG7rD5sXWwH8
-          50pmKC8Pi3j5wYi+U99YkjgeBeyEyhot9njV4RiUyn/qBSZhJ2DcsoDYr+xS04V7+TCvk2yCW7wU
-          xIvtQsuGX3ydaQ2WS32zYSTF26zf8FJT6FQG2vSQD3ig1oLXTBkMuLOCjdyYKAUpFVGW7y3i2ze+
-          XqKb1MBzA/kJydcOrP7FZ8F2v4lnCQtY7tZL/vkXWHfLozOBQ3+HF2r62LtIXj/7+RqjOHjQCQYe
-          cP7wDQ3bKdndma/nHfeZoZfbN3IoJCPi6/jgAoF1Dex1zTFawiRgUfYOfHzMzFajrXIS4cXkBqy2
-          pkJpVb/m7XT0gA8bfvLV7tQgBXUCcV/L01ndghfR3E0vfx4FQ+N1KtjgNAYHnIdKGPH88cki2pyP
-          +KiiQ8RqkRFDpzHzaZdcB7De4nBAoTuHpHjLek15XBYA1aI5fSapjehVN9QfnmPf9qmzTsXiQlfO
-          CDmK/UebiyZVobzcLOI+HlJEnM3C3/xAf9HKbZCIeGRgsaQN1h6PEx1++oF7U8bfX0W9Z3/6Y/Ob
-          if/lC7ocTXYFDV8NPt2zY06Pbhoi61u2vuh+S22WT3ELMSs2RC+VwaHb/kbzpCgT8XdBTZPl1IDH
-          /eFMywkldCzyUZKMbfBH5gUxndplDX/8GvvPYxhRKjMihEXBkeNVfNUr/XIVuDTXnugnKkTt1ehX
-          YOb3gshmrgFqR5IMNn/Vp7vkoW18uENbfPO5w+6j0Uv/rECgNEdswvhWz8TRRKhlkYoPXmvQ+cgO
-          IXTo6BI38IC2rMpSASd9dFPHvZ7RCLTbBC8Mu5V0tjhfD807BuxiiATTfQmmo0czKKF7Tn5+5PJq
-          rjo0VfNC7KhpNJ7vPy4Un4lOvJ0jaKRiP3e48jzEMta1nsti14J3+CLEDeMW0M0fhwLrG9gihbrF
-          f5wBX5hb/2Nwj3y928sMn5XhYfP1ujiLYTg6NO3Sx/6D1ygndYsPRzbcb3y2rkkod93+VBU7fEvT
-          GFDZ50XghicH/9bry7ntK2iu9TrN/Cuo6c/v7OQxIGZPcE+VwxnCTf+SH58fDXFx4cnEt2k/DRwl
-          Rb0G6Fr2H2zTG837eVILmB81AyvA6PqeA8YKvnwOibVQUE+/eP6Hd8uj6Be5PTNw8x8niW9djX3Y
-          2IJb/PPrGqWAD7/PEN6Yqiam8AnpPHiaDobDHJKLwPP5ED/OE0DtdiTRecfRio9IhdInpxOS7U++
-          kigN/vhIsJyqiKqfYwqve+Pus+hZasuKnRicVLhO2/vzlc+GCm75EH+Oub02/uLhlj/Air4ecvaG
-          BR8KpSZNy3qVtZlqRQs3v2EaG0uNuKjXMyC7q+LvLwvf94sxQVDZhxmbtfp2hs2/AJv/Qbz7ZDjr
-          zbQkeJXkgWx+ibYw89bp5ikfiBE8Ja397Ue2fpjYOt4/0RwPnxJx6+PpM9xGDBq1KWBN8/vPH45W
-          5WmvgLEVn2z+v8aeboP8y9dsLY7vgDb7WQe//SEKh0qbZ/ZqwG0/k/P4YLW5/Y4S/F44RDSH9NFY
-          7NsCfsy7hB07XWv6jqMZhlM7EcfbMB2KpwZu+Ruf3++XaD2cqxa0Spj73QiUmpqhnMCLKQxE+bw/
-          /brtF6k28YRlz93n6/1rBAgoxJx4V6MazcfI/10vsRTuU296fZVub+c+PcOVcehNfLPAgOKNaDUS
-          wSh1ex9e9/odh3cr6Jd3pzBIS9QL8ds11NZas0tQKNKVaNFn6ofLToF7c0i7CRzjD1iMI2B+fh9W
-          owPbT8XEJMAHhwMxP+WgrQ8lYP/8LnXMgk3PwwpOrbYQv0ddvbi1aMNKbl18fT71fC46S4R9Vs1E
-          Lu4iJc5wL4AUuhK+XwmvDbxyK/7ybePzsIvW4HSfoQGl27S+lzmnnfuqoPkgJvG8s0iHyO4suN0v
-          YoiNpi375PECrwr0E98XV2cdmsyGUT8PWNYfEyVnPNlg01v+7uYdcn7zy+GzrxdfqNWDtqbfaAUZ
-          7xfTHh19bXorWgKVfeYSPwSonje/HfSquSe2kp42PyIKYIbx259trtSmRmfd336Ypt3dqzc8kcAw
-          Lty0g/KHrkXwZFFCWGuaf3ooDsoZnVRm9ZnD7Gp8T4AB2QOX4Bs/Bhq/+1oNSN6KirWw1ihljp20
-          mXsltja+8523kpCNL+LkfSgdmhdpuZdvE8Y//vK337fr+8PvNT7wLWjvkjPNn3DRBp7VXqh5tQFJ
-          unSK1naRQrj50xOlWIzoGGIdzBqZ/N2WHyCJGid/37/VStANb1d0PMocTsV07pcnV+nIXJ8r+eml
-          /nWD25HnWMc28hRtRudnA5Xo8sKHsm60dbAeL+jC5o4tb7QpXzxfJSpjWSH3je8tcnuDsARmMu0Z
-          TwRrVFqxxPA+s+HFwRnOytGF43mQ8I9vD5XguXB9MSXGrKXXrNTW25FOXSeX4O1pS2H37g9PfXZ0
-          bz39+P0Ac433sOMUt4hcjrwuvZVbh6/KIXfGoJBFdLSMzwRKbDoCc6xE5BdPg1idnVPW/oR3pFlp
-          Qx5ov6eLB4sXiCVqELs2jxoXFJa0zWZu8TF3QkpTkqXgFLxqot6toJ6UpzqjB0IpPr2+YU/n3cGG
-          v/+XH9lIh/MZrlCtLgzxj1cHjC1kYpjrc040IsdguQvP4I8v/vLH6wdELvhoLibXy8LXNC+CEl3v
-          i+2Lmz/x5x/duyEiOnCmfpaprKP5ZlBsfk5Wv+W3X3/5bGNGWkSX17NCPz9oyz/VA7sHLYjaO56W
-          3WupFxYqKXwnjU78fjKdNhFKH6UkRNMb3N/OLOs2D25PTpkgYjmwtJCPYUHK48TsxsWZfnzBa2ef
-          BMtJzXvSnV7wv1NSsP+vSwq+liQQLe26iK5VPaDvSW7wKd9NGjV34x2kUXDHBptPUW+QIICHaIn8
-          Tt0JNfXPNEHjq7KIzL0rbfyE6h1ACDHxjSjWuMWeXyip5DO+W2dMhcRtdVQP1cWnxfTs+UpVZOgE
-          7YiNA/fOl+LoSlBdlgvGTWVFq/vgM9hXywEHr9TshfmUDsBO1dZfH/wD0B1kQ3C1dItc7qgF1GPv
-          Dbhi5uqLnbiA5bP0pQQhg33221mR4HNxhp4M5xDt2e+cVTWJC31jhFg/+GW/QHXq4On9PRFT8ChY
-          UAQkOM7EJkog3vr5+Q1UZLRshq9dz0VzRp86WiE/+0CsXYc/okSHVvNUsY74whFAVqhQhv7N7wyj
-          zRfHSQvwuqmjhwZlrFfGAjJc00rGh7W6gK9Cj66Ud4ZOonTbQ8vCxSjVFIUEfLXrF0bvQjAIQjvt
-          q89HW64c7yPGg4CYZxb2rVmTBDzvTYj1KH32gjpsJRW7k0bsw6HrpywbJfgI9ia2+wdfj4WIMnjb
-          iRlxds0hZ4P+mSD5A474CODHmZ3kYcCIlCpR5FnR+LN5KmGVnzpsG+rJWeZ9H0LHvaT+x+z0iD6o
-          ZoCgmCOSFbEAZsicWWgEw4CVFqs5Lzf6hMrztEwrPfDOajovFwrtIJEH4ly68B7aGtvZBbYDN4yE
-          6DonSGMmgt3d1QL8A18DKItWQ05CpmjcKzgakNz2OfbG3QkIML/ygPCVTnCey/UiltYLxHNJsI+U
-          vp4AX1lIabeQTvdCtO7Zdka8WSzErXQLCEqfh5CenCe2vHoB8wcRCHuqMNiucytfyiIv4WWaAuIl
-          wxit7FyvyEnnHEfF9KzZ6H41wEcQHZKKR42OI/8yoPtdTIxN85zP1KxTeLkXFJ9vZyPnYGVOUNCt
-          kYTGu3TW5MNbwFPtiNwqcZt9apoJVLn34jPPDoPl2gwvaZR9lng9SpxZmqwWTu/ogo8QHTQW7vIW
-          fACjYtMfYzpfnkGInmo2TvzbFbUx5eY7ePoxhw/XE9bo8YkhLK9zi1M5EaJ5OQs+qnZ8TnKZTSj7
-          uR8tSM509FkkRTkFe6RLvoGuWK6jNZ/UVk5QXb4wubj9NaK2MkkAOPcvOXwuKSBt1jNwZUcV3/Ab
-          1svt289Qp1WG/YHzgSB+hhB0X1BP/IE7RCu/fBI4yi6Lr5fCcthEXjIIF9XEt7090+3zxT05LyOx
-          t5aAw0hPNvrefIfokqACwT/TGJ3l1cVeA5WcjxvpJdli9Pzbv6xy3xrpSiPrc7Gbaete3wZNHHqC
-          5TK4OmNIdjxwyn2DT/fDU1vaSA6QXKoiMWq7yFnApAaE6fU+iedezpfn7RSjNS6OWD/6Qj8zpZjB
-          XbefSbEG7369WDcDxngGWHHFphbkzFDh0Isatl0r15ZZHAuYjXZPnGdg1kvNgBVMKD/4TFQI+Xob
-          2Qqxp33sM8HtnE/9UYXodL31Gz5FgLvtqY/GIrsSVXmpkSCJQgiJFN83/Gwjemp1G8Jy7vDjnl2B
-          4NROAy2JTfDp5TgaN1/1DA0f1iXGzTqChS2cF/x9vjHGTU9I2SXINp+Tvwreq1+rZV8BWUw1nPnG
-          LifuS8kQ0F4pPt10LWeH5Vwic/yWJHqMdT3JfGGD71JC/3kYmZocmK8ISRN8/DmxsbayMgjhdn24
-          2PYfp5+fFeTJG5CgDK4aPw/NDIT42hD3wXB0nfJohg7nStjxUKZxbOE0MB5wRg6n47df+VCuUPW5
-          BdgzyqDmdofWQOo1JZOYDZyz2N1SorxRPXyoLwrg+ClO4YbfxO6qQJu9a1rCr87JOLysp57lj68V
-          3S31iI1M2Wsjd8M2LO7tCQeZ30QDmIwUVnXHT7CxZIfukGRAdMPW1Hh72s9ZLMvoPWlXfOx6Lifr
-          Cmw49/qJpMUUANbmRR9OqKuI8nUfYB5OsACVE/r+fDHPNSc87BlWAmMT+SABZyksUwfAzFZirhYD
-          utZUXug+tz65hrmdCw/qGHCnzg2+TJYJ+AlILTRP922ipedqnJG8dZTFtMQ6nVdn7dL4BclhPpHj
-          RNx+e78OK9O/THHz8YFw8JcUtMM9JUrnGb3AN+UE1zTaYS/oTnRamYWFn083YUu5cNrqr8dC6vi4
-          IUGXaQ7XxQ4Pz1x8xfHRv9T8+TNnIIaFgC+VrObrg8wWQs/yhm9uU9fLi3QW3IG0I9okXvtW2Xkd
-          vDpiheXzccmXK8f4YLicQ1x4M6rp7dRk8KjCA446Ua3nYc1jiK7OifziH6vsDi1SOc7HuXDnAd99
-          Jh/ehHUghZjgnru8nzIilT/7H3J818PerRk07MY9uUPZA7Q69ynsjUbDdlvGPeu2nQ2vbPkh6qhl
-          /ZpmpYXO+qshKbKVmgvIqqO6UG5YFl8gmtFDamD8OgzYunz1fimLqISHiEbTKrk3QGn9LNH3FGhY
-          yZQvWHpd2H6+VBGFJkcqGL5goS2e+8y1efZr/fzwKNvHJ3wU2LRnc9rwcMNb7HzjM1ifz0pH6rdz
-          yWNq+J5UxnVFiWRrxHosnTMj3FtwzlgW64/yo3WaeC6RzXod1vf8QeO/Jo4l9XgM8eUqRpT7rN8Y
-          LnSHsXsYSL7WT8KD6XtYsJy6Nl2F0A+kbf3gDM6PfkXCe4LqORGxxxnXfrXcSgVY9Ko//CTFqWyR
-          u4g8MU/su168YZWgDQ8Au+qb6ZfxkxXQLu0LVulxzKfoxUCoddecGKVT58vIv3S4BmlI7tfmWc+u
-          pQWwNlGDsXJQgWAF6wovPJf/8IzOkvecYcIb7jQPBUe/AY58pH9ilsTfro1oRgwDXZJXhR34qXOW
-          TecWXZhxIIovVRqFkiRCpwQNMUdHiagVSDNcXQMRw2KZflm7Swq5Xg6xh3zLme/Nvfnx42ktAafN
-          4S0PwVcX5GnVKqNeobHvQGN0Kt7iUT3vC5oBU/FU/Fg7j7L+0echR52bv8UfZ9X3eQIjY5/5Qirw
-          zqzsDh2IcnciVy85R8JtMe9g+z6s3PQ6p95WIhJm3p04Yj04y2epS0ifKeOn+TfvueOXTmAORwMr
-          8vzU1vfB8mHtqgo55sXOWX0lt8DpdEYEs7MMKJn3K6yoGE3MMfFqLrOUBGGHalidjVjb+HIL2sIH
-          RPH5Dkyvui6gOJYvEinbbLwISTYsj0/Hf8rz01nHrQRYEQFHLCrLufBpdzOMPmk8Lan27mdpkjvk
-          uOd04k6eDLjKwy3cX5GG5diiPcmYxwSBaL+xpd/fYB33OxkeHiT34VNznFl7lj607g6PtYZ18vVV
-          13f03eee3xdO2C/mR0oAjXeAGEI2R0PjAhGUT0CxZ94u2my93hYMpxmTxNtH/RYvKqhynwW74Lz0
-          w6i1nXTWWQ2bh7ala3Q4S9CqHs7EzmMKaGy/CnCSfBX/+OeGOBaILpbg77f7S4+VrIKie/PE6U4w
-          n5ubk4AinI5ks5lz/n7vpH15ki7Yd7YuZP6es6Aw1LEvgFOv0VfSQKjZVkXSF8/n0zK+XjArgD8t
-          nWfUdI1CHann5jwNxY7SEdWHEn7IXODQHw/9tP0eSUqk4ocXlFOpD//0V7jHcsS+h4IBVR512JKz
-          qZ4/TCuDvJE9cnntQD0bW4nUfYj3+Fh+KzDr8+4F0LdzsFOdDrkw+KcS4dJkfeQ2dT+C9ZpC9du6
-          0z4vHg6Vv48WyFpznfgtPrZ9wHTgt7+t8IX7XkeDAbUksUjg6odoqe+FKI1DzhFHF31tZuRLiFQP
-          H7GmpnW9CpGrAzQWb5zsyzqn+zRrofh8FXjjUz1X9m8LoVMkE41TazrlbqZDq7o5xBJkIVo+ClB/
-          /P7vNRUM3ABLeu2x2ismWHReTmGmzzpxa4Xk6+I7JXw25IYP3NfqOZUaEC5588HqUwT1t2O7CdZF
-          KGF7aj455c5RASX1Y03f6z2ji511BrRfvk+sYpoB1VxRhVazzXaVrln0UWFbQVXRXsR4uorDXXlW
-          hUrw9In2WjGdHyaIwbG+50T2DZkKIItVWJnuBVs3sjXyHY6WJCDZx/fXeMwXN3+3yDKCIzk/z7do
-          LfFFBoWfsvjMfa2aZ1K9gz54Nv4QcmtND8xXkpZoSEhQxnM+ymomgvQSn7FxQh3t4CcoYWrqos8X
-          5uDQilcDRI9qgpVCg/2aiN4LbnrVH7b9smDGkyCr9MKEnPe7Xr50kGD2lhFJSFI5M39lXZg+3IZk
-          J2/WqPW0/T9+dWR2Zb1869sd8eZ9IQe+Ido0ZKkPT6cL8iXuK9ChylwbQitT8WN8p5S7HFQLjOIn
-          xyoMZ7Aa0l2E7VwPWC6Cylk3PQB2NID4hvzWWeQnYMDXHU9Yx7Gdz25b2fArL0d8vFWr9qdf0MHM
-          iGKSTBtLAF9AGWCAL+DkaCT16g69b2uJ7cPB7pcdd4/BxccJ8X76LblMA6jZzsC2qU10kdVQko7h
-          7on9nfZx5uW8c+ETqMvEh0qlrZOjJ+jLXZJp0k9iP5UEST995KNdsJ1Svh9t2ISfj18Xk9IvcrVf
-          AXveOdNOICrlPGQnAHyANQmrxVDyShoGHPt4II4pBNrP34GUG0LsVeLWKJ+1JPRKIf/H3xc7q3QU
-          yK+J3A6Pla5nQVXRIwAm1k511f8972OInj//oJ+k8+EO2ePyJvh5i/I+u/MdIF7PTDvyiaO5OsIJ
-          qAcznyqtanr6vrxmKIX822909lNPo8SyiLm7KX4wvF3Tt6h18M4OB5J9n2u+1qq/witsz/hR3Rdt
-          zaH9gu+Rbp3sBJ3yRUGCPzw/QvTW1mpZSvR+g34SR9DnA7bdDjro4GB9HlO6jBdHBht/nZDz9KMN
-          Lw1gpA2ayH4518vdkUvUildEDOmpOFztb4MaeO3ro8/eBOuQBS4aAHhMC02+dPUWrQN6pJR/+pHb
-          1jf4xY8MELumIo8kqN9R6/P8da0XjbNfQOTaCGeBu/70QwbvjrDDzlK8ogWEc4yaaXGJSg+81ltP
-          1QejZR6w+2DOgLvyWwHQqLhY0YjmsJeTtfGF480n2/NnX44YIyN+GiQ2XR28ae6tUP8k2+xx9KDd
-          5z3w0r3MtsGeb4XStgMZ8H2hI1a5ts5nPgXTj2+T86aPVqG6DfCHF6FSOtpc21IF9lNwwWGnK/mi
-          RKWNBuc44Adkscb282PY78/A9buyMPK5zo8MFK0dnSRFifLl8GamfUpXFh+Ld9/TppVk2F0lk2jl
-          lPZ/8S3t89bn1F0b0a+TxZBVvgI+CJ+BrlleDyAYKJlAbqCcOOprgh/KxtP8vr6jn15BguW+cLjx
-          k+n9eobgNYa2vzeDPprdNJwQfeN0mq9eW9ONTwAYPD3s0OxRE/nIv5DASqX/UV5L/63vsYQ2PPbF
-          bDg7wlF52qCdnwMxA/oBs3z/qjA2xQ67g73SUa1RAq9zMWPrMYa0U1srhuE9OvvMngmdzf+7Q/PW
-          6fgo7j06d085huapeJB8vakaR20mho1gpfgqe6G2ggNgwe5zSHzuqABtHrWyg5Fwnaf9wcdgmLmw
-          RD/+b0+NmbO/+FzYMSK3ZBjzVbPeMtLC8ET8gZvoEq9LAEjlztjc/Bre9vsUArPD2K+HPpqv6roC
-          9ZoRfxX9fT/PjSyCSphGckSMCqjxsHixB3Yw9T4j0D//l5k8Fjs3a+/0j3op4E+/aF/hRenOc7ZO
-          XapJPOd96EfTOoUw4GyA/eQR0DnylQ49jfsLa3GVg2nKoxXlna4TZyn0XNiNXQtP10c/7Q081kur
-          ijxwrIrx4bYfeG/2eHjp2ivROlHtxx+f2fQ4ltnXK59vTcCiBzq/t/hU1Cu8KDpKQX+Y9o+XV1M2
-          vnX7VfcHgpOk79e7HxVQKSaK1VGT6mE+7wsoyHFEbHFua3pUvhZcLuVMLuob5zO/1QgJInMhrktL
-          Z2sTaoErhld89KMcLHdpUVH+hAm2mVXX+F4EBZCdyZwAqHxnQS8nBkGLzliPr3y/nMr2Djd+6Kdf
-          IdbYPYwLaEAw+uO5J/300wM7g71t8Ux1OIZLm7/1IluIrck0MTbsjl33Fy8XJl6GfXHvTsTb9DW/
-          3DMIb6a6J0au8nTsYofduxwz+kgt9vnSrkSHL72viOtMNvjxe+kh952P5OxGF2ozCTySrJ6+Yd7l
-          5DIYEozoO8He6SPmC3czLeh/imiSpuYTrdGLYQBz4DyifjWtbgv21QKjhEccXD2rpv0AVxBFyW1a
-          DuO9nvlOa+Hmp06V5N4o/fZ79+cHEuNhvyO6Fzcvadco2PVm1C+VZ3aA69UQK/eDok15Ty205R9w
-          UttFtGSmVsIo9yfsTu6Ur/01yyTuzg/ErGQ1Wn77jctWjhjdaXRWbnk2kMYIYBVhIaIJDF7IRCKa
-          3ievBMIW73/rzX+KF4Yuay6rYO/RGzHLnd7PdtNuXRjwfgJj6jnj8TqEUvq4a9gKGifnzUEzYHJ6
-          5j6HxmQbHA1bWMeOO7GOC+g81WYBH2NyxOaWz5i9lojghq0PcWJTjyaQaCH4+eneZ/8Byy7e3UGF
-          4wO5kOOhpoEQqMC+UIfoe/6t0VDMGwhf7JMc2vIddc5D7OBFVRbsnHUbzN18hdCwzuW09yNAu846
-          WHCpx/XPT/rpH8SEMsUaPMQ5MTGE+9/zvlHdoLQF6mYMG6rfbv7xsnTXFhTdhyd2Hl3pxFztO9A8
-          BhIjVCqHnJ0qQI0E1y1e7h1SC5b+t77Ze711lfDGBrocHEkUV4DOe7eHktA+bj/9oC1mu3Xt2vie
-          /nrTaKXM7gWdxdGmEG0lzSspfdQIdorNTS8tIdmxMNwE0i9fNT+vfgKm78Xf/E2jp4N/quD2e7Ez
-          XW0wX9c6QNaURxMQ7jzd8MJAG975UDhl0ZoIeEtxVy5RcvWzHTFxZijEeeMv36B0Nn41SVV0hBMj
-          n5T654fDUukkoprVrR6i+8kAbKapPu+KZ7qIpfxCux3Wib4ThX7m7a6BH/PIYqeNUm1l2tiArW56
-          xL1IZj9P0azDC0MGjF8v3eHFOq8gl83cn35YHhI/g41fYVyk94gi13Kh1ACR+O/J1JbbHvh7RlkS
-          fDmxh5r1jooBemAFePMfKeUOuoymfdOTn9/Z2ZN+R7f6kRLXGEdteaLZhxLRmt/vrft0skug74pq
-          ehuqQmnvnkXoX7YDXVRstT9+eLbaG/abbZCxEYUWzFLuQryNX9Ii6Hh4yVKIff2U1hseJvDEqAWx
-          7vMQLWMTt4D1eHmCxS4CMzX7DO5oCPFR9laNLs9RBJufTaJJ3NdLhTgGGm9ZxibaBjm5DyYFvbEN
-          ZrVYklMrWGd4UpInNnfnfbQAtZSQV7VfHEaTFnFrd8mAUbQsVu23oI0/flN28gGn1r2gG77ZKNi7
-          K463fMNyOFzYH3/BWtrZ0bzwaQIjIZ+JlX/zumcpM4HNj8HW5g/O3PfAInROhE3fPZ1l4+vwxz+l
-          64mJlgu7tn/8Tf3lN8H17kKGeZywFr7KiDvuvQRuevjnr9XtZTsS4Unr5ed/17SDfgbd8fP84zc/
-          /w9+LVHA+rs5ab/8DdhXCcaGIwh03p1eW9fSsiXZq7jly+1bz+gjSA6Wh+IMZum2d6FoIfqXzxy3
-          +wMrAdr44GhJPw/KKMOOKWJ8VzGkW35URpveIZqoIG18SMwMX/ubi12YNeC76QsIg9M8zUw3aatm
-          jSrc89cKp3FX9X3q9S0sVIwnsWLrfuMjM3qM8ZFEVpZEy2LPDTrWPvPz3+pVPqMQdGtAyJXMdsTS
-          1g7hTGwLO6YwaytosuEXT4m1N7p8AtwrRslXbLbnCQGNr7zx51cdn51ccxVCDDQG8USu5Vel7Riu
-          AeIpCHzAFXk+fB/uABdRM7B3rG1n6ORnAbf817T5s/VffqJbQzLRgb87IzcGPOh3vjmNi+rkQgf9
-          FPh9ZWP1tRu26xFfsMiajMgmTPpVP3Y83PLDxBp3ak0D41PAn744+heq0UV1WbjhMfnx1Vl9DA0M
-          rKGY4ODbDs+kbge2+4V13asAbe24gqfjHfuj8z7UtDKuM5QSsSDZls8cN3/g/5YU/Os//uN/bgUC
-          /zTt7f7eCgPG+zL++/+VCvxb+PfQZO/3r7Dgn2nIyvs//+M/SxD++fZt8x3/19i+7p9hqzVAEsf9
-          lRv8M7Zj9v7//vSv7Qv/97/+DwAAAP//AwC4jL5WugUCAA==
+          H4sIAAAAAAAAA5x6Sc+DPLjd/v6KT9+WSmEKtu+OGcJkwhTSFSSEQAbCZMBX/e9V8latKnXVTaQE
+          Egf7POec59j/9R///PNvV7bVZfr3P//599mM07//7fvZtZiKf//zn//+H//8888///V7/b/urF5l
+          db027/p3++9i875W67//+Q/7vz/5Pzf95z//JhWwA/RZ38OCrhqUYkZasVcKhsb7b5+BrfPwSKmE
+          Ubs9cyDB027qsJnZMV3i/NCg2BOvJNXnBSzOY1PhuzxrJFiqU0tJL7Fw3noTmyPnUY7UdQ0lbp9j
+          S0/32gACz4beNKBZuodKye93lxCe8xbP6H18xtPZBI2k0uCD3SDMAJ3e8wueSeKQZLinw2qG5QUq
+          KNCCJX/FA2nGKw/lvhiwvbtc3GU2ZxMaUEZE91kQb+foZsI39CxcPFoeLEUbVmiXJdoccRKvrX7Z
+          FIjhmh22alKDFcpEBhULT6RwtI87aufWhIdCqAPEH8dhfT+PAcq3VpkHD+klzz0sB0jDHuNkf2dK
+          Wl+SDfHjsSOBXMmtsDRAhQg0NxKkldOymIUN/OQBwLK7R/HyfN1V1AirS/Lt02oE3XMZHQOzI9YO
+          B+V8POEN6LyaY9shLKXxWd2QaniYFH77AR9hGStJEkCKrZGYg1BbnYM6oRSIPcEIbEz06UFOyA6r
+          qaRT/hzddLi+PhdsTOUWb3UtsnCXZRrWM/Y2sB+zDdD3+XGVM265ndRKhmbP6hhzYgKW7U49mA1E
+          DnqXL+jG6kEF+6sckkwF5cA3tRRC9e21pLKqO2BdT3ohq2Z7LDt7BmzGW+lQMSRvcjYuN61ncMbC
+          uJbIvN9lHN12UuOgbJhkXO2qauAf/puHB9JVWJ/uYru1uXQBzYfaxI7g8/v72wudmjomt52hxzRO
+          dxB8GP9Asr5jhqUu4xqBen6S3/iTjnAN/eWakaiUrGGeRqf7w6dhzZG7vJi7iL7jkRt4asME5bcM
+          LkZaETWespYYqbghAMce5+PhrnG6WNSQPVwbooZTGq9zmlyQZ15uBOvDXK6Qbg4KK/2Io1TSAccu
+          rYoe/FsmBtNZAzsfFgk9i+dxFrzGcRf7PDESG4UlsXcfKx5nc9ZBbcMdudWiAxZ1bRpk6zwg6he/
+          dOvZCNA5PJDSQ4+YPm9NhX7rcVJSoX1x7zMEzK1esPKZ1GGJOsVGNu1UHN5Mrl38C+jhy34O33op
+          Y/5lsyGwFg1hWd9Dd9Z3io6ii2Ri3z/d6B/+xaOVEjl/xS37BjcdHhpuJAc+Ow688T706B6gR8BM
+          ruoKU7EuKBivGw6cqi2Fu37N4Mx2GrEklaFLl/Us3JcGi49+bbp0z7gyHA+KjhOH3YM10HoGMckE
+          5n2VmZrgT7CBTbxJ2NmHHqBDtNSIv5nRzIyDCtjrYs7oqqQAa8y9dtlX8HmB2wPO2NOdiW7GwPdw
+          JyUJ1vtZjflKXCLUR36Jj7x8iZdt3VgYVaJGnKW9DCzh51waOT7A1lNNKHfUxgK2+Qtj24SyuzHR
+          vYfK3juQU48f5cIYXgOfbeEQRfT7dpOKTkWnlrQEf/E5VqF1gc6t5+bpqQvxEifMCPK+5nCgr+yw
+          Om23odA0TXwcZM6l4ZN3oHAyuVns4VpycbBU6HDqYmzx2NHYRFZNxO11HZ943GvTtZB56AiDghN6
+          B+XC+7YKsR/yuIoZE7DX9ighjGJ/3lkDHvg6XD1oPdgHSZZ7oc0Mrnj4w6u5U+thffbeAl9GXuFi
+          F+Jh+/IdZLnbDruiY2vb9TnmgJ5uATFuQVV2WejaEruFG/FUxwGLeFV09Hw8CyKfzYiut02ZkaDo
+          bxwp/gzWEcUNSlhwIk69qBo3TaUEzvJdJ4eSb8EShnKEzvssJvo+cOJFPt55ZEGWkJgmfkvPiumB
+          Lz9jvb8L2kTTUwZvBfOcW5pM7VpXQgjXfXUNxBupwHbhHir6Xicmz5F26bKGh+97GWH7e53L2zcD
+          qX81yO2Ruy19wEyEr/ENsT1+5HLjTkUC7YrT8EUUUo1rNs0B0gdEs6CrT3d5g5sJByw/8OFxQHQ1
+          8jhC2h1rxGMeGpgwGPR9ccvuxIuEmo7X2tIhz+l3XHmMMVDT2NugDR5mwOfcvVzZZZChsDNkbMbd
+          OhBWQpko8/lKyhIN5ZJ26guRvE9mXrW7cv3qLbozCBAvFdRY0KfFQ/qEb8HC08mlxCIZtBh2JOat
+          E+LFUiYddFVQEnPihnKVBlGEe1+qiDs6TclrJ/sF7/fthf37qgD+qJY2dEwOBYKfXuMNkUxHve1H
+          2I2Q5bLSVW3QPhV7HAwVdae9tuSQ7cMXPn35bcOCJUMi9R3xxSNpt+vzkaPLaJ9J7FtzvAiTPCOj
+          lsWApcG7XC8M0uGtOwCc3dNXzJ/UTEat9GqxP+lXl+JV3qAXXZ7kOuiFNoNT6iFp2nv4NKingTdu
+          Bx4+H++CVFPFu8uuzj00PTUR27eLA7i35PPSHhszSbj50AoP0pjomeYWudKj63Kt4+lg8vkz0QYL
+          DsuavR0Eq5Ehhd4a7TYnWoCqDh7Jce9/tD++r6Odjb1bfwZPrhs8eM3sPU5HQN0NSt0Mr7nN41IN
+          V3eJbUVE3RhU2GII1rYv34Ibw/BBMFSxth2w1qOYEVfsZtc3oOO2BvBYxsws3du0pHi1FxgHUkFS
+          HnCUFpezhEgrTEThpi7e6nyVEWQnn8hivNDNj44JKo7ZjVh684g3F/smjAuLzuwjqOMVaHsWnkpy
+          mrdw4uIPK/czrCpoY5dHYtzvd0mEkveo4NvZPbvbbRErqFeqh4OcGWIy3KZMelQPlnjLKdSE23jJ
+          4RfP2DgHYFhZuRkRMzQ8OYha3W653+hIQ9gOKlrldPjqBdQr2SPy/XUCSxXiC5Reo4GtWd27Kxqk
+          BK7554yV3TRo04HWOTw5tTXD0KHtBqI6gGfmfp134lONv+vPwgtvN1j+4n/rRUYFh7TLSPj1A3SJ
+          QA71Ta1w4KxCPL75RkfpYz8TK1Y9ly21o4dSMH+Iz68D+Na3Djy+4rFPV6eclrAToWP0E3beoe4u
+          5LM+QEaJR3CeP8F2vY4P+OgeCFePaqXLtcYm7Hv/NcNc0AAHwrmHX7+I9TEwXf6s3irgpcM2I2Zd
+          hw1EXQAdq+8JHvKRbo8FZEC8ihbROBbTobybkjQetZCYQ4fcCYRzB9IcdASLYlYu8vHDw6737kR/
+          zzJlX+Zng/1HzogfnKqSlklk/vxzwIyuNtBKj0UpzsWWnDjS09WUSx6+jKLCcv+6aPQ2JoWU7ueR
+          HG6Hc0znaIUwJMc7OU5y7nI0vWWS6w943r8zJ161a8BCUTBa4nCL55JxWz10OpHr/FSDeRhfZZZD
+          LOoaKT6LWU67ASzQOw7iXJ9fm7Z+fw/wYjzP7FfPpoyRAgijeT/7k47cca/wPBwNzcEu0/furBBZ
+          hell3+DL+zQMG28VI+CvZkqsPR7aVa2Pf/4En7NPEs9dxzJA872VXL98sr4iI4G8fTzN/E6Vh5Hd
+          szp0Ph2DrUEVWvombQ2HwkfEoe0VdG2cOj+8EeuOa21xxpWHuzrxcHoAcskx9XuEGUcOwbYrzu3k
+          DPUDwo2ExGy6HGzLxavAgGSGyKppUNaEi4y+/jVgHeXVbhYQZjApyhvLb2pQavoLhPdi1xNtthh3
+          vVaIB2AFHMH+EA2L/Xk+IO8cE/zVU/ePH9J2rHCYvZZh7XrTg86nZwLGWjm62l2SQDe/GKSMr6+Y
+          Mof8BWE1MwR/9Y/vO76Anyxg5tWNBbD9/JJkACUAvGO43N1xOjiUao8VX36Brdhui3QnWxdszYTA
+          oHOLDAxGlQhmxL27KRqcYTFk72CvXq7D4DxBBK+yM5DwFsuA88s+B5dj+pjR1x+R2qodhHFIA2kf
+          jmDlw2GTxMG44pvi+oMwqKIE1WOQBvdtMsHIKhSiA+4tEoxuO6yZKekQnRsXY8dd6fJ8fVR43y8r
+          qSpm1taEETekYW/+48tVWiYJ7ltpIrqiNPGyNw493KJhH+xBq7gLNDQT4PvRxvL5FbmC8HLsH78Q
+          nd7LcqOJqYudVdbEejTpsPaSFYHHgfJ//LuAVB3htGoMVrLaiclXn+EuSUwcKntp2N4Lu8HgEz2J
+          cS+9druhZwR9ELok00HVznyCa/Dl828/TsFiX8QNIJnEOLAYxd3yJhthszx0csj5pl1/+EM5qYiW
+          s7VG7eIdQNgRa5aWFg5bGBUb3OaBCaQxtFsCMo358Vew73lX+/kD6CaVi3GWN2A7SmW0FwfRmXeN
+          e43HTHYbcEaZT7SHBcqxGMIIPeH7SeR73ALyJm2DTFaryaHPBvD3/776RSxdNVyyN1URfhqsf/Ha
+          uMsQjBUqnyeL2NXFi/kTd7dhf1N9rL+D+zDH0cXbP8LHhhMxcOnKuNREhZBNAfWtuaS11dlQO3sC
+          vsSnWlvf01mFNd08cph4b1ij9qnvH9vTxF7Wc8NmursCXnQ7IIZf3t3tN9692fHf+hRBM3UCC4en
+          SrGj8Lm27BWGh9u1mgOJb2/lt/5Y8O1vSbVUQju9HL8GwTvqsH0m0J269PyQik/S49OHPF2KKsP7
+          +fcZiieOroRLHcR/zJIcbtmjXW5D7EAv/WzE+eYPC+N7CVzBpcBn5xMMP3/5lwfovtK5myeFOfri
+          BVs8+cTbaO8c+PPjHvNowTK9pgSqfbkQuX9BbZWGRUK7cxtie4RJyaXt3IATU+fEtkgc0/PR5+HP
+          j8gllTXBuIoveAD9A7vWVW7ZKsQVPPidg4PerVuKKt+D+BmrX/yDePOLowO/fh3Ljjm047Us9D/9
+          kZW91G5RE7OoRGmE1VFaKUXnMIC9parEWEpK149xhiBixQjHtzevrfoSjcAbLxO+8UatLfRIX1A0
+          DEy0D+u4bGa7CRwpfyQ/PViutWWCTvdiXFmMorFFG15QEgGNWH7TtcuZ5jqE5kixo7fGsO4AyCHI
+          5/PPrwO6YwwRfvMFrMwyP/z8LWiWlz63k7VrN/Ute7Cudv5M7rnjstclmOHhxb2IristGOmBLqB3
+          MA5o9l7BZ7omEfx+HytpPdC1jpwKJNXentuv3534cFjgqa4zrDzlrdyaiejAb64xNofuqm19xxTw
+          TpYOH5SDq9Hd5xyC3ZwE2L2jIF6LmZVRF59fc++1Q7wOaSnD/Ul8k8pfc7pqYSSjjpwHbPuXJp5W
+          +24i44p5bO7TI+VdJ9ThNXP2we7pMmB6bPoL3gr4xO6nr13Km0oFdA4PgehgbhgvsllAlDbH73rI
+          7l8/FLzDbt77h4Wufnfz4C1jBqypBXC7b/4C2zO9YbmPuz9+Qo90hTP77Td/egEQqi/49hufTGkC
+          3fpyJGpf4HZdjSwEUWgkAbiEu3b1h0aVNIBdEliVAvjDToMgReMraFz/OCxo0l7wl2f6um61LIYw
+          g1bN98FsVXe6kVE30bv21HkUBU5bXsHngb58jZ1+eYD+x7dseuuwFaYVWBLRCaBz7OkserB1eXZ3
+          /D5/fcSZC3ZgDcuWh4xRd8Fyj1u6eX24oEvvXIjKvM14YVLPBoEWngJasQ3doi2+wJeVlwTHotwu
+          F3puAKM1w7e/rMvhNIY6mlq+wzIf+2DRjkMEI8cyiKeg2zePpSLix7jDRgWcknPju4M4oCvEX44f
+          MJ0oeUBxlc5/fn3V5aKAne35OKGz2QpcZYsw6fbH4KwfxnY9grH++c+ZzzmlXIo2v0DVPN/I1ThJ
+          7nTp5QtEy9STw5v/tOuQxiqaDRbiSy0c2rnrIIThEL9nri9Dyu6PTAUTbtTJyWqe7aLOpxm8bvkL
+          e0N/Gz57usy/fBIrpxi1f35u6QaVmI/0DZa7G4u/9SC+uAb020/ZqL+q4bz69UubzgztUZs/MJY5
+          GgyTG38c0HA0+PqLs7s07WWB93ZpscLLsKRbw17+/KH69SNffXCg+xxKohnFZaBis0vAEGCBWG5a
+          lJR72SM84lgMkPJ4xsuP70rRsQlu3GtJdU6UJVPUCqLdLJ6SwEchTMncYrdCHqUSrwWwsTY22L+z
+          PqZyNOj7X34sPUKVTh798MBnbjl2vvntN3/OYTRbGTF12425n//4zb8ppnE5AXft4C8Pcp4a766z
+          cWGh4Jsj8ZWHES8XOSjgKWv83/tSOBqMCH79ku/qHeWWsJPArx/85huU7D7nSPrmbzilnVwK1LRV
+          aAVsSn79ybgcJeevXz3OMt9Ov3oWsPkh+Nvv8X50zABXhIioVXEAS7EYIfz6NaKN7NBuu775+oHE
+          J8cwvsRTpR4K8M2/sNWTdvj6Lxl+/RD+5UPfPL/af/1wMHK6HLNprkL4y9+9USDxIjxlER4bUyLf
+          +QXrjx/8e6TNTLyC9tP1QSCFvHnFrnc1NPY7H+CLr2BVarkUzuwxgerRS4kVpACQ7jaI0A4FZQa8
+          83TXgqc8iEzLnYnjHilb1n4HT0kdYiwamst2w+ny01+SfP342jA7+Mevnqgr4KfncHOGiThWa9LN
+          LAX1f42np2dtOdveAm857AI+sylduDvs4TlNVHwphae2zMrelPAuduY79U2X+/YnUN/jJ7GU9DSM
+          ZWiqcLwpUcAcmIdLizVoYM7WDPYd3Snp3nREuGmXFz5R8qZLVB8y6RE9CPn1Q6N6byTo+h+M44pV
+          KWX2oQSrngmCvf5xwbLc9xuU2NHGRl8ulKwq3ZB28iRyctQ3+PjdyYO3hlmxpheVO77M+wJ0U1Uw
+          1l2sjYXo61COn8tXnwZ3e4XQ/OWzxPz2TzPuiwDI5M0R85Zq8Qe4a4+oFGHsLafFnbrrMYeymRdE
+          EWSJkvi5e8EnyFPsvJc2ptdLmUmk5SasjNPDJb/6pDD0SDqVUbkM1UOH3345WK261ZY5e84wRfOL
+          HO68SVdPrHjgdRdKAodR28X5vFU43wQdO0r7cDfxFC+I4qtKgrzytInafQ2MM4Zz3Cefcv35o2/+
+          TLzdSXDp6tAHVG/BKZgaPQXbkCgLcJOLi2PmLmvbCg0HjRwbYG8SJjBHfdxDr7r05MC06sCeFo1F
+          LHfd4R/f0fySV/DUTi0OUuYDlo85eABk4wUf0kyhnOL7G7x5sMG3XHy6S/xgMkjPNxcrflzQ1emu
+          m0SbSCdfv+ay2nkwwZcfyS+v23K/14FwiXdYF+dBW8O27aQqdM+zOMIk3m7d0iF97z+JfItrQJlD
+          +IB6KDsk23ExXVxPekCUT9XPnw7b3f/m4QdFD/gp9X79JytddCfAZt8x7WA0zxeoP5s2gzDcg+fe
+          fuaQH8x8nv1KB3x5HRyA7vWJ/Pz33NXIBpwccYH4uJB4deOPDR7b2/zpL12+eTLgw2OL3fR6iFfG
+          BTrYne4xthqVxnN5HWxgdqxFvFu/BytNT8lfPgZPDgvWfoouyGhUbuaXdGqXNziZsHDuLS709tlu
+          37wFTldlxPpw54YxDpX5z6/htzi6g+mLDHwrBZgBh/bghwf427/ymwenbSZWPeh1Ff3j3+EGLzL8
+          6n/AfvMc+jz1HfTCqiM2dzDiuZneJrxdDhxxvvuf7BCMF8jur3v82w8a4/xQw/ZOB2zcykPLHti1
+          h/ON03/1r83pszPhdz6CdajZeHXaekOGrN6JKr61oZMmx4GaEowYV+Kb0lndEvSd/z8/z6d9qiPW
+          jqJ5cJZM26I+7pDcFTNWK+mjDdFHzaECAvPLzz1YVOaWAfPCKkGukKUl8dGBsH2uT1zqC403s9zJ
+          8CibL+LunEO8dYmcIDG2ou/+CRyeoxHn0LQVLdh/+1FiNM8HLKGjYkWnHF2eQyVLUjeq+FBlL3c7
+          qZkKeTZmiVGVg8bVMyPBlnld553uEm0LmyKHxXxniSJOB0q3Hobg58dOI3kN8yuEOthohYg6SWG5
+          ce8jROObdXEy3fO2twR1huGoJ9jVQ9ZthuSwwSs8WOSLp5IEKacj1Qo8rH73B1cQ7y/QOPsQW9/9
+          tLmuFx7qk38jbo56bWoarYHCSed++QwQynsgAm/6IOx98z0hMLjqlw8Fny8fkesjthE61y6urJUD
+          i/+g1V9+HDNKDdat/kCo66qOne/+6spoNIReeOkCkIVwWNT5NsPKPvg42A0HQL75yd7KlfVb367L
+          z56WIyqFmGAvl7Vf3gjGvVIS9Tydh/ViQgj//Z0K+B//7f/jRAH3/z5R0DpmGSzdKGrb5roR/MCC
+          x77f2y3/8dkAjBbYiHk603Jb5JMMN96X50UounjJSWEi2xVtctMFxWXRE/Mw6NcP0cchaNlmUC4w
+          Pqzm/MrOssbtjmsowTIyiWfP8kCLnstRyIQOSRg9GzivG3WYya4+P2v1qG0KY7IwLJ8mvj3F2V0O
+          07XZD9dXQMyHWJT08mZkGEk1JOawde66u/MmyKTeIc5DCMFK96sOndtTIWllhOXi9pUDtYMwYmfq
+          5GF55PwG7Xh0yQUamrbWu4KBhWfdsQeCJO4zfWFgXAvxDLPzg3asOGxwYwpE1FMBwWS8EAMPqncj
+          5dVQAItepAaD+Onw2WJDl514rof7NNKJOr9lKlRtxkCtBnsSOCOOWd+wQkiOGcE67pVY6Ha8A+sG
+          duQS3dqB2vh9QRfPtYnDZ0JLNMeuYCZ1Dg6f4N5S9sRnKD32CzHm7w7V5qEMlqY3EYy7U8lxXKSi
+          2HEV4u1srl2hZcjQ2XoFK/FdpsLlzcvQ7ZhT8LGkmQ7djrFh0bozxozxLLd2r/Do6dgqzqZPr43P
+          pzqi+nRaAvHirsN6ed9DqPgMFzQ2ecaz1egNco9NSDRL6l0OcfUF9a1hk6qGL5d/CL2DNh7LAeEK
+          tqRbgUZYSUQLFjZB2qa6Ug25tF6xHlctpfZyipDYQICvSyMMNKO0gftrpczgQZ/tZu9YCJMyOxOt
+          cmog2MstgtYBSgTf9ArQuGhsmGhSRLK1Hco1PjQ5HHzmQMydvdAxeU8eLGw9IVFcl+36vosQgqU0
+          sDs/umHx8rVDh/TKE/Oi68Nm3wxbMDraEO/JjeUmV/yMRkxYrM2vsuXG9w3CnZik5JikPJ3uV+2C
+          9ncrmfmHKJVz6dwYONTcC+cHci3ZwzWcURLXJ5L2y71k+QS+IOggItGTX93FrnMTNm/tgoNzoMa8
+          XDEjeDGP9Xu/Ui5zMjvw5i8qCdfWbDnHKzOYHruFOC/2GE+exUZI9YyAZJYwaZTU8AJzYu6/9bGA
+          Cd+NDjV4h7FGr7222Ls6gEZau+QkhlnLN0PlATvOQqy02ttdA3aRUd8QH3uqHGr8Dx91PFcEx03e
+          8urgdDAq+4moZXAr+XuVb+gQKDMxW8YYeNe5h/Bg4hFr5zgq+Ws2iGBYrgPWPptBBeYRjjC4zRhf
+          Sr8YFqGpPWg8lhSn8HAYeKvxGnRewghfLWq2XNJJDTyzxxs2kRuWAkqNAp5N18RBt9iDMBzUDXmn
+          yzBL+PEuBdofZJgxx8u3Hmu68kkfQF/sNByozNCu9qI26JY+DGyLUa+tpfS8wGWrLayE96RkF1kN
+          wfICONjY/KEJ65UzkS0Vlzl/7zl3VT1Pgi+NLORgCGTYPpOegQd/8r/4ebTLjx9r23oFY+lL7SSH
+          AwS3JX7Mwt5v6XIOmhDcDEYmZhHfy+n5ylXUMeEV36bXkW6+6QRQeLANdq6HyRUq9sDAXS0FWPff
+          qiZsziIhMw4/RFa08x8+4W6yclxMndwK1hE78NBJC8Ymqwx088IXgmWvzA8ZHt1v/YRwPRYZcYN2
+          pmNI3B5+YM5/60um5NVOOXynsTZ37gaHT2KrsyRahMHeej2WY/Z4fk+QVfXMT5/e7XgtN+GmAWGm
+          yxUNyznoQ1iyRAne243GC+ysAA1sX85QPNbDup/oCzG6xRBraSIqHBhHhLPsngi2B22gbhHPyOGH
+          gGBw5LUtuiQBounVIZdhnLV5A4IIro+twzKtLXfdrYccxgrSg/tL+LQLw5Y27Jgun9+MlZcrMp4Z
+          pCM4EmW54JKqEmdKk3hKsEH6FPBynRVwjh9HcnEGReNeul1D45r52L6rtbbpNrVRfPcDfLqabiwc
+          g8qD6THi5t0pK93lkTMbtHXTxD69GDE9BNaG9o5ikShLHMBruQBhq4gVUW1ixOSMZB01Fo2wXUOl
+          ZHUBJNA5nXVizcMCRk2SZhDylY0Vyd/K1T3EEBXl9CLn8HYvF3l33GCzRWdstkpeLt7pCNGphndy
+          aRXkTsKxYdFq0AqbQjG5a+TdN6lpZYyT7/qv6siOUGGPHvEN3nS5orwm8HQQE2yEdQ8EILIvJKhu
+          RTRZPmgbPbQvYHXCd6d7lOJlz4gQJfyZYsde8pKfE6VA7Xmugy2uwTDL4fEFj76I8ambw5LfTx8P
+          To9Rne/LBcfc9XV4oKCnH4KBK8Qrbp4ZxCpesZ7k4rC0zrFDCfNccN7s6pYnCjPCYitFbAnZHdBZ
+          01VQSG+OGKfTDazs6f5Au2N4wOX8sAeO7vcmZE9FTs4v8dKOPUhGFE+BjKOwtQBbtZeH9NVXUhh7
+          TROuyZ6H4YvVSCrirlwC7f344Yec+/HmUjdnVdT3e4fkD15t55keG8Qw+EC+ZwzdxRMPGwxicp2X
+          9foGnVwfOnibZA/HhtCD7abaKjTE8xtnpzON3x//ziLbNmIiv0BCN6LwI+TYUsZeo3zoJtyvEfBu
+          fTezfLaBTd69GiCccT8jqF8BZTbEQknbclLsLCvmLu9PhPZpqJOC3pqYMmxaI3UrnwQfhowuaWaP
+          0DiSjChJmQ5reJsYyMcfZz4fhkjbHJCKKDg1EfavZqhto4Uq8JyUCh8eHIrJBp4N8sXQxjdduLvL
+          4HQmqK1pIJY7te5a7v0NKNeXNPPdVrasW5wTKChrG2yi9xoWIB1F5CqiS0qZ+cSUf6ghym15wkG7
+          Ewfqp2wPMdtIRPMHv/zzg0IaXOc3fj/Kdb12CRQbBgSbGD3jdeh2HRhPd2F+jMPcUuEovKAPhxBr
+          6fmoLehpsVDq2QdxzD1f0h9/A/GpknO/IbDRPi6A1MoNtnuquVugNzUKiSqTYHy4Ll+xlwSy2q6a
+          2W+9bOmz3qSwfJvBmuYqoDf1bcOmZ4/zgtyhnZblUUPmlkhEZXNdmyUYJHA11grLT64BdDK1Amnn
+          60oUNgsH9voqGbidkhUb47stB5QaOYxH1iC2orzKNbrMr7/5Y7vVj7ek6xxYYDHDXnjRyyVykwu0
+          pfwySw8hpEt30yDsZNsgMTh6w8fglQh++TVgkaNqnPHiGMiNUPSFfdwMNNBzB0JZc2apjFyXPjq9
+          kpC/vkkpRWO8FZemR674usyS6J/bL35l6XRtXzPqB65d1SGVpZe7n0h+IOirP8wIl62x5vspbeNe
+          3PkjSAOfC5hm9yw/C2ZHyMdHjJ0akWGW3PMIj+kYzfDF7YbZeLoi+PrzeU3zhlK1X0LQETUmyu3w
+          pHNiLRmi9WxhR9kpgF5O++Cnv9ggD8F93xSrgk+xy3DSyo7L9hAWcMZrSbybBeiavAse9s3k40iM
+          jHhL3nIFH3zqk58/+9ZbCO9qsBGv9Iv2fZ7YBQ5sWH/119f4Bioe+uo50ZA9t9uY1xU4qWYUsDez
+          ozPTajnU+UjBh4EM7tbAgwcT6dESTyhW8KkeHxFUUmoTQ2Yew+oMbQV1DYpEzYpDy7fn/Qifk1YF
+          3H23DiQ+q5WEruWIcRF+tImnUgbLa88SHDXP8j1rugyUUdCJsd4FQIAIH/B4bRJsMKbj0tMC7b9+
+          wxYjx+X1TgtBfruw5MAVuKX/EwAA//+kXbnasjAWviAK2SRJyS6bBAERO0BEQUS2ALn6efj+Kaeb
+          0kaF5LzbOYEOKxUabHonfnts6wVaBxPqnsOR86632PPnYALhcu9m9pYaLn8sHxLY/SKxkmzOt+ca
+          Q9hFeYHP7nQC64LhDG62FJPdb4B/epYfThei25MM2LKBIWyf89tHfCQNa+amb/jHZ7exWwd6mdoY
+          xre6IdqLqfNVOY8t/FR8TNQdP2jvORYEirjiUMIG4Hx2UdHLkVl/fSMrH5ycpqh0WZbkfDpoG6OB
+          QBI6gWDL+w3R7j/mf/o5asAtX3d+QB3Tp7O4vVpKpWLgIRL7H8Ev5VBPv6mcYbD9Iqy+1XlYozvx
+          pT/+cQ0RgVWTqhjufomoheuBtapUFmb9YZmn9dnQKVhSCA3VuOwT/C9t4ZI4+Fe/oarEYDPr0QP7
+          +mPMxmo+ZfDsgOvPFGYmieOIPlenhd8GWMS5pTalZRRasPv6F+wr4DmsHz7mYdsuBP/5QX66vnQ4
+          R+3FZzKfG7r3+LKgpmo9sX6LoC1RP7bwr3606I3dNRZuPfyIYY5lPDh0y9xDDwS2/GIs3Fg6Rja7
+          IP99+Pp/+PdvvZbn80TsnQ8XQVmyv3om3j2QXJJlYgvv90Ymuf8711sqXySE7umTPH6Dmm97fUNh
+          GTbiHS8RWFN5DMG0vEKseF/qrqe19xG6eG//4H10ymdF38Ph4UU415RuWLTMEcGz4wp8Y05iPtvM
+          Nfzje//Yjwd3EeVgRA4fRdiH5iWafr7fwvOkuUS/Xj9gy0ZSgC7/3v0/f7AKW9ZLuS0ciIkHMmxa
+          9uyB4FuBf4iKO6DvsX4D3EgctivlW29DJjtQlr3Ub9NAdVeOC2Ww/z+Skq/49/0luH+0K8a6oGjr
+          5j56cP/5Bnau135YQo+1kHWbUqyl5yril+fXQY5Uav5n+ib18potHlKxsrF6vzBg9rrLCHL2ZmLl
+          oFegt+e0hG/mUWP9ln7chdcCHQW15vviS63cbeg9Bs6Rvxf8qkZ977DsH36R6zV7RrSqbi2MLl8b
+          q87WDPRzlQOY8U2H7aeead1W5Cqk4tv2xfiGNbrrcaB9zB82Tty9XrRjpKI9r8GOcay1Tfv1DEgG
+          2SDeC7gad5mPIdyiGvqiwUFt0qRu509UEsMlGd3O7SYj8LKAPyKDj+h9ghtodWMg2vJ41NSnHx3u
+          14PVsa+i7aYcG/gefA8r8mHWtt0PQjW/pcTXufPAGcnRAq6jW8QkrTNsoP/xwNTVJ/7z99RgmRjs
+          eY7PtPRLqVKOMfjLN/59f4XPBdSWmsH2vn822oER9hrLYA8atUuByDZwZaPNp7vepaIc6fC6VId/
+          /paVD/cN3iccYjtJaneqKoeHsCX5fARuONDi5PtgY1KEH+70BdMbRi3a/eG8drNbLy39stC+Pnms
+          Tk0Mlh9TmGAdhR7b4+8JVtXTJQQUafWXPMJ0WJ7FBmqxJfh8OhrRdkStjIzrPjFlre+I/uU7ERuc
+          yVUXP3RlrST40xuzxOh5tLTxbYYfGHXY3Uqb8rs+kXY/7LNeH4NlZd5vqV6yDTuy+srp2IUS3Pe/
+          HzeC526106Zgz9dwSF9ctDS3pw7vSxjOa8P20Wafuw5QgzN8uus3enhdEqki7obl7QHctbDuFvq7
+          f9pJcrTZzVodIse5YpwHMBrlw30B1o2kRNm/b87GbwHgc/Cxda6fdCYvnwfVm+lmyThqrrDnYfCt
+          WzL+xw9/ednuZ/EZnWzKNqIpAf9WhT6SD8IwXRPCw1qRSiIbrK1R5aF36HKdQ3w69xrgxlvuQAH2
+          jQ9q9Z3v+pqHVYs4ormzN3C7nkIvR2XxiY84sOXODcK7WGJfsqkeDWovBjCO3reZ+xxDsKIkiKE2
+          igPxNLTU2yI/ZagS67zzc+9SqwoLMBibh236mCkdW+qh9hl/523q6UCfLyGEex5AQmf80On2inWk
+          Rq8E387Nx90iyeshc5LozB8vRJvHtCpQ+0y+xI6K616/qgR3/YXt3+bUwnusK3hV5QHv+qOe4hRX
+          YPeb/uyMOCe1BWPY9VxNrjKjD//yuSy/Dj7C35+2uXczQ3/5bPHQYb04wLb+6dU//8Ki5D2j70gc
+          svNT3cvBvQFqPkX+dHBsbXsPpQ/v91bGjgbfeWc/0hlW7YEjVnt8gaWNnyO0Hz86R3xWuvTKRR7q
+          nplP5IqJc9oPWQgF3wnwCZ0MlwbLZ5SE83L1ud2/b3seBZ73T/jf/IraHAO7r3fBj11vjJnbS//4
+          C3+5eVjG26eCan94EBlaz2G9o4YH8Za1+AwdWNOqFCQoucyVeOJFHjgmXnppw+KPeC13qHe+8oDB
+          Zhk+ufRFqVzpKvzLJ5RzU0VUF9AMl9vP8N/n3x2MicarUL6FDXYYJ3O3hTkEwNk6hdxP7LLzxbWH
+          9DGciEZ+p7q3IWpBJmHJZ8RwBkvZwAC2Lpj+rS8xjFcG//Kf00v2Bh5++wL8TL3Cei33Gr/nFeA9
+          cyXB6dmmawiYGRi+ruGbkChAaPVH+C9f3P1C/eff4OveHXGWe2NE2O4Xw/oef0j2sM+ucFoZCP76
+          AePzBMCuTwv4p59exT5hzEfPACI48ATv/nC2DpABalQnWK6ZCux+w4IHm1fwOXr10Xw/3xLg+sZ1
+          PkJL1gSOazfw15/IGEfS1uNZW6BhHyOirdVvmFnLFWHQ8toMrHHSpqeaZaDgO4y9N2CiJRZTH96X
+          /owd8lHcNe+7DoxbdiSnY6TWxMlBKhXSUMxDy+tgvUz3Fux5oX+4n5G23qdKhnt+iU9+L7jbBg6i
+          pOfpgaSm2GnbQc0b6H3NZRZ1cBoW2GFP2vnQP0RvsV582s8we68UW8HjTMe5PhaQ/aqP3Z/cNII+
+          S4bWj9Jh/RjIVHgY7RuZUd/43zc6u1xz02d4GbeSaPczHWZTj3W47zec8nnnzpVcJWivT6zEOTeM
+          WMUiuN2rO77Roqo31DoLUJ+VRbyje3UXC39M+Lyfb/giBhe6/vm/+yXVfG7PV2cr6FT4lwft+DR0
+          H/7rw5SvFWKNTRvR5lT0x30/YuehzflI3pdFeokvC8ukNcCqQllGVb/12D5/aL7qacCjCBYOCd5K
+          la/D8d0D7dG9yNUe82F+rjGDWMvycYx0Lac8i3VQuVJOsHRRKWuygIF7PoDNwqmj7c5IDjAe8Rn7
+          ijK45BtaInyyRUwycG7dtawdDxZS9JoFFdJoRe3VgWcDHki2+9W5ei4FnE+H+yzs678O/TM5/ssL
+          eyLk45ULWLT3R3wWnF/R+LkeUvDqjtrMZ5GS8+PXaOAHXjoiq7I5LDYjv//6OzPXTaq2PFfZg8dJ
+          N/GDTSSNwFTf0PXxPGCjhptG/vDAf6PvP33GIk5i4VdM1F1PHQfKaJUE//LnhxiAfHm7xwSK21f2
+          0fFs1dTCpITi9pHx4+7NYDmbLQMDJnSwjIyRjq2eSf/1Z3f8dbc9HwPbaZ/45zIyUFO3R1jwPcZ2
+          WCiU7Z4uAze+BdgZP2y9ZcNpgfXL6oiuHoKcCoq0SL0nA5LkUTxst5cywlg2HuR0cPR8CyoaAoNN
+          M+w7I8mn0cI8+OMz+QNewzqmEg8Ol07HujOx7vwNaAP++kG+xjB73pJnf/w3t8i41OQRrzya4Fv3
+          K3f91dvCCAEcztDG+kuz63kryAb2fNb/01Nbt7gz8Ae38SXct9rWD00Hzbc0Ezf1aU79kAsgfI8+
+          3vN+sOexC1z6Uf/D45yij5iB/Xpxtr4VytHjasL7zzOw/7C0QWCizwiRAtN/em69vWITdrJj+El2
+          fg9rJN1keKuYFznx0RX84G2R4fh1IdGDUojm+GsVIBp5Y+YuVal1bzhBmBAtnLe3OtdTdP/68GEf
+          W2KEteOyz4uow8VS5Fnc9Q0B96ZAfDvb2M3ciLLw9MwAO/NPH4SPwN37Vz58XUqI/V3Prnu/BwZR
+          bvujO7A54bWshHt/FT+RJWrLn//b+zc+nVtQL1DcO4bMpfCnc9/Vq4XDEe31Ph8uz2NO//Cc/5q6
+          L7TCnG+zVmbgdQ8Z//3hV434dRWgne9xdv6a4F9/6GKaZ+LfblU073wG80fHkjJ3VTDajFWBXZ/u
+          /FkNnZeuPbCXmWJTiOdoeQ92CRfmlviSEOlgUcofA3Ej/uUPbc2tTOrAg6l5/mvvX65ftWPhlt8Y
+          ojeCpy1QyCqIHOuKQz6vc+KmUIXmW5zJfdfPtPKpjo6XJ8a6GEX1nz6XfmfpPaP1qQNiGL8Mtky7
+          EvPh8ANBZhegpPa0vZ4zbW6EtwM2z2CxHb7lWrDKbfvTz0Tf857Rj7MWZtKHw9re79iu3KcFu17a
+          +4nWIFy5yIdfMVbx6ZabdPGbZ/rPr6fQ9AZu7z8enx/fIViWw4Hiy6OBu9/Gfury0SKSqQcy5os5
+          OFij+yu1zfzL7/71V//4XLqJabfjb5Rz9vxm0YktlZndinUYl2eYwe/jIc+CAittW55f6/+ZKOD/
+          90TBbKYmsR6PWVsfl7YAj6LS8Ck8rZRuybmEJi5/5OT1eT7yvpJBt3WE+Wh96nqxpcBBAx6d+WC3
+          x2FB3TKj7TlLxFyKuGaPRPKBN/It8YTJizh9zDJIJzMi+vsw02351ilKHpOA5a+g53wXXFUoGG/q
+          S/HHdbfOzh3wu8tXfC1k3RUE/eeAwP8WxONaZ1jqwg1AcHisRH+ZCyB3NkvgKFF3bqaYdwfhvfSw
+          fdojub2GAZD7cszgSHGE8VeL3OWGbwnawltHfOauRaznohCORxFi31dzl+SNyUA2dX3i5c9PvSrd
+          0ZSyW9PODJ64nErthUFMFdjEO6YmEL5hnUL13gk4GfYzAaL0UGGJHZ6cdZurt/B4NmF9FGVSbneF
+          ct5LjAF5XxNcVtU72ory1kF8WXQS2eYXrF4nech7dwopzq3pLugkB+h+TxiM3QulmxZJPhzw7BDZ
+          8U7uetNeDCoc/CROZMU5J5aRhE6/X05Op6al66k4yRAtgea/imjT6DX8VRCJs0NMc+WG1S/wAstT
+          wxDN6uWczwbVRNunuuJS/b60ztC3DlVMcCSGc6A5bcJBlrBxkbFGhWO08E5VIuUmRT7a1NTlrDFb
+          4OWyBOQyd3dXIAvoUZ6MD1zmIBvW22stkA3ZGMvILbWJhYMMHwotfUaGJuV+8CUhVnl8sAyRlC9i
+          fUrhYFkhSY/4HC3vHstA1Lue5KrausKFvbRIPCrAX4sodCdMYAH1k5yQ282S6cTCWgXZlMnECUcP
+          0Ga6N/Df/dJvBuWWDkEwONsBq1iYwVaUzw7KkXAhvpLOeYdD4Q2TSvr47OOd5my0njKEVivEzy40
+          NWGYwhgOKN+IqphVtPC+sk/MfN7EjMWjuyonuUdyFV9xUL0I4IHBmuh+WU1y7YrJ5bG3luhx5TMS
+          L36db/fjmYfX1j7ilD8VkSD9Ngk28+VCYizAfNzG4I2UUD+SRxiklK6PUwKLZJ+R9gM3omTKZvh4
+          ZCGRl2iq/9YfWa9zRhTEkGhNxjhAUueK2EvtVdsWZlXRAOua4Pxyjfjhdgvg6/tJiPzmr9Esz10K
+          X5pnYEM9qZQn8xTCCqU9uT63/QzL4DdQyJMz8ZIyGYS6mjcYj1zhrz5/BMt2dUSYLGqC5ah6upwm
+          lRaY5KaducOmaey7nXUobWKJU5w4dSdKV1WSY1Jhj7VZl1DLnpHylXVcnlNMeX6eVTgJwRVbxLIB
+          G/XnCpbnNMUlAGiggiL7yCYPhahD7uTc2KEGOPStY6M/8BFlnkGJBltc8Hkun/WSF84b7t05os+H
+          IKIOuyvMJov8I1+2LvUTe5bSqC79npGumjDqlQrt94kQ43KsBnqdAhM51e1G3Ff7GhZWSVpQ6fCB
+          zbxRc5o3JgT5rRmJvLwuOd0EToQ2FxT+DOefu1E7DsGRkH4+Xo9g2H5Vt8F7OFyxlW+0Hjmy8sj6
+          HrUZsrcb4IWHnQBGYBUsG66oUWIpCdzxbD7qcuHOhCMO7G2px3e/VGrhFFYqYpJ88yuz8+sxWnEK
+          sHzjfE6WFVcIGoOF8bp0JCwPr2hLvM1HW4SFWcSWSQUeuxCQogbz7Q9PEl/foA2gge/2Yxu2IeIT
+          mNR1SMzf8AE99ZAPNe/SE1u0q2HT52qBc3NAxO4+5rCpWluiXVbM5+oG83ZU7z2UkKH509VpNe7O
+          CwX8XcoHOakrqMebErWIjzZMyvlr1EJgP0NYnbOGqA5/AAvk2RKG4KDgv/peZl/uUPO0K2K4v3L4
+          yUSCQA6Ris37sXNpE9YqClyGEPv6YLXuLAVvaOmZ4gsGfuWs0esqqirwJSZ/mgG9goiFoR37+Cqd
+          LMoZWqcjFblHLH+YNlrOaaVDIY/PRHt7j2Huvu/u2IxvivUoZ8EkjM8eTmYmk0QXhWFbql8FpM4W
+          idEVk7Z8LxWLFj5L9+t5Atrfpw4yb/mLlYIc6/aaISgeQhFiW5ehu00P2UMRdylJfIkjl+77EYWu
+          OeLz7enWG3goI1pm9kn+6mWZ07pAFaxyrGtnMqzPTEzg7eB4OEp7BfB/fBwqSzKDTBLdNTu5ARxt
+          id/57pqzXGE4yLkPkx/RH1cvPb13MP3FIvYD2EXr7ROmaP1Ue8OLzkCofkuIjPNoEBm5jEsLEDfw
+          9buy+MZcJZfyv61CsN6OvggSrAmSYjV//ECyCR8jcrwTB5LOWYic8BGgWiI36KWbMS5YO9a4zGk8
+          9Ll9Z6xdF3ZYM1pW8HcpHqS8OJ67uUEmw1/Q+DjT6Tnnk2+37fOlJYmaXouo8BY7VO8DNgHVpWHJ
+          lQii82MGxJ+/n1pIDUGH5qEkxJhPp5xbZK2D9Ry5f3iYczBI3wibNiY3NMxglS9D+YePJGwzkC8z
+          DWX4PLiqL034Hm3Ct7GgNeQHjDtdzblntiRoUIofzgno6u3BfQL0Nbhid3Qu5UL6WOCR7XmfGefv
+          MGHfUyEueJHY6yABeglfDkKrE061bZ7AWPNHFpaxqZKrXw90kyKBR9tduxBXkoA2Wb4WoHsld+R+
+          PYJ6VZxXA35MxPmg+8TuBtTIQW2/vWbBE5/aZHVHFj05dsSpZhnREtRuAN+sWfnd0Fzy+ZBYPjLP
+          o4uv3/wB1tPzy0BruB+I6nTQncryHkI/ce35azw+2rY0aoEex1tBLJw4gwCegY7sudnIqZLXevU+
+          lwCFiDyxTnIBbLonxrDtlxd5enM/bMw8b0C5eP3M7/W4tkerBX/65XRL9FowQRZDmRQGcbQmy9c7
+          fyhAzwmsf/ikKV31q75ID/uWEO/X/txtaZwSqcYHkHslP102TX8+jBfpPgvl9ebOIgjYP31Cwr0e
+          1+ykBTBU+w9RQe6CFZRxAN3QAP5xPZbDcnh+fWlgTwVWjPcLdJPOb+DT6NsMh0udb+DeLZD09IFP
+          0ea5i/H8+YjP4xN2yVNx//Hlu9Ian/TfYRiDwk7hxdXbGRnt6NLj/evAPz5xD5OZ7+vXQuOkFkSp
+          f229ePszZJIHEWae9Re6PK+2CuR7NxAvkRhtipyhBC+W+RG3owKlx/ATgJDNbXyegxzseqyExnk2
+          iFJEm7tykThC3rIzkm1SVFPbE0r4Sx2TnK+O6W7Egyygo6/P4KeAen1cTync64lcRgODTQ4CEcXz
+          R/KzL3hpMwB3XwJSURCb/XQuvbIXiKZTgOc3t1yG+e5JjfRiggOx+7IZ5nBQYmRsh3YWPZnXZoE5
+          bvDwMF7kPJeHenwimiAtiL/49FHkgf3VZ+lvvTG+p0I+XzPEQJqkPb5FjZXz4r3KgH86frH/Y6WI
+          VmHfw6cObzh0sjRaIfcSQSk+I4Lt9j5MK3x34CSIiJw+SlX3AnNcoFwlV+wloxRtITda8NaVNdHq
+          X6yNux6F1m94zYdcu9Qr0x0K6U8vnV8tcZezEhaQVx4rcedgzv/uF9jxgfgwfA20crsN5tprIe4B
+          OBrbS1EFnU/wJrjnSD6ibj9LMn8kbHLHQSNV4rbwUAWYXN2z4G4/9R7CO7FSEr+vWt31hSfDQVoN
+          rDNXs6ZXLDcoGQwH49vz7vL83Mqg+QgOkV8u0La7tzWwLCqb3PZ6Wg+3cEMEQYfk5RhHbEWDCu5T
+          hfO6vs2c7759D/b7QRTVm9xF6sREtKvrZUZU+2rLNgYVVNWDT9zcyun25doM7vxC8n3/cn12LAH2
+          PwlWQs8f1lPamnBlO5lkjf1xtyYoOuiGJ0BOryMeNnCvNvSIGXdm40J3hWv4qtB2edxxodMMCPwC
+          9472gon7w4eIEr1KUeCxDHn2bqMt6FKb8CEfMfaPzlJvWgZN2Ebej5TaM3BHjhx5dI9eDbaw1VLi
+          hFUGBzUWSRyI7kDz71eCUWtP2IdwBOv7KPswlMUTjo9vkM+Lmqng/mHVeZ27ozs7shnCkItSbJ+2
+          1F0V59dAOGJ55ln5rK3KJ7BgqOcaVgWBRtvj+6uk5P3TsMNInDvu+AArFtbEP2h+TQf3J8KXrsf+
+          pechnbjN8sB0PKrYzZPDQIuqVeEgNxk+x1DN2Vutq0B36hA7l4ek1Xx7aaU/P3DW7WvNSt2SII0l
+          oo+gndf0yD5mEEEu+ecPtu7bd+DPH5wrO63n++2aIjbJFp/nHtog7HpTUoI496e5fA60ZZgektfj
+          RKyAKjlV7ccGtLK1iK6YE5jw597DcNeQsbIctfF4ec/QPEkrOdXNb5/ISkQ42PILR2pW5ms5PlTk
+          h/3573oioX6ceXjjRwNHa7y482n+Wcddr+JzWMJh8k7KhkQ+9+dVfKVgvcmKjG6VXOCcTDrYXnaY
+          ISYeYmJZ/hH84SH8mUTwRxcMw653QpgHKktcAqxBuCcqj0LyQNjMN9Plm1v5htfB0LHZyG69+mnL
+          wz9+WcuM0u79bDwgSWVC3MNTrdckJS3g5c8bB5/lXS9ToWfADg/MfJXqIBcuICoQ+jV3/BS0uOZe
+          hE9QvSUWNj9Hux6hckugelMd7J6VdE98VRNO053B58AWtM3PkCdVuumTk3oKchouSwf+/JAPQ2VY
+          V67bYLlo3jwh9kpp3eBRurbukchm1lPS/VYVep9w/of/1JhJBSJlK7A7tZpGkTtsIO3Kn/9VD8+c
+          mAwNYftTNew1dlj3B0Hs0cie3n96VFuVbjXR+aaE+KTWN8r7ZenAE289sXYTkmiJVpxJchGlRE1f
+          ORW2sKnQvDQbUdko17Y/fM/CIfff2vntUlstOsmQY4rV4WzWLFecLYian49dKSB/+VGG9M24ELlC
+          t5wfB42Bu7+dXy9mzOeL9mXgI4YuTvJGjfiREXvw9CpM9PAwReNb53b8N605TCNRIzNzSGF0TDJs
+          O+MnX+X0E8O5Pj+xIfoOnbvgIQNUctQXXoNLOZiBGLbF+zBL73HOKfNMS0j4NMSnU1K7Gx4sBuCw
+          i2b19x7zFW4WhM/jrcNm0ydgubUN809Pv1DcaFOfHQu450n4UgtOvkDpkUHwqS9YvjINoH/7UeJe
+          LvZ4ddMmP515sOMJNvU+AtuVayo02uoX69tJiXgfTh00t9ODmIsItUUJeRmp914gxnTUan5ULz3o
+          1WTz10iwqIDYRAeiU+pYf9fffDsklgcOj9PLL9/cCbCrFIeo8qqrzz7PW70RO5Lge28NSq2qacv0
+          /MQQzNyX4F1vzb/GHuGLY8U/fvuHH+DwQAv+82vrn77d9xdRz+YLrHp3LCRSvABWVO+sLRVNK9g0
+          EGCfXBawKmMmw86PfjN/H/R8SwZ7ht/4cMb67n8Eu2qcv/wMZwdLBGv+OvLwRT0XZ7r9duklUXU4
+          CeEVa9d4cid3zB0Yb53go5ZT6LTrezRaVoqdUFqGZUXIh3a3pn98km/OUU/A95HHez5W5cKOpwge
+          28h/iS8RkEs1SrCgL+ijhKtyCsENwnl9KBhnX8cVVPu6gCz85QSLek3XRRtb8CjeGpbjqB+WVLr3
+          gBzmDqvcstbT5+SlMD4mFVHbDESDNOU8xDn8kdi8ysO2qJkMx6M84YyRru5S6lwIq9fKEz2sP5RK
+          itygZugakvweqtvpIt6AanwBtv/ygO53lOFfflD2aulOOawycChwiF2FfedTQpAHf85C//yURgqB
+          dtIlkBTiFreZrllHZxTcYxU/Py3c9UK2QCVEFvbBdKcs5GH59/9I6Qcl2PXTBryb4mGtr185NQa/
+          hVt47fD5e7HzGdvpGzZH0SRRttbDuudxcNgSBruSOrp0WEAAdfXk+pTmK9iAsITw+on6Wfhaar6R
+          4LEBiW7TLKjXeH9GwdmRDL+Jic5c22F259cbucHtgS3Lv9M5GxwTltbzTMyt5nOiPtQS7Pke8fiA
+          o/Mpklp4TlwNY7Eaoi20Awk2T7ea0Wk6A9ZQ7jP83D6zP+z4vIbSrfvzA1jLVq3m998D//T4kMga
+          vTw0BmEB0Bkg1sr7Pz75Ww83Ap96fg0qD98fliGX/WDB1s3jG7LPySQ+8/1q27AZPNz5Cytzds0X
+          Lh092P5kjcRL34P5x4gBWPg0JVn8GdxNvHcpTA6Wics/Pzuwsf+3/vNBuKT5ZpbXDBz5PMY2h2lO
+          Y4bdoOZFPbHgR9WE/mG2kFeeK/Yc9VxvjH3NoHP/TcRIxchdkK9a8Jst331/99rszr8Kaoml7PmP
+          QZegUNK/fIG4gf0bdv9igZPHq9iVbUujnMDsJ1iekQ/6kaO96x3Nv7zHp3uevL6zZUafsTpiu5IP
+          2hJNbQF3/0+sx3ABtBZgBkJZOuG9PxF1OZIgON+0cObbOqbTq2NLkLw2Fnv59IuW+qqkkI27kIS5
+          sESEZ68JNE7SQGxOIfUoPucSED4LyV8+uF1krAJh+cyzcEuaYQlcroePRxqSEjx57V9+vecfBEv3
+          Xz6mSGrB0+Bb/NdP4HQCErj3P3z2ZQZgDWQ5QONacBj3rq5R8AxMtP+ezw+NRnnn6CVw/h0tfK5B
+          PAjD75hJf3mXoZ7eYAl0sIEjOnj7fjHqZa9nCId49Znw+x6oN5xiaOLih8sAWtFcqqkFU+KExNrz
+          u+3v8+SzJ5yT50tblxerwxGPwczAysjJji9Azu/2DBuK6GQ5fQJDlwHEO7etRpFwUKXeFntcvu9y
+          ThhFhvAW37/+Er/mfHlKYYoix6uxCs6dRurEZeCeD5AQ5C7dqqPZgkRofWInp2dOG/fnQM2pPSwr
+          d0Bn9l7JqEsdmZisPGnLDT+Tv7wQ//HJJhhgBJri8fPRbeJolQs/ANqzvM0L1bNhOx01iG7fNp7R
+          rldXTSoduOsvUv7YLBrOD7cFM8NHWNn12ojI1sJW1qCfQmrQ74bdBlYcv/mSliT19jGO/D981MkP
+          DIs1fWJoCTJLvKNTa9Mfn+9461O2eGnLU4njPz2J/SkNQWfUqoP2fgs5rcM52pjhzP/lZXs/wc/5
+          hVlluPtnn9/xmfV6b4OoLzp826TK3Zpb8obnxNaw4RWORv7yzj9+MFfzuevZLIPXU6NiW/cP9N/6
+          jLb8JeqPoWCaXnSEh75gSRnMzUBahulAexUSnw0P54j3gywDr0opMU4hobSvSAXr8T35B8n9DJt/
+          K0JJTZeO3C36zZcnfyzAD91b4uXg7C7G1DBwUMofNtwfM8zJYI/SUjXM7r9v0RZuricp3qXEanlQ
+          otnJIC+NclNhjf64YalpIEFG4BX8l4evP1mVYPuOs1l6l3299LzUwPkwvmd0urQRuU9pCeMmv87g
+          1SoDP0R8DIsrG2PnkMCa5o0PocZOIjkdGg8s3KWPQeGcn9gVP9yw5/sVzOZwP7M99/WIaP6G3aW4
+          4dyjLN32fBUoXlRi21YGd+GdroB5WoK9P3AYFsXKfUgvj+eerwRgMdAyIrt1Br+7H681DbHsIS9x
+          ELE/iu+Syu0WGJInmv/6UX0YZAuMJZ8Q9Xn+aNtY/Zy/vIdgrzLBPh3ZARxVb7LznbZa3cqimnq3
+          GZ7Td7RGstzBE+88ia9p1rC91OANmV/73PsfP0q3sHnDpt+u2F4fgjY+0x8Dsna84fBn6nTtuUpG
+          pcFW2E6pRfm/fPhxZTNiO5LtbvJmx5AZEvQvP9vIZnrw1hU1/utvrOCFfAibn4UVTThFqyw9Frg1
+          nYl3P+eS3T/Av/wQWrco6ptbUiHW1h7EV9rQ3eToyMIjXf70oQhWbpM9SIbfODey2GtjQQPnDw+x
+          ajPLv/WT/vIMrRFPGpvyy4zeW6ySXa9o+8k7D27B1yHOJkXDUvBHHQpnKOHgJrzp3r/r//p1RDev
+          1TBL9lVG//zA3p/4y5fA3k/DZ6p93c5yoQR5n9NmYZNkd1FcaEHRzK0ZNh9JqxT80EF/V/MdzxdK
+          NwFJAIqzTvT9/8/hYMd//Rtf2p+js8T8EsPz83GfDzy3gL88Do5KQfBp9w9b6B1ZaFCOw2bsnwH7
+          h0fn5/NONIPhwYY2PELzpL6xXvV2xIEX8uAJjTei4rNWL7OUSxBuYk8umvCNZvodNviQ8OB3VvEY
+          6K7nJbSEGvELaNMJOKSFYJOvpCzgj9JYvS7g/5goEP73RAE8EdY/WsZMN728NvCpBSo2t62PFsvH
+          LcSVUBOrOVfueIWXEoXNbBLPtHJKAX5tSF2kCzk90wUsv4ftQLFbKpK+sq+2dZcmhFcdjP6KgaWx
+          /ZPy8HD+8LNYvCdttC02RudL0s37Q8FcAShDCIbvzcDKMlzcpUi3BeazbOHwdyA5hWFcQpszSoIB
+          7Ic13LwYZu9FIyU9XGu6ffs3FGZs4BN7GPJZKhcZbuYvJpdlWLWFM8I3as2t8UUTbMOWpa/5v9fD
+          +07NCbznw4nlX1hWwZxvV+XDAwe6ATHuukiXwmFDKU7jjdhX3s2XFNYtvDgbS7SgF1x6AqiC1hnZ
+          2FRiG3DNem9hyTY8Kb3TSWN/D8WB7LdPyclrSL2AL5bB3X4VOFMvX3etaouBQqS9iZe8zIH2ZS6j
+          0RwhicPx7G6uxaXoffTbecCFWwvbvVHRBXURefJHA3CyZ5fw3/U0YZ3zLSMnqKJ30wfXm1N/W/ac
+          wOUk6Ngqbu9o/RHNQr2e61gefX0/w331YKUrGJtNXA5bfrglKH5wR6wORMsFl1VGhL+ONUuGLrvs
+          p4EMePAvOktHbo22eGFbGHmpQq6em+T8lkYe+hzWiDjg88nZJLd99LYdHXvxug0re+d0dCgilfjx
+          A9bbaIsFrE6V4K/Hu0VZJX/xKL0XEs4GTxo2NwEiuMfqlajb9HWH14AZSdbJb96ex8/A11ufQQXF
+          JlFjoLrC5/S0IPTVO7mtsRjN9HxKYXvgOHK+avEw8beigmBRjsQ+lLO2RB8yS2wwWNiqJgFQ+3GD
+          0BeWC7kprUvX21OfwYOvKcFFdhm4n3HqUX4aFKxnt/0ZHOvDg4zH/4h6Nz26ddMrQHHOZtjMgK41
+          EIkbnKre32cQZQDCsVLRlxVtkhl65bJbrvNI1/iQhIjnhuV+Lni4XVgRJ90oUyEhDQ/rq86R+Ltk
+          0cp/IhUZykkg9l6/NIm+LGgOqolPly+bT7wSmFB4vDOiEmnWtrLdYpRQ7eIfnLLX6FR+LBTgasZh
+          JNca3e8nvIKAkkfOTxHX1LkO1zmcMOY9fli7MS1gFDRXnJywVbM55GYkZPJGci3XNC5+TQG8htKZ
+          +OEbDRs9nzJ4DYwAY5fPwVYnU7rvZcmnPq5y4fQ56uByQwKxTYfQbcIPFjyHrsNX0xiHzcyRCp1b
+          EOJbZ1p0s7VURTJYc6wwxbkWYBUy6JPMKsbDvt6Zy8pomqwPTsWGcVdiHTd4cRZ27u4kdvn7aamg
+          pRSbLzZnWWNnBvVQeMm7YnOTiH5DZALY5vLM7Z+XKj80ELwdl2hlHg2r+RFVGIriHXsWYOnmxIoP
+          +29Yz0xnpy6VwSVEbu9FxCU2GSi4kRHs14vPTfPJf/BsWXB+5bmPTqEARhluOmq+sUssl471OA73
+          DYJFO/6tj0s/12sPOlsvcFlEWTQOWdUiNvhZ5PwdXVco7KgEJxSWfqXz54iVoWQCQygZv5n9NtrK
+          fH5DvtxGHL3bMtrIfH7DeyxfsW7Qvh6HrGshk6pnoi233OWhHJbwe32HxEPeHE37fkdUDF7Y+GzL
+          QE421EGmmwLGAOfRUov+DMIV2NjAUeEKNE63f/imeU8v39ZhhCCIiOpPt0GttwjKKTTGS0bkpbkD
+          ItKwRek0nPHJa/Cw2d+QQcEXXH2enX4RF7GCDIpXGxHZWT2ts5s1QTjqKvJUOy9i1aBU4aEOInKD
+          3M+lqsyPUJ7bFPtC3w3E4AML3YP3hM1RcOsVr5IP9vrBltiU7vKSSAiluZWJ6jx4tzfuTgIbUeWx
+          FoUfl3e3RUKuJDHEfaVUI3fgLHDrWAvH30CtOTvVOuS16xln4GNENL2cQrh8/f0tJJXs0tLcROC2
+          44DzNhfounx/Jfz294A86leVT7fJ9SUZey9yvdm7pUIFC1EFc7+9yp98CsqqAKx41Xyg1ra22qzc
+          wbSAb6wYFskpf1k8dBGuM0nDdcnpZw17VNNFwblMOW063uYOsl7JErwpw/77rwK5T5XMbWwN+xli
+          t4STEtxwKN+8gf3GDxF2wZLO8PuhgOqgTpGv+yfiNGvj8i9NeaNjVTHE9B5pNNmO4YC0tz84//kB
+          2A4NqeBf/eXOvQXsp2EZRN6M6a9TKuec7RgWdA69iJXh8cpXIVQCdMvvws43TE3viCvQYUQT0afE
+          i7rbcZHQbMss8dWkzzfR8gOoKu8MBzC71WzkiQ2Ss8zA92z+5H/4B/uTOJJ4yKd8bdZL84+/ks0A
+          7mJbMD4KkfImafb13e2oUhnN9+mJT36sDezD+Mnw678Uki/HmnLfc7fAOm0epPD5aBDOx68OVcaI
+          9usXczq4SogaUJXkws0cWB7Gb5+IZJ/kwS7isG7mfX+KrzT6Q5vfKL2Om4UUM4j3epbyFadEgvZX
+          zHGGqiZarNiykHr3r8R7El7b9dWC2IbLiUrODP1JfJLA5n7t5yNBj5wK71eGdn2CLeZZ0H/7nyGz
+          RQJWf2vj6R5l6D6M+1uIRlDP9jeEqOKlmWhWrNT8RzwtAFVMTk4CFrTuD18G/LPno4U6uqxpZiHr
+          Z0043co42qausiTty2izGLyagcSyxiAvMd/4VNf5sPFsn0CAUUJM533M52NwfMP2Ai2idcqn3hYP
+          BTBP4vMsYcceuGx6xNCBAvD5uxu4mxIeOljFRMJY7cZ8cbWfDv3jusxTOp8GvsfaCF9+8/PFarqB
+          0U4kFg6RsxFVpAvd0GR1ULbOF+xbRaxtlVUsUEpEY2Z+Sqitd/HlwMPyTMjZ2ao/vfZGqWiZ5P79
+          fgEbD10AZQtfiPOgVb69o21EzbPDpGz4U87v/AWUT+eS+Og57oYmuYNL+iL4fBvew8K27wVwgr7u
+          +y13R2jwGzw9pC+2fXka6B9+vJLgg6+v7wcMM4p5xLqLjcO76QGud2UfnY4bj88qVHMhDAYZitl6
+          IG5vOkAIx079w2+fMtZtmLz0scHuTk8zP5FPvZqfRUaGYgjEIm5dT6fH/hKs5OVgY5hIPuJ3L0qv
+          +3YmSv/5Rqvm5S2giHbEENcCbPgreBIW65JocwHd9S7uE7zv1Cc5B616GyaQwdmrCnIK8HtY+Vtc
+          gRMf+QSfL5q2z7MU8IFeGil43/nTYylMZh75r8QrhvWCAgu6muDteKK77A2jFPL6hSXuovzAfD+J
+          b7gHYsQx9EqbKZt60EoLlch8fKbbUxjef3hF5PXyc3+qXUnojy/BfOEG+vB8Bz6LQ4GNkCEuGYjn
+          wwv5bfv9NgBrxbID1SnrZtHj15q62SGDwnw28JM/fuh2ksYZXAXqEuPEyQP/lEofomI5YRsmXU6Y
+          g9NBhU94rDguq21W8lugXR1dEnWKUW9FiXU42ypLlKq36k237hawh1QjZmy5+f6mMAjznIvn7eZO
+          gH4OF0dK2b6cmfhRDKvElwmwyoH1m/qDa0F6gwryOSIEq52XrzKjiiBMZGk+TGVJt+753uBn+Mgk
+          TQXJpZ6+MTA+uz4xGikZKEflArGNtWDj4ufaVNpNBYIhQ1hJlAtYgs+jgaDs3lg9G3rE/Qzcg/l4
+          Soi7HGtAFUZj0NfV7mR/Pr7GNrG7wLDHZ186xS5gO3pugHQIh7k3iwtYplSWkfgJRf8Qxl+6HI2m
+          B/ANUiJXqVlvWGMDyT0lLNFJK7rL+cs4MPIyBZ9VTDVa0Z8JVV9eyU3jhYGe15eFEhUSkmHnNyyW
+          afcw359yrR7a37Cy3KajNzcy+Dbc77mQkJGHJWhMgrWqjbaXplToD7+fQUP3/zN28O/+fQP8rtfy
+          83tDe7q/SfwbjtF4JJ2D/urjtOuJiYxwhmumZySUan1P7MMSdg0z+EcubYb1SIcOMHIc4rivo5zs
+          +hlw5ez49XID7tQFeQmvIKREe7fMHz93QD/M1Z8/AKTULQ9O0rXDfmenf/obgvChOtjSguf+1hHZ
+          h5AzPWJMnR/RGi8BbNLugJUL/9VmR9Qt+DSil89sXw0I8XZOwTQ5n3/+aimtaIRD0mXYujZ23rh9
+          OUt/evOS60m9HN5nCe58gC3DZerfKP10qX33lGgvTaH8yRpCMAMxwpcDe8inSOUaRPLA8fMsI/kf
+          f0I/PHH+Xk/D0lGjhfahScipMzvw568kuLbNrif9aD6Nsw+xCxtSWIAFJLtLFUjeSUus3Y8vZ6pA
+          +GCrGF+3IXLH/f+i+YFP/nH+uDXLsq8QCo8qw8b7INSzvwSx9JqYCntNqEUsjpsMxWfbJz6czoNA
+          zSz451fCy/68rfP7wqPnrbgS/Itid7O/GQOvTVT70LQAWPNbKoHT/An9Wb/YuTD+RAayjZDP0o/t
+          AC3svITnmA1wHvf7U/3jPJF+gqcQN4gNQJfCa2BLXIfYUstq9A7UDbBRYeB7dXrS5dNAKF2L79dn
+          f64yCJP0ttDDZo743JFAEyz+HSLFDGOf2iPNpzxzG1BOn4/fSl2nTbPsvyXNMBsstxRp1OrqBa6G
+          ePKnhFr1amajB/YZUnze/Rs1mNKEh+tl8z8lO4KZOGoLqeIR8qeHSCqm+rGpEoDNgtdcbucPcDK9
+          caZHY6OTInM9FNxb64vWYNLNSl4LrHL16S+srmprPK7mHz5gz+ejevMuXQ/Ha2rNa8o6lD/uZyCZ
+          JWOxo16+2lbLHSMF78wnp3Nh14IMLgFyCcl8cfG7eoVX3wQDqNM5V2vb5V43zoJQOA0YM0SrBdb2
+          IByHr4TP9jmh458+7J/Nl3i3uzywrPPZoKq9juR0Db/5n98B0SWSsaFIL7rGr094NJ9CQ+S68vLp
+          zx/Kxb0hlhRvGjnqLgspux2x0fb9sGjkPEIjNU6zmECgTT9kd3D3W9hR7pNGzYfBwsvp4vnAuZtg
+          7Q8wgcqwn0Q+FJm7Tm6YQJBb0u43K5cm+0TQn/9eSedp733/wKbma6w1L5R3h+k+woh3GWz/3i2Y
+          5TzY4BlWLrZ98TvQ2FdL9GoPwdx5/GVYIBIXqEqfAXsf7kl/nFnHSPwE/6HoXnIQhKEAAB6IBVVI
+          P0sFIWprH1oDcVeIH6goagqU0xvuMcmE9qzn5UMhf0VNwouebzx/cm0e3BmQvLS4IqlyE8okW+vq
+          ZU+foFMjA4yoLgdnWd2l5VTvgh+2hsTApTl+F6ZRKXOHt4GoxzJe3nAuCWTbEC5t5DXjVRSCGvSQ
+          /V5EM3DXz4wm7aDgDwAA//+kXUuXsjAS/UEs5CUJS97yMkFAxB0oIiAirwD59XPob5azm2Wfbk9L
+          qLp1701SZcm56q0n/u3L71cU41NqKrv+Xw15f9/Ev7NC9N7jXZK1CyaeNVNK1+QYQ7MOBwQUevXK
+          6PMdobjsJxJP2o+OpQlcyCNLxX5xM3IeY8WAd7zfeebLcaBVrWnybTVi/Hwct3xsYm+TrsyW/+MH
+          M1adFnpM2mLzvnb6JIq8KKfXQ4hd92SAFdZ++0+/oS8zeavTai5Mqrgl7j0vPF6V7AKG7fTB2l4f
+          iPN8MVBpTuXM6SEdFv9mQLggPsbqH//x0+cCWPGmE7d1OLowl3gGf/rBBPu1TO9aW7Csxhz7XLLU
+          W6Pn3Z+fSQzW+eTfo6HzMB5rc06MbzYs0paxcPn6AN92/3UeHbGAGevcyR4/lOZi5cvzd1TIpSDO
+          8KuvjxboduPjh2WDP74zwhz1F+xI+S8i40+EYParB3Zz5ZRz7bxPSUPKnbyUtKwJLDNGWsAd7V3U
+          lYgP4qmAlF2O+PKZztE//o5BnGOFvGPKiZVUQP/euORVuJ+6B80zBXs8osF5j4BQKwzlqAuDP3wf
+          FuPuhDAW5h9Bw0/Rx+r7LGH1TG7YeY/OjleBIZM4kBDZ/U6eu0o9PCXghpYh6b1pOG+SVJ+zI1oe
+          Ex1WSe19OLXeFf2qRvemwhkrGJ2tEf/5d+uDt1t4+cCU3GNmzTdEPQ3cO9QR93PJ6ZTKbAaPRk/w
+          WQxKSpUpW/7ihcSHgwa4P/zIeCb550+sz1iM4fFXT0hMHnrEPWMxAd3RZogaMGd9dXmQwIzI5izl
+          yjcam1hfpD+9kDZnxeMFM9+zXjFJun+eHY9BKLvD40Nsz3pG4x//6R/WAVteFkVkzx9IgjUkqnSp
+          wLbw4naMY8EltlMrgFVcsYNajlkkqlOtc+VgibA+ynQeH98ln8XGC+FTUnOc8ZUyCGF0nfc2Jdv+
+          fSd9+/u9vP4sHOJSopPTui4Mm9FCnOJOgC77FMm41GZElUKnvzv6dH98ZBb+/O1v9UghZnidnAPR
+          Acul1BJR+X5s7F9/fr1Ocr7Aa9/Y2PkIFGxbmiP4W/wVsU0X18Lt3mWAtWX/T1/WKw9uD1hcQU8s
+          za/BmhJZBJ6QJzt/hjXpg7iEtyrfpwwS3uu1VPSl3d/CXurqNZViTpHS8NUTHX83fXvrTnnc+QtB
+          eXCNaLDSQKqzLyR45VWdnVJbAXmpdgR5hubxdVNL0PXpnfjDwtRb8ZsUWFZzPgvPDoKxUw0bfjWt
+          n3c9Q7c/P1p8rwFG/dp62696PuDkHlbE0bSKyJE/h1DNii8+2XeDCrW6bjL77faeOxcn50XbCkHP
+          wIKcT+ENrGfhXMDnqo1IMnzL2/2cQmacmzofmgDni5EDCH3pUGJLBildjLP8AJ1m+sQU6kmfbo4d
+          wAG8U6wXOa0nh1V6uOPhfMgrIRrf0bGHNhtfkEynqF7pR5HkzmxYYhWIBeP5y9iw0oQX3r8PXc7U
+          gVA8vry/euYt6joHcGmrAHFS0uqrd5y1f3wj4F9pPcqoV2AQnLOdb+Vg7i5jCOcYpVjJ5FdOWMdn
+          ACyIQU5qO9A10rgWTq684tPR5XUyninzh4dImg7RMJzXnw2Lex4Sf7RVj03LeT8R7WPilkjQl+dv
+          YP78AhIe2l+9CrzvAy8sU2wnjzqaD31nwUnmAmzUHzKsT5EGcnBDPT5l11Gnv7xL4KSGN8QVrA82
+          Rl5ZuWdfLTF3/T7Oi2DDPz9J/YmivjncpYDixfjg66N569vk1658vN6yub+VL32aRaX6x1eMe7+A
+          9YEOC7jpBM58JCv/1S97PuFTmXOA5P0wgl2PzE0uPeoVXWX0z6+O3roK+H5QZlk2N2FmQu1DN56t
+          Eum7Zm+CKnT3NipoImQPcURuX10HmyrZD+AOxQcdDwXS+QGsEnwRO8Dn7zjoFPKvFC6R0hH9ns5g
+          y4V7CpAcpUTFoPOmbL9RRaReJbq+svlmN10IbtXdxqqnI299q8sIt463549l+vVydVMNDnNyRcPu
+          B67wahmwg32L3avZDeu3/iCw73cgZhw/3ig3bQH9aXkS1adVtKi/LobPq/2cywvBYOXEZvnbv0JN
+          OE7egpd3BmHoT/PnNbZ0x9cYflvQ/fEH8KfvwKJwLHY7IwZ086byT2/OrDc70XK659k/vnxXDx+d
+          SoukQQdaMz47kuWN6tqG4I/vHpUsBzQVA0uexMSZ5bfx1Md5OdjQXF4zEi7bS9/Mr8LKijceSXBp
+          Pt4vKrYGbseS7nyoBpshhY284wG5fKpqNxhhD6MuCEjQRp98ta8BhIsXj0TnwyOdvxzx4Z9//ceH
+          euScKmn3g2aGeb6H9XCIRumtWSG2o58brcVt+OeHY/SIpGi2zkwFlrQmGF+/4kAG2R0hfWQhVi6N
+          qbPH97uT+fxAiHqIvwOVr9iGLz3U9v2qfaqKxypwLDIBo11f9p7NZRKV1w4jwNFoU/J0+eeP3G0T
+          0R2fHvDyKxSiSXVDf4FWP+TpctDI6egm3vJ7qrbsM08bnxJXzbfLUj2ghxIDu1+V0DV5ZNqfP45R
+          EK5guR0XESbeoUDwUrwpK/5I++d3EYzfM1204lFCS+urfT92iEanWWO4fZIS684YRdvnFfSyo75j
+          4mb2OR+r7R3L2pR2+PbnX/358UjYLtj5fk97fI0bfDVDin4vyALS71PenUOb4L/9VPqYkgxGzdLh
+          v+chf35r83C/f/sleY+WNIaCd21nAIRTvoYJTsBf/bOq+2tY+MZF0F74H979BX28lG78xxfPgRyu
+          w+KMhxA2ZQxIzvRKLhyeUgpVCx6w8/gZkSAxYgm5SiyIW/GmNx9Qbf3Ts2k5CXQ5gACBWpEqxK7v
+          m7f70Qr48y/856vPf9/zPhUjbJQ//0xfsPUR/58eBeL/PlFwTKyNWIfHLVpe/lkCLuontD6jKSI/
+          5DIQ2m5JvLD71pP4qXg5Y7MAa3cpomN9tC3ZNLUX8awADhvlvAcsxVEjt0He6CbidoEfjlXQ9pHv
+          ETcZUSEdBNObCWG4YYZ1+ZAnxq/JyTJcIPhOoEBaRMGcFmaiz46SspC/xU/8XMkDbNpz3mCwpE8S
+          DavqrR6wYzgDs8SnT296sx6vCBZ1ArBpVobHv5S6h7WrZUQ9XD/RVmxNL1/WxMEmw5RgdO+bAp7j
+          aBGbv/H1BoqXBZfqNczVrBRgy0qegY/3qyZ2hiyd5oWO5DZdCMYvktU9WR8zVK6ujcC8ih61v68Y
+          pOKq4CxU3x4vTksP06G+E2PJp2gDsGRk2Ys+SLgJJ0pf0vaA1mZu2JsSa59r07dw8olA3IqG0crF
+          bSlb9tiQFBNtEEr7+IDIaATUOnEc8dPpJkFfKS2SSJM3EIsdJdCcvRcSObbMWcT/QpnTgDavXT8O
+          i2ZcG6Apioav9w7rfOkXDbyssTMfwovuUZrcWWgo332u0NZ6/LvvCvk82ymOOJwC2m98KusPicEa
+          k/7A1preBvvK7+Y3YVqdMkU3A9jFPLnFWZHzZ+zY0H2lOnmBawx4kj6QDHwAUX3WNcB13hxA9L4U
+          RE2GI/iVcT5C9EnO83o/RDU/188NsvSh4SivLI+X7RzC5I3KWQqbW7SYkhnDs3ANSPS76jk7OBGS
+          P28VYB2/lIE3YaVBqTwnpJBdP1+BlrmC7+87CpM4Ulra60M+f8WABPFPjWh9KljYYkXAsfjVAPci
+          nQ+ta+4R9LJjj7VsPwHlUOTE+RrfYSWnlJeHV9fgEDdKJKDZe0DJ2QSinPYEcaLSl88OiIgioL0L
+          vgQqyD1OR3wil3Fgn15cwX72RKI4Tuix0jXg5VuXxiR9vFnv3/uy7LnB+P4Y6cb3IATVjzfIs7O5
+          aD7c0xAYDe8Q7ZFc6HI/fRYowx0hxZmlkz9tm2wwukKUJ5b1fq6vG+h08zcvZqh5q3i9ifJ7/pbY
+          vm22zsf9dZPjl3gijhLVVLDO0z4lobXR9jaf9Qo3bENbuZjE88VFX+aDxsiZ/8v/1jcSzidDkXuz
+          VImu1tHAfrSvcdzzCdHm+R3G6OI3UOm5YI8fB3D+JG1QplpGNIe1KX87nQ0Ir9kJ32CqD+ydWWz5
+          c+N0fCGM5S3Ji5Xk7Ov+sNZznL5JZW3JMDcxMU7SZVgIq6Zy6L4VbDSA8ShjdkiGtl3icxiGA88q
+          TAGSaVwwusl9tH5YJZFD9omIETC6vr2UoYfHxNhQOEz7HEiwjvL6LSxiOXGc89b4smDjMtY8RJ5M
+          KX3hVLJ8P8L2NXFztrvcMrgkVUYMfs699QyOMxiD5oIVlemi5ZeUG/xaaCQnbln0oWXvCny/7BIx
+          8yvKx7/P7/mI//CQ5xCXyT6LPJypm+Wtx65E8kvZGewn2QC7uDIDpfZZYNs5eLpgf28JZLkhx+g5
+          ad7W/EweNqwU41jSYrA6F6+Cm1xL2EtewrB+zooEzoG0YdeWMRB6XU1lbkoxye5+D6aMBxrU6fWJ
+          WvD55pSfhBFmi/jGvm009QryrIfN6XHD6iXYhzwbjQsBk3WzwB0Vb5n8tIVjYynErWCVr+/b3YD3
+          4zzOhPnNwzr0v0q+XTIem8FRz7fEOM3w1tz2uXE+1gVHv4bwFnA8ce52Vk/nWAqhwagKiYGu1Kws
+          yZ1U2MJETOwMNWGEtw9R3l6x42i4Xnzm84DeAZP5KLdLPT9WGsg/pqqwo0Q6GONJK2T7/oTEcSQv
+          Eurrc5Pk8GJgu7oMg7Ca1wquibcQJOZKTe/POwu3s9jgcH12e724GTJshBP2ZS+n6+DfepAeVJvo
+          wsAPK4aDBV/Oescv/z3Um/j8zHLJDhFB/hPkNFwl/y8fiWc4RrSN1ZgCZwK3GSbZjdKx33zgbgkl
+          GoAe2DpTtmGucwE2V42CrfAmH+Y9O5M77iuwXCtFktVKN//y2eP4bUllqQnM+VoGWs0nodXJb1WU
+          5vDLK4DjPJEBl+jmo8V/DmCOxccoXaKrT5Be3QFf4RxC0WMQUYI4B8L4ACF0jStP/NXm8+2wpQt8
+          0emL06Y51mui6oHc6acfNiNRyBfzbfAyaz5N4i9BNizheDGgyIkPnAzJmPfuYrKyKzYAaZA9UVb2
+          7E6W+vJMTuFh9KbC7jZItyqZhT0fuIOliDKF4Rk/nbqlAitfAll37hhHDvl5ZDWvpXzRJZ8YHP/K
+          10J6L/L+PDi0bgdvcRrQgMN0i8gtiUywHOd7LJucz+FkXJlhk451AzPt2BC7f751bpPtFggxzoh6
+          fDwBF6OUh+X5WRA9SpZhM071zlj9lVz13yMaYeIiyPQ+IunyPejjodkqOc6FFP+979WftmW/t+Ti
+          q8ddABtGQQMDkWPwK2SP+dqxx1FuD/hMVGdJa/rIDz501vw0UybqvSatthAezraMlb1ejdVTQxDe
+          vuVcRfmSj3LE+/L3xdQkgKHqTZf0p8k5sk/ksvOf9anfUllTNI1oHpbotp/YlJVLf5/F9SWBfRwn
+          BN/7nGNtfXbDGD+EUjaiN51l8Rbka5evPnyju4tkpme8T3yz/uHTvDzx01sN/HcnsqkQPBh6vmq0
+          56EatibR88rS+fNH7iCv8zN2HGnINznJRKhuS07Oq9/Wy/F0F+GrLwm+odMSjeds7/n0eqnYc1TF
+          +4tfSFlC0Hb7moDiVWHhbe4fBPPtT98SkBlw6TVn5oJjHS18l7TgBiSd6K3q1PzRmBCgn4AQVARp
+          9NuI08st90xIEoIc8J/CCOD2vDXz6O49oxzHSmWmGvYeGXuXkffnsAAvshyi/NXPztsV51Dk2BSr
+          2puzVE0h5rwjRq57jsZQChR5x3eMX74RdXyXNHCPb5zmP1GfD8BKZDJceOxGH93jD845gXv8Iokr
+          hnxtZp6RbJ9eiUaPbb4FLdHg4oSU/OEv9eJ7A/KLIWBtbxm11KHdwfhnHIi1P8+mXigP77RoZu6V
+          WgMNrmwMYnI7EX02iL6ky4ogCO7jH78A2+z/QpgET3eW9GOR0+dbaf7wk1hSk9dUvu/15Ti72DOn
+          NidbFBfgqH31GaqPVadCprRSvF0EUjyc0tu/PwRsOI9EXe9itJzpIMIPtOwZ8kro8cdh7GCHv8dZ
+          nkQfjN4yl1L7CAokfXCQL5MfNLI0Tu1+Z8TWl4mmGlQ/JYuEQd7AuB7YBO71F03Xdsy3qnsU8HY+
+          WliLXZiTNjm58PDtPHw5Q+Rx8fcew2ukntFN9Gd9vM8TguebLeErwyiUGhSUsHCyiWhv8zlMol/F
+          4GR+3zOohGpYlpQVIRHrJz4bw6BP69sdof7NfOLMeI3WRzGI8KFGe9c/2Y22+owZoMj0MG9PdB7Y
+          9rQ8IGHWD3Hul35Y6o6z9zuyF2KWQTVs0fhe4Cnk7L+fa6E93xuYilSZhSQyKWW+SQCvdKvndaq6
+          nPZ3ToLvqg+INa7FQEv7WByvz9gg6XeUh+WQgGafM3rG9+dT0emRSgX4/rwcG0t+zv/4LXDisZzZ
+          u2rXXKctI3z59UbOeVLTbWiWTBZHuyEWo5qR8BRkAziNV85LdWCHJa2kAFzLkMWna5h569vJbHi3
+          tC9GpxnnayE+F/AQnyo5xVkRLTtfAexxdMkrmFRPWIKdTyXghtHOHxfDRAy8JCwgl7zmhlGdfho4
+          1U1BHnQy9B0fZ8gcjglxr+Kqz+enYkD9cWXwtTmgnC1ueHek/HGumajXV0u4NzC6+g0JOjJGk/YZ
+          REBg4++tmbZooYLowteCRWIG6rdehiqfZV5nZ3S4BLeIigyrQe/BKuTep++Ifhtkgf796+br8/Xy
+          SieBvdT+ShPb3/E5LG0wK+CTxxvimaPqce/wNMOLHN3nLmrDYUuhXkBTOspzv+f7no8JPOJThP/h
+          Hzok7NG9cZ9Z6jLJ+1t/sOuFP/yN1taFEgx+GTNzYqXr69McMih6EGEFP16ACoDvIUuYEInmieRr
+          ZmwKtKVziA7iUdB3fpzB04cKaN3ry/L+HDYIhZWfC3IjHpXvr0TCnHOchVM3gkmvXxJYpYzD3kGh
+          +qz2bCz/LDojCBZn+Kc3nnf/hm3ij4C27F0DXOD+CAq2knZQVnvICxUl/gcp4BvJH1e2n+VAbigo
+          o/lqRTOon6VD7qpg0k17tgt8kNDBeDyoA3X7xywL1oFiHEyqzjoJ28GHpxtYXe9pNFvuT4MBvE5Y
+          mxWG0uu30mT1EA7E3/FFUD6eD7H6ZPHTF8p6mz6/DW4geaN3kPreuslKA9PhfcfGXbWH1X0wD8m9
+          CZ9/fgTnWs6//EXMgj1v+b2SGN4MByPaxUJNzfbDwEcaDnPbfpVhlK4BC9+dmJJLyP4oPWm1CEV1
+          uGE/yW5gPP5OjGRKQManQ/kd1rCJoBxIdoyVfcbg4vtjAbuaP8zgebAoN4plAa8OfyVWzOoDt4xG
+          ABvVxzh58U99C4U6Ab5SWdgWT3PUvR4BK6MLX6CJOX3B8Hs4EkwmbyHqGc46FQDTwUpjW5ID7pf3
+          WxBocmyLP3zaHny+zVnpQ3RhC3xyYVt3ichlUHdyjJV3ow1b1iox/FuPWj9d6z/9IFdJsvNtycuX
+          JbcleMX1c2YVYuv8T6IV2Pk6ttyrorOP5qlAHG4usdjLmXJ//OzI8zYiz66KttvpbIGf0VyJ2x++
+          dI1RwMp80xg43fUN2wq7Ht39lcvp2ddrzJx5eDpGLTk/TLL7NQyEwyh6JDzbVb1F428BwZI9//RO
+          vc1Zt3cltgLiGmjHE22ZYUEEDy29W0S9Vb9LOQ7NN97ro0eZbxFAOa197PoXZ1gyt7ZBpszePKb8
+          ldLq+GJh/PkG2DI+9rDzZQYilz+Qv3ycS1Ttfs4kYO8K3zkRVduAml+FGHEHrRYaN0ZwuIoT9q/V
+          Q1/CKG2gBr0O+9/r3aM3NYf/8AFP1Y2u+XHJ5FtuT4hjz8+B/h6OCDM2DXZ+LQ2/73kL5D99+t3x
+          dgOwg/DwTnVyrUYlEgTAd//4pVLbTU3aNrTkTBm9+SPLnL7F79KX9/wn2iH4DFtPVgZArnni0ICT
+          t0zw3MJXuYkISKw8zCXqWzAtdxnfck+t13MsBeDTvHsEJfFMN+nUt6CWx9fML3Ls0UMfddAJhhW7
+          emJ7nPvgH7JfHTmiwvM7by4I+6A/+hZ+1IWjb5ZUKBC9owJR6cTWs/acF/i5NIA4vQ7A5KBDBRXQ
+          tMTO1kfOx5drcOzOaYmt0z4l6k/fXzkZYqwUlt52iW2AQIPlzqesaAmlQJOT76PDiXDf/RNGtOWy
+          BjJW2Wnzdnzb/t7H/IvvM6BL2SvAiGo6LyN4A+GP/0hWZOOTEtN8S0Krh0Xm6gg4TRJtg7yI8rUM
+          WCQdryCn7GTFkuYdQoy9H663A0DJUet+R+xAba5pvA0N+KHEx+5V4aLFgPcYRrdcJnb+S/Va6+wW
+          vsVbSryTnebLcb7EcjCKEw60NzOsj2BkQMlAl4SV5UQUQS2Vdz0zU4f89HXIkvbPP8Vhz111AYcM
+          hNYFPPAfP95sL8zgk5MYxO16nArUMSCxxRO5PQsyjHqZF5AXSorY9xJHixQZvLzXY3z1myddKyYo
+          /623PqyqzpVV1v/VG2J/nW/e5GvVgp2vYKcSQ29+q08NDm2vY6yqMBoh0eZ/fphzJMrApYNiyML7
+          qRIsPY/6vG7IgOU3H+fPEEJvLauwl3e9hSSfPVCiUtcFPzd6Egt8TjnniC6EibuoSPYOzUDBYcpg
+          +b2PWLfnZ05F1bbg5ybo5M8PWFg0zlBqQpOc3tdXPZ2QZYPPx+qxJixJRLPf3pPxzZyI9SYGWDnr
+          28ITVQtiZJ++niomqGA2ZStG1/dYL2IYFX9+HDpeTE7femuuYKnIaGblZK6nhzCmAG7GjJ+vcwR2
+          fmFIB6mRyMX7KToHFcsG++dnqIuILvnat2CT3xL2Sib3plB+PEBtHoadXzFRf/k1GdS64UgMbOb5
+          QoNllGOtf8/tZDU6JxepAlEWHYiOvgb95/ezrZ/jGwRHsKTHdgPfqIiIMuqW11WD40IvMhx8O+N4
+          WEl5SWCUjhGxjuML/OktcfdHsdYyH2/NhvUhvbn2gL4vba13feqD11qiWTgaDliN9hnCvI9mbDdq
+          HXWuByxpLNULdgao51NK5Q706ivc8UCNdr/uARJ2xthW6bXevm+nA39+99WsGm9lbdCAk9MFxPu4
+          yzBKo5nA+ZTn2N7K9s+f6uCub//0Vz7Km2JAp/MxuY2OPWxfgbHhpdTpfOC0rzepilhIu/9ClC2J
+          KNex6whv8+mBXqoK8wVIRghz0Bik+BnviPrgrsDn1euI++rsgRYjKOFf/v3F/76focnfo7QSv0xM
+          b1k0JZV5TJndLwJ0/BzXQs6f3xPWhLOi8/faZSBHvh1qyKjmnHeBEuw97MwMawFvXHJblP7qH27o
+          qA9N/Zjhnm/EOaOPN+SF50MQP3Kc7/WOkLA24CHLGmLs9Xjbvn4FUrvpsXb7fujy3CLmaJ6wiLbd
+          7+ycBrRw9xdnuHwUfVN7NpHPs5v+qy/TkBWN1HZngu2gmGvy/PE2ZFuUY8XiG496U2ZA/3Uw0TYr
+          BZ30teDhnz+3+yeUtudLC15n1iZFEaT58h1rCZrZ9MVn72SDpRpUGxQ83xP9dFj3G1GLK/PJ+sSa
+          VWJ98oAS//EHrN8tOyfV0geQoC8mPvtYvFntYQy/L1jjU5UM0WLflV72NfIiDj1N+jZfE/ZvPZHg
+          sVpEg5ll4eVp6mhDdTzQXNBHWWVlFgnUftRratg9/FYgmn/CoQN0e+fpP3/3/HNUj06XdQQbZ9wx
+          Lo0yorJWsVA6Hs5YCc91tNB7G8rVqD/nox4KdD69nxWcbotJFJE55ezFvHcw+KUM3vHN2xBlW8jg
+          ScFJCADofq8kAVK5JEjY+TJdi0KDzxBifFFVHyzed2FkNabFzBaroq8jvmowmvN8bn6BPnAvK15g
+          sgwlOUGd8RZZ4jpo91u4+6Ok3m5LWkEcy/uE23LS/+HFnB3dmX/xsrfEsQPhHi8kXV8ZoL9GKED4
+          rl7Ebpr7fgK4FsFSBiFxtAx6I/2tCO5+EJLMH69/8t/0ALu/j3h98oc/vxPm/WXG/okUYBGMuIK1
+          VQ3k9NLW4ad9ahFGXjGiu538oiW2dAXe6aMh1m9z83/8SIoqgta85urt4JgJiDonQsd86iLye6gi
+          dF+ZTtw34AcapHYs7fGN/eop59SvglLe84e4xfdBt7/9pb/9ngygiv75RRARw9jz5zZstRFmkBKl
+          3fFKz4XD4zGD8a5u2EYzDygbmyx8CUuy17dTtJp5PkKneNxI/lf/+Z4GkKa6jUDYneop/l5iueRQ
+          RPTm+a0X1Xq3skU8jXinS5evt9thAdR434l7e1B90Y4RlNf774Ux63rRzp818N5Owc6vJtqrIgig
+          2PXcLL3TMtpO5FHA+3EciZ69s3z+y/erEIb47B2aei65XoF1tPcgauetXv78vYz//ogCZJBP3wMI
+          oMDChTiq8AHUUKUSSM+wRXyjhUAQMrsBy/Hp4FN48L1FF04Qromz/NtPJf1FieVOSOYZOq+knv7q
+          d1jKL1KIeTksJTVj4HwHjDh4jzzy56cvB3LBu99MVzdWRLD700R/OxP480eAyh7Y+bjHA69hwsPy
+          hJM/P5ru+6kQPl+P1z98IlK2QjhcpQkjNVfrbWlzF6YP406yUFX1P34MFSPdcKqxav7PPw2uRzxz
+          u59Odv0IIdc+iWqIDzAxvQbl7IxyxIcgpxv3smP42eLLnz4aKLVDCX7QySPW9k703/73EKpSOtP2
+          aOb89ycgsK8vkqg25dsWpBpc6/yG2sjw6IKe5QK/0SPCOdl0Sr+e2cpFHQNySYY72PevfJjGb4Dt
+          RBqj5fg7QXj3AzJzt6vqTY9ikODledKJs9ae99v9aqh/U/+Pn+W8n7njnx9KbJt55atYJzzY9QfR
+          8ascyDrG8P85UXD83ycKcjZ2ybU6f+nPrBkb/tZkQuDw/uXL5f5koLbfwXBtZdWXbk4RvPGWi633
+          s4m24HHVZH6g6XxwF5AvVvKTwNdHDHFVdanp6UMY+DqjahYH0dYFUmcJfFhsi09Tw0fTuWIaeNnu
+          NkHy8QMW68DbYBTGH76zW6W3kBdSuClXB19wNw20zQJXHvVvQNzXvayXuxGKclHsXc7OpM4XrXxC
+          8MRQwI8bXw+0QNMGg+KrETNplWgaXZaX2Zt2x6qMRjpeqRxK7KheiOocQbRKpmbBk1Vc599hrfJN
+          PagNGBDuiOqOuk79nq/kjRuXeVlgpo/WgXGhx/0wMfVzMPAa8gOofbkWR74CwMKrbwl+/Icwj5bf
+          RlQ/L7wcey2LgiLZdKp2biF9z08fW4/kqC/PTZ6hSuSK6E8G1gtYjFEOZL2cV17YLWNHGeVDNYjo
+          YPoOZcPB3oBwjG9IimcdrK806GX55VkEPeXG4xd01eS66zfiTcKo0861A5iGio/Dj3msKekiXza+
+          32leZTQCcoJRJ1cc/WKX1pnHvW17kyE+Ddi5Ft9ofJxPqTwLxYJK/oDBv/cJ0/eF+MxqUiGPgQjf
+          8ZMhWflDQEiluITRnDYkv/PXXPhhx5UP1U/EZmM+ve12ukDAbAef+MW7HKaRPwYw/Gky0UR3n0JQ
+          5iEsHgLF9rXVAWcd+hHaS/0mbilv0cLloIQ33T+QwjvUeiO/WF7OntcPxqvOD0swtyNg5/dEHiM1
+          vbV73BmodOaLXMzPjdLffuJBSz4pyb3gHH10FinQ7sMMI/1DweLny0MurZglj8PdB3xUiSzkAnsg
+          rlRJA5XeZiVXRRhiM0enSMBrFsPscboRExR+vW3M2QADOndEc4NapyeY93BLFANfROmX8254bkGU
+          kh9xj23gsa9oQLA1YkBe93M5CMrpqcBF5QJ8PututFY3PZOvo/Qkqfo5e1RNXj1IjusdHT3WoZt4
+          u/lQvOs6Rp/GGyY3sBO5tYQbOVvGD9CnVCEot0ZA3Cy85uP5s/myjdsWa/X7RHmDbq38jA8LsVCa
+          6hwx2hFaF2vG9v7/FvxqDFmcdUBsSiN9c1glBK2RAOKFeKLrXX0F0PCGASsVc/f4j36QJMP7Dfg8
+          3kyPXsF7kafzgSBZ+eUerxluBdXa1sgpiC4197aVBeqV5OC7xzqAnd4UyvNdCfE5/AIwZzviVpYB
+          sJIQt57+1iMMhBZxndiAzU6jEUrREhJ1/X5ymjo3JGN1PmFV5iPAde+QP3InOSLO99HpywGPDMyc
+          BuzxKOujj1EFvpezQLwJm56gnxdWfi3DkfhnzwL784hAPSEFSS/0onwFvBiOqsESo77MYAmLhIeq
+          9EsQKdZN37p7ksBCGi30U51J3/0CBd7XvJnZTHgN28Z6MaRB2pATQLQe5RfkYWectHnFce9tvYMK
+          aJ7gA6fwbenj3Yk2yN5LjjjQbD3OWkpL/sPrdf2aETvLXQX94KZja46PYF6ipwS7uynhS9ob3o6v
+          LlxbUOPzFJFhy9vNhRHpNmxA/pZz/mFJ5eX6kUicCa+aSJuYwKD+AOx64zkn5TGG0Pa8IxJ/dhJN
+          7fjjIW8Exrz2XQOWW9xvMHTbF/osXkfpvdQk+USwMAtZcsq33jg3UBlLH/ulGeYctkdGvg49RtVK
+          /XzNIteAD4jOxNmIr7PPmlry4MvZ/CbBQNf9/UG1SQPyZK4mZV/PkQExfM8kfZ+9fI9vX5bFdsQn
+          rNfR5nyTGF6HDpOQPxEwteM+p/57Aoi5/8phvV2IC199us2L3I90afW3AsErPRDtUn89VropMSTe
+          OSOaoGf5pkWmC1BwcrHTpSHlL22yyL0uOBhvrvqHfxJ0KrvAZ+ZqgmXW3gW832QG53YJhmmvL3J+
+          Pf/IufxAQOOX7EvoQDlyZuSRLueP5MPj0SoQl/NztH3NkIezyVHiWosG+HjcGnl+U24W2+c9Z5XT
+          pZGdOh3JwxfqfBuyNZTV59PCYXVUAIuvfQzBGzywN7CJvqhJ/C/fCfZq3WP7Qkn+8BSrgpdQ2onX
+          FJ65PCE+86xydoDnBj7aOpyle49yPlN1Xj7xjkp8iz3nLKP0MdQWhcFBfhDrxX0VKZxekoKft/nk
+          sbaVaTAJA5Nk7wsHaHInBtz5AVb0voiok9qBvB4sCTtzbtfcsxQeMs6JgEAc1mAWbzcE+uryxWbO
+          7z2DzIMCuS7RcMqhSt/jB8KRf+Q48Gxdp+5qdDKxZ2ZmvLIAm3kRJADgB2NLc35DW3+2BkhJOJME
+          JIs3/zhXlFeZHxEjIBsIMDtkQNyKH1FW8qb8jSMG3O+9YAPBeOAl6m1wr7fYRqAFi7heGFnzjg3J
+          h3KrNy06u/Ci+Ap5DS+D0s+x6mV2rqeZc4J2mPP3MYDzbTNQBfjKWx73NYY34ig42fnUON4kX5bm
+          h0nwbbvUS5MeF2AwFU9MWSvyEV/7BGB1POH0cTyB1eJKBjZcPSP5dUUDlcfKlymwbiRybate56EK
+          5Vt6Fsi+H1UvidnZsnJQOpLSF67HU1l3f98fo1vb16S1pxg6j2eFUQObgd7auyLPeTnPIjxXw++v
+          Psb15hOlNJth+ONj31baEH0yj4GanMACO+C5Ge58Z+oTnYef82SSOMFiTXmPWKC5f0es7/xoNRRR
+          kfPprhBFebbR+pDX4F/9vgYC0hc2kTp4W4cnYrZWBTQjZim1YhHPh3qCwxJni/i3vsRsmne0pX7G
+          wqRVCP7jn1v9kRqYHuuSqIYcUMFWHy34dp5CvDtCOXUByuSI/Q0kPZepxx1/zwdMYMRho1JLuvkb
+          VeQtLUsSNJM3sGyydXDjGQajkNEHLheXDF6vcox9X9Cj7eTcDWjIYYc1siT5VnxGEToGg5A83kx9
+          e69qA+vETTAevHdO3y89kV/DoGBVkyRAxfWZQXadz9iZT6Y3B2EeQuOSfBHVOG0Q9JvUwqf2igm6
+          Fy+6xmdQHvf3g/XvNNNtnOECJHxr0MZoGR05ImjQjcyUIBOeo7XbT3Q9zHa/M363dVZuuBF+vvaA
+          lfyQDus5hTx8not8Znb+sHJlCUEI6jvBlh1Hy1/9UTPYE2OvXxM5fDZAvs5j5slJrdn3+WlIe30j
+          Wlp9h3/17sZ6R3LOTKXm/IOYQva6edhMTg+PHm/eArDh1xiNAql/Yez0kscNeGZ/sUG3BwcXqEv5
+          c94W4U2p3zMVAMEPYd8UK0pO212Casb0xN4Ee6CXt/YAw/eHEPCCc742FqhAU1Y8NoA0DpskmyV0
+          ffZClKLnhtllXA0GvtHibBo+Or081BZG5VHdz5Qjuu7vFwi+eyKGdq8G6p2WDFphAvG5lrl6KAN7
+          BPmUKwRjwaq5+m3akFXMgLz6UdYnydUgJJ8jIhp/wmD7eB0DzVoq5pWIGyDPw2D84TPRa/MEtike
+          XPA744icrvihs+ODWrCp9XAWr20NqKI9bLBKhkaw6TtgY2tQgJNwx7N01U45fXK/BCwc/JHijNd8
+          9eZzA9NQ87E/ETKMWnll4Pvqqthprw/wr77NLBMTLFh+xLlXB4HMZC/k+vO7iK7V2YLn+zNG0LwX
+          9WI5AoTX2R3mtnsYgBtNAKEdf15YY7QM/MOzwSM+PgvJJ6d+yS6QzVadnF/XuV7RsQqhH3IvogFe
+          8wQ25xlYe0WFfucU1HNlmq7c8cyZoLTi8mX7uiWsSFmSgnVpvWbIQZDfeyjpYuLTpjxeSvmcni2c
+          73p1OwkzgvTlXond+R5dfQQMOHL+mSQnk/XGBP9EqCyBgO/QbPXtMAetLD+6nrzGnNRLOn1dWbZk
+          gtFFEHMSSogHD+emEXO2N7rkR4+HZ2JjYvwUNVot6cfDhegvJF5bna55ZYzQM5karbkAvb/6A8Wh
+          fqFjuQ7R/MdHkmZ7z4cQKR6daI/gn35QPj9eX4wMsyD5hjLa+BOmk38QM7jaL3OmhhlQGmdsAplx
+          NEkR9squxwMEj0XWY7MTDcBmHzuBdnjS0S/my3yZ3pQBF/yGGH0CW2f35wN/esxG9kv/4zNQJNAn
+          4ertc9h/miKe9AtP3Dgr8/VZHgpQACbGqObu+trnxigX2fVGvA9867P+W3jwV69F9NXz0Xgvkpw2
+          VUf0xzwPxNR+PCS/n0jc19To5evZMDJMFI4UbsNGdE31GPLJVs5SOzb1kOBPvM/BRLgY69HrLvHT
+          kj1qU3yah3fNf6zO+MNDrP8e73z6y+/CaickdJBEu14r5JEvcuLaXeqtiVy3f+uJz7esrv/x8x0/
+          yKlRDCAIz7sI51l10XLUPoAU6beC1CUdwWGlD2zivjXZXS4dNvOqB0vfaQZ05gMzD+V5phv//Vpw
+          kBOHnCOr1DfmMS1/+ECU5+zppJ9QBvb4wAbqVm94kRxB5BkXfJsaPt/U7db98yOsfF7BrwVNAYcO
+          PPZ6Cmv6bS4iiNuwI95xu3nbsVHtI4K6h/1jL9V98H5Kxz99ZD4tONAvjUv5CBoJqz3sItr0nQa/
+          174hyqU7ROOgWhUwrRGRx663V6bpA+BY6LHryz5fT3sPk84wNawvxIy2L5+6cMyXL7qIoRat6uGq
+          HdPABNh4SNdhm+LalU91/8Fe95Cjtfc1S/7DI44YcvSPXx8dWcYmtkG9gl7MgP9bOvQLaR+tvrP5
+          cmNyGrGuN7EeAxD08lfep4DBTIi6nd9CBFUP3w6VoK8KFwUyuzE5NqprEy3l8VL902dKeKqHjTNK
+          KPf8GJP8/G3p8rYfvtSWofznj9B/fFbsowuxM34Fwx/eb+r3Njf1Zaa7vlrk+bYYRDV+U9R/lQuU
+          le70wk42X/NN7Z6itGTaF7HGRQDjVjkdRPLljr3tRT16z10NnliREu2C9Xrg04sCbmPXYOx7fT6P
+          +44ZdacOsQsY82b1nowUO0aKn1RT6bI9lQ0YkaBj+wTbnH6buwiOwfGEFX4Yo2UNCh6y18XDl92v
+          WT4VLeGhaR2CxE0aplM0B/DCHptZmg52zZKyHeHOpwgiwKA8qmpbVsmh+tOrdEJM7crN/TNitb6W
+          dHuP9giNw2oQ93Ed8qWTQxbKFVjnL0B0WB7FhmQzJxaS2P4zUHSdFvgef1dc7PiycB8u+IeHI/PU
+          IvYRiwVwvUYn5s/v8n9683MVn1itf0bOF3lty8A8ZMQrOY6Ou3943PksduNMyTevWwP5MjwZbF+l
+          Uz6pUmzLf/pES5Hh0fXpI+id0EpOp0vusQU8FHDXm3ivNwO9J44L31dbxWGKGm+QtiX55wf6g7HV
+          24FeCjnotA5bD+06bDJTPmR2gzm+7/xr7CeNgdnx8p2FRNOB8KWPEjygfyZR8Co9rj+pCGLzsZIT
+          11fe0p6rDSqR8UWiVAR6cz7KI5wa6Th330D1+PyKYyn+KBnRDC6Odv2HQPn4SNjd45NW4mkEL8qn
+          BPuvM6XGG8Yw0seV4KNTRUtf2AkYeq8nGmbZYVm2ewmbWg1xeg3LfGtYGUF0bieipFs5THQR2T9+
+          O4vV3hNh1yvw2fcDPvddWP/zq1AXvHE6Y3V/n58F3lIsYEdKon1qHlD++DQJe98Ay60YK+g9zj/s
+          Zm1KZ+Y2SrDR4xbHIDSHWbarQB7au0LOxfSttyW6SpD8BpGoJPDA0okXBux6AEFmNQE9C2Uhw3j7
+          omOXbnRqwfiA/TOYiU7iJF/ZA33Iv1DC85djzJp/WVkKTbNQiDLG1Os/uiBBaYhaRC+nk/6vXt61
+          g7X7g2HOouD3gHD2fWz+yoESZ/Q2+Oy7AZ/Ue6sv29PeYFwvPsna0ajHv/pxX5yEBLt/te36XqJH
+          3pm5xnzqq28cE/g46jNRPirxdj7fwq7UDaKE+ckjunXaIDo3E36dTyxdbPXugmVaL8TghISut3uA
+          5N8XnIgj9YI+y+fahR5//JcP0bj/vRR6/ESsbrEjDpA1hGejeGBbPQbD79mVJWzNj/OH7/lYMlkK
+          r3g+7/j+iijjkkp6nf2KPPsuHJbtq5Xwhh8xNvYTorz9fDQAXW7pzr8qfZ2HPgBHgQ1wlGaDt21H
+          H0E4qNN8PKf5sGqlVkFWvRXYDPDXmz6vg/SnnxDjHWpv2gIvgzxlFrS5TTtsAnvRQJ8tIf7zO0fk
+          lS009xOvphO09TjeNgQ6Hp7xZffndv6tgBKMOTEeElcvVaMsMErOZxL8PQ+9cAjsegK9RcnJ11oQ
+          WXifjycSrboN1nb8saC6cx9iIv/izZNZVjJ4SDWi9X2I6BX8NnBKmRUJThcPZLzJHdz9bnKqLls0
+          6NZpATtfnEFWwGiapVGCnglr8hK1my6gYBRh+N0IPr+Nt7e+gm8Ldr+RuBIS9JlI9weMMLTIY9cj
+          8/XcGfB4NAq885+aPpaugC/GexB7OfGUtllqg8uUYWx8P2FETe7AQ5ZFP1QqjkbZ02esQCbqdyR7
+          XZ5zcigU//S2FZz6+pfI+42Hlnp49/f1mTuUmhx/tAz/xePESlIDH+8yw8GFKjpFWdtLcJl/5DQf
+          Pjs+yyFodWNCrKu4+oaqwYb54fhAovW+DdtwXTIpDj4TsdX9BN2nopW8xwc5K79cp4dHFkPBt0/Y
+          327JsCpt0MEXKha0Nh/iba6tsxDUTo8V4ZvQTU//Q9qVbCvLM+sLYiCdJBnSiXQSBFSc0SgCKtIk
+          QK7+LPb7Df/ZGbv22ppU6mkqqQp0iKztDXSDjoB2rhrCR11RGs3SC7DG3BNI7ZHDf37TP3yblwYS
+          QT9/jPF1Ki34DnYxPgq9bjA09gHohcLC6VZPortXHPzVByjmDiMje6LL6Dy6Gj7aqdVI91zX4d7Z
+          IWqIoGQz9QcfbPGNfT99ekNjLuOfn4hPsiJ5Q/vd8X/6iOzE1WaC6e5X+E46HDBZ/+XLnj0D8Ps5
+          l0CcDT+ffWxVUPjcF+p0Js7J493KsDbFCdunKjWYvpoB+ltvxF3e4Gf0fgRn4/DY6l0HIGz6BBzo
+          cw6426cf1rPsfODGD3B5/xTxkjZ3Dh7ufo+t+uDFM36OFnx32R4HSXAGs/T8uihA8Z3ih+MZ7OG0
+          CkyhAQPwhpon/OZLAcS+cakx5xr75yc9nKODjeuuMNbf7OrgdqE5/fPjFptmPEzDIyAULU7cb/kP
+          /Dg+pKX6A956lrUWbvo02Ft34M3oyfPQh7FJBBs2Bl1KM4DiNulyv4seBnnkg711es6o/W3bZv2K
+          oQ02P55wVffypr/6DrJlFauD2bIxGuxZ+RR1RNafrMUsx0yVFxdtTSCPCZumhGvBn/62usLc9rMJ
+          /ukrzgpnMH+Mnwp3csKo1p69QfBjBuEzwjkOoucuX2czDlHkXM/UokdtmOa+1GGknD1cjM9Xs+Gn
+          D/eeHGDzHBNvjXQvBcInX7D3Cc1BCEkcQi4Q1gCsHh74jt0t4NBe+8ePlni1ZLjpoU1/DqBdrIsJ
+          KBRv5H39VPkyujyPsqP1pKfx9v7TCyv0uzqjwcIyjyrS3odQjzyyLMBmq4n4BG14iN1vMjTs2KW2
+          MtYG+ecnToq73Zjb9CIYqqiZ22DWkbBvQ6zVIhzmXTKJyuav47/6zBRhe4a7stth+3XyYuHv+xwa
+          +UHNXK/yJSs9Hm7fl/7VjxbeQSHQ11f2D38k7yhnyuJMMSluojGsEdILFHTRK+AkEYPF4C0V+bNG
+          g7XeV2CMHg8e3jS40NvrN8Q/013mv/0mq5jH8eoaOoSb/4dd7XcbiFEf/+XrjQ9eANEUlcC+UCvs
+          3bjKkDY8gNqDJtQQY5HNmz5TiHG7UX2Ll6W1WK04knPFljMvxoRsgUBj72Gqpt8n+921W7T/xraN
+          C9WZB2q+4BX+fd8hwicwJEulw+j5vQUzuv7iFdZMRupY+//Wf6uHJNA6JQYZP7btzXVrr+A5goB6
+          FvyxmTs0PtBnncN+Nd3zv/ot3PRWMOc7eVgCWtXI7dYY6+/DvemFXacqOJ8kfDYvDiN5MWdo9+Zv
+          9G9952kQxr/6Cr4Jff2Xzzvw2m40uM+72qxDy3R0beqYbvVagzmjsaLNX6OncegG6deYPTAD0aWb
+          /h2WKHE65a++7HSjmE97dvP/PzcKlP99oyA6ZSfqxgcnXh72a0R20BDsvaPEY4XKP+A393fUfYmg
+          YT8SiojusjlAwsIMkr/eD3RRS51GhrcMv5/zKQDXhhGN+kvYiPaY2JDLnBu2xWtoCAQvHRqUC8TW
+          vpgH4hxhBeOyZmQartJA+CNO4IknTsCRNTRW63Xqwf5pSjhTxjVnYrBwUG0Cg8jOgzLiFG4C2Ts+
+          Yd2TvWGJJxLBTnhUGKfgC9aXcdeha70yGjRl1czm8x4gWz4VOASin/N2MlkQlLDD7nQw4xU3uwCK
+          keIE3Fwtw/wMnQ8kzmkirN43w8wMYsFfBUWs/nZBzryty/lTuPlUr27PnA/tfQcvr0LHlt+GuTSM
+          ow4FKA3UpM/KoEGtukg78jG9Du81XiIaW0jxcwG7h6NssElaa6TBoqEhzq/eOjWKieZ+b9GSAzdv
+          ZsbHBIKVMRoUIDKE07n5IFWxbOpYTx8soheOe4WeymD3M9tBgN88QwhbAXW6NBnW11nUIX8RVGyI
+          j8ZYn7JbQMtXJ7K7PN/e/BPeEK6Zb+ILKjIgDAnPocsu8LFlcL98Ln/RiObSBdgTx84Y+fCXwWKN
+          Uqr5YxOT2/MawvRzedBE4fGw+D8sQ+tNcuo8lk/OZ+B+Rb98n+Jjvhf+9hOi/KFAenp7frxSardw
+          ueYFEc/Ct2FvmD9gqQkeDnf07on7ZNLBO8YJ4R8H31gn3EbAfOs6EQJx761ZFnGIPe7HAH78EqxJ
+          72ZwKumN2rfi5bE93UFg7W8DPdwsxxBv4RKidH7c6eX1MptxkZ8VTGoiYasIG4+13amDw3H3ohof
+          j/m8yLcKnrr5E4hv6ezN3dfmUIpODQ4LoY/FmGkj8neWTPEFYo+l+ZoiL1Znwu5pEdPD52WhKZoF
+          fD56ORAmMKxgNxCXatW5Brxq8wH0izik+mFSc6l3lgAp/l2gbr42OXVmfYX61T7T5Gj+GMGzUsOx
+          1Xrql+LR+43Sd4bOZfcle13X2XIIVh2Z63yikX0R2PL14ghOB70nYKdzoDeU64x06TXiREpHtr7p
+          u0ZaffvRE85fMQ+ltUU/wx9ocFAom1xbk5G0l3n6t/9Tfnrr6FsaX4r9i2YItSvL+y7kw0Ddtycg
+          jKnMwTnRNHwtXcmYn/zLR8v+ZNLTcL0NfC3OGcpx4tBbRM8xbz7vPuQTPcWppZ+89X59QDj9OgVn
+          9FazybMuFpp/5gNb8s5qlvn3dtE+BFUwq9YHrKWm8WgWdC0AA68PbJeKOoLkEGBz6b1BCFLRBNej
+          otBj94TxuoZB/3c+A4XnFmMeLm6iBDLwt/i2jbXd7RKo3qKKeoN6yQVqrVeAy1dBzpM8M+ZGQg+m
+          9l1SfOwsIJz9KkLaUmvY9ZsMzCr/ucK9uUPB5yhdjXX5aBHy5YBRW2SZx1a5kCGXeTdSI2X2Zgbj
+          GtrjeY/t4vPOCdQ/GVqu9wLf4xoN1N67Fjz+9g96kucBiMU57+FOxFUAkvEUL6Mn9Gh9WS4+NWrF
+          Jm89BgD8FA/fU3wD6zLlK7y+hwMO3p7uUUvXHlAOuDM9iPwh5x3pJsOY7UbqGvfrMMbiyqHS3R3w
+          4TtSwFxvsBV60i/Y1e1dTu59u0LPTXR8VrSpYfowZmDL71QrHgVj7/CVgLuLCBGhzHJa2tsYpjvH
+          gr/4YzxMFXQgUY2NzHeGz/Z7YRvye3qTSMuEm2lckVetIOAkXTVW/ni8ggHMDj1Df2+w17pf4d5K
+          XZqsx8uw0OEOoRQZFPvJ5Qmo5eQcvJ1ql+pT4sRMupoFehk/l1pqzoY1ur0ypCSjTZ31emDSNHe6
+          Ul7lDpd8lQN+y/eAF+6MGnvlwBg60Uq5TSbCt2OmMWGU6AwlXrjhcMoXg1zu8geyXXoke1/p8uXZ
+          6iqcNCZgXQG3fOpP9QONrdFTlRMOngSvHx7ok3qloRHd85EPXxlCHOZxEBl+Ix4O7wTqpcCR70mb
+          PVYZRgd1phRbVzKYz470lGF909/Uf0U/QMx6faDG6wVs9oEN+FtSV4j4RU198OSatT10PiqoUWOL
+          m47bhEAmK7K6Khg/m9KjIWAdlF7+kQZRdR0kjR9GCB9VTi3LSYCQpmcbOvKC8fGYaUCQQy6FS1Xd
+          cLycBracrV0B5YN4w8ZTcYGkPD8ueml8jYPLk8ZTMT95MLM3j/OPpcX8ONcdYiGeCf+oRWP1vLlC
+          S33dUYO74W0KyhhBFj/ewfyK+Jz6jniFXI52OAxx0wjeevTRa00v+GHv7WZOuS8PNfhoqFOiuzdd
+          yqKA98/+jIvL5+bx/DPIYKPXgEate8iXS/uBSNPnrcu8dsqF/dsP4AOaAw2tc2SIG/5CoU6u9BkY
+          ei52WFPgtR9rehXLG+Dz94PALd/Rcr3M8dTvi1Z5A+tO9ZfnN/OsmFfkHQ8n7Ecuny/xJ14hMCSC
+          tc6lw5oshQI1lQtw9NlPgF2de4pqJ8xo2J5PxmqPhQ2fjigSMjApnkaUfuAkfEpsdMYXzKwCAewc
+          6GJVGDRvTdlowjfvJzSd/NH4vWhao1B3Jpr9ftpA+k5IkZntj/8+X/ssTdGrXE0ChDxk897Zh4r4
+          WwOsRRJpphuUZ1ReLJU6+Xoalvp+keE7PiXB3reAsXg9T+CjjwyMP7snWLkTVGBqcgY1qQ3ZsHW8
+          h/eV56nfnfVGfPppAk9itVDjqfTgd0KXEYaxO5FH8ei877q4KZRuRx/rWz7s/ME14TtwRKyzJz+s
+          2enWwcC+3MnYtHa+lOeXCh+L6wQj3tlsOomeD17FTcKn+oea5ZqUNqzFd0r90+TG4oVLg3/7l2jX
+          buvRYlvob38tqgneUu36BO6mesXuAbxjepn2KvqgbQ5hU6qDADxgwrNwBOSDYxmswHsTEIzoh08H
+          JfPWa3dp/+IHa9C/e780vdswiB4JdoED88laWh4+WdXii4v8fHkn0QfAL3aw4QdyvgqelyhPyeED
+          9JhnsJ5GsYbf6HCg9v5iA4Ef4BVCcgz+w9vpW3Jw4+tk3wmPZsR8M4MfdU//zu+48VuwllJCD0/W
+          GMtLbFQgTvmD4jI9MzHMJAVmlbNSLyzKnA3pNQDeTxGCDW/B8od37XwfKTYPi7F+Ui1ASWyb+Khd
+          ypjsTOEDt3xD1Ua9NOwy7XVlw0caPfwYrIlMU6DNR56eDurHYBfBqFDsnjnSHF+cx5IoHKGv3kjw
+          wGYMFjBHI/jjv0f9wzfsF80Vqvl5JgrlfbZ8o/cKDa3/Bi+LnAEj1vMDfFodqEOUxhur4adAp6Er
+          dtTFG3j3yT7wl4Y2Pl/0zFtv4RKh0/u1/MXjwEo74ODTGx5YFRLE1vHJWfDcf940kPTKW6bKKOCT
+          1S0hMwLD9BIHFfAB3KZy8PtmObl3E8RS8KIHcKbxDIosgnzAKVSHv5TN56EtwCcVW6w9Gi3nvYe1
+          wjKdwoBZbuWxaPjxgB0b/R8eCP2pL0CjV4B6xt2PxeV+ghCGF5OqZ0ca2mx787zhM5luSeBNz9ZV
+          4XpF+I+fxn/rC9ST9/6PPzacHe7Pr2LATmkcjCl9Nj10TbJiz27mZl3uBw6iUbzj4Ix38aReehtu
+          fIoa8/xiq0VsDkan9ERTS5+MpY68DMLwZmJXzhhY4ukTQXdweqpf58VbPl2XQkm2/ECY+lc+G7RR
+          4SG6qf/4ORG4IwcayfOC/nTrPKa3dwW+np8xkLd8RL4fEsD018Y0U8YoZ+ms+srJdK/U17VbM0un
+          4wpzRXySTd801H3OENKmDPDNi4NBQlktwsPvdAiE7PBiZJniGQl5EdKMg3q+5gKLhPVlujhiz6SZ
+          fyQutjeXd3rmYz/e8IBDrhC+sUGC2FshyEU4BNKH2oNWNYvm1yK4Lm1HhDkSGRU1sQMbH6V/+Wq5
+          vsICMr18U5dN92GuFEuBgxdcqXl8MTbAHnZgFvlfMH58BEhxzjvoP44ykbyYNHNyn0TFMd1dINzJ
+          Y1g64GQAjfz9Hx6t9lvrwNWhNd3wlxEy+C0o3HsUwGvW5st8eSaKimhKhjZVPT71Bh/u1k8YCK2T
+          Gf/2u5r8M9bOHylehB7X0NkNSbBEWTv8Ihc8oDS6P2qSIQLLOT+EsOevZ2zslTfoVP6TQOg8OGzv
+          DNfbzl8LdWEysa8djWEu53cAwkNWU5XTbux9Pbk9FIBhUG8/VIzZe91Ce9fI/jt/rpl20HVmTB8c
+          8MGqQ6+FABCGzQ6dG1oXOxfdB46Q5dFosSARr1JSkAGM4a81VrcpxD1FrY1j9uzj9f1Sa7Q7DFPw
+          izpnkK7tfoRIeB1xOboHQ5SU5YEU7RkHyIjMQWwuqwrdb51hTXnchrX6zj3EdasQFMtDvuzfZvDn
+          hwTyIXgC9qzSGYz3OvnT//GfHoBGdkmw3eqd8XPGX60I2uVKb8A9NstcZx0M7skdG+oBDK0ohYFS
+          xYcbtioHg8XPahntpmqlR2+WmxlXJfePfz11/t5MwXufguTKErrtVz4Lx9r8t95n6N+NZZ1+LjT7
+          Uvk7X0Z/ez5CCNZ2jx0Limy8HWnw56dQRxmL4Y+PI6QqEj1yThWPwVnmoCMzjDc88fhPsLOhsACH
+          iEdJNGYknlb49H4PfIx9kBMaVxHc9DIZI5ePmVm/LfT6FCu2vZnEzFaLHjhIHMkM7nW84l+nKqW/
+          TMHeeo5s0ycdfKFEotujpHi9N1mImvzUYSuKlmb6OZ8HZIcxo7fr7pXP1L36IG9ghs/0Exl8RLsC
+          Wvm3wkZeVmzmn1YGP3T80YTC3tv8nxBu+YXMnPA2ulbwPqC+qW/sH9QwlppDxkNtm1WvkYvCaMLp
+          PHg+5JgG+9Ow6f9bBU3dz6hxNHlvESWXB/Nb+GH/ES8GlfooAifTvlIvZGojeDu3gso+SXH4ipJc
+          iD/5ChE2A5pbAjVGgSUBOB9nhM0zxDnD/qGCpA8m7Px8jUmlbXEwft7yjb+9DJZwLg9rJ8qw9tmn
+          3rpqvw7+9kODjxIxAdubBxFC7/zBR+Wa5cswlyHwhqkkWy98o/vka4G2fEJVORab2bf6BxCAZtDk
+          9HxvNzbjbYqMUAZi+9mz+bkNWvtc3pSsdWEwqbrdCzgvzKfex3rFRDceNjjy+h3rnvnI//Qs+tuP
+          TT/nG79yFVdXXHwrv1dG9smkgj359Vj9ls9m7V+1jC6LKtBDyvfD+twVHOxWPGCr/ewBs5O6QMWQ
+          RdT59Mz4eTu9guERu9jj3glg3UITSOKkw0V3rpu5XnALfBSFVN/8jPkeIQKFZe/QSDiJ3tJ9wEfZ
+          /CycTzvizQ//9IF/8WVehMKYi+KWwWv47Sj+7La501ktoo1PYos9nsY8a1cZ3R9+g9MxfYAllKMM
+          Cc9DhfXqtsvnorYD6NP6EOwv3zoXVPsjAnyXfZyz8BAvPpkJimr98S9/rVWNeej+bjpZr/HXo4AB
+          qJgfvscBNhljzW8t4LdfVuqWiDDCd+kDfjn9iy1t7NlsRtsUOim2icBSfVgvXBig8+VlB11yFeLx
+          z0/5+/7R5n8KbXlW0JVcVnoIj3MzFO/E/OdPHTa8WsN4ykAW5V+sers4luIL9aF9kDTstUJvbOvX
+          wlHv8eaXqs3K+7INk/Mk0XDOfmzzBzn4MdiRrE9VM/jgPHPoHAw6Dubq3IzotYMQyoFDFv38ZX/r
+          B0X3K1L/8pEMIu/NHtSW8Q7mOXPAW+QuV5RqNMB6ILXxdGf7AhjTx6FeJskDazg1/KfP7UFTG7H6
+          zh0SDI8LYCwLw/R9viz0x8e86KUxOm83uKhyianqhC4QrGXk/+Jt68JvedOfXiEviwVS9cHN+OWm
+          CJYpDal6F5dhHcxyhfGcFNR6S4u3KmbuQ3lXmcH3YDc5cefQhY97bFB185sIWW8WyC5dQa+qjJrB
+          6eYQJvsPxG68Q9sNrO8DvvgAYUssb2ze1gs2Xidgw/q63tgKXgs9ey/gYNM/7FKhUZGci0bVltwM
+          CVmlruD2XlPtomfGQtfxAS+KTbFtLgJY38nJ/9NbZN5F2FiE/ljBHb1k/37/OrsVRIFktoS+uhcT
+          VmjZsCNtRtPb3jN+ydWB4LFyCza3/LkelucDPuVWoxkL6UD/fs9Hvt/wfe7MZjKMoQKGfHyS/aeP
+          PcYquQVXsTvge1lRbxHyvoLVNfGxGfdz0w0X/Qr2i1zRcFuvcb1XBFZu9sMW1S4eOfQ+hEGtHfHx
+          F/+GbtPn4MASlaoHvjNm72HN0DmFe7LPzDH/AU4aIW9bAv3jn6tWNRHoj3dCVkDNgd1GM4A/LTOw
+          cTvNjEmyFIJoe4HkO2WWT5eWQPD2LwF2nMe7WUI5SyFI9x7hyMUyJgcENdj8kmAvMszEtXQgeNnk
+          S5TND+MTwXIhFBmkp7Oj//mpIaz3/IlmX1AZi94ZNrgUaUsNKb0Z0sGz139617l89Xi5lMUDbP4k
+          1kqaGMtaTTzo394+kFzRbMQ4qM09HMMPdejt5P3Te3/1mUAr34xVhtcre1fLsFo3w7Cd/wBt+oZc
+          HvUA2KIVISyzl4z1ZzkYC8H7DraGSWhw/ujNyuelDd6BJ+JjXnj5WivnHm5+aFBt/srmv9TQ/Ig9
+          1ZL3bMwl6mo0sy9PTXg4euN5FSEs24791VuaseZcGT5euwXry8LyQb89WnBz48vGH64Ge4e/K7x0
+          yZHG97TIWfkLTbTpDXoMVRuQq5AqsFT1Jphm4wzW23huQeIYDtXXAMVbfHLwLBzAX3w0jBIWgGNn
+          iji46O94/av/pG0t/tOv8x9/eRyLHJfrJYzZn1+61YOomd56tghJqsK9iRBBb8/Ph4evc1DNwIwP
+          1XTLV9xI/l996p9eXl+PfQIfXy3AQXXjAeFqdwREtMO/9RwEUdJ5wCvPkKyb3pof37cCv6X2xaez
+          U7MZ+uoDXcltDeQ6sTb90IswU9sdPd0W2VtMdu/g9jnZ55dmWG/PRwT/4vWa1Vqz+C+Uwc1foObL
+          NNlChzMHHT254ae/Dt7aJ/QD65jNVGuUXbzy+cWFHflk2GvTytv8cBEcZ9ZSNx1vw8ByPEP87W44
+          dbQ3W6w+SuBjNwFqKrd3w5pDxCOOCYdN396H5eSeTbjl1w1fr97qfUNR6c/Vj+qX5x4wwBgH/Xn/
+          okH3NcG8XNpxv9y7M3U3P70DTTuDMucOhHmylrP8bG1TEuz8n/8w8aobgFyzV2weuZLN969R7zc/
+          kur9qjTroTc54GePjqrBS/dWueX4P78ea/r5CNbCdVxQJftdIO8vHWOn9Q6Bkn9O5NyoQz4nn5cN
+          fxgJWB25r7c+45pHYa+upFKtD1tGia7gj2+4V7M21uAS+bCPb2fy5kLbWzPr5EKu3V6MHrBnkL/9
+          Sct+DuTIcwDfVGiFQVQkwWtZUMOeRJihd0IRPU9yyP78MVCvnB10ajKATgj4FulE5KjpGnVD+izN
+          4EDFDz0cxoux6W0I7/xQbBMEBtYln5/9Dx/UOXOYtDsPNbzKxYTV9J3ly+YXQClIHwHEu44tX1Nd
+          ke+TMvhdvno+b/n3T89grVGHeLbKMd168ABsk9KIpQos5l/9h6pe7cQsrusKdVEvB12orMNSBThV
+          JDAV2O5PLF/2+0yFTIxO1H1kKZv8F0qhAIUBx4frypZsNTtkvlWdxparGuu7y1WI8XIm8nv+xaNM
+          Qhlt9QB8OKdfNl+cRId+2qvY/6qesZTnn77f8IZi4fTK1+F8tqBB04Ws/DwaonmMXJSf9pDiik8a
+          fqc4859/REB5P8asLiQbCmbr4XjzL2g0/ERwpr1Ora2e2L7bZUb1pPR4+/thVpj4gdp84APBqvR8
+          xoCLYHcjF+ps9TPWO3sfhp3vYrzVU6d24GSQ5qKNcYTEnDo5hPDbs5U6n5NjCJE4taDVIgu7IrZz
+          odrVCThNohH84defX/jHH8lfvXFVkNrByLJAwB9Nhy1yuRDkmuNKo2v8NehYRD7kHVDijf8M64ZH
+          EJ+4XyDeGhuw+c0UJC/XieoKkGL6jMsHNB3zic2uOg78LUcq/KtfnFpSx2MLHybYiaeKapt/Nj6q
+          PP3/3CgA//tGwZt+ruTeH5Z8DFLBR+DeJFgTWO3Npdgm4KNpP2wMt1s838JjDY/v/SWAy/djjAMX
+          iUhiMk+LsJyacXDyAL6Co059KRDitXT6Ah7uWhPwN72LV99dE+SfpE+QBPYzZy4cRiX/vmSstpEU
+          T5NtySCsjyq2gl0QS9K9TSEZZg3HI1W8tTouPoxycqKBgTiwhomTwtxvmmBhP85j7z2L0IW3WLBs
+          33+5PYMR3HZeRNXP8GW/523RUWtPQYBevuSx+89K4am7f7Gp3rt4MfbVAzlsUojI7BSsdv60YM8n
+          GGvqDuRLNS09snbygB/B47ZVJO4KSMxdHoiZ/Mv5uuJTuBt2ObZp/BnYKKYr7DQYB1yyOUYawhx8
+          GA+Jet5dMhgSVAW9focb1vaPS0yF6BnBl5u6NBW5PVst99chRTZ1+uwzZZiVwlVh/AkD6tVEbpjU
+          tgRxYdFh9Qn05jeDSwQ1djewcabvXJJcWUHL7aZSbF9471e3IIK2+xiJB4+cwQCkEeRf+p26Hv4B
+          tnCYB80rX4P5iV+52F9MF2FoXbFLRuZtXWe2Cpr0xbY1HQfyjfUA6g2oqVktu4H696VCT6esaH79
+          hGz+RdsbWnKi1H/2X48//WyC4OsSYouvwLAmZVigMvRj+mj9X7O+XpMKfjfVwerVGprl+G0I9Ml4
+          wOktaoBUFIkIRc1qibytz3T8DgRqucvIjq7IW8NJCJBk3myqCUz3JJaXPXjutqkAV+8erwjqCfxE
+          PKB5stMaETM1RTX7pfSqPq4ee5usg0qgVvjOFDuXAuejoucXK9QR90o+EzXh4WG+qURuG60Rbk+L
+          oLDR2Na1/WCIkeAmsAA9oOp7Zw1sDvIUrlpWY72z5XzY1hvozb7Gl5+TDPxvPKTwQtqOht/PBYir
+          WK7gEVUmfRaDMSyzdemR0aGUWu+7BvhSa0eIY/5Is9K3GfkgrVJKxI1kX6Ktq7NG+G2yYEe1c3tr
+          WHBYRbSdX2o/SB8zGFEIaFvPf/GWs8qTTaQd+h9+HuVdvAqmbKErsRMaZk1l8GUhV6gIhITIX0n1
+          xnfNJXBXz3dq8r5msDmIs3/xpf+EYyMcz4MFDlb8oCYXmoBPUbfCIrk8cfZLwmbWSVFAr7wcceA9
+          37nwTjUCb43v0auJnXh2hTWCduC0ODvVSkNoVqkIMrfGj2JuDBYknyvyeT+kpyl5sFlLYxFNHMyo
+          Jxcu4LksnNHx5ts4ejtWLsgn8IBlV9Q0tmpvkLbzDjx7mameNzmgB6MK4Pd14PGBv5J4neyshUI2
+          KTh2d6qxnHmugwotV2pV8JSLdzXPwILNmfrX+eHNPvim8HqQD9QCV3UQ9ilb0c4cdgReHALYR1ML
+          SKRp68J9atjciEiHW/xT83Racnaiq42cdHoT7teO3jqhKICZZNwJZx23uqepfbahd99g4a0ILIXz
+          WCHacTbZZa/nwD/rdwdsZecFcMu3y26XfhB3KGKcCrd+YN8ZKvDaviNcrDXvretwecBjePewahVl
+          PILV7aFI2RyAz3MAy6LXBQoX+0ST571gC3xvNzJy4UAPK+cNYi4lHGh6jsdYexOw2P5TAdv+4VB1
+          fLY0Di1gDo+Yumv5iedXQCCgiq4QOe0/DbvjrIWDer5hCxIj5/l8uSIjACJ2ukftzR0MFbQX1jNN
+          ut03Fl/jdIV+nXHkEBg7tna6SGB5Kk7US2I1FvrxbCH8S840Ad4KiEK3LoaeusNXN568hTfHDGY+
+          kqiaNRvDKewWreGRkuYds+ZHhMpF9HSKg8/ychrhnTqjAjv7hJOdlHjiw3xGsNuNIzaPqeJ18CW5
+          cEwPEc5/D8TGyA4LRGp/h+/ot2t+pSjrqILnmYij0OVroV+u8Bx9n9hTaB4vvDCLKI1JT4Pb9+SJ
+          i/W7wnGXkS2/ZDmbOxzsE85ysK1dDobkqFcIyBtI9Ph1H/Fi8mUIUznU6J3Ub8CiveYjx8A5dfmX
+          m8+BqxHkP3sZm+8g8UTebkJU3A5twDM6xswP9j4yn4mGb68VgHXXGT38tN0JOyaWhjGWfQWu7rcN
+          PqWU53yrCSl014RR9br6QHB/Uw/eHbtjR5cSwGe/2gQXVcQ4btSazcATK9iIAAbC66HlosiPNZQv
+          o0WxqzfxPEuPDNyabYoHc47D99bcQ/gKJZuEPhLYzPqRh+7h5dNjTm5s+Ry5AH4v7oj1/mUDOg7h
+          A2ntRcQ5PD4MwZ/XGe0fBY+N79h6JO9+BZQneKElWbV8MR5Frxh0vuBSq16elL86HUUiqTd8vYO5
+          KR0fxevpSoMkDgYhv/cRNGvrSHN+uDXk0oUz/MMP3/Ax4K1OVuHb/OjUynzbExhpCHqXi0mfvvWN
+          l1NFI9g/V4nsSf1ms53srxCtY0Dv6fvrkbf55eDlGPtYfcWHfHQxccHzPM34WX7OAxF3I49OYqXR
+          9Kxo8XY/TP7jD/hELNWYzqFe/9u/qFmMQbCq6wfyCs6xEeri5qBO6h6cPj69RFUSL6UyBOgrvjl6
+          TIwWrOtQFlD4ajp9nBonFh0kq6jmvBNprXI0Vpg7mdIPdBcwTexjtj3CRvS5SzGO3MGbpz3ugBJX
+          Aza84RUzTTlb6FejM1azpvIWWQc2mLybSF3blQ1q3TsRWjtloEb1XeMVKGqKWoBWrK06YUuaxxWU
+          4vRCNd+/GKP5vppgy6c4x+IwLNvjavCsVoQxD2KPfm+OBYQDnumhuAzN6KpKJ6uppAfjRQi9JWdX
+          c6+a5wHrBeAaptyADV/x9xQs4tOIpZhxOpSudvYPX0kq5DqyT/5C9Y+Z5NJ7z0K0c2sHe8JNZiTo
+          bBNtncboo+Y/gE2fQwhvAhdSFSWdN8GZS6CXvXXsGqzJFzonEHAeCAOp8samH8WTCeVqzLcbLr+G
+          UAOnwNNSFWdlfhlWuXqLMG4qB2dfOLGx4pkF3dy4Eu5xi/IlltMP3JVREIBTCbY2aXkGjmtQUtMq
+          fUNs0k+/zSnNgx1dS299RfsKVh47Y//iBGym17JQbvptpG6kIG+LzxB+TteZFq+z2Cw6ynuY+6+G
+          ukRdwPxywQx9ZTiRfpheXnf7dq7y8hIUfMed0LBaXwhSlS7BxjHw2Wr+ql7BZ0unh2OsDDRIPoki
+          S84fnxK9cZtCBZXfrqNHfT16zL0+WwjeYkFWQddy4fgdRhgZB46Ag/UZFnp9uai8/kIalEWbr9rh
+          MKOGncyA/ebO6H+858L6S8INv1DOSJ2Z4MhzNYHae+uSuxQujFd8xcbJMD1B948ByNo4wQ7/ccAs
+          SV8L/vGbZ21Y3qSYggXpXMrYVio1lsbQ7OHu+jzTYFHXhpow18Hehj0OBqloljbnFRCcqys+RkNt
+          dK/gA0Gx9YjZ+F6zFG3dypXcytvUjbcxmuoPgo2v4CigERBn0HGwHL1se9noAtZNGgHD98OoE80U
+          rIVeJqCXjWMgfJczE2LozQA1Pw2733AcSGoGLRSBe8DHabiy0fUUCIXfcqSBmAreZGavAhrcs/7H
+          t9dIdUfF3X0mbApszqfD1vU9nzIdH2SmM/F9VkOoRtkBe5LZGWtevmyE7XIlM4DveNHtQoeHSzLQ
+          i4BQM47PXISvusuwO883b83HoleiBIQBk547j9XSPoGFnd228yx47HWVU/hb9Qf1x8ecL6lfqVCv
+          /B7rSet6PeVzEUpqHwa7i4MMVn4v7l+8BD0ZY29BlqQrKz9Yf/FrTE84uVC+EIuIKDOHBU2GDfhv
+          ecXl++cNUrhAC8LXLSSAH6SBnA1BRtA1GEHjPWREHj42vA/1G6v7hmfr6bL28HpQDvRMzqAZ7OeF
+          QyfF32M/VWpvmUEZwdvOiag1lO9heYSDAjZ8D3YWOseTixceWjjbesyFo7f9Ph0+5uiBzUzL8rnf
+          3sADVzxSQ3N/3m9Ms1QxDTQFSmowj3Ke9oFvwXpRY8u3M6++K/iX74y5OuXi/O6usDT2HtVWEhor
+          /eUVEJqrSw8f0QDj5ZKNsCT7J9a38zTLsz1CPSNPHPhSZ3zF7ibDlyL/SGu/QoOQx/amK91pOPi1
+          viFt/B1GDSyDeeOD6/MzB2jJDZmeNrwc5dN3hk8fv7GbRDuwqtW5hfSpv//xRWYe4xQRXj3jw4b3
+          axZ14v5RDHsi3fNjvq7a1YXw2SDq7Dk/nrOt9d7eGym9tZ3mrW+TQni3ULD5B6eGHYzKR3//z35N
+          Rd5v/AsVH3uhKgekmIlGs0K+pWeMiUSN6fYMCLQRDbcXAQbjpz5xlbEXblTtOHlY4JtTAVNhgMv+
+          MjK2KkkPX94VYfXI78Byac8KnIQ8Jf/FrzXKii4X2xxuMQR//AH68W0JuOAh5bQ8vZJ/+fvJmTZb
+          xfeio6w9J9i3UGMwmb5VWAk8o5lQpDErpK6Dzr41sXnarwNdD6UK/vhk4kdGLl2/ZrE1H7pR4/ko
+          4n/8HpxanxaDdWpGeVYJutTxi+oCqQeWJJIK3N5scAwgG8ioHR4QDMkn2DtfxaCePFdg+/8Yf/Ou
+          Wa40ChD/Uu9/+cH4lz/ucXQNhGOcNfP55nEQ36od1ox0AGx/mEYgF45BS8idjPWw+0XwbMgR9hGd
+          wIwHt4MiJyJ6ug6PZk0OkoiiyPECrn8qxl+8K+0UvfExjM7N8jUNHV6Jm+C//Z+kUSngtf1GQb7l
+          GxI6jolQni140ws5OR4eD7BSG9D8603e7JhvHvrLwwu4puqMuW6/LYx/Owtv58nY/B0CLsVypbmh
+          18O/+JGGrqU4ez2bJQjsD1RRdsdBLO7ZgqlWKYeeF+g57/KcdbWTwm4t1mAxUo+x8lvaMIBVj41G
+          1YHgu/8HAAD//6RdydaqPLO+IAbSSYohnYh0QUDEGSgiKCJdgFz9Wbz7G/6zM3yXW3AnlXqaSipN
+          h1yje2Mr3kfR+oirFfoTf5v4No0oL1mUQSrNdXy4igkSVJKucDa7K3HVT1kP/k5NZCl+FNi9NXW0
+          cJ8xhgELGlYQHKK5ddwCUJCE2MQ9rhcDvywgISmw7ndRPuOLraDf42liO2dNh3s8rynCo3rCNvvq
+          8qV60xDeWniehLHn6aRIXgpDnGakIC2hI8nuCUz2viJqdaJ0TVIvgINn5hObJF99iR/GCmMEJlHE
+          1qRs0kcxvFSKiFVnfb0oZmbAvgyOWOvvPFqkic1kcg9KfFBxgmaPPWl/+hin8vR0epzTO5TN0mD7
+          WCT9+Pf9yuQWYvqz2rOysFtR8fLO+I+f8zLYMWz4RIxXXdK5LNa7bJbC09+9rgadl7YToZGsKw62
+          9T99OjBACdMDiUp+pw+2snaoztGXHB4g0fXSpjMSezfA6ZY/lqJ5l+j0LCustMShS1Aw2h9+EHvz
+          I8aXLiWwrWfi/AoZEebNpfJJDgCbX2Vxxj/8ozwj+JU4sv2klLcGGlX/+VS6GDl3+LzWP/2CXVfZ
+          6y05/hgI9SODdf2xr//8LwhxfpgEVHpbTwk+RoMv4Wm5HwLns66FhMZfERDrNOx7YnVFgPjs3GCD
+          12R98W+WCLdFm4n9Ejt9ejaiD7Ybn/Dfeq45KN7QoIONQ481kHAGyOBPr2/6CZHZj1J580eJdWUO
+          uqDlmYH8Yg6w8Vi9mivDkYX5ZBxxoZAymu9n0YUxy3ViC1yLxvspmf/4AUmSnKVzGAXrP/3gWXCs
+          hy3fyl/cvbDF6z1tde71lsOXm07IOoj1jFathcSLOIJZ5aMvKu+XKNsvBfb4B9tPZfKeZLGccqyf
+          woDOtiJ1SArWhniyt0fDVY0V+aK/Y6ItZ1/nojENAEXGFatltfVQS1PmL/79ub+e9LW7uBa62PoZ
+          u7kX9sJ0Pc/QYt+bhJiY+qjyZoVey/U7CUG41NPmt4F4d3SCaR3km9+c/fmZPkt1xxE2fwzE9y3y
+          5/CSRnP+LkT01a8Z0Y67sV+Uc5j98SFSbPmps8ehBK24XbHBgKkv+5U0oCr25vBHjb6weCtpq9HB
+          5/vHp974jQLGm3Xxxb3P/RwVZ0MOmPSInRGfdY5z9iXcmLAjlnr56NNivhIQ08L55y/y3kXqIP35
+          LHaGuHaGNjFmdFPK8+Y/+WhEWE7Bie0DMXjtobNdm7loUVmeBM4ncujcHn20+c0+Lb9rPlQlpNKm
+          74i1EzU0bnrhH7+6SNmqD1FxNmFwbdvn2TKv26HGGlhCEOHI9hg0n/afO/hfpSSu3fLRRK/Fumf8
+          /kIOQueixTSrFWpt+vhLNo45df3FRQfPyPHp9M2cDa81STs7D6IO3RAtF8Yb4D58p+n9MId8Ovh3
+          FjKN14jzOv5yCk8lRP/4WsF8EKnvnxIRD0f4pLzfEVWoA2jzz7G2+YG0J84/vod9bqB043cByKOv
+          //GffDCcLgQfE92/8fss+vNH/34v0crhjLhIDBrYHVeDnPwd1FS87N0//4tcNjyl8o0zUYoU04fY
+          V6iw8Ulwfh2e+AOf9oPNSSHc62zwadfz+iKVlgis+1SnBTnveg1vfCXdBUafGHrTHc61p+7PPyZ+
+          vnU1l3dyiaK6OvlhOSx0/VonCYIbP0/iWVJzFn3tWEyZgSHWu37V8948ZWhu+Ne/+V+PZRUg8ZQx
+          2Nr+Pc9afbDfxtdvUFL2f/iHlGe0I+6M3pTyrOjL0xK65KhsJ4zW+jpApq8c9ud4iYZ8Vw3Qv9nt
+          3nnh0i+vR2MhxnJT7OT6Jxr/8GnDi7/3O7P2LEG20+j87+9Nr1YQPF4twR9NdNbBPcxoHNwLuQ/F
+          HNH8VSqw+bU+rwlmPWtx28LQCdeJPaaZPl6DyJXe6zqTU/LSHcE/SCx4Jlxwer/c6BLrKQO/oYyI
+          v9UX5jUeXEROZb75F2q0Km93BUVObzhKn11Pokxz5S9uX+Tovoqo/+Nbf379QchLZ/3t9DskaWf7
+          701PrZbaB2jzP4jSkh4tf/qquIQn4nmtRXnjiCcYTpu+ukikJzHDJNCmeeDLfs2jtTODVqbmPZ1+
+          1P86KyqggVNXCvhss2u0SHuY/vQAUQnT0eEXnhuYIe7xxTE8tIT2LoEi8YEY72qly++VrujPr8b3
+          vq57tnkAkuMvS/BWH9nqdyUM4/eOMascdO6zcCUoz/OO2DRlo+U3G4HcHnqHeCeHjcb6wIbQy4ZM
+          0h966wuf7HlQ03QitldJ/XIOtBJ2j8DH+lGadOqfJuXP3yPG2Lf1glRVgu6hrMSSyjJf9uu3QdxX
+          1/wFOUZNcY4K2OqNPqe3x4i3x6FC/n79EPe5p3Sewy6AUbNZckwSLh//1uv1MSj4/FAKhwo7sYLj
+          MIREW2Qc8XStGiTvwCK2xGZoseq5gqrt9Y3PVWh1bx8WWMWRsJ3c9VqQOUsCdHvFOP0eCvqPX278
+          Y9ofoEFbH89Qts9sjLf6C102/xOkJpix9V79nEtOpgmbnsP2OfIo/0uFBJ3CoCXRo1WijW9WqAgr
+          A9vMx3emrf4k29+kIJrRE4eyVbVC8cJn4knST58VLy/h3B5/0x/f/eMDkIDwwsZVTiL2w2j2X/7B
+          2BuTfpIXW4FAbV5EUU4DpW2lZvJ7DD7EV0iZj7axryDJM4yxKS/RHz8CRY9FbMrZu163ehEgxujJ
+          85BUOvnpWipfer7GWIjrnlbmW4RPldz9mUFCvpbHvQvpsB/IkbecqF7s0pUvCotxGtwZShnn9P6H
+          p8a283D9dKwhf+782V8XGefz5pf84fV2y7RRsyw32uB5eYhxHpX0n77Y+A3xHq8aDe0SvKEdmO/U
+          2+OF8idru/VLuw7TIPiXSAhSK/jzz6Z18/vGSEzfqGxog72Uq/rPvmYNlCJmv9X/9tHreK4NeYsv
+          bBr4l693ut2CtyB1qoQ305MND7dbty2ijLnnTDWzzmiyUeUzF//er95FamFaAhd7vH9E6/l5GoD7
+          0SPZ/Gd98/dZ2PDMF7Mzh2YdXwqUc13o77LXrp8zPwn/9BfGu7sT0aP0m//8Yj/Z+PHwOWkV4kQ2
+          JjElbt4/o+QOmGFznOdMFK3QnIZ/9ZujxTs6YRJVksWRuRDjr55u+m31x2fxgXhiTr+uMsOznGVi
+          bfND9CbM4Em3EyxCYDj/6jH/jx0F8L93FLTFoGITn5qaus9jB08pcMkxef6i9ZR7Jqj7QCXhrfno
+          K7pdNID2TbczuHNNA+XGyHdheJNcuhmIS+jNhuPWYvM2X3b6WjaVArYnU6ydk7heXr9zA5/A3WP7
+          +VNz/qNWgcw4wdUXVcFxWC0+rvsuFht82C+Xeu7Z1x2ST8Zit/AnZ37VqilD21By3Ec2mte910Ja
+          F9n00u1zzo1YMcGfb+VUntldPl6vex+BFkbE+oFByQgGI6ffco+xfRrQyBjlDKZXOsQJmj5aX45t
+          wjyZF58d7aweY5vT4DC8TsTWc4Lqy9E1wdKn2c92vuSQ01A3ULLHcRLt3MlZV1Fi2fQXG8emdsrZ
+          kvlpkGAjwhjRqV55LWUgZPuOGBd3X1PLchokMmNLTHwya44Wayh/dO1GkmPjOzQ8ZYrMf4MDSR8W
+          61CDdzKon5fNkV/rmu7Pr0pmxjIluTTG/VQ9A0vK7VbBVla9HY7IX0Y2BxjILdb9aP1exATUz+Pp
+          vx/zns6SyyoyQ9k9scJdX5PF9yw4x7TBTh9FiC0OKyOfX8MJR/RS9tO5eN3l3BF32OyP335+X0YL
+          fdBbItqJbudLDp0Nta3EJNv/Qkd4tkwKOF9eJK/nPOe+xo2XwX/O2KBWh5bCde6gK9qBOB+V0vmw
+          XETw0P4xCVK81uu3N33ZENXj9r5jz9/jnyjx3/CAzWLrekK9aAYdZSaxRuwifhGqTq41JyIGO247
+          IOYkBZ/YJYmP+uKMj3VJ5Ti/jSTe3j+eQQSo37eYpM6dOjMrn2Z0+zJ3X8g3BYyWWJGjaR7I5cDR
+          flk7JYSm13OikHuJOvbU8XJ0Gh1sMpyoz8t79wZmt97I8fs9UeocuFZ+pppD3ODG9avCFB2I0u+E
+          ozj99izXjCvcCjYnWfs697y6KrxcOrVDjPVYO8sphgaqjJundq5Y+ln4xJC6SWlIsRQRpa9z2EDe
+          ma9pfO6smjs/Ygk6wf4SxyK1M1fux5Qt3AYkPqmvLZ5lBcnajk68EjXRvE81RUaDR3CW3wLK3aNL
+          InMXriTmRStqnq+ABYcb9n/x2w/TGpUycyP8RN/1rl6kuijg1GQxOdH4qnOv3/ktF0/STJzJ5zlX
+          a3UnT/ERT58DF/UcgdKS8bbDwn5cXznr/4YQtvjD3rdSdc64BXeIXcbHaXHK0frT0ztYmRrg4rmu
+          aG5uv1BGp93k3xco6lU4xpJs3LiPPyspdnhNcOe/+Mba0XMd4ceFvPzD+WvblPLJhffUTnDfCRWx
+          tczSqRotibxP+R5rW35bUrj5yPFvCcY1N9Zk3u8UYJAsEK2wDzn7rV4x4kP/7UvC9Ux5W/rZqNiz
+          P+yF9uwsbbvngRFQSnwmNHqWlygLgcoeiAU3Waf3RslkPnrW/+JzeaLlLh/K78/fnYdPtArN1tMh
+          i+gk2Uybr/3AZrIxHJt/z5/dmbfhQRQTn8BqHWEUVE3ujoPpzxOxKJsZxipfwRZ8WVGPaC38Kw9v
+          XeBwyAqTswb4moB0eA4+Zx/ezvL+6p0cTesw9WIe98KlKS3ZmyaZ+MXSO6NVao18PXbcJGaV4SwD
+          6QGk883DWniFfDxUQYX40H3j1LlHzvytfjGwqCiJMixiTyR0KBBreY+Jca529P71vxTyi65guy9/
+          9TBVp0Z+iR+C/+KVHuu+Av6gGOSmdpeIL7xAg9WDG8mcMNXp7VfYYLaiR+yQm+uZKVhbvt6HhESf
+          0nImOdQtlJ6uV58676Rfh1ksoTtOJnHn71FnUSBacK9+OrZXc9/TrmB4CHeJQ/xJ1BERUpRK5nN2
+          8Tn63BAXiMBDNXXhf+v5d3jzUsQdPBxx35Ku68ts5cgtexzOX7memaixwRneIj4aierM83xoYGL8
+          M8Z9ajrdqb9qcuMKe+Ir3B4tfbJ1NfOMlvzl1+UMM8hmxA748uvutGn42IfFK3lin+Syn5NRaWXh
+          uvtgrZk+/Wo1uQE2d07IQwIVCUfKFRCFgotVzGgOpxyDWBZ/qU0OuWfUMx7bVJay2sNaef/09P1M
+          Gii01xHb6FtF7wivFTze1w9Ro7PtCOFe2U48fs9/69thzWDV5MHUfz66CHovVKbxRvfLvcY5Zw31
+          Kl+Phux1XYE1BQ0OzcYwlPNBUokyK69oZKMhRNVeDXE8Cmu/is75H/5MnFY5NY8/NJaPTO8TM1UT
+          uiYXtYMNL/z5zD7zWaQvkLf8jK+aUVJWjD0RZN7l8d15ffLVk6+WfHoEEUlHPKCJfuwZij3/w9Yn
+          fffcvf6GQO9CTtKeifOl/Fzu8vXDXnEwEQv95S8Y9wMm10J70S3/a8jb7WDavxwf8QG+xpBXuCTa
+          tWX7+SMdbNk+7WNy3UcdnWcUNTK/9IcJhmtSL6Y5N3K9fNhJLE4I0U9kzfByYMKXGBk9r0zGgEze
+          GHGsLGedlF5yl8ci8SYpS086C/ZkAAx9OO1GhtdnOyx9WQFRxnpoHvO/+QX2fCl8+gqEfr0o9C0f
+          9cgj8Z2E+spNNi9LzX0iT2lt0JyL/CBbtXMmnhl9/8Uv8H38JsVjrqPR8aoJ7OF02eJBy1ctKUU5
+          JT/B77rnC/Ub3qC/fHaYvp9oRGvbyK8+x760fU73zS5FW74l2nXrWl/tWA3WKBKJbTNWxP0ePQv7
+          YNdhO81ESjhMY9m68zPxdXahM8MErmxcqIl9ngwOdbpLC2NLPILDcXTIdbdaEPueNzF5oTuLIYt3
+          MHlzxMadrPp8scpWegYn298/RJMKSf82EAy/kGima0T8Tdjuah27lRhtI+Xj9/adZKymFbk9G7MX
+          Dll/hzttD/77av8oEUf1Lpte5RBztyo9Z2GxBXx6ldOuyR/9EiW6AkuxcNgctjMBToRc9LnF++lJ
+          oMmHY2cokKU9ED2wBL3z7igAnJUVDk/0rv9YPUxk/EYVdt8s4yx9cmbkXR1l2P5V+3zULnHyj18K
+          u0+HFs8MeAgt7UdM89NEq6wuPtiyfcWaVRj9Ol6CBtF23TpJ+gdnGXXJkKTde5r238eE6GMXZuiN
+          TldyXle95hijXEFSbN9H8jCgsRi+CZJtnsUn5ef1Sx3KzXZrlEyUrxtE3HmcePhyHDPVTmDS5eLv
+          LSlBJPb7tzLoC1rLBpaau5JrkSw9bVx+QNZxwZPQilW0ro44w4U5nn1hH3Voir6/EuI2DjC+RA9n
+          eR9JgzpqWj4ZmcQZasgNcM8mmqB+mvn0blNXej+XC1YY/tUTRIQCRnO7NWztFIfz8maC7zd7Yqvv
+          jH5RVTMECykhTn9gILa6IgONwzIQV3Kxvl73r06u5OOCnd/ZiJZr61hIugU+uVwZhL6qVcfAHzRj
+          quekrYkm3hJkUKbF9mx0OiUsNSC/qApRH1lYj4avFcBa+DHtK5evh+PHMkFvkg82KqXL56c0iHsh
+          QiZR2WOer4eTAVAP4YVgvkryJVw6BllfPE/M9+JE7G2nzPLN427YCduMLvNLccFCWoiNNV/pIJ0F
+          Zp+8ksv2/rXuOUwT+HrRnSiXWXHWxykX4SS2F2xZj1yn6Tt0Ed0d7/jwomy/nB93EUj6OU+96nY1
+          nW+5BX/82T72ZUSzMQvh96vexCbsPlrv3GEF1563Lo224bCdskvgoJ4s7Luthv74EYifb+uXZA76
+          RZ3ZEPQqMInW6o9o1p6XFYyO/5JDUbr9DBcwQQi7o99ydHTmzHBXyCQkk9N82TlbfrVgYdkbCbfv
+          U7/FE3g4uPvL/dah+Y9P/PHpUCaMs5QcyeCh8B9/US0VNeMleMt987FI6M9GPzNM6kK2rjufK1eX
+          rhu/kKefNZOz3Br68pcPGL67bfFU6tQ/1jxElPfJ4V5BRDiMElSXCYedQbw7840wrbSWfj7daCw4
+          lBl+k/S3Xuus+/ZLyX1TydhJFvH6U0qH5b1r0NmMj8Q5zR0aevZVgNDC1xeTMKrJ6X5r4U9v6Z+y
+          ddbYPTUgWWd32jl2XNPt/ZAH8CJ4Z/L1ovZzjDpn/fho5d18tm6SCU0lPbDpOXy+cN81hiVpBZ9f
+          5FZfjqgqwT8z6rS3fa6m3yGc0R/endaI5LSnhgQUKfL0Ps4/ZzqGBw3eeynF9uU4U7LhvZyy5DZl
+          3+DmUNk6TWj9vPbYQsYnX2Z1sEEJKSK6riT5xwmbDrrqaBLluuK6zx5KIkvZyyNPkeX74cy3d2Dd
+          CMiGz/W4+QfS8zDbONjWN53KUZMd7cETrSouOlcM3xg0CWrs2qyXk7/fb7i/A97mt/4XH9GiTMRR
+          HA0JDzyk8MfPo/ezjDp8+WVgwflMVMxUzuIje5Wmj3H2azNi8r/xRtcPfyWq3BqO4HxuA+xH0SVZ
+          ydycpZn1AcaD6+Err2iUre47DbxpkH3EKNAT8v5ZCBldQMw3962XRnlM0nEdp7940RertBuQqgxj
+          W95XPR2OkSLfL0Xty8ZFqJfz2PDylq99duBtOmNZSuB2mPJJ7OShnyO8lqB+nk/seqbXrzz1V8R0
+          g4g9QT719BoY1h9/wHaDzxH5DtkKm14jJqoCh5aye4clIwlxsfXQF/6cxGjKmWDbsbR3ZicvQ1DI
+          9PBXs4ydPljwil43x8fGKKz1so0/0tKpwqf58tRX9sau8gP8Zmo1MaTL33zn0axi21R3dP24Ygjt
+          qSuxGgZatLyP3zd8dr8bUXvc63SaeZC35/lM4nV0vsPKw9MXbZIgv4zW/t7dwV5cAefjJ9ZprB8B
+          jEd7xNn2/PE59wXMk3EhQRErOTergwUP0TqSpLF3zpDRdYWi5b44/kRrNE+V+pav/YkjjjSy9fKN
+          6xn++OzIMks/yVdswGF599ipCO1nYSfMcL1JPLY3v2fiw05EKekFvwxfQrStF/Evf2/7nM2cDXOr
+          gmY2ZWI/+rMzqM5xAlYxn8RtVj+ndRZ2AM9ixYdfB3SqY9sGws8Ue80n/fOHAG57nGOj/4T5AkNS
+          IaFfj9jeodChiaP48nO8/LB2eg75ejBUDW6L+cD+UlBKhYcQy1CSlXiDqfZLdNgbaNPbxON2//L3
+          LG946Ytnpqb0SOUCNr8BWxz1dD6DZ4eMZrUmOR1KNMjEN9CWL/GfPuL/+NzQnjvs5C5yptv3tO7F
+          o33CITpN+uqwVwMsiM5+ZJx9SllH8KVP9xWn0Wl3+TrZWgMbn8Jq1duIRWqj/Msn4vZ+midMAJkf
+          AjZM8oq+arTtULvVms+kz16f1ezGSrP4uGDvXf/0Bcd3HlXhsBJ780+4kSUSstU1we4vLfINL30U
+          nRvPFz01zzvp3Wto49N/fCZfvKRboVBDCyvHPkGToRiiLDp+i53zlzpLO8oroNYJ/E97+eSjpTSl
+          9FJUnziZE+VCnvAhOGaQ4udRGPolO9xi6XXWAn8SFaOer2Y2/PElohtMg+gfPr8cZvKXfRrV66Z3
+          4Po9Jv4uP3s5odeDC2eJP+GDe31HFOpXK/Ps/UMOjGo6Mx13HbqU0kr8+eHqa0u0WO7rpcV5ORoO
+          e1ge0l88EP+d0Gh6LqIiH/WzNyHoD3/5M4GEKdkNLwtdeKbDHcwr+s+/+nzf8oAmjQ984XX5oeXo
+          QAn02SJy3nrS/fkFaPOHpm3fczTDobJl4zx88S37FfqiuPcAUi/nJ572R8qFKstA+2U1crVbVZ/F
+          2JPQFGgztuLN0f7Ce5L/9KD2Uw6I9tXK/MtX9r075awsxYZ8ErsLOYphrdPUYCzIrqk87WrO6+f3
+          IfehVZcnVrb1OHpJtSKumnXi20nVz0GVpcA22Q7bLi7RnKxugzY/B2vzV+7fIv0x4KKHRKzafOer
+          7oQSEn3FIo/Pe0bLnx/FsaqG9cEU9aV3HAYS6X4h+c3ue9pPCgN+Zu6IG6Vjvez3UoFo/r7jU3KZ
+          8j5eOebP/5xQPaOI1t27gebBInJqp280o2C2pPO6szC+Mp98ddingeLEwCSWej3i9F+VgVKQnGx6
+          LKJqKgcIlUqI3SfmEI1GSUF7QfPIEctiPWz/P1AOn3z6vEzo1/jslXCqG9ZHr63LnZpyIXqdlYA8
+          sinICSK7Aj3c+YDv8/foCG6mD2i9mhmxNj+ebv6NdGjvHY7XY60PyUvqxIiyPrG7p4r4U//U0DY/
+          2LyQzW9RtRK0F19PC2fUlAalzCIMa01s9aZEv3/+JDUsnFck6ukB4Ri1vfjCSvdMo/HnnUUIPpcD
+          UTtfjwT93KfglH06zSdZ0Ofhl9/hbjxf2+d1Pu/0uwtJ86PYudl9PW34jphuEvFRMxTKXa2vKU1b
+          y1ifJ66zvuXGgN38lMjG35354g1vEBnSTt3mr9CjcSzAveH9BM7rEPGPrQKpW47+T3/wdaxZgJ46
+          Jm4OI51DNKQgPPnGL6ku9gP18hmctrxh+8JalPvkXAd3a2uaeRTcekz03kKGMn7wicaCvtRa34Ga
+          m0+svL5WxC74N8GXExifM3mUL1apvaX5pLDEqm5uvn4zCBDYtzN2OMut52ba2VA/r6u/6pLh0NfC
+          3+FU1CG2dimnL6WxvP/8HeLvoiFfgrYSUfeDI34i6tcr95gl2N/39r96DNc1vYTk0eT++bebP9DJ
+          11oTyFE9itHwornyj3+F9fOOlor53qEH1Pqb3kdL2y4sPKXQ9cfAKus1TJ8ZqE+b2fwrpaf8W03R
+          n7/0548td327tVZnbKx/q2u/xb+JmDhLifKzSzpfHkwFd+WmYX3DE+I+j+0fvm71p6Ae/upFf/xR
+          zTk7n+9DK8JffcD4nrVaSNnBRkfH8km2Q6u+8fMBNj2Avc87oGuqvVY4LE2PjV9d0c0PGGTt3eob
+          P5IdIotChYpy+k1LGFQ5JSwy0ftJL0QLr/d8lqBTED9n5vQhrecM9aDa+41/br93ovPZXAt5q4f5
+          ++b+1cn5cJHgruSaL0wPO+ff8mTANt5Ypxel57VG2vS98sNnzFR6N2GzAtawGB+uwyNa8Hta4XKd
+          F/xY01c/Tm1oypu/NdHNX/hcyEUD7tZpU7lqM1o70U6RMSFzuxViQkvcnQ04kTLG0e+4o2vBHHj0
+          DWMGGxf3VtM4DA25N65HYn5OQjQ5+iuE/pa2JBU4qIfDcpEkuwBuQptfuxzv5h3MVfF96dGfdZI4
+          lg/WBxb/lbFaTeNVBkl/+G9/zRD0dLd82j+9iXVtaPo1kE4ZSLfQx9rrMeZjb1oafD5hNsm+YOl8
+          2X8A+t1oYVVu3/pCUsWCZ+DYf/omGjFORRSyvw4bavHTV26f8tJfPcJLBwVxbbtngfArxVqoD/1w
+          uCuKvOkprF3jN+rts9NBCu8Mh6fnEG16roPNr9v8CNmh5rRUUn11WXwiyjdfjn3QIOa8+bs/d3U2
+          fZXA5hdPk2FUNfWYeviHH8Hz0urr5m9I+xcM5Dg8Jb1VuGWWucf0mmTr0+qTr0aJzFZJOa3belor
+          tlFg828mgqjf/+PHJXsY8fHsn3XhkUkZejqHFhtue9v4pyshVshUfJBWOZr3x3mrTw4z8coo7Tt4
+          3GxQ336JPeet6ML7Wbyh2ushPpTrQKkmXwL5jqhOfLLv+5HIBKATrC/e/LJ8xmOZwo2zwWckLXbo
+          cMw1BHIX+5IxWPm2PkvA4mDgG2Nf61UQNFH2M2NHsHdn0XTqnwr4CuzIk2I/+lsvsPk3PqWXreef
+          6odovBY+tmP6cvpYsywkjwZHXH5/dOiknGzAdVdP7O3e6f/qZdvzJ5SITrSyp4r9q/9N3zLW9HnB
+          rwlc3rrj9M//Iqllg1T/fHI7SAe0fT7Il1JccWLveX06eqqJXheDTOzpskS/71uepKNj+3/+gz6a
+          3/sdhJb5/vn3+vKHT/PXTfBFr6NoyQ7nGPZ46ohTkaim0aM10cymPLYynqJZ1zkeVd4v+IePwsnD
+          FWz5AnuTtejDs8tg6132wlj/3p1Vz988eLf+TrxTWG56rA3Aqk9n7G71rtl86QDrO5CwoSyLPvAS
+          4oFPzjoxfrWGfvKcdYC13wv/4Tc3L5kF9x1XEYO96dH6cecQsqVSiBq+Q2d+f3bG/2dHgfy/dxQM
+          FWQTreVPvfCocCGIkeZHX7jXs91qFST2dg+OL1j54D3cDl4Hvp6+D6+NZt3aM7KtSQw5yN8ILfLv
+          7ooXbY6Ic7X20RK9rwDOjWJf9FZULwMnSpAEMGLbDSxn/k55DG6qedOU/C6OML5eAxxP2JjEEXs5
+          lc2fCOJvUPDFg9GhCh9Msp155lYxNXue/4aDXP8anZzU8ZTTS2s0EJyY4zS+fZ7+JDYzwVWmA/by
+          g6vzEpt28vY+rDoVjygqbQmu/VaxyIVZn8+d1gB1g4b438eA1tHIWmTMD50UUFaUppxWovs7gqng
+          81s/F5nSyWYgG+SQIg0Jl9guwe3bHT5/nrecLZ6XRMbirideqqh0eASrC0ylLuQU8pQOR/FhwIPl
+          X74wzxNdLLWyQaUHSjL23PWDScxW7gf1TaLRnPNljNQ7tGGGfWkU/FpIFKuQ+V7aE62cSN0crhik
+          ffaJsZVoVc/vr5Ytw7p/Eq2pz/WQhc8MDucM4aMeHChn21MMc1ubWAfj4cwKQgBYV0McHblDzp0K
+          qQN0NiOsuQHtyXAaRUBnI8Kn++eV089xNuXcu/tEE3lMZypjE7LMJaR4yY+ez7o0hld8Z8ljd+9y
+          /vHMCnl/BhVnAacivm2XEqzGiEjaE5lSS/RL2P+CE3EkjCNBNagk06LxcKQ4r1ww2FcoS87Lneau
+          7HRq31IWqkM6TLALi54vl48Jh3rrajw9UVS/md8bLHZ6kxupRzQfc/cN+xd6EHXfav18lURFFq/p
+          jTynC5P/hG9swYEZFFx812e/dkpvQZC+U3Jd0dBT//pL4Xp4XYmmnmXUsmteyDG62ziqjlktXPgF
+          5M9utydOf9bqWdydU7k5tR7RPtEpn8MLH8L59hywz57fiLvwwP/FNzkfRhZRr+8LEK58QBxalv1y
+          CrwQ2a1wneTfZOrzVTFmSHJwyPnz3OerbQ8SdKEw+Pw79fXZJP525rzBWJ1+AxqGB1/JfNwsxA2v
+          uO4YvJ+RZucIu1hjdDq9nnco2LTDaaJpNRuprC+rAT8Tz4NXzTYfQ4ShCyocPIYw35DuDtz4Q5Mg
+          HsqIxDaYsPpqS5T73daXyetKOFmXhLjz3kHC33rFDjlhZ5VkNK/ZS5Tnwb1jPy2uueD1dSFT2ZEI
+          jixaT2rUDQjfNIwf5+aAePX7XpHa0w4fj/iOZsjWSo6z5zQJk6roa96ZJpSSYGB/+Co9fwp0Vjal
+          hk7MAFG+8sM3k9etC9CsE4KETvkN6HZmiM8J3pUuyznT4CPEDXZta6lX61Ktsst/JHzXCi+aF/m2
+          3WPYqcR9JIeciyGawdoNGj7v5UvEmu6vgILNOqw2O6vntRn5MF1Wjdy6n5oLys1yAWRRJla6LNHa
+          JHEnH7S1m1ANiz5xOBGheio5URW6VdxaiYHjV7hg7UL29Ktf01UOlbTCj23+u1/7DYEpMoZ4yuo7
+          wk/IfdD4a0jc2jlGvPSpQ/lvfrd8RP/yz2Zc/fDz5UZoidvzJFvFbOPnwaD9nPirLYuN1hHvjNKe
+          +2p3BejvZZH763LPV4evVhmbU4v1/uw79GcqLWz5D3uH65HOjNn48EptGxvPl98PfCrdATEJS0zO
+          PaDZlx4WOk1nQo77+Nkv9azG8nAFRNx7TuhYjIIG1m7SML5VuOdxqEuyMTk5cUzJiNjs5a5An/uU
+          2Oai9u2N83nwXq6JD5nj6Fy5zKus5dmVpMrv7Eyrs2/he/ITbBsoqelpJW90PpUBVh9ltd29J5bw
+          YNnXxOjm1K/JoWjgpicFMTpO0NerVIkoveZHrHZG5AjP2qrAuJQWwUEK+syot0pw+a+EVV0M++Xs
+          Nql8LimHcdzquoCvT1t6yA+WKF3ZOQs3IANIFg/Y/IVZ/cN65csc1jtiUYPkVLKOJrpeWYYUW7wO
+          gSsZ8A1ZEz80uafUsOoU5sR7EjVFVr+eisWVHbK62xnIZ0Tb5zMFKzdYko/mG9HwaDRyQ/HNr7b8
+          NL9fjxTtzm2Blaop6LJuHVgPzk3GimBIaHEO5w6yz6nDbro49RSQOAPOzK7EqWFxFno5lZBlPpko
+          7MKevcRnU1ac6IfVQ6o5PGLNFFSjNPH9O6s6fRPWlWeOdfFBk6/5v3hjKn3BB2Pd12+yf7Ewrs8d
+          tkdh6sfHMxLlwzlFPsPn+5pmLmvJeoeA+GToUOuf7AY42u19kK0foqVyMyAJmBGHnXehbPQ0Noao
+          cRgXx1O+JhUxAN1IQ/T9xc/57rBjoX/cInyD6wdxNVcoSGWOZxKnrpwvT+f4lhOpuWMtUnpnNs+8
+          DaX2NQg+/cZobYE24IvGlehe7CB23x8MaEjTEIMnWs4V8M5kWNGT6KaiR1PWBYnc1bw1yZ7q6jTa
+          em5gBlp8ZFgfTaxCZ/moioBvQ6H3XCWxDAiqEGHzVPLOovsHV2bmoSHmp02iBeQiAP97RNPy4C56
+          l15RAfbslP6sPb81UaNXCHyLa6zzn6Sn5VK3MFoS/cMT2nq9pMlnxpSIK/z0iPvjd1Vw+U5zdXb1
+          2a36N0zXo0cM3LrRsj5lG36fj41PcP3QuVPEAD5C0hAjXRV9fZ1KkL6q0GG17q467U+zLf+bf326
+          9HMY/N7ShrfTGnBezqnRYIPAGevEd16gC5KFDUjIW8YGyWY0U0FKwf6WLskHB0cLlN789zc+F7Nd
+          r9bbE2Hbk4l9JREcqkVPBVyROZDj8/rQp2rwLTiObIidhDb17CwBoPeZNfDxdzcjYepmG3JBz6aV
+          P770Vdy5IZInliO2Paf9HJSsLUvnyiaYBBHiL62vgNzYDMa1ylHa0HqQ09x4kEucnBzhJa2GfKkH
+          h2hJR3LKroYIwpUNpkuz0+gcUX9G5JI42G61of5t8Q1PXUE+4j+98xOMYdiPVVnjrKlkfUmlIUGU
+          E1asHG/s1rV57uQjZ+fY1Seup4xqM6hqkvckAYfyeSktdh9lcCLRFm9rEusMDPI+Jofpd9SpYPxY
+          9LD2Nok/CucMn65nIT/NInHXE+uslilne+twFHwB2XbN1fMpgfHH98S6DQ1ajGvUwc/4hdhtOKef
+          6e+gAc/4JVE/tllzArcLIVySDLu7sKhnzU9F2Nb3tCrg6HxySN5gt9yVPN+vQ866O9YEHe9UbCbd
+          rx56nKdQVb1P1GLu+lG+hJaMnfGE3bbzKL36dQOjJVKi3I5pPxfCzYKcyUys/kgZjTj0EkDO8eIL
+          xWPuZ9V+WsiAZZj4DW8Iq2z7G3Ttjc0c6/mau1wDjnf/4Oi1HhG/PNGABi5UCf42uKY9sgckfi8c
+          vnFaHC3rGc/oL98/Wjr3yy/zGvTyHzxWBVpG05vpFfTJ1NJHg0OihTHfKzo/HI2cSnzo1+M7sCAK
+          g5Dov/ugD3r/y2CGk4jNA7+gRe8fA1xdSce+kBB9OLpPF61jeyG3xDnkbMX9JjRdD94kU8+N2I2v
+          oq60V+yE/oAm/T5J+5N1Tf7wtF7R+eeC0D814v4+db7se71D23iS48Nr84V0SAHp6TD4AFen/m78
+          HdVsyeCEXuuN39YWpGNqYPNhfOo1P7YiOrnKQGKHsXSW7F88PMtEJR4nGzoflF8FHS7GeRL28a6f
+          3R2YcNacNzYVOORsr0wK7M5dgfXfUiC639cS0I+U+KC+FbQ0H+eOZn+f+DWDJUTP4iuTcaHMBFNu
+          7EfTLTV5zZOJxLJ1ydd9r7nw+4XlBOnSb7cCzJp84JXTRE87KV8XrXchtssQx+bJdIRb87Cl++mq
+          TjtgxLwroAJZYuaeXPFTp/PfeuicV701dCL6IkaYhycD5z9+Xy9m+eRBOTEF1sUspeQZR/YfXyIP
+          xq30pUoPFdr4NFb3MpcvfLrXIJC4fMu/fL8W0AG0YtL6q7l4Dlc4Zx7VpeiS0ElMRHPGn9CWX4jj
+          /ai+9sNLkQNJyLfx+0S0cIwJil1m4ZN1/OR/+hImWW8IZrNj/Q+f/IyeiYkvqb5e/VER0ipr/J2E
+          fz015bFAw+aQHk5Xmi+BO7fwxwf6jW/OszbHoNSNTw5bvhJ8dpHgc848oi9956xV6pqIzZ6KvyNB
+          RBfTbRUkSMcIu1oxRn/fl5dl2GHnHo7OalhvFr13xgcfl/6dr1vLTfSHn4f75+vMOxWHoLNNQA7n
+          ZommmosbuTCoTIzsWzlU+vxYxOqWSOxIGvRfqEozsu63HfbXu9av4QVlcq7d56m+TseaR+efL37F
+          9YmN32dCVPnWCQISDDhjz3YtPAWtkTX7hrDNm0NPuUJjgc0eCr4+qlwfGUFIwBjYACvi287520sV
+          of69dZyPpoFmbzEnaUJT7vP4IjoLo6YmPMcdRzTNpVHPmkcF5MV+YF8MEJ1pPSfyX7yfgp53+j//
+          4m++/PipROy+90z0Q80Rm/Kc1HR8/SawxjTH6eW+Q6Na3Uq5keqXz/3x9e+UJ2AkXEQ8SZh7IllH
+          AxbPionuv1ln280TADvfMmyy5yB6v5Yv8x9+vNQajetTtkAlTwX7cyPUI9K4EBRnG7WPgvM5J0SE
+          SiUJUS/n97bDa+lkdZlbfP6dHj33x/c2/j1JSNnrK88rppwl9c1n330V0W/ABtsZKnlzdOuIBnkq
+          wce5YZ+Ttq6pVTMrwOwve2IwjBJt/KKByzl7Y29376KheD5iGDxNmbhbcKkJW79mmQ/2Odbyd06X
+          gFx4+LwuP3LID0JPlrMhoeo6RLjgzYb+8Y9/61PFLtKJL/lvtMfdbep/udBP8zl4y4rWJuT23DH5
+          YpZXHqACHedbvp7Xqd7ywdqT0/2jRmtIHQn98Y2DVP1yqka/AN6fO4+dgHn3yz2YZ7DcosYH/7xD
+          S+t0xV/+2yrtAV2N/S5FB+PI+esiZA73OUoMpG7h4uOjQvo6ch8fNv3mM/FTySlnW+t2y4aLXbGe
+          nck+pD5sfMFnJ9uqF5CTACnhd/XfDFPms3/S3n/805eYvsnL2TposKvh8IcHlJC7NksLY7q+6Ogu
+          Xe60dWUmm11yuZplP96IOECniQG5e49an8dIE2UnXid/mX4uGnxOKeRND/nD+xDrNMtfFcKfeO9L
+          BuJ7ut/3olSaYYZPu3vg0FuYG/DyrB4b54dfL/pdeiMydBHOs/VRb36JjTa9jPXf3dV5bVe+wb1d
+          082PcNGau3KD7KEaseXoA6ITs7ry6ag5k1TsX3RWD/YdSWuhYdXx3noH0/cOKSgXfEpKUZ8HhBVp
+          058+ndQDXS/VPoHoszeIkmi+vhhWE/z5jVi9nI18El9ohdfe0PB9X3xqeom1Cu4yg6e9B8eIFtsO
+          rA0vfJrQ1Rnim6jIP0UGoht2ut3q4GV/ehs7earkwpuwPviqU02cdXQclv48DcI8VXBSF2oubM+T
+          7v6lwvgcLfV70SYDNLnPJm7Lh52Znya0g0+KLdHf5iO9vtE1PrW+mAHWx8uhC1AxjzG2RjxG07sr
+          QRZz3cHY3Xq2Xf2mgEpsHXIwv6ie1yfzhpmpdHxao0PP0ovGyLC8Y5Jnj442SfU1ZPVxum3zNdUr
+          vSj//DGcf5YoYt93a4BP2y/YrYKF0uPlF8OGr/7F/Ob9+jNt4y/fkMcl6Jwxld4J2vyGqYufpi7Q
+          li9kx6fz5id+6HLO8xmaRfSJcg35aKkNvYBNLxMdsxA9gu5kw7lcOB8c/euM71fEyNeKfWB9nuOe
+          oEkMwf8eEDn4QtWvrIJmqF6xvp3uVSKhGMGCw6y7065WObQ+D0shF6KpYO0PX6dOtJDs1v4ktXLl
+          LIywi//myy+l6amPn1xW0Pv5FH1OF120+pZcoNNLNsm1fQV0KcadIq1N4hGldtV+ZNdQgdezCIlu
+          S4TOrGpJsOlNosphg+b33ZpQ6t5d8sQFjuYPM0rodgbyp/f7fsMjmH4p+5/++uPPGz5v8RbqdN4q
+          mn94hQ+7kzPb9qpA9xBs4olDSIXv89XJf3xMy2Laz6yqSJCfjyo2Jtvq+ZNa3CXHtB7TsvHp4Xlj
+          Mtj47cRUInXoazAGSK+3IzECr4l4+xYGsPF/cspsiNpn/JtAaIoXNrrSyIW2FQ0EpzgiSdKd+uXX
+          rgz08azg9HL0dBqQDJDiw444eqA4/MZ3UPsbrsQ355WOo3E3YGRZG9vyHFD+fkxaSXD5hWiPG6NT
+          OesZ6U//xsk1d1Zfb2fEiNqEzZhlahKD2aFNz04EFySiqyP6SMJ+5a85PunrQ90N6PmJGKJG92qr
+          B6QDVIds8Hn9WOt0hxvjb/w2P4nUdJoNHk5FHPnrt/g6MzoPBmz5kljemveLezimwA7rlzj8x3FW
+          8UVnGIKOTsLLfUbCvrdmkISi9tnN3/rTfxCYwf+Rdi1bCuJA9INcyDthyUsEAwQBEXeAiIAPngHy
+          9XOwZzm7WXefbk1St+69lVQtxL2xNaVDkvng51e4eNH7NbpVAnxHH4s4l+MnpFn2COAWH9MC7k29
+          gDJRYPpCHT6ChxzOl292gvgVi9gzwEwXkh++gL0oX7LpT7DksVtAa0wzj4/pEJLTLeGg3jYL1q4v
+          A3CjEXSyWwgFwZOC+vV5r5Ufn9jw51yzf3wqM5hpPt+j7Me3IUE9j63P/KZ/+Xk8uHev79+XjN4f
+          Nw3ejLYlh1y60XlFTCWvWTSRx7y9OKBmbv34JDa39d74vwFL3p7wMRsF0ForM8Ajse9ki0e6dKud
+          QjODFUm9w0kfHgcmgrVYPza99gItEctU3vSgJ76NYz+dbmkAVbv6EKuVso1/lppsbz0bGLrv+iEj
+          HwEKT8XGkcYw/ahyWQPqUnKIIVtsRlc0e0ClR+pVGCg198uvYtkE3hwkNmVnMbZ++nVitvw6fNNz
+          AN9252L9yG5TZs8xlAvHav/8kLVx/Rzudc0lBtM0fVnWBgNhvj9MkvGuAVnTLJakO0O9WbYbNIn9
+          yQNx7Uf4vntGdLCaUJNl+WF64vmN6gVV1Uk+Lo8Dcdx7jeZD2Zdw8xMw3vzYRa1uFRTD0MFGfAVo
+          lK7qG2z+6jRIyarTP3xscxOH3VXt+Wm3bvMRSfTjByEd37sEIG+ZseFvNxwTaVyl7XwR9azew3ZI
+          vgncU/DEpuaMNS1GxgLX7vSamDm616tWuQysnrFOTpWQgHnjl1BumYhcNr91zWNHgQ80rFhtbbn/
+          0nqOoOUu08Z/YzSH1FzhDbdHj+nKJhyW0uJgcMj0v/rfOFuokfL39+ix47T0a0pGbXtq23o7Jb7q
+          y2G7AXIZLgVR7yyrb37IF/7qX0e2y8IpUJdIvvtuiJ2D99LXw/UIYdv6JUa4uOhb/SQHF9p+iLJg
+          gQ7PhUB4JOjuTYlt9LOkWxBWkfbjr3rIu5LPycCeTzi9NnNIb0+rgDcr3nvDvRcQ0WdSgjoFHtYp
+          dwQ0EyQNwuuu8eD0IGAx9WMMojOXTRXr9DX9PNpO2vI9+fljw5SfI8gfypZY4efej2HzgD+9SvIa
+          fcIlbyQOFq/5tvk1F7To1lxCcBvfW32jRJseGWB5Aw7W9KNFecr3HJxticUGyzhgPmcXD55Kz5hq
+          ey+F9PG9e/ArRN+JkS02pNBROPkjLwo+fe5rvaqVb8i/eoBZF2rIvLqakW/DziXO1gOX0O8uh6/d
+          dpNlWlswV3bP/PQ6NiVzzZaK/Qbwfff32H0bT0AS2/nC7HxQ8XVArD6rp6sl96tWEY11UD2Xd8GC
+          H6V8kGO0O2XzK25neLiYZ4+NYlufhztXQq/IP7hIims4jXNSgbY4q/g4qQrib/o4QO72CQg+iZea
+          n183D+ZSIBLFpb7OHWTRggtHygnsmFaft/oV3PQKdsLghTp29WJ4C0OJHFfliuZmPs0wONx07N+O
+          Qj8m9rH84SOx72xbr6WSVn/74fTpIZyzLnRkTgtPHg68D1qCrQrF3ocHvj0fLl2LGyhhOlQxUYw2
+          rxdnL31/52tafvU86dVyYKsn/8vPdutgALeQCqxhoPRUcGdfZod4xkZ1NrPxFZexfIycmvjracp+
+          +gL+1atbooT8+2U1cOPj2wtHAzGXQz3JKf84T4JpK9n0OooV/Pnv5ueeZJztIwbO9+fHW9nnLuwE
+          V5xgJB72xM2lKaPWKjL/50YBy/z3lYISIWuaHdOs129uN2K2DxxPYDifcp7qneBxKxWcMCI6VTvt
+          DY660GFjkA8hE8xJJWdQfRHdODzDybRzH7gLErzBj6hOPztZAFLO2VgNAllfMytiQPnSHazuOoqW
+          5KRCOe3PIrH1uEY0VG4z1JbihpXvhaE9uqwz/GhOiEPHYvrVXhIOplcZkaTsLmDOv3sHKuLuRDy8
+          TGgGZZVKZ+cZYn0/1/30qGksl8Wd8/gXkfSRV/1VjtRLipFMAFhEbGmy61bcJFAXhLN71FbZ2z3I
+          tJxcIVvV0ZLAq3lbxLe4MaSSjVIo5ucOO2yOATk9YQGFrDUmSXbzbJ723QA7xkU4GRYHcTgLC5lI
+          TkwcMn906idiBfbkPZJDb37r9ZVGikyHOMKG1TH66qmmBRWHfZAA0rinz2nwZa+3VZKDwwHxoPan
+          f9cnu610/AhRITuKsyeXXlAANUM/geVu0jw3sR+I1Rc/lWv5bJLwLiho2YunN3ikhOATTLWQb6nf
+          QJ/d77AxIFdf9eM0ALrODc4Eac7WSxF48tQWHdaSR10vdhYqsn6eB2/PFncw892uguvFumG7PUt6
+          v62PPBFBJDimJWIsw1Egd/SvxNaqW8a/T3wn971BseE+Hv3i+lUFTHsKiVHdVzAX97MgMzQ7Tcv5
+          oes8f7xwcn+aS5ygFiPuTmQNNlKzIzcFXGpuEhZfrm7e4DHKC2fMmTAW/Ly+R3LpTatmfPKYIYNX
+          i6RC4oPxbUgN1PtnS5SdhACze9JGXtG9IpdnWqLZ4kcJZIdQn+hhOCBW7jgI31nUEY2ZznRwx9sK
+          mkZvvXlV5Wzt7ukqXzETY08f2pCla+LD8jwUJI14nk4Hay9AhWNajIHYh0OOvQCWoHniM+bcfhYP
+          ZSBL7fAlvqGqgBEfNw8KlZOSOym9cBDFkwWZ9ut4zG9/2pxLoZhASNJEbENi9MJJNhALiWIwgLZ+
+          kJhwTquWHNBH1Wc4soF8aFOFqLJOsjHfn1NQpB7GbulW+lolUw4rzjnjeM/oOt/SpJFOD2tPHikX
+          hnzKEw/CtH/iU5BZ2fphYwsiJ+cx4ooSUAWzPtTSRSZ2/dHADMQdhBcg28QO+ifiVHGfwquJSow0
+          bunphGsov1lnwspd+2a8WD12ULDimGA9n+v1TlgFvq7vGvvkNYK5GbEFL68bg7EtnXtGofcdlBu4
+          86h8PdacAYYd1Fdjjw+CIqI5/26DsCYnwurH9zOu95lJHllxxrohZBn7YJwSCuvtQw5bvEzxITaA
+          jcKtpIPbrSAEJSjZyQUnx8+9Xzg3yOHEFXhiFiXpuYc8BOAQMD3WAiav2aadU5l7Whm+77srHXLc
+          ddCaPJNEpmf0fOSpmkxukj6J3J7R6UtuJpkd09CjtB0zGnsyIzwzgcGG8VEo86niDhT+84ZNSX7r
+          09EWOtnRoxJfqHyo6eAFM7ya/tsTVDRlXBz4lbzht8dCPtYZM69X+WLFFna0t0AHuz9yUAiOEc7V
+          xQ1XVeRT2B9rETsTlLMF4XMsT1AoyG2FCuDtKShl03wM5GiXPZiV20uTzzTkMAZHiroqeec/PMMJ
+          dbOMitUDCufQaPHjQ56ARqrZwPnenchhadp+2mtdApOy0cnjhkk/J67ly0ZVJiQfr0inu13Kwfsc
+          OcSRzlvJLFMDWe3u3SZpI8rtGGBCThKTaRE8HfAafynkXWDP3iq+PMq4JZ2gwbImefD8DaznvPkK
+          e1tNMLoyDV1++Ld/PD5bk4ImXEA7ztA6dosnyncWLcOzCuD6fRyn5yFxKKO+eQmq4wdh7R6XPb8Y
+          VxOG7isgqW4kdHIp9QT/0vZYAYOBBk11/a0ERXHWXU81e1R8Cfzi/4GfbEY1nTbweSlexN72/zU3
+          Tgdz7Q2Irdj3bPkKAiMV94wnrg4rfXWVcyQPwkfAJrp+w5nnZyg7dUeJo70TQKuqauTzwL49saI3
+          tP18B0fEPMi1egYZ51LgQZk1DA/6UYh4o58tuQ0fD4+dojmcQUgg7I/dfqIrzyLy3qmmnB+GfNor
+          Xquv05A50iKoE0H9bsqGOiy8Xz4nLrvDGTO+Lqkc1CPG+uk59wt1VB9uf3+qaetmHSurjqx+LOjt
+          YowRc9edN3RH1sbm5x3Xs0qlGO4y5o3PxY1mo2cYufwl3H0SBCOp+ZrI+R/+bfFXzzByYjjsdgpR
+          4uaT0aMpRTAY0wMO7rFSc2PgCtDV9yZG7PDtl6OLUzBqPiG3ScLh5HtbG9NvcsdxOrwzbn12A7yX
+          2CThDopgtZt1lvdvRcbh8XzNWAkzHOQXqpJDRm46377jE+h7k3pyX0CwyN1uB2RkSh7r5A5gntsj
+          zudDuZDzA/X1YN3h9iilScnxuw9DitEp+DtPh/M5ySgbXks5XXiMHXUZszUFtgTj/ejjZKybbBXX
+          ZICqGwjYUm6cTkc2foNtf4gtpipljfXgQby6PD5MkZ9xQFE08NG8EFsmU9fD3uJzmHy0gFyc3KH8
+          XYxWOc+vAlFrr6DLu8AWHLzqQwzxcA/n8Bol4PZ5rkSDahF2r1RIgQ8jE294QJkmlBpoRU/f48qE
+          6OOKGgHKifnAxjjvw2l8WPGPb+Dz+VGjP7z8xdcuJ2rPu3WnwaUhyl9+Wh9yE4BW0ftpuVVcts7S
+          KYeOHx3I+QrWbIvXRHaZ8DYJRvbp5/KcOJD/KtsAhYPWc0wFBPg2hAzjfmX1tivPhnzn1gw7wUj0
+          qdOfDPQv84L13Q6F3+S9ePKPjwplt43VYD8aIAp2iXJjyp6O368pF/JXJ8WXMTPOmmEOmpDLsSHy
+          bL3hZQIjENUkfMkNWOjq+7LF7w2v+LhVRqdcU2SE38nEz9ipiT2lJfTXOcYmB6L+dT6sCmRmIycX
+          Qev6VWaKAWguKLD3cbWQH7xghe/14GIPOnw/MHlawGp4pp58X6OQvq+SCfmpCIgp39h+bmdXAnV4
+          00mgDU29vIzYgfnjfiPoqgD924TrGxy08UX0740JF1utDJjoTUF0QwDZMDoKBwGjHbAxNbbORefH
+          CsFYEOzuOx4s2cswIfAfyONHtQELs+9P24voihyY9RzyCNorxIB+sCfsMKWI1AO82umR2PKd1ef4
+          pkJ5P9wdcvt0MeIOUI1hfgEtPpFCCTf+W8I3chuiavIerfizlPLG5yZWuXA9PYFXCuXz9shXK0Sw
+          3o56B2nVFhPvzC+d8E9zBnUOKT6q2QcN/LndQeNh1JN0nyKwfE19Btt5nV7DOPSrt7XRD5+Wi2ML
+          pmD2oksHx8vnThTvofWU5DsOmOH9jC9LJejTKxWSH18hZnROAL3i1IH2mbUwGj81HZ5CpMBfPKpd
+          2dYLpzAJHNjE3/jbky4oPzLwTFNIvNvDCvn30msSjHCA1ecnQ9StKwVme98hh964ohkdljfc+DTJ
+          mEMDqLecgz89ZdLRoTSgD1/iugHhwxqrgFaAP4mBXmpEs0+vfvqyawU3fkziDV+n3ii+P35PnKcf
+          AXoCYwLdtMxwUNhSTR5jZkC2/EDsOlzQc/uMg9CwvtEkKoCtSefajXSVVYvkPNvT5eXDAFBHUbd8
+          qNTMYxs0XIswwQcCGDQX95sEN72ErWY4ZkwLayiD+7XFeuSKIfH3VgWL1MF/v09KoMXgdoxeRPV7
+          MZv3pOPEkrUCcjLGKSOI1JOsvElNAqjuMtq+CwtW8FsSSx5dumQoPMnHUsD49/03PpvIWifqOBK3
+          D5wJ6A3Z984gpzkcEIVz3che4Vck+eHJnng5rMtz5ZUce0TtI83eP/1GMnhq6xk9qkqOnu2I8UGP
+          6tW5jRLk7tObnHShqn/8DfZN10xyX+RgVvaMJsaPVPbo3diaTJhvBnKfezNRhbUQW7jWBE+a/yQO
+          51n63DflG/70YDazqJ6p5lowDwaVOJ2thysr2x786QkTrEu/7r53DSzNqJDj9L5ug8CVCerT7BPf
+          7hM6R9d5BUTyYo90aMlmJyw52WWSB060dUX08zIgPMfeyeu377cwt9yCzMAzxIPOtV5HIZfAxevP
+          k3gRLTAZl8tO4pFWeJ8Nz2bv6ZvQOs0BfhhnGNLg/Z2h8P22WLmtBNGJlXbwlrahV7Ywqady6d5g
+          zd5fotXzLlsP1l6CUJEacmpZhFbwJgWItfJB7judQbR1RgdcKschxxkP/cJS1wR032reVxC0bA6v
+          eSq/hTon7jcwKV+UlgN2GffG2mlps/V4ReUPf7BvZvt6HC6GJ9/z5YxNPdB79qlSBiKxb7F2sBg0
+          Ls1Tk9OI7zxp1Few5MmkwFsTnXAECjEkGGkBPBAGb/lU77f128G99rGJAp+Y0tOlSGCcwAl7u89L
+          X4xtpPdEJHGaZhGh2SmvEVy9wSb+p7TRwHdcBV+7ywEjNHr9PKKmgLdPveJTCfN+0XemIIf3IZnY
+          Ta9S0kaSLC/sHTvK/oLmpky+4Le+IHafOrnmLwPaZ96axk3f07VoUph5DMWaElo9aeKvALd4wtfg
+          atE5Zb4F1F/HHx+h2adPBQYQPw4JdmGtL/ZHNKHGC18c17Weca5yjkGhdxLRb5xXzxl7CcBLPUVY
+          vwulPp8JcwKXw/GJjT5+hsQo2Ak69ZcSbe8ZOgPE3Q5E3yMk5sYX1vxCJug1w4qVbq6ywQcyByTu
+          dZx2t8c3nONXqcgbX8UIwiedA3s8Qf5cTB5/H950MfewAGxnD/jyWLqa2lHbQCHrDeysTlyv5VXs
+          oBYVzET03O9Z+rowcm1/D8Ta+NSMpw6KxzQScRQnW1vebYzU4xkefvpUJxu+gueXhlgttS8leZBA
+          2JoPafOLUvQdUZNDd7EF7G18hmH1IpKiI22nXaPk9SrsggT+/BLrHSLEB+9ylUVSnb2lD550EdlP
+          8dsfoujuFVDv9JKg6Jh3bHJ2nr1hOq5wQJk5ifnVBkO896HYcmJINFVywr45nTiw+TNeLz0jNPtV
+          G0Dgv8/Thwn2lPTpzMBkpv7Elu8468fv15Dvc+wQJxjx9qjfTmCZ6B+CplSmw9fWDPmnLw0sgL5G
+          BMeQjbkdNm5vls7aJwpg6jku8bTDoeed2v2CHftp8JEVVMAsnsdA9apz2OaXIaRFqTjwrMk1frzi
+          F12L+FtIG97+Hp3q67F+NvLFiixvzcYedQdS+9L+AnhvfxpaMCdK5cjFx5ymdvOHtlk3Dry+H/SH
+          f3Xz43/3Ovrg0ymu6ymN4gpu/GvyH1kTLkptrHDmK4+oSv0Ml/KrMfD29NpJyD9av6jxNP35CUqE
+          UMg8fMDB1/FxnyT+SfvPxr9kuu81TwYfo/7xYTk6Li32wBXR2Ra04M/v8GhwREzJ8x2E58NCvCu3
+          ghlKWQy/72DE5hL5dHqlcwptY9dONA92iOSDKsi/fB13HKaTai6SdA/dp7duHe0GKIURdPS4nAQ3
+          aOqVPwklkBf+jpUw8tCIcrzxiZDD3iz2+hKW8AS2SVbTimq1nqzTK5fRfBQxehz2YKly9SRnPZeQ
+          ozWF/c9PkUvwfk4UhRbl6OWpyeoJXfExP+g6A0Yr/+PzVnCc9SWZEwhHLSDTbmzPYPEP9y987qMv
+          ifWg7jvXxYwYfh4x8RDJ6z9/8J1gGyPTuIWDW4IBbv4GUUtG1Vmtue+gm2YXojnJmPVidd3BqBEi
+          D7ixgfiQgg7eIry1cbbEbKhNPYZ1XdlEjcYTYD+Bm8PtvBIj54hODofWgmT+vgmGs9UvK2okuXo8
+          WYycSsqGy455Q906stNc+j5abLUzoJ9IAbYY5pEtrt9VEoL0hI/7KqFz/WCCP39v41903X/FFLxc
+          cSDa3gnq9c20EazDUJ7WsvmG9Fh6Etz0AUH8WQKzW9JBQm2RE+Nrg3rol4cpbPoGH4bRqZfomVTg
+          XfSJV5+Xls4/PX2pPGfaycozXHBxXqGqE+vHx9H8BukqpZ7nEpw/LMp9stGDTtx6+CB+IHj/+PTP
+          37HZZM5oBfYW3P4fOZ0/u3oQg2KFP/2O8zufLf1kReB4wtSThGSmzJETTdAdtRs5vO5huOnRCmx8
+          GCN4are2zLcCjMNpJT9/fEwXd4V+UOjYDnoV0TgTfLDlR5JUZ7GnA/Ocwcb/vCBQq3497S0D9sen
+          SJQyUGv+GYFI+vHj2xiiehkujgO+GqF480NQ/3k5EP70sMdVSvjTv2ASe967Xh1maxqcveFgmcnE
+          UvnQdz899vNTMK7fYAxCRwBP4lbE+zLvcHbCLwO29cPah1HDWdlDDYpDMhOtQgNaqi//hVq6XWlc
+          GC370y/Kjew2PIf9Mjy7AGz4Ni3wfNV5IKtf+dU0Fta4C9tT4lsRNBAPp58eXk7sN/rT+2l+XNCs
+          uuYOXPOJ9dbkofckZlvvD5/9T9nqg/JGBtj8aRzcI6LPbGdPPzzZ/MubPpvtrgM6wvHE03uE5jbO
+          oRiLoTrtj0WFfnwFNMqHxeZNgP2S37T0r14hrYOF5h1oSliMlYxxh84hfzSlGHSfaCDujh2ypRv7
+          HThhXcQnaRnovKhJBB5R8nbBzPb9Wi6eAxTfOG56PMjG/ePcyW+1Z4grUYkOwcku4ZHx5Ek05I8+
+          L+kgQNWfxokUBtCH2kQRDN1PMN2fzAHMfGFp8PZ0WpI3paevcqZZsNqanhiZK/aTEoA3XHYPGdvp
+          fKCUC4EEt/jwqEuScBYKyMGDE148gf3aqBcvz+LnF+L7NHH6bLCohEGHCmKtqZpx8WAXAE/A8v4+
+          38+fgVGUTJzvHerlE7jFT9/+1SfGbjy+gWSnF0/c/KJRxIoiqyHnTcLlaofc8YoqaDXfeKsHvHRa
+          Pm/pL78Q6yNN4MevQJn5Hv75ZVt9rAFBzMy4eIBr/Vn4spJ7Iz570Px24XMAmSflFfC2/dTQInzz
+          Btb5jmKnUEDfAq70/vKzjbMPmBfP48SDk2YYx+qHzpkKUuidUwObZYIRG19IADe+/lePGx9p2Pz0
+          6yTzL4pWEl4NsJ0Hcjy//A2vUw/ImaPgLNOcep5eywpTISy8uS74epvu28jLkWTe93y5Aprc1ULO
+          bfVEAsIz/eL3wxcK/Xz6BwAA//+kXcnagjgQfCAPskmSI7tsEgREvAEqggKyBcjTz4f/HOc2d0VJ
+          OtVV1UmHeMS/VHRWuwD88OinT9my3XfAuV1j7MQnWaUHkiaAE0EyzT/+MzDfFdyR/iZHVbHBTFzU
+          8QMgNw9dozBb02OhIO/KhER99KK6rLszhO+Ck8mG3+FKJ7YG8cqsGM/fNRyO3KLBy8VrNn72qpZX
+          9l4hl350Yljzu19J+NSAxSbKtPSBDNh0Oc3wG38kjFEpUVa+qgYSALri5D0cQ2ZulB2yg/uET9v/
+          mQI1MX54iK2a7fplNCcbIlCEWG84ks39u61hyNe5N5WxHm54bIMK7z3yq6/MPrnOf/pgj8qtSc7N
+          gvCH79KGB7989Oc36L3GO7Ms+Tna/BvsufUNUJJzDIyEk4LPIHdCpugtG172Wocx+0Bg/BqtDRtn
+          Vb19Q150xpGo/Pg/UXe7PhvzT/FAwpo1Hver7/DHO/OXP7xdo6us81V8lPbhYeovt2s2pEyRoz56
+          PfDPb1uyHStBQ/U1rHwzPdv03/rz97DbT2y/8RkBhTupx+G2PgZF1v1fPZMoJXqHa/ryISwcy8SO
+          dr9UdLcwKwD+e2tSkTt0gSowxfl9brBEPiewbvUi8MvP9q+e+hn74q++dDzqO5X6e6lEW72GyGuV
+          0zU6X2cYk0IlsV3tqsVWYhE+wlnC91Nrg189ARqSeifetqFs6cYK/vQWPlfeDnzT6+LBc51dvXcu
+          V9X6+rgl3NcKmkSrPFDKPtk3+jD04s1yHW31bFaAImbe2AfDW6UAWS3c9PZE70ZD17fUa4fl1Twx
+          vpx2DjGGN4RbPR0fI5pknPaCCvjji2EKeiJxrg/jDwx/+qZfEH9IoX7zRXI3kqVfqm8uwYPeesS6
+          FkO1bvwLbv7O1Ez11VnV6GWjn37+8XVaX1cDHNXl7VE2UAAj6KqAroXZkeO+FOg6F+cSjua0I/hd
+          QnV6Xu8B+D9bCtj/3lLwFNaKGLd0ppRYhwCsH+ZI5HFQKjb/2iWUovpFrADp4YyoZUPf2roMnD8W
+          ZVRQl8ioBJ5oQyqHY65mEMQI9Z7PsVLInIV+ECfk2BgHUxZyjCfM8DhFOpaXuwZWZ+0luBiT7wnf
+          WcuW015OYF7PmkdVK1Bn6g8+VEcnxrK6DP38mRIRHry3QZ7ci+nXKGoKKO0OLdHf4tdZrgYsQaOU
+          JnZ3wsdZ4JSUkIIiIpKiHdSFY4sS8rVUY19ODJWie5KimsPOVF1erUqvh2pFbbPdhGnvlIwhNR9D
+          YbmEJHzco3A58u4KxWE2sKSSIlssMoqQiNePV069nHHP1vegM+UcjnbzJWOc+DKhc5jr5Pd7c62J
+          Irx9viq2sLvtUq5uOZjFLPQoh1d1BpxQg6cwV8TX2Syjo+IUaFWFngTyQ8rYKhgFUTavAbZYnQ8X
+          Nt1NsI5CQgzrdslaz9ttsr4avd0DmhlHb2yJjGaQSeLlpbMopKhhd3k8sBbxcsij9m4DvsT51Kr1
+          3I8aNXIYBq8Kex3GDvcC9gTzY8PgY5c6v/Er0D0t2WmP+xNYHvMcoO5dNkThuT5cd6WloG/xJcR8
+          uA+HtcgoQCt7e0Q/gme2xcOEDrWpYCca9Gw29gMD63NZTfye9TLWVQQBpu0dTTe+xyFn+ZWIVun4
+          wrrMaj3f9kEHRyvqSaolD5V2u5MJn/fb3UM2/wDMLz4ZyUPkF2+rnVsalH1WJ8+kEbMBNj0ElXL2
+          iZFe1YzxR6+AdHg4JO6Oz3B9XXIT+iIMsJc5hsPwzV2D7WPtpz2BSj/npluL1f7ekWOw9RWZ0kOK
+          PHd4Y5951Co3xtKM+pN0I2fFPKp8WvkD0sdg9Q59FjvrqddsKN4EimOFUTP24xwVOIqRT865Ivds
+          U8opzFnuRLyz+q0mFsAOPvfRAZ9Gfw7n5/XYweaLILmuB8WZFebsoVrJU3Lat4YzW8JpB6Ff19O3
+          9N3tFNYcIEA+Ejk74dkZRkvS4Jm5VPjEZWI2XNNlRp7IcPj6vScVf3IVG34v6Ux08eKGLHBvKbzY
+          lot1eLec5ba/vCEruyVOlUBVx6QFHcw9/0ye1fAN51C6FfA9Dio5nj29Z+83JMLZaEt80hZNXcLA
+          ZuB7/0omcWkKwH9l2ILoGAdEOt9e1WJc9BbMCpvg+/c5Ocv5Xed/8aeoVABUga8ADaJfYnN8GRUr
+          JbUHH06ZYk+jc0b3dhSh2lJmjx1vksPHIfJgN0IfG9GQOxxR3QnYDbN6n8Jlwr603A5agfnBcSu/
+          q3lHzhPqegNhrLGwaoWTM8D0LFnEEKbQYcbq9vjFK7YSE1fcRacx2IV3j6jpsDqrT+wHlByTJ+d7
+          f3RYeLgH0Al82SvtbxfOPzzYxmMSvXMO5u4ZmlA7ZOJEa9iHc7hoHJwUAj0kSy+wTEsWI+WQfHCU
+          3z5gZlzIALQfcqxdxalnJIMREe65DKv7NFc5IXVTWNQiSxzneQtn6WUEcO6vNs5HT1NHse5WeJl4
+          BitfNPTUOMIdpIvNkBP+0H697vIE2sn8Jdmp4RwqfWoRLU8deA1cZYfyl2yGbLvesX71G0p1Z0hF
+          LSIBljne7dfeyyTwduZmo0w8mBAMEmjqojwx7MfJmH1f+mh6iS4J5cKt+h/ebs8nBp5xP6uX/Q6G
+          6j0liYzjkAuavj6Y+FRNn6vfgJXx5hVdn+C4WfAMpW66iw/e63Yi/vkmV7QRPQ7eGR7h41weKRPj
+          6A0u/LWZ4EmUweLStwu28fTWXDuBWRqqB7I5AZBrKRgV/2miGD7OtoiVk/QG7OdbBOiqdRa5n6Cn
+          UlU4cABEsYJtZRc7pIpeDGI06Yhv5pFRacLCCMr62yBn06/Acsj0Go6z2EzNC7/U1ZALDr3WU0lw
+          ZH8cyu+W9TC5zoco109cUXT3E/RkgT+V8FJWs/G1BciJ34J4zzbL5uSIBviHr61+d+ZtPEEKLj6J
+          ypeSsVKzcmgfPaj3ktMgY3Y6GAAyzRex76yqMn5pzdDQ5w+xSt91tnji4OHe4Uk4qI469scp3yyE
+          YhJkzGVLMKstrIqsnKYtH/BJVu5Q31xf3i4yeGdc65MEXzJGWxeUq0pOV0/44Ze3Ls+zw7GxZ8D+
+          pNwmATJjuNiXqISXiWXw0xH7qhd6dkDPwl/w0U4YdfEIMyML3gcS+9gAw1IVMbJweCa/fMGaSimh
+          faoHOHHMi8pflp0EYXhd//B6rfnOhNxtVkhWKbds3eIPIfsw4jA4ZQ7rKrMAi+rYk5yZ256mZi2g
+          XTEp+GJdv87ivQUJ5KusklhQCpVPUWfA5H4sp0MtexnzKekAb4WylYwMDbDda89BBToLMbrjPhyM
+          /cDBnb3PvPeLjtVwD78rfDq1iW8H6jpkt9trMOj2jcdKQuBQz0wnuBpfHt/E7SbnNWEitDBMSbzX
+          LKhUSw8SfMPV9WZlHSnd23kMud2jmxax9QCPzsCDPGsQLAkgy1aiugPkj2JEzl1Dw3mcYg9JVdtN
+          S67I1QBP6RuqWv8mWM2YahlCtQV3mJ+JelLOzgy4uUaulIQ4OMiXavH5skAPbad50GaDfmm/j0Fk
+          7dbB4cx2Wft73xK2M77/8OrFPGx4fOkBdkbBBswYuRyEnYSJurxQuLxSbYaPAqvEOSpvZynUjoFl
+          cWWImRhqxnHCyf29jwd9RDJ6PEgDSu/ebuLC1wKW155G8M6wCLvmQwiH7pmZcIsXLIGA7cmHKyCU
+          oxbjozW81LmXgxg9i2DBZpfz4aKdngK4SGNF3Ni8ZdRlWxtdF+ZN4t/zZeoroGyUszdnOxrS/WwL
+          kLnwOXFsWmcbP5yRuGuyaX+hXb9eTy/tF6/Y6LUzXbdGu7DBHYMt9Pay9cw9Z+C32n6zsL7OEts9
+          BEDDAKt9J6mcrMspGvQ7xVbVUUBZ5RtAD00WMc1FBOOWP8Ht06sTg7dTmGNsrrBvLi9y+eFv82Rz
+          yJ9KSiQpC/vxdmskMQTqhUjHoqzGvdv6MA3pZQqYt5Rt/9eAUZxkOKQCX1HG8CfU5QqDsSP2Pz5d
+          QnH3yYiiHj9g/YL2Ab0GVSQjQVD94VeAGBFb9a4AP74ppva1J1ILX9X8CYkG1SyWyfmVWxn7PKY+
+          OD5OO2wX35V2+vPVolfl3Aj2bwpgN76PJjq+8AnwKmBu49sHbCjzBPPbqaL48XV/eD7tNz734/Mg
+          Bt7TE7ToU5Hn8zrBs61k3j71n2CdGf+BMPrORPcPY0/pxRXhzps/+GZpRs/qJyGGG98lppdvW7h6
+          14bb53GYXK50kZqVgbdjsZBkfkcObfu0hVgU3153/nzBUr3WAm1824M0liq2jO8RYE/ZlZh++Azn
+          1i1aOPPdceKZ0FbZfrwrQO6CyVu/kuisrR0NkOFXgXgTUgEFl64TNOfckutHqrKFNzMD5sQhxNjw
+          Z5EUNwDHKda9PfeKqiUEBQcby3gQxV8ap0VUtuHlBGNyu+mlOr8eKP19nkgvC/VjexQkWI51g/Gk
+          oK1hv2rC7txH+I+fJYLpwx9/VN+fRV2MnrzBTMyIPNRbu423X0K96UKikbtXscuXeUCP8QtyZMLO
+          oa407OCIgex9nUwCLIFzgV5FesJeLzDVGL9OIszvUfrTK9nGB1L4cbgLMbxj58zHT5jDm1DG3m6o
+          rZ6mlT8hsd1Bks9KCOilPviw1nG95UvdWX75bbe+rtjlbp6z+klRoIV4Cs6H87nnf/GgY7v44wsL
+          ixeIgJwTkrknLxwXKc6h+YY2tj4aoLN+HyfYzpNJQhHVlG7fR2GPXOz4QFVZa7eWcNNTRO27wiFC
+          z05g3nl3T3M6NlujiBRg5zcAG+VHBNQYqwK6r3CZDk8HgpmRBQOsE149VF2XkBhwttG+KiHR7+wB
+          DIPZtHDIbR/j1in6rlMQB7987GIjU7lshIe7D7qHeCRKUwcqPbm2DWPbE8kJnR26mDlIodnVX/yb
+          7z8+p8hMhxVDaJ2pej9dSPnR/o23ujxmIRDzetWI9AyKcC67oP7xYXKKM915X0JNOnSiYxAlCZ2K
+          2uXdA4GtWThKlT5c65fkopdAhW38pw2/Swb8+MES4Xs/ZNKDgf7UX/74ydrc/RVNt+RGIlvGdPzp
+          1WOWr+SqyQewvveWBMnOJtNM57NDibUE8KevpN31Daij5Sn6xZ9U3LuKFn5VwL3HhPhpFypYUntl
+          wFpKCF+TuVOHVVQCND0lgaiXl+lwkjkzKDneVXxXvsdsLLymhtwHCt6oLW9nPfehApRD+sHu9/6i
+          VIfXCW7xNM3fNqrI4O+nnx4lW34N26GRtuP7ZwtLUOqqVavOBqKnRMFGXL+c5Xx7DfDb+ipJ/PCZ
+          rQE3uwfnmY7T+sFXsKa9sIJsiFksn7q+3/LtG8V34zR1qSZR3hirEu2KQcE5OJaAtrmhAAs+h0k4
+          +wsduxfPgFo/1Vhx1TVsg0cQQfwJ9Al6NUPHCyPvgLAdsPBe2sch6XR/QOdAWCLNY0VXnrnPIGeZ
+          E8ktd1SpPa4p+ukrK52OPbO7mBHcaTedHN/BVM37vgsgvyuT7Xm6Qx9I2MFQGjycieZbHRXS1nDT
+          P1NnMU218RUFlOkYkdNOXMI1qhgTNLhl8PFhL7TZ+DKUDzE/veOzpbIb/0DgIHX4seEFvbmPGBoR
+          M3nspSnD9XY2dtCafR5HO00JGWcPhh8fw8biehVr99xD/OmzX/yyZuu/EegXzqsM75URjuY1yNj5
+          ieNoyNXlm3YF/PE77N9K2r4ebAKD4Ml6o6TikPK7wwxT+9J71NpX/epGnQt9ND6w2rSPbNPTPvyO
+          QkkMDUoq/5HHGYavZvAWrIUZq/YHG+LXAxCM+5GO0b1VoKM44gRuVtqPjlHEgIIywlizvtWs7O87
+          ED7X2KtC+1QRkVY5HDAfTrAxjuEvfwNYYx3jJzg6cwF3HkzSKMa4uTvVekSHCLrZ90xs/eL3syXo
+          ECG5dqYDq19DmvtRC9UuscndYc7hHNWShqq3O0zz6bqnMy9PJaTP05UYn65TlzK+xD+9Pe2K2M+Y
+          9MtwwDS/J+zXjAbY+WBpP/zGhuT12aZ3c1GM9S++Bnyvjo9Z8GG3px/slWNX0ct1aKGo+RHWxH3o
+          kEq/u+AyGC2W/Jw4VDi/I5Tu7XTa8L+ar85owqLSe2wTeAvXkEozJJLy8IQtX2/8cwJ24Ib4uGen
+          cN5zjSIq3j6e9oKAnXm0TE0UAYf/8Jr+8NY1lBUf0SNS+RhlHvzxP4OPHGfOMqlDryI5eYucruF6
+          rI4F4lmNYHkfq/0yh0EJb/FbxB6rSz130UEMLoPWbvxVc/hg5CcRo37GJ7M0skVcSAnWtgm99YuG
+          iqoq16JJDHli3RbWmc7cdYbc6a5PcN7X4XKyPVdQi91r+mKBU5emtBK4ExwOnxjjBcYVThBqLwlv
+          42lXk7KeAgjzJZt2KEycdXzpBVpOfo0T5hJnbPs471DGrk9iZskUVjOHTHicrcxbWFFUF3rdTjlf
+          Cx5H2/rjG9FjoFJXAZYel5Fu/N0EhhsBrHvLDKjfnZlf/ibXaN/Q78Z3xImSF7HnbgrX6y5KES21
+          ftO/kUrFW6r99LPn5J5FOVt+Bj+/lGTtQ1U3fB3EeLDjSXTuo0OZvubgzz9QgxNQlzUzA2hH+ycx
+          aGUCfuAmH74i3Sdu8gzpXIZzC02zP02oLUG/hqfAQ6lQa/j3vlNGDQMIz4yb9k/QOIv8dhK45c+p
+          cM5vQI9hYEOyKOp0CL9JthzPsQvhWijEvzU3ZzYBm4ANj4mdagWl3M1xYZ2JKnH2pUM3vlHCc2uP
+          REtatWf3kwfBgfUc8sPbYX9OBBggTsSacMtUeu2uNmzmLp2mxt7TJQ/aGm5637s4SFYXVxFEQCjF
+          +JSxA6jR8emBVHhrJHrMksqxjrXhITcR730MquXhyBPwDafCVoA+2bL57X/zk2SJl82rjg0YCoFF
+          fv71KoXovfXijbC5BC1lwyFywagOLrls+Dq+mNgG3/djuwe4UMHGV7d7FNCVqIfo9Vt/K9IjKmHM
+          snK/OHzWgdnKJqIzQOt5Fx/qw+Yn/vHRhYy9ABUzkybGI+9qva68B9SzkJC4eBbq2Je+/6ePjPB1
+          Bgtwbwncrx8dp+CB6KRvp3wNNwZTFb3Zai61Qfnzg8ywcVXybSoXEqNmyCma72DJ4kSC8GpCon3e
+          mK5Ocm4hOtgGxgSW1TyvUQnP3eGwHQHMqqGtVwliS9yTY9yO2RzFIAcX23GJcTwL/RorjiD+6gvS
+          Xr1SLuXYAm5+tbcDh9mZWeuUgD2XYJJH01KtL+NY/PITuUsqyejhLhcwcNmLh5RvE87+8bqDyROy
+          WCJKns3tdUzgx9wr2HWxWK2v4hDDnFgEn7qTQtkwsDnYcMFhmvWtK92O3CZwXbi3x4xGlK0HJ3HB
+          z//X1gI6VCiEHfwaUUNC/1hk06+eglv1jPXw+amotXw5eM2PyNN2mrIdYeljKLDmHYfL6x7++X1l
+          cWHIqTFpv2gJa4AMpDviNPOk/vwp5F/wQFxcHbMhfrxceLnhC5adcHGGpWoj+HGYC9az8e70vi/l
+          6B7untOh9Adnbt22g+P705GczUG1dvxBARv/nJbNn5rt722Fvppc8W3Dvw+5WrtfPBJ8zX1182dE
+          +BqLA5Yyf1cNWWZ2cOi9G1b17V6B5KpEyMS4Ii4zmz0/nn0TjvggY8XCSsWkB+sBwq2fkSHzM12n
+          oZxgfybKH78hYC91P79gElOtAKusywmCcnn3+OdRC3kzbR7ipl89YeNzY6LqhjghyyY2FJt+jh8v
+          7zCLt/CvXjTZuazBN5xdHG58YczvnxhxLed4B06x6GIqnSQealsheMOnsXvt/+ofWPKiIKMX2Z5+
+          eIOVXXbPaFolE2B3CZw2P1vlDSjYcNNnf/UDXlV3HVx2voMvSUfofCAKB9Lj+znNclI7W30rgZtf
+          TtLEBrRJsm4HOFaVsQ3dla4zkzz+4vHI7O/qcrqlDKxF5TJVz7QG640UHvBzTiJPqzqHU0jNGUoy
+          8YhWnS7h6iS3Ttz4BT55B6lnLiqfwuPsZPiovrVwjO6FdEDl/Yt19dE5Sx0PHigrfCTW8fZ0lsjL
+          0h+eeAD6BZgNBndQqLWISFu9jF1hvQOO+0qJE1w6uirybSf++Cdu7n01DqHTie9GrrGz+9xCqj7a
+          B7yoNTcxV9HrJ8p4AtyZ25Z29WE77G+8TyY/eMz2CqwwyR1yX+cFJ1s9gXsYN+Pnh271hbqa3AnU
+          QKq67le/zH56GM3EjrDX2Hvwpxe2/ON9qy6ktJqoB5ENRqK8HmxFiHXw4fI8Am8YRd6ZUNwz8GxL
+          2balXQq5bXzhjx84KSMDloeIgR+anj3UHS50cD5dBOl0LnBafAPKjqy9wiV5fbBzcM79kgdFDX/8
+          IfYocvpffGhN/fH43tipw8/Pg/VJx6e3Xofzr94Vvj4Dli62SlktYTW0Xxud4KRJww2PIijpReL9
+          8is9nKAAhmBq8FE+2c4cLi4H0cBb2N7qP7RcyxZ5H/eKN/wJR2GSW6TJ/J5IWDmq1L4mOZwmXf7z
+          b9cjWmIIU2h4l8t2r+r4OpUgWFod55fcCOc+6wcwXl4vLN/7xlk9f52hN7XS1tGRrea6+z4gXys1
+          wXTUKFt+XhC282CSX32DfcReDg6s6+DAEEz15wceNj+cSDH9ZnPoxD4K3YOK8+vyACNA2vSrz0zH
+          nWvS5b3VTV3G0Yjn2F315/c0kMUeCmOWDsVyyME0wwvORXsOV5iGAVBczyYn9SKGf+ttwjuCt/HM
+          Nj/MAMtlvmHrnZiAGatzDuVRFb3dFj+Es3ZvaDVUw5t/1m/+tQ3fKTOTJ8DfbLl7iwlYElOvbOpV
+          XStlLtDGl4jjnqZsUfOhhHqXPclx84/W6R4b0EBRgd0yWfs1J48WDift6C0of1SzFvspPIcPnWgS
+          9wGTkGrJ/9pSwP33loLLpy6JHe+9kPl8cgYszuGJJWSrIeO9tRQyvVYThb4XlZTSUEIaBDI5niSL
+          ssFz3UFY473H+DtLXQAyZzhE8dFbAoWrKFv0PpTs9YElhgp0/hKJgaMRUaKIjxKs9cL46K4VK7G9
+          pnZGI6xa+GZQRcyneezXiZFMKDxbiIPbUcm47qwHhxc+yER5fAQwG17kw1dWmCRXYltdme2qdCY1
+          fKy+70v4LQUjhccQOETmv3lF9/VcIn7X1R5A+30/TYxko6KiM5bLxcrW+TSVcIoeC3bZdcnorjJq
+          SMvVJTlzz7KurI+16HRJPDHvwuznu3i1oT7twwmoRe3Mb/cEYS8lNb453d3hcompIXVeO/KYs6O6
+          RtIZwvRwdomK8m+1+twowEg2OWyE81Odvoe9Ak2eGUh8OQnO/NxZGrKHuSKJcNV7dq3qAT52s0yc
+          88ela9CoChI0lSPSnj05q/RIH5A4M0sebnDteenTldA5rQdP2MZz1qvvCiNjd8PSp5BVzrfWGZrD
+          6eMJCL7UybvdW9HA++8UepKSsYtrGdAz7ON06vpz1l+sckDVK49x3JwlwLqfNIUiPm+Net+ZumTe
+          qqAmLngScXc3Y+xUguh2ufTYuL/Lni3L7wPNnKJP4ykP+9mrTxqcvfMwUdq02Vrn9QybRlWw3TS5
+          ypjRI4a1qr9wrsuMszaWUsJgd+pIVIKBLsO5KGDvNIknnNSXwzgm5AAzC7bHx2OrtjgoGLRa8pFc
+          X8Jdnfa8Z4D6NJ0n5ote4aqiKkGMVevkHtUdXavoLUE0wiuOGifIuG08oCK5L4/NXTYkT+E1ifTM
+          jgSXpeBQ5LQ7RM7vG4736ofyxGddWH8zTE6y5oSseRsHKBTfEG/zo1LiI/dw2J11HN+HT8ahxVUg
+          aIsLSR+yApi49gPIYeVILm2/XQW3z3bQXuujx5J6oaseizE0+EEhEb+W2QiAacDjd5ow9u9L/12r
+          egLi4p09IZPelLDOfYXf2IqJQQ9TtTYUQpgHDfJWfqCgnZO7D7fxwck5NCqmNFQRSX6tkPDmXMO/
+          +MHqtZ5oIyXZ/Lr5E2icWMPHJbgBkt38FX2Gc0PSJG9CGnMXBlyit0tuGu/3K8/1D3j+3HScRqdn
+          T9y0b+FYPnQPJn2c8T5WbPD+zjOJQ15TueCjxFA+bFfdLJ4GOGm7aviR5CG+fU0FrMOQcyCz6NVb
+          7L0WMl3GKEgAV9HjdLHI5lR/+aiB3Ad7AiXZPCG9Q4n70idgGc+eVU/fN8TsWk8lifpqnNfVRsdH
+          s2IscHVFT/kQwz88CK9uRdV+eENN7yqi9rhwWPt1VsD0hhB7ps1QaphQgICOJjbMcXTWLJJTJNnz
+          g4SSu3eWRgccDKPXDbsO0CteNxhXfOleuuHNNxvzWvKgh2Ds8cdsUtfvOzAga9A3dvdP0s/taNro
+          hnP/hycqFYcmFTW9rcjF7C6AG+QuhVS+lBP82FXFXW4Fh0Ci2MR7vpeQskUVwKTtrthvw5Eu4Qt0
+          8BLVLrbP6QrW4yoLMGgOkBw5sv7wYYY+erNEUt4aWIvS8FAaPEOs7KY2mxkP5nDXWxyW7+5Il2kS
+          Vnj9jC6W28cRMPIVGaA8jIh4HeeEy0NuArG9PZSJZqyatbSUfah+qzORsEZor0rbxQsWe8Oac7Z7
+          jpmKCfWN+yT5un9X7G5EEYBQLSehb4N+KY43EZ5IdCI+squQe8fbqcFcr0hWX1C2nHbfALCuAbHj
+          m5HKyKPyFomQBlg1diewlkEVwVKJFJzVuZKxwgMH0M1EfmKdSKbc0+Rj6J+fb2w4SQz49DJxMKFb
+          I8LdyQfrh4AaPv2gwna8n8KVXs4MalbMYpnhZvUjeu8U2I6vEF9Tsp5Hr5MAt/WAY6e4Vcvn8pjg
+          6zJ8yDM0QTaHliT95pvYS6VkTEjFHFoMjKa9Horh+o6HAR6C2iQnP/6E89QUA+LH1veWvaBlI22S
+          FsJMdYlGKrFfjLDq0Pe13rG1P32z9cmGElxkVyB6oq0V3TdHCFk5vXjcB3Zg/ohdDAc2vk9Dj3yH
+          MaV1uzDCveArGR8OczqcBTQ/XWebLwy4T/JJUfntDOJs491/v68csNdBxXYUvXvqqPccWmbEe4wF
+          o55Njt4EP69GwvZsfKuW9KUB75eXibf5y77TJMwI7XbjRCfFpXz8PLYIXvCXYKssnemjyzai1L96
+          c2xoGYNbfYbXJQ7x7X0A6lo/fAkBecqxc/4MYNUns4CS/1bIRZwth/ffRIMbPuEo7ZuMbe+2AsE9
+          u5HI5epsLdFlRhwYM3xJm0M/B/rDEDe8INfpaofMpZwikC2fxistts0W0IAAjmWuk2fWmD2fZ+cc
+          4FsfEaupGmcNxMYHN+16Idt4VNOVEVKgvk0FXyn8ULo/VxJy1Pru7em5AzMXsMwfv7n0D+zQJeLe
+          iOb53btdajXkEhYzsDglNnGPtKSLKkTKH19wV+HZ8+6ERZiMrwybVXJyNvzQ0BgzO3J/vkR1zu6G
+          iEi8b4n66d7Vmse2BvlrXE78uDV6h18AYSArrgcPIuPQPn0o4u0JM3zt8LFi9fZgQvFi7LGT2WY2
+          fUHrgxF1PHYn/kWXNzyucHs+NotP8eNr9m/9YmU+NNli7GIDzuxnwdv4qGO71hAe5O+X/PBvhqdH
+          Ahaj9L3dA2db48WAQe46Ldir6w9YzvTpwtlK20mIBcVhm+mz4bGZEPelSGDmOleCY3OxPLbIRTCg
+          sxmBXvBYjE/dGzSx06dQqUuMj2dzqNZvna7wN1/OHbHqUD3TFTGWs0xMdkgyRmP1CLTvliVSbLzD
+          2TEZBsUHnZA86bmMpAOSYNcZPDmKPJuRw9XOIfcsg2n9El+dPup1OwUZHLDW6Zo6O0tdQxOZmoe+
+          cRb2W7xAYjzvWN8JPV3H9BDA/TE0sX0pL/3643/F8d0QfL2q6nTAYgrIub5hQ/t0GX24hgL5NhLI
+          pfGsipUmvwZfQXNIFH4D+j241fDLf0SJBLGnsn+RoMXsImzduRbMu9CSYJmMDY4e1FZ5Z5wfaEFM
+          RGKRStnCxm4pkkY4kvspp/3yYk4KLHZCT55WWarz4RjF6IYf/nRGXhIOp1Id4DlKtw7UG3+HezmH
+          nHa7kvR2kJyN7+WQ3R1bj1/sq0McOZ/hvhI+5McvGe2+N+HLz06epCmgX56TvYOJzD2IugZBRuHd
+          LaAZx84EWCKqJLhoHlyEEmLTkN1+CC1J+fHbCeTk7VBHvTygWXMxxqIrZsu8ijZ0bomEHV7zHU55
+          RwX46Qs7O55V+tr1M9jyJb440YuutNutIqxNk1xa+slmdL6ucON35KjN72z+4UH7NjvsRd2e0jtT
+          ROht+pjc54TQ8fBaXKTA25dgZlIpc3I5D0ZCLhKlZKSemn7rwiNRjGktbKZfB7UyfvND3B7Nzkqc
+          kYMpRQzx6smsGA75DETuaySqwvXq8JQsDsTGWyDXVjz3dG7VFDKp5pNH68jVLIV0AO99HU6r5rtg
+          iWW3hRPwO5zd2CCbvzcaw2u/XQxx1i/Zctk7AnS2EpBudhe6kPmQi2AHRIKNmapz28cizA+cTZSD
+          5VJu3alveOPmi8eQjAdz5EgDmp+e4/34FZ0DJEDryyb4KERTODwlmYHvkxVOrFaG6gKDcQYKHi4k
+          5Env0JMlGXDjXx5zXS4VNUHQId/VIvLhuWs43bzHDP3R6Iix6Q2+U+YUoXvuenx1os6kywMDp9uF
+          xQlic4cJ87cPtB6eib0eOGdRrMJF+71+JXnmoWwESJohf41KbEmNo/Lp1TfQb/xusCuzdtNzSP++
+          tenyWny6bPkCsA0VifeIpWzjY6a4fuwbVsJUBZyRgkGcZ7fE/q64Oj+9CNQ7E+IwrLN+NRKqwPfU
+          MxMZrodsvNEy/eEFsbf1MRph38L8Ci4eL+4FZ9wvu0EULcEl5pQ9s1X1Zx+WSqwQvX9gdXVqnhGx
+          2HfEU9chpOVoukBNCoAdby2c+dnSGu4DAWP1Vcpg00+RuOkdovY+oq0Bjgnc+MEEJC5V13jxHj++
+          4bFtX1Y1UHwXPqqvQaQwYkM6lXIEQVtesJoWp3D84TEptTc58cErW/B4N+Fsinei8eLHWUt0n6HF
+          Pp5T+2ZrZ0XGrQaP44shhsliMJfZOUXrx7yR848vGn6+Ezd9M6FND1K+/sQifDI3LK+qGs7pmqdI
+          TJMrdsfSoWzkNyXkuNjFR++u9KNA81n48Xdd5y2Vic/Kio7hTZqq9/2csdRXcrjFA/ZHwcomoPge
+          8gzz+KcnFuFx9OE1LW/YVu8e2OJdAHc7vmz8f+iH4koeP/zxdhvfn5Zz8gCb3t7+T08pQ2cDVf7O
+          wWqPJWfTrys4dRJLrk/dz5r0mmhw9bgOe9fIASOnFD4cTCJhOYJmxpNaGVAnfhRs6GCn0hadJjjc
+          Ts7UXxW9XyJgl6A8lYy3tPFHXddzI0KSh5JHw4dACdB3ESiOdUNO0cNUKXzqLrxZ3ThRclXomn6G
+          HWC8fTSxA2hVeg7VAgof2JNHPbV9wzqXFYFD2WPP+NycZYABRJHD34matrO6APAswdIU9QSjzAd/
+          81uHzYCt0f/0tEvuMcTRFeJjisbqz2/J21sx7bPGrPh0YBXYspaEf3p4DOwxh6cHp0yUJ47KlPdU
+          g69BCbEi1p9qTjPDg51Zxx7kj022+szogml+q/iW3HyVKRS7gK1qRtjf8vNqWuQtiPXxQhTJtB1G
+          lmoBjevOn3YVwwHysckOXjRNxpezsnPqEtwNsHI2mRj0lOgXAMmAzPzkpuDH79q7Iv38k4ma1ben
+          r+/DhzR/3L1CAFm/mlZiQqLvA4/Z8ju7VtMAfnzlp4fZ3/OmLoiI9i7Marx3Vg3Xmb9OwnI5Owun
+          tTuwb+kXO4FYUrLhGexIirH8+NbV4LJ+ATW+xx6qq6knXNnvgDEYALvZRcl4J+4COJijhI/a95kt
+          ovdOwOO4M6f3g9rOMo3HAq2aqRI3lYaQLvvbG3hOFROs6d+Q+gD5cOPrU4u5sVqK41lEHBe5JMqt
+          nTrNglWIrVlV5NQIWs/H3J0B23zgkzAnDicIbxuS/CzhwExIteyX3QT6cwLx5XLWKS+JgvSHH9oX
+          ySEFW+P4DHpXonqm7sy+vG2ps5wFK/Oi9XypfFyUh9KZ3HNuzkYNlz6YOUmfyMZ/+M2vAxV/mT32
+          cwj7cRpxAZ+1YRBD+9gZDa+aCOftiIZVfNlqkTN1hT/8yJICZtRzzBXCJQL4qbJVRQ2breGB0b4/
+          P8ahoVp0KNOEEOsyMcL+RMUCBa67I/r91WfDL///9Pa2HpyFU9oAjjrTEowloZ8/YhlDsZgMrFt7
+          hy6PmFmhc7vzP7+xn0PrmcOzKr6JfsioQ+XgPgC+UgviZEGvztUzmH/rnVjBsFTLlbyknx/mXa6M
+          Sxf5uIPAqGk17YfrIaSh2rbi7A0SuXCtkS3NTWrRL540d1J7dvWsFXY37bXpk7YfI58Uv/xKFBzu
+          6Nxe1xYedqGOTU50Kz6asxmegdtuemJfrdx20YpDzunGB1iw3jUEIRjBm0jjXFdTJN0gLBXuRIwp
+          oupyplcPyXdaYGnuY3Vty1sCD+76JgYbHyu25H54hh2iXyGpvptfBTb+6q2RkPYL8EcDfp3HhFWx
+          5Om0M4Pg57eR++CfHK4oTgU8ES7xWCn1wxF81lp8M/dkoqwmZyySFQ+xB/ft7erJ7P/4jFjrFyLp
+          zyhb7CeZ4aanptf1icP5GNw7sNPmM/bA46bS+z0wod3cHeLTi6IuXKJ7EFBieuM3BhmJC0E4yKFx
+          mKC9XZSFuCyBy3BgyfFQ7rNl2IXdn56ejM9NHV+PVoODemuxdZtqld7tUwyXpqynfWoTSndivkJq
+          tCJWGs1Qu/CMSqDUBcaX19dzKLT4CcxssxD1nuWUdYRdB+rvDXug4GswLhwooVA4pselK+3X9yiK
+          oh768eaHqNn6fGgc/PPTjn7kUJA5HOA+t3FrjExC/pcf8gNjY6vKtHBOj68dDMpixCkCXb/E310C
+          iWx45BiPpkp//l+2NA0+qYR1ljfEK7yCghC8MIEzy4pvwzVV797+LHYZ/TxRDr/2riKSeVZD5jB7
+          GrhjfCM28KVqSfl+Bee5kHEQphX4bvMnnL3G8bJ9nmTrMN1L8Kh6wxtTtaqWoyIZiJWTC1F9StTu
+          i903mNVGJ7al2P1SCl4C9pX4Idi/n6sEsMIAe8FlN3+nDIsmXHywzSd2buyaNftzr4D3/h2SgOZe
+          +Of3bu9HtI3P0s1/AOl17olX1zrlyqCPYHhjlmn/JE7GuZKxgo3PEumaJyq195EEW3LNyenHX07b
+          liZYn/bTK73JzoQyroRcf/Kxe7rl2XJUngWc5lr1xNn49uQpdikUU6HEOjwpKh9tZaoBmBKRRyD1
+          TKq/AjiFsCbqrkv7Zbp2NZAnymGv1fJ+0J5Fis5vUSSnVmr68SE3Pqz3A8IeUhm6rALjQUI1cToE
+          w7miQlsr4JPRHOuN962+07V7wyderx4jv4ewdXK5gz06HiZu8d7ga79uyp//y8SV1i9NZkXQkxiC
+          H7ukozMOWgbmjNJMuQM+/UBtqiGDnxTyw/fxqJgGNF/FjjzkY7kdH3KlPz3uHHZbV1P9G/38MnwP
+          ZayuhzM14FO3GnJ6GSyde9t/wIt197H8ivxqecjEB/LetfFTdMVwOPFnF214SQxUnxwWNMCH/k6X
+          vN20m1S68S/A52SZ2G18meKaSIAdP3fiUcOnPbSKAEaB5WL15vDZ8iqKGaGAzzc/WQqZX30H3G83
+          IoP5VQ3mt2cgtyjMX7ws77rkQDLJNVHmwzGkdDZsWF14jHUpGHvqAzZAa3QSiUSMNKTQ2k+gPhxS
+          j1uMzd9KPgkM0whOwto1zjokcw2lpU6wAW8HsJCs38Fnimziha6lLgxENbDES4U962kDXvqUJYzG
+          NcAW0OtqdtmkBBfOGLGUxl86MpHKwP39zZEro7X0uflFQImPAMvO8ajyTP4V4QUkOn7OtazyjXfe
+          jtig7aDLfvPzRuHx56+mSX7Mpo9umWDDQ2LEnQ++jxiughIrmseJtMhmYdITwHTvDMfD/q6O17GN
+          f/nOg2PpACYqxhYyz/tzEptJVqmb9h28w4uMVVZ7hUtgfx5oW2/b+37VpbmZLeje54gck6ACK35K
+          Acj6s/Cnj6d7osxA0+1kqqxFrGbc6qtYKsyJOJsenUmUCaLBnycP7UsD/MXHOl/c6WXv3+GsUq1D
+          TzvfY3+rh/Hh1RVBLJ+LiX/tS2fTq+sfX9vql2AM3dpGSLmesV7kKaD1a2dC3uCu3pPIerjxXQkc
+          T5+chJufuahOIQK7tKjHhoPt0Af3khC6P1xilYYXsj65c1BW6olYHKrA5j/MsG+8J7EdllcpX48R
+          HHMzxrm7dVlatky08TlsFYuQUXyS89969YCuv/71k1oxT4gmKKa6HNj7A/rnPcFGcrToIt1UDWa9
+          K2MlW12VO27XSmmv64s4Xp8581b/hY+ti6KMPCH71R+hInkvbHKrBWiqKPXPD8EbHlXrRcsiuOHz
+          Vp+L1DVrxhZat+tpAs90pGNy9AaorYE0sWzoZ3/13zk6+lgpx6yfTIvU4Jy6AY5czghp8YlEIBaD
+          gU01VnpeEmcJ2dl6+unhkN3pTg39/P0kj/20234/jGB8/XjkbPCv6ue/QrDjVOxu9YOllsUHgLbC
+          /ZsvPpd4+PkHOPNNxqE173RweDMBVll9r06Ekzi01ce2jaIH0F4RK6AiWFK86d1wzqyyhXKSnHHK
+          ywklxScSIAO2i8WrT0P//O8t/3riV7uokysZM6Tl7OKtXg7Ydp0gWCMs4uPmr8+2RnPIbS2yPfZw
+          71vNDkR0VASWXIVoyiip7QGubPeeGLOWKB87fQLFNL0SqQ1PYHnqZw9t80usy0Pq5/t79eDlue68
+          bLAKsDaO48L9yeg9LpyfDpVEQfnla2LB6h4um37+X1sK+P/eUnBeji6xz0AL+a54xaLOKZ7HMXpW
+          LaMci/DiLBeCr2UZ0pJlS2TdwqNX+o6hctx1EZFzEc4T/0DfbNWVuYCJTO2JiRs75OpSmuEjHUJ8
+          299DyiZOAeEzsBeiO+PdWVtm1RDopwTjez9ly36tGbgq/mMSxvOrJ9n70sLP445w3rhcv4ydm0Iv
+          DXNiouqQLUYpz+id7EfiRLcsHOBwecD4Vi5YvstFRgVklDCTJBvr0eujLv5Ni9HM3TF2YrhkPTwf
+          YhDeTzuPRZdCXb5uUKPJbqknniKQzWw5pSDbJMFzfyeAPPxAhMr4YbHhjW/nuxx3PuhzwfbEktEd
+          pusrBhrVOcRpfXkBbpVnEfXm60aiU/5Rp1S6BtC89mePe9ZvSu68B2GVTS3WA8iGtdN3HNw/0JkE
+          t7jPlvddb9F5b+7IXVoO/Tw+z9vvN6zHfg+WyiKzMpD2ThISM+8dHQPwDMAiqsH0Lblrz377C4ei
+          iWemmbwqh1oi94Ba6u6xXZyxyqN32cKhyD1v1r7bCeRT6gGhaRdsVs/QYdNHGsBE5Hx8vKxvdYGT
+          JCBwvTbYnLDp8HIrxUgN1nLaq42pLvMYGagUhZH42/O4eb9PYMkr4UTTpez5XE9T5BV1hk+nj5xx
+          1tYIF6/emeg24fqVXEALz8hbsAvqSGWNoLCR8v2HtCvpVpZntj/IgTRKkiHS90FQhBkgIiAiXYD8
+          +m9xnnd4Z3d8zkJIqtl7p1JFMmweXm7G9UehgWd+r8qFn4CusI0V6GwXhTgkuWf8YoYz3N6GM7fD
+          Tcy2ZzN0sLWTgkSRIIGl4k8QiPy1J1a9DTVFdrQgzjwZ5GVsU73ZuenAo5Lf8dW1j/YGjbsC1FN4
+          JOKlqgB9Ho4LHIJxI+6p6rLFxkOAHkb8wv6QPEPuO2AGdg00yW04zuEyx8cbvAs/GcsmSilNTFCB
+          Vn8rOJGsKmP46FZA7dxcSTxdLwNz9H8CbOWuJ8HRGMFyIt0NeG0izcj9vMMNJYsFr8hZSaZVlE5w
+          NgQ4FMwD6+yF1KMk0B5q5/aK7eV9y2h4ClvkHf4ucjkL3cjhZ8D2yUjzqogJoF+mUVDsngguEg/V
+          6/p4CKi9zk/itnUms3/PN68y9LaP+QKL2mED3APt5nl3UxnW5p5zUNJQSHy2x/J2M2wf5vb9QkxK
+          TtlSr0UM+MO3x5KnU3mp9kbuVnDzsFricmDaZ9bDc3X8ES0tT3UvMp0PffK84+cU+jbHahEDBlpO
+          +LHHlyVV8xTuDouxqNn1qv6EFjZDfCUWP6l0+XyUHDmyGc38JW6Hbf7cA8SNnU+MZ6RnTMQrFhgd
+          PSeSdErpajzLHi1dkmMvar1wWT9rgJbDnGJFNAV58eBhhNGnf5BLcLUzLtHOHKxOhxJfPpMU8mBh
+          GjAl3AnrlmIMbBq9C3g73mySDZEHWKBmKRzYQsDyfeDCRbCkCsQC4xPVXX177K6XEVrBsHnLKGo1
+          fZ3FFIUpdPHNBV1GScxGyH8nNY751A370lg0uK//vIppY3NCcQ0QcfzfjKYtDJmSPe4U0PxhTUZE
+          pvf9iPqkCD/sq9/sb/8saAhJgouYpNl2sJtFeJRHTNzjLx3Y4ikyKLjTN3GikAUr9+QDlF+Pjcel
+          l3u2Ng2XwygpV5xM7VivkUmqszWyFjZdFAFmZYMTxLb+8KrHmtXkXNg+HD35t+eXJqPQEkuUHNKQ
+          7Nd+7O2pdilCwX7EoZWfbG3cUYJsDr8kkB+FzFDMarDM3hn5yw+Usr4AlY2SPV5ENRO91vHcH8Sc
+          vFLrOiz1m1mAaosCvohnPWQraaggV1bDPLDfsl7q39RADsjfedy/jxrmRUDgt9jeoaDu3+zPBe7+
+          jtUwiwdGP1cO7IqfRQIut+j8HmQJHk43gm8fkNVdNl9OaI83uHCeUj3bNz8Fp+uDEs2wPJtlR6sH
+          PmgB9r4vIq9/8fpwb77k+dHWbDVbMoMg5G9Eya/U/hTNuYNCLhKsXN8HmZZZFkPREj/E74XUnj97
+          CYsgF+JMi0ccDiNNO7g/n9jH689e2oMfoX/5IW4Lmwumt4Kq6lfNJ6jhml+2i4N++nglEnN828uH
+          mRXgbLIyCyYtBspVTQwz+dRgS6zFjCNaKkLlAG4zc30f7PVd+hW64IrFzvrssvUqmCJcH6GFtcfJ
+          DJdf8IIwEyULq99oA9uw+AeUxsDH1pm7Utqstxg+3z8XJ4fXFFKvShtk2PXgpds3qZm/9Xx/bz25
+          C9sPNGyKWrjnF6JOIhi2FxkN+OsqBycazkIGf0Yf5nr+xb500eSFG+MOXnDJkue1F7JlwouPPLy9
+          cKhxXcY9GCOHdotZ4g8JyjbOiH2kK6qH40DH9vcaGT34ZqpOHlyRhNx906WzKvuadxjta8ZG5reC
+          x4Af57W2Rnt7xdcZKniWiNlkekbf9nmDp7+Gsh5XhtuxWXpEolzCf/mcHvIzA0/O8PRO7Xsc6L4f
+          cEOfO44+xAfMR9EXVHSbRuyB3eT12HMiGmMsEfPlv8HkMkcB/k78gvV2aMCizL8ZTrITYYmemYGW
+          WRijrdYSkj+rWSYKNTi04xsinTQ69GI4NH/7S9S72IV0rFcRvW7KAVvFeAwnNv9J4MYaFD/3fEOc
+          R6rAFPxicjkGH3upFtECW05TbDnRjc7BZwnQg1wuWAdqla1CLaZI3w5wjqdFAbx3/kgQu5dmBu+x
+          Dcna+zFSLntJDJruw1gthgGZR/4gtqHLw9qzooJU3SqxlRqyTB/erUNU5d5YD/eL7Oo9Y/7woLdY
+          UydTjYtLCEF88dbgOmTdWw96uF+5947pjwGDSd0e/PnDul5ovX4vgQabFAjEfru1PO7rh+DeKPcQ
+          tV7G06lT4Pwr39gbe6ZesxMTo0uGjsQHNAXLu5gUyH4tcaYZ2SsRghWijyQxHpheKe329YEC83lh
+          t0JquJoPTTnt+c37Kmlpr5n48fdZtR6+4XiTt9vp3SJT6j44ioQKbALKq7/380IrP9jzK05GYH7i
+          iYhh0tv0x4MNLkvXkachrnSR6p8D0QEqxEG2TLeas0u49I8fMUuhr8cPLE5AWg/fWSiXLVu3062B
+          ZzZ28W2PL+smqgWMxIM0o87owUzpVPzhFaIe4uMw93pdwMF6tUQ5P7aafu8lh8YgzbDGdddhje0O
+          AkiCzGPvh5lOQM1i2H1dgYTUP9vb7j+wSpUN64TrbfK9lwyKrmFLvG3WM+5UbTHa2gOdmeHyBfT5
+          /UTgd2IXgknFDpt5NUZ4ZlPXo89kpWMsOTO8WfYLOzqy7c3V1P3WkWl5H4f+BvodaQAN93nCMnr3
+          gN6qRwpd9ADYVLZ1oGNuOMImBQXRm28gr1b3s/7hi+i0D5LIA/GGFIZAYnq5YBP7oFnQuWLT88F8
+          AZvjsgxs0rOAnez0CZdYckbIKiQnMlQuMh/lpYj4VgIzraFOOTs3PRCY0WPe517v8Wgfwd5X3Bw9
+          ktZeq8A14CberuQK/QH8w3d7viL692eHvGxlNzhfw2he8XyX118GHXC6ipik6OENW/MwAtgnv4Go
+          wvajc+xVHfy+p34m55tiswr2c/SR0QXnz8qTV8CuM8ScMuCQ9HX4y1e7AUL3PGM9nFeZdlgLhL/8
+          W2yzHrLNSAKw7x9xAxPVdAByAe836Y0d6yNk20EGELxKr8EO0whgwU+QwwssIiw7RyabdfcswrJe
+          vt5ZXWL5+7HKCIrB906kt9ICWrWZAMEwxlg94ZBOfoks6DUFSyK+jWVi+MIITitjkRsfvurlEngW
+          PLiPzOuL8RX+w09vKzHx/e3qNs8aVgBXgF5EOhoO2OIPUuB2fFck1k4cGOX7k4FvrSLYCZ063Fji
+          RLB5XMrdvwW6aPGnQkIuEWy19zddnsaowXv5GogbLW29HP33Cd7h9y9+scNG6SeHitw8ceb5JJsy
+          XzuB00u5YG9dRLDzlf1W4kf01utm2PM8eRoMwWYQ65i9M9qG3xgORp3M7XIw5YWcGQniaxoR2UQC
+          2HRNdGBrPq9EFg63eh24IoIPdmiIOe5DPthQ2eDnAG/YgolhL/znoMFl6Tvv/D6t9io/TB84z2gm
+          Rs438ipukAOu4+RE0dyRbm1lbPDx89KZPwyxvNFb5YHDdXaJfuF/YBJGXAD5bZ6xyrppOLFNwvzD
+          j2J6OWd//Ajal3fpQWTLgNle0QilLFLmrfnUAyVla8Gs7UdyUcQzndrOs+CJLg/y8rgyW66nZwtI
+          VEjEvY0hWLZXNANNST4Ytw8/pOCdHpAafvt5Vogu8+ypbKD8ts/e4RX42RqHyXJ+K02Fb0Awar7M
+          whSF0iR5hPevNseoRgO5ID/he/Tc5FFfzylcT7q6lwRdMv78YRQ4La8MX3zmMqyeFooQ6aw9Mzfl
+          lm01J1eQT8Cd6ON9GmbiSQwcy8LDuqtJMreWcP+e7TGvx9XI6JHPINjtnQRokOVlK8QcRq9H7K28
+          2mbUZ2UBPD/1F2sTJMM6zJ8S4R9S568UTfJmA6eAfig53lsGZT3ebqsH9u8jnpXggU7PKAd7vMTa
+          2dbBlhxFCLdi+mLt1SpgetrTArnoEWD9HpZgfCQvC+ZdUBHn9ujoUo5LDmx7PhFPX8tsrRL2gJh7
+          aeHERRxY2mfWwbzzKyKmlySknXuSoFwyd5z/yEiHe+MzMFfLFMuZr4KtKVYNfcMoxO7Fh2A8L1wD
+          RPbxJDb2WLpl1qWC17bB2HF+bjg19xuD1qkxCD6xIuUKj+T7qCgTizt/XrLZFCBahGDe2Zk8IIAU
+          4JVNhsOf7oYc+81KCKUbwKlJD/X2zAUOtFsVE5n0dba6k66g6eKbRPqYRzrXCEbA+fID1vvlSSdj
+          soJTkfclufzCfUjKKrWQmiOY1/WY2ovVohGmDu3nJW7wsC5TrsA/Pqj7LjMsFve4wffgKkQ5JY68
+          MG/fQLErECwi3gVc0/6EP3xITL+c5AUIJQecb6VjuRS8euumSwDYtUNYvjtUptKqp6BgsY8vteXI
+          0/0hnOBTZAMs7vmGGufSQa3a8NhZDqq9VfmxB9+T2GHrItXDmqBnde7Y60RMyZKy7Tp8OzSsbUn2
+          59vkGhkdLDf7QETLa+hy7ShEu740z+tS0vXDXSu0+z+x36MWbu3v3MKDnXlEt2obMENuOXDJYIAz
+          7LFgCcxlhju/wfZ5TOrZ0KMCOr/1hFOxFkPWbMkIvokleDAKWbogtJR//j9D5+dmS2P1N6CJbxuL
+          r9YA3LD4EDGy3v7zn+56ejaQdwsbiyi26uXhxwrc4z9+xOeoXoGrOHBTvIEo0+8hj5IAejh9T8N8
+          bLI63Ko6cABShQO2sXcH27U+cHDWlgSn8DSES6uZ3t/7eIdbfwmpHu/8MMUjdl5FJm/3M8+gA752
+          WPzemmy+YUaDyCYf75hPOuA/VncDXT4jonZAGjgccxG0YUWxnsQJ2FXbDdr4E+DLNVQo4fqnA0sJ
+          jkT9spy9TbTsIFucGK95aO5AAlHJoXc4rt4aLHO9+X0SA+dHT96ZvRnywvxECM1vJMwousohZ0ns
+          7Y//EGNln4B+P1KOLnLm/+FxwPzlR86xz0SUSjObn03dISLaysx5nkhZs+CEf/z9eksfIQ9D3EAX
+          ZDPGs7o3IaRbvt8CBN52rp/ZqjtuA7F8q8ntzUnDcj3dG/i8OzJ5fZIf/dOH0aW8rbhYF5Fury+4
+          weZXKMQdrEbeHmAN0M3PC/JwP2q2Wt3bAsdM4YmTJZW9RLxjQQBliN1z6dE5uwoRxK/cIIHytAZm
+          uRUO3PUpYuc6R8njsMFz8io/xE5e+sDxgsKhPf/MR8bj6YsHSwBQYZi73vPNllgIGUSQ0mD8dAa5
+          H39c+ocfZvKopHBB6juGveu8SRLKtTz3+lDA3X48JjW+8gjAUQEHLq08PuGf8s7XR0HPo4QYocoO
+          o43rANac+/nHT0m6vUVgepuFLVLq8gLk7wEu6nDzgH+TQraHp30QUDrPsJ1oSC7HdAPnBnDYTfaS
+          wIiEEQT6fuNdbdyQ56oxBa/Zj+amun/odh1ID7vmYGJ9O9XDGPGOAbKSU3c+I8v9/BwLuOtHJExX
+          aaCWc23g++fzRN0+g8zctQ8DhVSr/vgk3X4fv4AsWiqcPAxob9lVuME/fCynq1QvdWof/ulHpmRV
+          Ifl+rALq+rGb1z1+rnlytuCvDC9YW0Rp4CfNEaFKpn1QqEXp8taDDojjNhEtV7twcau8AX94r7BO
+          G+jcYDv86UMejb2xHl/MLwDJq/oQye9/4ar+thaKcQa9xR68YSzZYwl2/kRCYpf2srLpCfzFP2/q
+          gDzngFNgfu1EnP3pPU+R+uBwHV38Fx8Xnn3NYG8VS3zDCuzle5wbqDLahVyen3zYpGO3wB2vE30K
+          bzJ3vT0dqKFi+NOH7F0v7yEa3yWxd/21J4e3BUl6y8mj37smXLIqBgXKM2LGXlfTJ4kM8OShTYyP
+          IoHVLA4n6LlMgIPTJ6Kbar0jlPRyhaWzIshUO5g3OLJGTQz9IdhE4+IK6hwfeUfGe9A1lk8WaKZb
+          gQO2UDKO3noPPiaNIW6yifaS9IIDu46rsRWcLcpzmyeB1007EPmnT+FUMFkAoVeUWOmrpt6i6hPD
+          a9NJnpBpv5rOh9ASeDmgRDvewqEJ3rKFwne77CXe27AV3jeH6kQlrB9/h3qr7x4Dh+H6xo52VOoV
+          +dnpL98Td75Gw6L3Rgv9G0xIXL+oTMXo48Pn98l4wq4Hbvv6ARmFxd63sJSXDywEoGwr+U+ffwlF
+          D+XbSOazX7r28hnZ4G//caH4NV0TdhyhIOcisSzXAJyEpQJIB8XBCkfkkHFty4IcuHyJpZicvGDW
+          PZ1TfjkQ5y33oN3zFyjWiMNywWXDdoSygliflzxaZkO40MckgB2fe82u9/VSRH2oeQ3a82Wbjc9f
+          t50sXqyxVbi5/GuebicIzN74HJ+PdLxY9whN2aoSN09xuJlXcUbc3qXNE0BrU6+3YwA4fPeW440f
+          aLlNHHxFso0vhfICs66JHiTt2hKFY2DYW9ZsgYb4A36KAZfR+SvOyJM7YWZj6U0pPbygAFPQe396
+          3tbj3P/jd0S6+Ueb/NmjHCwVLpz9istbMQ7Q/KQT1paXSllRKkqY8tthPq2RMKypt/T7HdiexLte
+          tZy0jYEna/KJGGV1PUVil8NP8UIzd3IvGZN/vxE07PeADf2R2hu+DAIIbL/xjqI2DKsTjBAWwdPw
+          XtzqgtXEzwAW9CrPJz6dwuF5OG4gve9HwH/5Oo/dGRijJJFLiK9gVAkPwa4veiwz8zK1blIssGuP
+          vKYp1j3epP2/85TLWzuH9a6PglwvvlhpEGsv+rrGSGg9Y3ZWaNeMSKiFmvPa4fuZkUOOcEsE08m/
+          YCdDRTbVw1VC6sCxGEMhARs+AwkGV6DjPd7a/O84NuBySGus7fztT0+DqZNrpMjWsF5EAgxgKs1G
+          Ls9SHpYu3krkxxydkcQ6IfNunwLkXwTOx6dj21uV/WJosVo09/z0oVO3LjGart8JY3O5yewxu6Vo
+          tnqKzWT403PyBs5TCv7sMfzT42H5fHbepwNSvbL5W0L308xhmYnU/bxka+Bu3/gPv/JeL8doGUOO
+          SPR8q2e/KhvUKYZH5KCRAdMe4hsUuYOG7UMoDYxYJhVA9vTB7vDTw0XOTjFUfPmLd7wN2uF0Wf6t
+          78HNfvauJ4p/eOePT2QLOUMRDGhUsdRjR54vszqC2+on2G/WOZybYlXgPBQz1hMe2dRpwQgrVtP2
+          fHuvuckCFkyeTUziq2nUzOCUzT/9Sz0zdfinvwKlKmxsOWwsb6wWcX/4neD9/Hb05OsNTYe3i5O+
+          oTIZ67MENRKfZq5Z+5DmapCifX/JZT7pNd3zOdr5vbcdfr96qd9wgf37xOPHft62lLM2wqkRr+SV
+          GSd51598yFzMBJulYA1buqBW+ON7VqaZAxeF8vLHv/Bl1wOW8fA04J++aek2DrcolDdUfM0nyfrY
+          CMliZiPcaiUhtmDndPXuTAdfyflDbJ9+hmlOqw2xX0MkER76Yc3EKQBpyj6J3HV7iXXCQegt5yO5
+          WIozrJdwH7QZf02yxxdK12Hu/18lBaf/u6QAPeWNGIZD6PbrxA6tPvl6h9ry5c0d+QryYWdg6T63
+          Na1WtULRTE5Yz+Kqpm50S1FSPWyizfoEulS/5WiVDzq2Tj1HVzY4i9DTewa7nuvILNSfJdTHgJtP
+          Z0YBzP7/cDG0yEvUVcioEBQiEMSjMlfx70PJSYxa+M0NiMNXNNuLmVsRdGsDEWx92oHq6QThb5zj
+          vRfMSBfRywuImGTE+hky9uIxbw3NNB2w45/TkLtWWo+ORMbEVLa3PV9jMUV1e2ax9jLXmrhvpkLK
+          M1KxupzrgeVfYgoW6yOQ59WwM/JaFwtaEVmwWXwYuozXToKlxWoz956WYUFQUGC1bTl2j3o58Fx1
+          OECmFDlS/B4eWGVFnCHshISo97dl03zwGTjeyRVfVg+HE6vHArSDz5tcV49kS5vqC+qAVpPn/rzN
+          PxwgOKT3hii6oVBeXPQZsZduIEFyPGYrt/gtmAYGYXWhuc2WOuehxZEBsVpeAmPQiBZKzNrHCq4q
+          u1fNwQedWczYVrNbxkjrqEGuEe7zANUj2Oox9WB3t4b5XHjMMObhwMBPqceekFVttqqRaKGn0BsE
+          P3xYb3GsStA6zTJ5ddle0qCEJ/RoOwU/7rZiM0FcSsj1firW5JQHK44YEX4fzJlkNDWH7UfLBWVd
+          P2DXT3vKUvHcQiMTfzjQCwtwWcz4AMvlh0TxZ6PrKSx96J2DH3a9xsn45RF4cOEYk5iqeQnX2vjk
+          cGvZkMTmdRlWdaeoza1RiVoFek0LvnPQEkQBSSRYDYMhf2ZguYDFppqmNuOKpg8did49ARumPOGr
+          DGHzyHViSY9hWCxLsBAzNwy2nnFDmfcqdJBDIybBcKjkpWsfBpTsqMP4Kh9kasifEX6Ee4jDt+Da
+          bHClDnzRl0sUfJbCEbyCEiXm2ye56j7r5VQMAYR8ERMViMIwWsfkAFmlnMiz7bWMu3yaCArJdsDK
+          God2f5DOHPCsisMiwd+Mfs0xgv7BMuaFmT/1Nvv3Bea1kpHLFvryqB+qETXo8savuj/TxZ7NDXXW
+          iZBXUleU4TS6AXX9hR4dFjtbL9vFA+wz+hJlJTRbXqlsoeFIY+I8ex5MD3bTYHJ3XYLt8Guvrdz0
+          INLHJ77P+CkvxmnrELXvlndqAhOwrZnPcO2PFTHlJqtnyWs0EJBPiOOlPQ6rY40dWKVSw8k3CsLN
+          VKoCWIKlEJepL3RfPw89rpR4mzn8hg37uoMaTMhcfdI6+6pIi9ByfkzEvMVRxinlUAHL/GzELrAH
+          1n1XEE9uCs4VTwkZy+89qH5QhK8gm0AfzoUI60IXiE1XE3A+MToBPVMfe3bGhetZihVgvKIRm/Dt
+          ZkwxhBFs7kNHRAEoNr8KPwZs8vok0qtRKK/cvB5G10OCVSEQ7NXI1Pb8+Nkdkbo2CzfngGeoinKB
+          dQkYGb1ewxZJhHnhK2N69cr8zgGwVe5CLta3BMzkaxZ65XpIHMPIKcPF9gFapO5np/Q4ulqKeoOX
+          Yz/guFBtm78kuIDLYDh4t097S9ixhXDkD0QeEtvmDN9qwGM5ieT5rIyBi4PbARls8MHiS7DANlzF
+          FPapaOGX3RzBdn3uVayuJuILY87DZp6tAOZpUBKPlYeBxNxlRFhSGmLQr2bzhvlc4GKaZ+IdKnNY
+          izKO4PwsNmyciGKzopwU0HgKAzH77kr513qyoKx7CfY2zgFrXKwcPMu/wNuqJK+5vXeQ4K+iTfIj
+          JnSU05r7i58ex2O7Zpx8bVFZuSKWav0pT8q25Oh6ryQPqu5zoE9jKVAkZKwnnMmjZmAopHB/X5zI
+          IAMchEF+BjdnJuGELHuLneb0937Yld44Gxgb5/BoHxOsCyGTjflLPkC9Z9j5zx7XrD768Cl0Bn4l
+          Qi2vezyGnjD3xF2PEl1B43IgRmxIgpme6dznXQXNhZ484bdJMoN4S4TkGGTzsRrKYVHHIQB7Jwwi
+          HhoZ/Lp7o0D7apfEfdx/YGu3tULbJwu892tk7M0/cBBGpyMzD+pfF1oqNQh9Owc7/vWdLd2IPXC0
+          3rEHNzYYtls3QcBcc35m93iz788Nvg3jRGT/soL1yR5mGJx57B3zOB3W6jWN0DqNMn5F5zxcswI7
+          8Mizlkcefr7H/0yAd5S/8bPjP/L6WCwJNN51xkG1wP37VQZpUJWwZTRWyI7HTISP/vsjf/mTum9Y
+          naN+Cb3mc49syti4EP7s7anMnswuTG/A79HbsClxwP6zN8gtTUAi+DAHdnOuI9rtDSeSV9n8q40l
+          0NKHRB74/hl4WukjInexxLGcBfZ6q4UeiqpskN0/90FF7xg9r4yHL58qGOjVHqrzch5tvNsnYBFg
+          b7CQRIkYTfCjfZEMFeizwp5beY3l5c/+gFGtWBON00AfriSiy7pXkaNXbdMpz0SAenPBQV08M0a7
+          DyKyNdAQE39P9XqUbiMSWQcSMwvZ7L3jEZSE1MH4cXjaVD2UDqh+8I2jpsNg3CqGQf4q2eRlh7q9
+          EYXtkfi6ysT6ZRe6Srhj4JbZ0SwYTZ9NifYaYb2WeOazSxVuae/kQsqLHM5U5WbPR/a4wKdmXedD
+          jtZhoLGZwy3/PrByJyJlhjm+AV1fjjjocGavRTNX8KdtJRZTZRyIpzoe3La3T4wFHWlPFNSBJUxY
+          ouBKspfWuhYQedx1PqvmO9vXt4TZWrTYUcHB7ixVUtB0OgDv/BOuGc/OLwUm5GkQt9S+9cax9gmW
+          SaZis9zosPBsXcHXJjvYPs6vcP1hRgRvThiIDvkw/IufcAkzlriPsbfHv/gZsRL2wuVkZpwkyxC2
+          /VvHTrux9cKDsEFN/O5JInmSTdn5ocDBVUTijFcKtooXbtDpJpdIwH3Im3t6dKDfOBVrocYM4/7+
+          4NXeMZb0ogeUAVcFcokXY9O4n8OlfR0Z4T6fKvxQue9A2fPRg6L80bEhqM+BWtnTgy29SzMb3uyM
+          Yx3Fg5ATHyS+36Z62df//CjASBTBXOp5vboi7Mx8JgEP+GF9XiIBvGdtIZLO2jb7PSk5XIebiK0y
+          bOTl6J1bKE/W9Q9/ZIx8A9u//CVX1ymbRn8IoK5vRy8ZCz+kB+4mIHsOn1hxvrI8UWDmcJW/P4Kj
+          Y00JF4odit3fi9wcXwJs9vv+hz+2TyqHZCOXEenEOJH7SzRsFvWTAZIzUeZdgBmWpyGPYB2TmmDX
+          /AyjGaU+1OrQwLj9nOXZUa8z0gMJYGlTk2zPnw28Vr04c/FnA/TEcDFQlNLGmbrdhuVe3yuIxCDE
+          BkcP9uZWawAZ3QMznZAlr+q786FlXyh+PQ5PeenlwwKDEDyI8Zx7sLXfawqb9yh7ozeCYSxl6wQJ
+          TBPi/rzP3uUq4wBaBYMovHcN//wVmp888SgKtJpzN9KAPGZe3sHeuGGs79YNytf8TrDLt/bSmzMD
+          zMx5khSG3EClsdwQ51YZsWoo13uzoAishSdhMeRd+vVzOsOZxgMJ9/2Zra+gwUPiX0jh10y4Bs8s
+          AmxffIhoEd/mNsEZ4QFl6R//sqe4+QkQ9lGKPS9iawLY/VbB24iwNJ/f4br/XUBp6ZFYUFFNhVjT
+          wEMyXJK2vESZYrX3rm85xH/xhRdiTxNWFhce8zL4bPtNy4j++JfxFq2MKveuhPPPIPj1K08Z7Q6K
+          AR6dphLH2mp7Ta48B7fMjIiclIRuO/5DXNonxJ/fLSXhfsTWvB8fYpwfT3lmrjCAvA5t4m5RbU/r
+          83eC6bgI+D6dIFjnh9WAiMv9mc43K+MxBRAKx5Ej96Dt6UTJ+4Z2/Iid8ciEe/yVoBfeVvLKY6Fe
+          E31tUZ9KFnZ3vjejT+rBP3u17NcvpPOx72DBf3KPE414oN3WiABJK4+97TUOW6CdHLDzRw+epTVb
+          hlPRwvMTuPNhM8Zs/OM/pJyfRMrrIlsfiyQidJlvHjOcGUol/RgAyEmPGX3gB2ysOCqgmRmRxEbt
+          y0ueZALkKikkzni8hStRhRiMp1XHirY2w9bck8Mf//LeO36l8nKA4DRNCdF6dg7Xe5yW4NJy68yE
+          9oVu6FVZ8G+/C7++Zf3O98Gqyv3uzzLdPPsswrpJr1jq7lVNGfURQ1Q8qXeWGzBQthdPaD2ppXd8
+          HJBN2cZnkK3EIpFAw2frt4UB/IovkVy0w8We32mwofPr4RG96CWbdWlzg9ZB/80Qyxmg57r1YHxB
+          NTZ3vE/kwRMQWut+5jVXpzT6bRHc+cGOT9JhfjyRdvr7/4KAqaaFLKZoboNpBqdKH3i9jETolTnB
+          8YJf4dR/hwreUofH93MoAj41TAfWq7lizfSjbHPUZIQSPDznc3zh7PGNgg3pfisQW917SFnZc+dr
+          Txfb9exQ/oIvHqqRZ2M5gAslSf9r4Gh8Q+Iaoltvw/FkAMv8bt72Ah97Evk1EGpGph4/2dFAFcW/
+          oVFwDW+bq7dMH4Ggwe7cV0Q1i8mm4bOHcMdj3jafLyER+0cP4818eGsu34a+Pb0bYWK603w43QeZ
+          /v3+EZou1vDzRunvKwt/9usdiOva3ZV0Abh4EkecayTZdIqqAwJz/sO58UL2svgohlmvjX96DqWn
+          pfRQnbUR1o20rZfJ1wyIihfF0qtp6HSP0wq6APJYjI82IOyZ9+CjU1RylztvoJdEL2CYn1VseWlX
+          TyU3QficSgtLzVjRhSGK88dfsHYPafgLHNsS/vzDsfkarL5g9+D3YyIciLVNGZhUOdyOg4tVYxnr
+          7eBdIejCuSfW9yNntJFVEf3lQ5umZj1NVBBgk6DBqyFow224GjHcv4co8zMEv0d/hcBox5ZYj3M7
+          kO7gGMB9j5A4/vEN1j+96izhKxZJ+x0WRR4aEBZ3jRjHXpa5NUIKXMItxJb0sAfmoU0e7PHm/eEb
+          mT705AD92PO9Lf6puz9yEEqEe2EVNUlNuad2AsyJW/DF8sVhvLLxDQoiUjwE2LdNxf7VQXQUVaLM
+          Gh2WP34hT8YVS2jl5N+1luM/fjqz/LPKZuMudIgS9kKeh2UvGbmprbDzPRI1V1wv7f3c/OMXbJMU
+          dFuqpwcjfX7u+MEfpkd/PUD1c4zIhZCrzbjq+QbnXFrx5RFEYNEtSQD/8DISIZg5VhagBX+7JB+W
+          lGbwJ8GIr6kH7TSXN+1gK3D7JIHHvF6PYfPP2gky14LHSmhfANOmePnL70QRXZX2gRrdhOUx7YNV
+          ii1cs9dPgYXfXPDr8YV0PRrKBuRh9onyMh7hknGKB3+zlczCni/5qEgd6J39H05rWA8r6icLZl03
+          4PwZPmq62JuGHpq+eXwWSzX7SrwUtuv5grWhnunCBeEJle5kEOnw4uoFfKwW/vkXJ1g9oEpyGMGf
+          HuCwywo2VqAQxpdjjd3UN+1ZSUEBk2jwsBiW7rDUd+mGLOfFzCz/EMD6ctsAxun6JJ69cTWlX375
+          izdESh5ayDe3uwP4ctGwTWUzXPCzZNAyNi62rmMn0/jyPsFVP4/4D8/TY88syJvaEZt/fNU5vlt0
+          Sz2eOA+hBH/2he5l1HhHl9dkNg++GtjtCRepFITcx1wZRJOziXXvoIbcvv5wE0E2r+g4gu19q0bk
+          Z0pAcuWj1Et/LEugXDpz7vpXF1IhiCTUKl+MzUah9vI9Xxw4/yxC1HfzlZcg7iRIHxedOFdfqOfO
+          +mnwGsfKn/2B5bAmB9hN8IMdNrnW0x9/IAeAPP56Vgbuj3/UGT4RqVpySj98w4Fdz/BYk52y7ep0
+          AQKg+XpM3Jcydb9NA//8WXWk0d7QTRLRpJ7V+Teyfr18sncPQrV25u1gROE4+Z4lxPUnJvkvutUj
+          9KQI1q74wAoTBuH6vBQneMkblujXc1MvpFJbgDY0EOX14uuOv9gz4LxDTqwyVOx1/Vki2Lba9078
+          u6jJMxV7hLbj4PGm8ZX//b5y6U3s/Ol7chmeYNh9JYwtqNHlIsEIJuHqEKnDQKZieykAYvlpnk7O
+          uyaGPM0wd40Ki26PM2qOnxgIq3X6p2ePp15OIRy2jPzpkeul/SnwMw/Rrr+0MufdeR/2a6qQS/jj
+          ZcL4fAUZo4fYsUt54DI3N+BtMRZifN3uP71nlSoNq/xTCimjvlKw40+vW/Ar2z7KZYF+LbjYKT8P
+          eyvXTIS843vYsXmZMt/zxYMXUTgTlyp1PQuJxZ1Dxj/i/DfdAJUH7QRGpFoY+/fn0LS+WcGF6OvM
+          CKZfb+hmSTAAV5/IiYmHZdpnWe/7R/A1PWSEuVwc+NHDf/laJlEj+X/nF1jL+M3ujG+Vw/ana1jM
+          r0PW7/o/IOgFicqoYO9V9nSgo+CISFWS7+cJnwPc9c5ZkFVH5rD1Mv7wlvfDhxiw6bIGcPcn4qVL
+          QJdzTB2wBLeAPBaGy8b7T23BbW1WD+x6C21kV4J7vp+F2/e7D87p/H94JHenKtzabxJDUlmFt5pV
+          KdNAyHyQXfxtPj/5W0bbFFaw7WvdO+PDic7Pj92DPz0MO5uasVmhezAqbWFezUqU//RSeKulbe57
+          Uwp5N1cKoPwkyRPOF94euOoAgRVNCxYZ8WNPNVJ9wDLjm1h/gyOxGAsw65Vx57uVvD2XekOFdlOJ
+          egZnOtDvcYGuqOtYFh7fcD8fKpEdfN/e1kowpKrE5XBojwUxy4yG9OakGwhOiUd2/V9m8gaKkAiH
+          GDuyWIBtFEQFNA/9553331u66afBe6R0JHmXjLzNGRKg+UWIGEU+hGN/PuWQUTcBe2my1Yt8o8vf
+          ehL3Qj3A7P4FeybQdr1gDZf3unVANvrU+6nl/wAAAP//pH1Lz4PM0tz+/IpP79Y6MjczM9lxM2DA
+          DOZmLEURYBsDxpjbACPlv0f4Ockiyi5rSwaGobqquqdbrugDeT5cDDAQrMkfsFyYoBHRJ5iwk90P
+          Nj18Yw8d2MCYDrVG1WXzl6GkfgxiHLlPRaUZT+Kjez6mYfMn1iljBYC/+Z2c8E4Ak3s/uTC/Jg+c
+          hTevX7Z4ijY+TzQeXugKYZqDfHZvRHLgBKbmc0kOkQm7SfguH7Aqqr2Dm/7Dricy/fgMHjFoPt8j
+          MbPXoC6cXDAwUyaKNZR5NkN1p4RXrV/IL1+yHGPTgt6aO/h6KbWM5ospwCltZoIbV6BDP+xyICuh
+          iP2NP4xQHnMwGld9Km/7fUC15zTD+GQ9Jhq78zaIXHvAwgmMPz9qqFTRhLNIJ2JkRKFUfuwLsOHb
+          BLP7zV6tsbPgSwgHbGJjomTTh6AOm6OLvu4xY5+nRIPz2M8uoz6P6spXdAKKqGcTOh7dYHi+Kx+i
+          T+cQ86c/1UYYwJZvJJrIX+zpeKo8uMvo2z3YY6GSn56Eo5tPRVCcq9WjMQdiATG/9aSr7S0MujiD
+          Me0Gf7LnrzfPyODK1d2xi6NyT97W//z+fN94KtPt2xJsfgtWSlOlNLiK4laCXGB8Y0D/3fJ3qCVJ
+          g++7W2FTZU2Ygyr6eOPHekV30NlBlH0WctKfIl0vpd6CLhediXtkizp2Y1CjTZ+SxL9NwVqtlg+D
+          ldlNME2EYP4WRAOoJcQ9HFPRHhiG8WGCjQIrP780uckrck8ai28DO/fLlV01NJPjQvTk7dOv4+UT
+          tERTw1qsy9sZk1cDrzSrsXKTGnX+mPsa4k58YOvoW5SRQq1Al1CTSRAEF3v58fP3iKMJZroAfvpF
+          lAR994c3w4feTMgcZxH/+PZ0/d4dWLZlgc/DSavY/kVztF2fPFbOoctgAQce61f0H7+9i8AArag7
+          4+Mo5HS6xE0houXV4ef9nmUkXyQBma31mcTQM2zGsBQB3eBbJw5WM8qTyX8gIJrNn1++SnCowYbv
+          xNryc9z3kHBAscMW6yEM1Bneuhxgb+syFb+9agyJP6N+vyQ4nDu/X+rlbcG29L7YLuhIxzd2Vlgp
+          2W7jD45NjsgNYawxGVGlKLKXdF48uPFrfDx0L3vDBwfErITJk8RctXZ5USD9+rZdlmfKnkrFJYVe
+          XgREzbXpD+8QsFOKzY4ze6K5cf17/+Q4l2pAb/VSoh+eZHdhqgYeZDW4Bz6eGP69VOt5uiSwDiyN
+          mHOkg/7BFy5Knx2cavX5tpeQpCsI+JM8MfWOBfSI9BB2H9OcDmO12NNcbvzS8VwSmjs1a518qeH/
+          T0nB4f9dUlChB08cIe+C+fukA/q4yRtfMJ3U+ajdGwBH6Y4d7TzRfoolBzLW6+zWfMBXq9GqMSKs
+          bxLb2L/o8BB9C2BuwESTL6HKsPpco8e9CHHuNJjyjZloqEWPyAX5/dXz6uu1VfV4A8b81mhU0AcR
+          qgq6YvWUm8HyfugxPH3PR+xJjdFzh3PbAuj6HxfMZWGv5Z3xAU1rkzyA3QIq948G+KN/c/nusoB1
+          j+xEvIOd56JibwaMtjIpao7b4IFS3Nu0KJ8mjPQLwnqLin5hD1MDmeF4IaoNKVj4K9jByzGziLru
+          7/2yGyQFDXWY4nuQssH6Ii8NNc+OuIePaAP+82hMeM0PCjZXO7eZE+MocP90I3cs9m22flczBFVl
+          hOP3yo7BcnaABDlnlbB+1K9Z32cmI9KTopGb0lnZIpJ3iPLwKJNQXfY9Le6dC8ro006wunzU5SBy
+          LkruDiR2WaGsLTbKl6e6j81cegEecC8d7U9njUi3pevJO7mL0DQiA58eMleNCRpTOJ/alGCeHjP2
+          NC0xou3+hJ3q8rHX9vzUIdMJCtG9p6xyh2QpIB9tw2bW4GKvRmvHkHDPq/u+8lqw9KjygbSYIfHQ
+          iwf0qh4FiIewx2qYKRlTVvWEYqGcJ8ZVOXvlxNqEAyhEcjHSs0q/t7GA02fNsZ48/ICVozn+rS/W
+          qtYE3BfdHJg5dUPy1ZNV/rkNZqAoyrAisxfAlOC7guolHokrqRKl31CoQZImEz5LbB9s+9NE78N0
+          I07D88Gq7oQZJQCuxLylJuB4kvmwvRsFls1iASs0Cwnl0mGHcfA1szmAoIDbfiLn82cM1rGpVnRu
+          tAxfNPFVMTj4KsAXc5tcH3tNJbeh1qE9fA1sF3OUzYALQlhlAsWPc6lnvOcbK7Te5kjyL1/Y9Dg0
+          DuAuVkAufd2ps5byMeSOp9kF1wvuqT/fNbHKRErOwyW2lzETWji87Cu2PqxGGZ61B2B8UgXbBzek
+          y3qXfDSa0zDxOiME03ueJzDctl4rDx6rlLGeEM5O3uJLtOcDCh3eRWEx5cRjzZgyJ+dkwmNKe3dZ
+          5iBbixIK4ueGEuyIeM0IW80xYve1S8KPe1NnoXqIYCdPHXHiNQFD39g7GPBvBT9nCulsjGCGt4+Y
+          bnjiAlZ4OC6w/aCeVuZyDObieE1hwMwMvqSraTPg9orha1YMHKLDXC3xWjjiwTwM2/8LgNjkYiGY
+          dDbB+tai9uDTEO3RzsankcoZp8edIybs/kUUKbr3vHlwt1OFLLc9ZaqurlHE8CT3M1bfRWKPebPf
+          gcI/NTgTwEtdamP2thSdQGTlk2dsLpo6vHGXbEKVI9mUfF4hqmh+wm704nv6MswH9JzLTK6u+O5X
+          7oh0uIs1iLHgNBVzSHQFgnehYtd3M3Vm7bGAeIh7orRvgy7omXFgf8Kai3KH79f1EJaI1IfAXTMp
+          BOR0XCFa3UtPzDkJbe5MKhdteEdOnKMEfBhcU2iV4RNL5r6t6EdmLLiThw7HHLkBhnyyBtJ7EuMA
+          HC3Kt6aWonuaOMS18AnM5JPV8Pf/csc3PUljK0adGi3u7v6pwfxibyX43X9cXXdg2heXFIVP84rv
+          zFXNeH5iCxR53xe58veqGiiFOoh6eZs1xewq4iknCF/vtnIPxuzS7aS7D4vzEuCbT0zABIVcwvR8
+          B+T66RPK11Uzg9v19SYOB1m6bCcVIfRbEZvvW6ryUWE38HvP0q1K8dvPtiGVaHzdL9spQ6/iHDnR
+          kUk9Mu1eZ9aeX+ylQPzlccbHZyUDTpCYfJtqOZNjfPXUhVZJAXf8V8JZoV4AX+vMijxeOWHj0wt0
+          FHRswYtoXvDFlRp1YGNusyhFOvFyJtmLNKQ6ZIfMnt6BRntq3WcJPdDzhk+3lu0nxAELRs/8Qi6S
+          4QHWvCcuNKamJMrFePYzNGABjvHqumzFRRXXnLsZCjS2yakygL3k2UcDvZCuRFeKXdb+nidEwpk8
+          et3KeBBkFgxl2GwlSwZgJ6FrIf6Wd5f73B2V8c5HDRlZ9sTal1nthcmZGrohcyFSUzk9yzu9BrV7
+          x0zBM3QBd22WGmiCkhBpKfWe2bABJkUiYW9W/ICsjMxAWegm7L7OrLok1q0V5WPRkGvcqDZ/utgc
+          LMPkhgO0u1ZcFHkPcM4GHkfb+q/6YTYRWyZ3fImGqpofYmpC3tC+5Fy/k77fw7GDyK1fWEmDJaNI
+          nmLgmy8fP1UeVRTJTQzPknnEAesrdDn4IISLTi9E4etXz+/hu0W77u7ia3zgAHv3Hi7c8JCEbIF7
+          9pu+JJTuU8atxuYdEPVU7dDx/D4Qb4LnfjltjaZu8m6b1SmGGa9Ry4LXj9cQXMspoFrsmairhoZk
+          +V2ueEb0NSSv3zve3pe6KlHawA2vsKG/tH5++WoNRY0Pp/XlPOzleVkK5Buhio+vuLMXCV4FFBRp
+          SU6ZeaLMEF5NBJL44nJj/OpXyF45ZO0LD1u1mQBGqGIR8ob+xcrzFgH6u/49TR3yGPe8PQ2nw4ra
+          r64Sua87ez61wNxmFbBYo+Mn+F64Y4F23rHH8vFzVFlBx6bYdhcfZzMbUB7BQwh33dPFJvFJNuca
+          XoFgvleMbWTRORd2jAiS8IKvkvvsV1V9r3DDS6xG2a1f/fdrBxpwLv/wdzqcixbZiccSh4/f1Qrm
+          UoSu/YVYVdRdP0/RNvhj78ZYJ9xoj7PwgPCevTNiYlDZ9DbUGtyh9kKuTf+qlg3v4XS9fbBZ3xTA
+          JYI/wWEdM2K0jxOlXXMZYEktPLEVx1a97agu6uKCIVehaoP52ug66hSzxGfmWmXsmM0t+sUX09ga
+          /VdnC8JzRBriFqIc0HWfDvB55RAxFmvX0zC4JjBPNR9bam+A+Xx/NNBrvuFEvYhV10wDPiBeJU9Q
+          SfVqvTaH5i8+b+tRrX0RlMDzLwr2782ZcsmyW+E1NCp3iz/2GqEshtbzlLnr88aCJYDR+uMz5HI6
+          RwHfzoYPtviAlc+zslfmQwYoecuTYCce7GVUaQ0RGBM3VXdZz2GWPgCoDtvsNvWlzqJpuvDqljIx
+          fXlvr+zXloByYhGx1UYC1GRuK7zFYTyxD/Vc8S//EiO3yDQs3/yAbny5BpSzADlVrw4Mn1uVw3zK
+          a+I/6bGiv+9lP75jt9+eZ76PI4TZmbLEKomUMcJEZiiEdTRx0fvdz69O6tAvvu4OW4tK6JMW+sdR
+          w5Zi035s2f0ERYt74/PQv8EiLViCc6JmLjOntk2dWvLhV1V5rJYfO6PZp3ogw1DP7khrP1vdOo3B
+          eAKAqBjPwXhObAHsVUyxER9iSuF8NKH0rDG5mVzQ0yp5NbBTrwuWAnvphygzRdEtJRWbt7SlC2lY
+          DjbHwJn2V5z0ND9o9d/7NbOPVLGCnDpAfDq8u8ze3p7Nz5MTTTniCA4gtOfxZcegoo8TOT9uOGO6
+          0213oPc0xqYETwFjHd8OXNpr5LJf0quzmesQLs5ckphTuGxII6aGQZd5k2C2Op3Xq6IhP5uiqVNs
+          Wo1qwRbwh6/PGGqA1I8DI/74tW36EWXM3IU//olDaScFPFPeFVDf1A5bUTVVlLGuEIjcfCZ3KQPb
+          /l0aJKDwgF2HLcEccs8avDnRxloDNstow7NC2zMu1eIKDLfPd2uKbdrTjq5Pm9bTvgX22t0mYU4Y
+          u//pNf3AZsR6t2f7ix+5BfWrbhJ/44O0OZ8l8bdfTszgqkv9vbroXBgWVrBcVfPdAxD89GqQM1U2
+          h0vXws9oZti+PIyeNcujidoISOT8PFQVSbCowcvxZv3x/1nObAWetPuOmOORrxYNkRLYB+aAtQwb
+          YAaul0P9WGhEOb9IRnnfLmDv8Xds33iz52CnQ7jpUXzSPbHq1306wQGUIpYO4NPPNy3I4d3Ap4nU
+          ckqXnSnqcE19d0tZzmD2WGMHD/NTIcfX904bWWhLuPHhn96y2ejNKNAaojM57z38F9/AudEzor1Y
+          iTJ3j+4gQuEVm83BDebr62aKJtRc/CjHU7Zei6j98VPi//Bmu1+g3VsGR0tmVrxQ1d0fPnTUWKvZ
+          vKaKuH86Ebnk7zkjAy8yIBWcEOOQjGp7y70CqvdQdOn+0YM5WVcP6TcxxkaRwJ4an7GG0w5C97Xp
+          pyWzzjuI7T03rU/6rjb9IEKT0xC5k11pz4+r5sBlChvyHMVZXUzRcqESSD4+W1NRrfsbeiAV6jM5
+          nndEHf/4kqxCdxe9+GqUT44Ff99bWpsJZRS8mkA/8BnW22oGa7GfBHgwwYBtFJb2uuZdAT5MCPFV
+          dVt7ZZlMBG8N+djd+NPsvRULDlNk4mN1WlXyZOwdfAtGSk66l1ZEcocaMPfBw2nC2epoX2iHckcs
+          8NEUrH5m410CNj1GpBV36jq60wCunq5jB5UTXd3aj0UlxC+si+zHps6ReJAJxWUCKCzVpZbDGMm4
+          CqcPPAn9uK0feN+utbtiWa04lJ6s3/O4b0aW+wUqXw6YLbCn/f6pUE7CVgy2xtgTM487OkqLoYC4
+          gQMxdrEXzGc2aCGJCx87Qm5lC+ITESlg5vBt91az1XkoGgJnOJLr2q10ruVVR1qpGvgI07L/e98J
+          i14Y63euHxuffcBzNDbEdNyr3R5x8wDHCkrEPfRhtaTCsAIzI7epNdsGzNJSz5Bvu9H9ZMOnmjQh
+          ZJB5DxMcg9Kqlm09oRflR+KXw5rNUe9O0M+GCGeqs6i0W7oabv8/CaytUSbhiQMONhHJkZne6gLg
+          pUCS+hknJLF9NnBS3sGn9bXxkZUTun4CIIHrieynHY7cYE2pr4PbXhenMUijYHm7UoFaZUREfiWy
+          zTg2yuH9kX1d2HemvZa156A7sp/TXq2/lFZs0ID2fiw2fZAA3uscDsRL6JHrzFt0ltXzDloX1LmH
+          w7pW1Nx3LfASL8CR1a/Vph/SPz4dvM91sMjRHKJv93bIiXty6ndnrjqgRnbEP73PVsCR4OZfbfFe
+          tdljmXBQq9nIfX+gQjnXaEP0Ob51cn8e1L65JGiFxrpjiT2XhfqdonwSpXidsda4Ml0xCx7gkn86
+          cpxY0tc/fp/2UkniUFDshZ3uA9z4Er5VL4sumiA2wDswV7z5L/Yi1IWFAkke8W3Tc8zFLRJxbXvs
+          vlxJt1fNu+2gfgZ02i1+0M8f7v44NIvLYC2DfbbCdypBPxENgrf4uYRnDsIs3X9csSjbat31nQe/
+          qszj0xCM6kIslQGR+iQTK60oI2YeTlC/CfF0iJV3wC22nKDhWNf4kTChOlxuiw8e0LdcJoN9QONw
+          nZAn4GTaB982oJ6PV2AY8hkf1+xJxxvWa7T5E24zwwV0RcmIaAj2b3eflpG96QUFbHVH5A/fN78H
+          9kevw4rlrnQc0nsMD7lGsJE6QfC9S0kCi+f16u7lq2+vhmQ+4KnjNKxsfI+2bhHCl6Y9ydU9Kyp7
+          opMHZX9IcFI1l58fwICzf0jcw6YnqFHOHXRNdprW994FY9OtBfrxf2x7RsZvfAU9rwwiDx2O2ero
+          Rwn9/Cp56LYeVK+LBr4MnDFm9FvAjC87hIdQxPhkq32wPvZrAyZoTe7SLIeMbv4s2L5XgvdPBSzD
+          mqbCLY7jaXBv/BaPaIxER2awfqQi6L+FnMO0V0qCY1jT9XYCInhHsUHkbT8Mqvby4exxAMuH3KNL
+          Yl06FFVcja2CzbPpeQlWVDi1RrRHqWXML547x2yY5gmO1ebXrcDJUuQKBhsBZrHuItwXc0qOxlHJ
+          Jti5ELZMx+HT+Vtn6/PrMWjDJ6wsl7yaD8FFQ8r00SbumpyreQif1iFudgPBLdP36/KhCeSSmGLj
+          2ojB8IGHP35P8LZfVpSeTLitH7lvfG3mqrKBFedfiW7qhb3cvYcDYqVOsb22GaAXblFQtEgx1t/d
+          Ni+HBTnY/KyJH2s3W5cPSIBpnSJ8vlIum23DLGFiyQc3FLcurY8Dk8Cvh79uf72QnhAtS+G3qB//
+          8S8O57b72y/yq2coYenOgtlkdUQ3AqLOZ/88CEqg+ETXaFXx7zmFUEDxgTj7iKMTy2TCgVHj8e99
+          z953r0Hv9iyJ7du2/YtfYh/0vSt6852uC97F0JSsz/Q2ha6fin0jwlI+x9ghnpDNm16Fz33iT2Jy
+          +lRzrW+1hdXNJfbdOqpdXWsF+Pll2Y03qzWJnBWU762Er2Ie1YanNSSCFk+Dmt7pIr9Ozg9/iLrp
+          841/1jD4uluT/D3q57ngO3AUYh8bJ0ZWh1NLTRTkEsYX5ZMH691WC5jtpwkbYz1lP34hGpgbiPsO
+          lGDzE0LoooYlP71JI/XS/PwnLG9+6HzcFzW6glaYvh4sAL/hPZxiJ3HrLb6uhbXnRMf/PIj8OG6D
+          AcJkBoHCg2nHC05G9Nh5iIObqthIbnbG4DlQYOyhzJ03f5XzjLyFT6u3J159ATo77SeHP7/p5JMW
+          0AGSGfz40WkqNDpcuMoHkDA9tg5Sa89OSx5gXBidXFxJV5cOe9aPDxAnfr7VGcG+gZwKX+THl7te
+          SDY9Ey3YqXZWT0VZlCC5jq/pECiw+grfSIMP+bWSIHWtbPPLShTF7frTe2DwZOgcsLbE+NHddEoH
+          fmUQqSbNLfKOD2h+OQ0A4idHdI7cKJEWsQTJ3YXkvPG9aY59D51ChuKffztxsmlC1+Qnly/9olp7
+          dC7//PDI4wGdr6dcE7+7/eOnH9Qt3pjwcbIUbAc7qlJTe7bwptrB5OUdn1HYey7qZjHZSmR6dQlv
+          mIFCNrN/+ao//2jzM4h+2+n9on4uD7jdLzZm3gLzhas89PNnENPx6oYXOmLuk+cy11Na/emXb+7a
+          RKbeZzvCYA8/f8CFm3+/damJxYM9itNhpHKwapErQuh3Ijmv2kMl150nAhRRxRV9FFXrvZJqFPWq
+          RiTN4cHSdGIJf3hqPP0r/fNvU/V53q5n9CsnSyYMJHXEdrhoNjuqoIEvUWKJo49psLRdw4B8etRY
+          C7iHSgtJcKClUYFIN81Q18rv04NQohjH0ftY8Zt/DsZA87Cshk9Kx1MoobJde3JkZYG201o/0Ba/
+          yJF7jeovnwBD7/oh59zhq941rBo81byfSr6Wqzl6sgxUwMpt+qityI6LUuhozh1v+xewguw7kGbL
+          leiHaKULp6cc/PFxk30k1fy0QfzL/5ATzodg4SqNAdv3PvHyFIAZcFkMP0wM8SnZjuqRBjFgi/8k
+          iLJDtfDMewfz4yBhs9RRNUXvhweMT6JgVec2/2rvz/AkPV6bP3Wolpczi2jzG3GEH+qffw5GwDD4
+          vL1/4vcbvxHnI74FSl4tgm5YqBeSFYfTRwFLy/IDBLxuYLmvLZWylRBDhOlM1PKcVd3oThP47tAD
+          4xjLwYLgkUE0bHiC17EAi2eIKSyRhSZOKXbBMglli7yK1Yn1Kp9g/SquA0FDfGyVpAg4U0MpNOUr
+          9xe/2yQ2vb/4o9nWN1gu8uOxVZS9pkUJ22rgktsEwzgU8NkKPTpbx9EBJtRdbIYfQZ2hwRS//A95
+          VNLdno2RzsgXHzZ2OBiBP/yl8o3BtjzkYPjlZ8pLbWO8X+N+dfSzBO2LFuFMHiDd8qMSWq6WTtxK
+          QuqULLsZpur9jN1GeoPeEksJAieaJvCJJ3Vxv6MCvdu9xHlTV32LYF/D5PXB0y5yK0DXvT+gMA9P
+          xNdBHKz4PDdovOs74hSXXbUKzjkGz0giP/874HZ950NuL5rYOMrzxvfEv3wP0dO+sydX1hKkdUyD
+          Y/8NwbKMug65d/EmRulLFX8B4+7PX9z0UNBa99JD0rj3XGaWsmyE3TDArgM61lrZsgfWl3O4+SPT
+          ytevih6SYIbPSCGTuHwe2V++bdOn02AXts2+H24IyktjYyNfh2BmdaGG97ObEok1Y7BqWcfBVi4n
+          Il13SrDWjpHDml+KP7ybXR0yv/zhb39Qmh+cBuJvcZ9E727ZbLLmJfi9n9N9KsEi1uEDWved435c
+          8Vitw+kww+OpzslVdU17QLeo/d8lBf/6r//671uBwD9Ne3+8t8KA8bGM//4/pQL/5v89NOn7/Sss
+          +Gca0uLxz3/7TwnCP9++bb7j/xjb+vEZtloDJLLsX7nBP2M7pu//66d/bRf8n//6XwAAAP//AwAf
+          5B46ugUCAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1c77faafafc-SJC
+          - 8ebdeda9095eeb2e-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -2898,9 +2941,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:40 GMT
+          - Mon, 02 Dec 2024 20:04:51 GMT
         Server:
           - cloudflare
+        Set-Cookie:
+          - __cf_bm=vQbWSmy1LHdcet8MSIe0Pu_LJbTk2vKF4kot8gct6A0-1733169891-1.0.1.1-5jjUvUtGVXwkhGuKgm1uVVFQUwKieMZ.YhVDM3ixDl9dCIsgQjpLbQ3uFO7aZXhGIEQahV7mRTDNcIy8WbP6eQ;
+            path=/; expires=Mon, 02-Dec-24 20:34:51 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=MAQzaHxWF64xor8G21zhSIb63aks6_Qa0g5cwMlC_l8-1733169891495-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
         X-Content-Type-Options:
@@ -2916,7 +2965,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "205"
+          - "642"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -2934,17 +2983,17 @@ interactions:
         x-ratelimit-reset-tokens:
           - 121ms
         x-request-id:
-          - req_828e37e7bde49fe9d7f1e2400f10ce9d
+          - req_a54cb5bf5fcd436c17a2976d3f26a8a9
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"input": [". Characteristic\n\n     aroma compounds from different pineapple
-        parts. Molecules 2011, 16, 5104\u20135112.\n\n\n\n                                       40(149)
+        "{\"input\":[\". Characteristic\\n\\n     aroma compounds from different
+        pineapple parts. Molecules 2011, 16, 5104\u20135112.\\n\\n\\n\\n                                       40(149)
         Stumpfe, D.; Bajorath, J. Exploring Activity Cliffs in Medicinal Chemistry.
-        Journal\n\n       of Medicinal Chemistry 2012, 55, 2932\u20132942, PMID: 22236250.\n\n\n\n\n\n                                       41"],
-        "model": "text-embedding-3-small", "encoding_format": "base64"}'
+        Journal\\n\\n       of Medicinal Chemistry 2012, 55, 2932\u20132942, PMID: 22236250.\\n\\n\\n\\n\\n\\n
+        \                                      41\"],\"model\":\"text-embedding-3-small\",\"encoding_format\":\"base64\"}"
       headers:
         accept:
           - application/json
@@ -2953,13 +3002,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "453"
+          - "442"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -2969,7 +3018,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -3096,7 +3145,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1d02fbefafc-SJC
+          - 8ebdedaf9fa6eb2e-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -3104,7 +3153,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:40 GMT
+          - Mon, 02 Dec 2024 20:04:51 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -3122,7 +3171,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "71"
+          - "85"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -3140,14 +3189,12 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_11d0e7ee9fb0abf5f394f515f7b39ec5
+          - req_b30e91c9c76d8f104027a8dc07d053b0
       status:
         code: 200
         message: OK
   - request:
-      body:
-        '{"input": ["Are counterfactuals actionable? [yes/no]"], "model": "text-embedding-3-small",
-        "encoding_format": "base64"}'
+      body: '{"input":["Are counterfactuals actionable? [yes/no]"],"model":"text-embedding-3-small","encoding_format":"base64"}'
       headers:
         accept:
           - application/json
@@ -3156,13 +3203,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "119"
+          - "114"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -3172,11 +3219,11 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
-          - "1"
+          - "0"
         x-stainless-runtime:
           - CPython
         x-stainless-runtime-version:
@@ -3299,7 +3346,7 @@ interactions:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1d46828fa92-SJC
+          - 8ebdedf0b972cfc4-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -3307,7 +3354,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:41 GMT
+          - Mon, 02 Dec 2024 20:05:02 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -3325,7 +3372,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "62"
+          - "109"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -3343,84 +3390,86 @@ interactions:
         x-ratelimit-reset-tokens:
           - 0s
         x-request-id:
-          - req_cc0ee3fac2d392463ae84848954181d4
+          - req_519bc847bebc9bbc2cce49853cdbc49c
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 12-14: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\nnterfac-\n\n\n                                       11tual
-        explanations. Unlike the counterfactual approach, contrastive approach employ
-        a dual\n\noptimization method, which works by generating a similar and a dissimilar
-        (counterfactuals)\n\nexample.  Contrastive explanations can interpret the model
-        by identifying contribution of\n\npresence and absence of subsets of features
-        towards a certain prediction.36,99\n\n  A counterfactual x\u2032 of an instance
-        x is one with a dissimilar prediction \u02c6f(x) in classi-\n\nfication tasks.
-        As shown in equation 5, counterfactual generation can be thought of as a\n\nconstrained
-        optimization problem which minimizes the vector distance d(x, x\u2032) between
-        the\n\nfeatures.9,100\n\n\n                              minimize  d(x, x\u2032)\n                                                                                           (5)\n                               such
-        that   \u02c6f(x) \u0338= \u02c6f(x\u2032)\n\n   For regression tasks, equation
-        6 adapted from equation 5 can be used. Here, a counter-\n\nfactual is one with
-        a defined increase or decrease in the prediction.\n\n\n                           minimize  d(x,
-        x\u2032)\n                                                                                           (6)\n                            such
-        that    \u02c6f(x) \u2212\u02c6f(x\u2032) \u2265\u2206\n\n   Counterfactuals
-        explanations have become a useful tool for XAI in chemistry, as they\n\nprovide
-        intuitive understanding of predictions and are able to uncover spurious relationships\n\nin
-        training data.101 Counterfactuals create local (instance-level), actionable
-        explanations.\n\nActionability of an explanation suggest which features can
-        be altered to change the outcome.\n\nFor example, changing a hydrophobic functional
-        group in a molecule to a hydrophilic group\n\nto increase solubility.\n\n   Counterfactual
-        generation is a demanding task as it requires gradient optimization over\n\ndiscrete
-        features that represents a molecule. Recent work by Fu et al. 102 and Shen et
-        al. 103\n\npresent two techniques which allow continuous gradient-based optimization.
-        Although, these\n\nmethodologies are shown to circumvent the issue of discrete
-        molecular optimization, counter-\n\nfactual explanation based model interpretation
-        still remains unexplored compared to other\n\n\n\n                                       12post-hoc
-        methods.\n\n   CF-GNNExplainer104 is a counterfactual explanation generating
-        method based on GN-\n\nNExplainer69 for graph data. This method generate counterfactuals
-        by perturbing the input\n\ndata (removing edges in the graph), and keeping account
-        of perturbations which lead to\n\nchanges in the output.  However, this method
-        is only applicable to graph-based models\n\nand can generate infeasible molecular
-        structures. Another related work by Numeroso and\n\nBacciu 105 focus on generating
-        counterfactual explanations for deep graph networks. Their\n\nmethod MEG (Molecular
-        counterfactual Explanation Generator) uses a reinforcement learn-\n\ning based
-        generator to create molecular counterfactuals (molecular graphs).  While this\n\nmethod
-        is able to generate counterfactuals through a multi-objective reinforcement
-        learner,\n\nthis is not a universal approach and requires training the generator
-        for each task.\n\n   Work by Wellawatte et al. 9 present a model agnostic counterfactual
-        generator MMACE\n\n(Molecular Model Agnostic Counterfactual Explanations) which
-        does not require training\n\nor computing gradients. This method firstly populates
-        a local chemical space through ran-\n\ndom string mutations of SELFIES106 molecular
-        representations using the STONED algo-\n\nrithm.107 Next, the labels (predictions)
-        of the molecules in the local space are generated\n\nusing the model that needs
-        to be explained. Finally, the counterfactuals are identified and\n\nsorted by
-        their similarities \u2013 Tanimoto distance96 between ECFP4 fingerprints.97
-        Unlike the\n\nCF-GNNExplainer104 and MEG105 methods, the MMACE algorithm ensures
-        that generated\n\nmolecules are valid, owing to the surjective property of SELFIES.
-        Additionally, the MMACE\n\nmethod can be applied to both regression and classification
-        models. However, like most XAI\n\nmethods for molecular prediction, MMACE does
-        not account for the chemical stability of\n\npredicted counterfactuals. To circumvent
-        this drawback, Wellawatte et al. 9 propose an-\n\nother approach, which identift
-        counterfactuals through a similarity search on the PubChem\n\ndatabase.108\n\n\n\n\n\n                                       13Similarity
-        to adjacent fields\n\n\nTangential examples to counterfactual explanations are
-        adversarial training and matched\n\nmolecular pairs.  Adversarial perturbations
-        are used during training to deceive the model\n\nto expose the vulnerabilities
-        of a model109,110 whereas counterfactuals are applied post-hoc.\n\nTherefore,
-        the main difference between adversarial and counterfactual examples are in the\n\napplication,
-        although both are derived from the same optimization problem.100 Grabocka\n\net
-        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\n\nwhich
-        improves model robustness via ex\n\n----\n\nQuestion: Are counterfactuals actionable?
-        [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06", "stream": false, "temperature":
-        0.0}'
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 12-14: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\nnterfac-\\n\\n\\n
+        \                                      11tual explanations. Unlike the counterfactual
+        approach, contrastive approach employ a dual\\n\\noptimization method, which
+        works by generating a similar and a dissimilar (counterfactuals)\\n\\nexample.
+        \ Contrastive explanations can interpret the model by identifying contribution
+        of\\n\\npresence and absence of subsets of features towards a certain prediction.36,99\\n\\n
+        \ A counterfactual x\u2032 of an instance x is one with a dissimilar prediction
+        \u02C6f(x) in classi-\\n\\nfication tasks. As shown in equation 5, counterfactual
+        generation can be thought of as a\\n\\nconstrained optimization problem which
+        minimizes the vector distance d(x, x\u2032) between the\\n\\nfeatures.9,100\\n\\n\\n
+        \                             minimize  d(x, x\u2032)\\n                                                                                           (5)\\n
+        \                              such that   \u02C6f(x) \u0338= \u02C6f(x\u2032)\\n\\n
+        \  For regression tasks, equation 6 adapted from equation 5 can be used. Here,
+        a counter-\\n\\nfactual is one with a defined increase or decrease in the prediction.\\n\\n\\n
+        \                          minimize  d(x, x\u2032)\\n                                                                                           (6)\\n
+        \                           such that    \u02C6f(x) \u2212\u02C6f(x\u2032) \u2265\u2206\\n\\n
+        \  Counterfactuals explanations have become a useful tool for XAI in chemistry,
+        as they\\n\\nprovide intuitive understanding of predictions and are able to
+        uncover spurious relationships\\n\\nin training data.101 Counterfactuals create
+        local (instance-level), actionable explanations.\\n\\nActionability of an explanation
+        suggest which features can be altered to change the outcome.\\n\\nFor example,
+        changing a hydrophobic functional group in a molecule to a hydrophilic group\\n\\nto
+        increase solubility.\\n\\n   Counterfactual generation is a demanding task as
+        it requires gradient optimization over\\n\\ndiscrete features that represents
+        a molecule. Recent work by Fu et al. 102 and Shen et al. 103\\n\\npresent two
+        techniques which allow continuous gradient-based optimization. Although, these\\n\\nmethodologies
+        are shown to circumvent the issue of discrete molecular optimization, counter-\\n\\nfactual
+        explanation based model interpretation still remains unexplored compared to
+        other\\n\\n\\n\\n                                       12post-hoc methods.\\n\\n
+        \  CF-GNNExplainer104 is a counterfactual explanation generating method based
+        on GN-\\n\\nNExplainer69 for graph data. This method generate counterfactuals
+        by perturbing the input\\n\\ndata (removing edges in the graph), and keeping
+        account of perturbations which lead to\\n\\nchanges in the output.  However,
+        this method is only applicable to graph-based models\\n\\nand can generate infeasible
+        molecular structures. Another related work by Numeroso and\\n\\nBacciu 105 focus
+        on generating counterfactual explanations for deep graph networks. Their\\n\\nmethod
+        MEG (Molecular counterfactual Explanation Generator) uses a reinforcement learn-\\n\\ning
+        based generator to create molecular counterfactuals (molecular graphs).  While
+        this\\n\\nmethod is able to generate counterfactuals through a multi-objective
+        reinforcement learner,\\n\\nthis is not a universal approach and requires training
+        the generator for each task.\\n\\n   Work by Wellawatte et al. 9 present a model
+        agnostic counterfactual generator MMACE\\n\\n(Molecular Model Agnostic Counterfactual
+        Explanations) which does not require training\\n\\nor computing gradients. This
+        method firstly populates a local chemical space through ran-\\n\\ndom string
+        mutations of SELFIES106 molecular representations using the STONED algo-\\n\\nrithm.107
+        Next, the labels (predictions) of the molecules in the local space are generated\\n\\nusing
+        the model that needs to be explained. Finally, the counterfactuals are identified
+        and\\n\\nsorted by their similarities \u2013 Tanimoto distance96 between ECFP4
+        fingerprints.97 Unlike the\\n\\nCF-GNNExplainer104 and MEG105 methods, the MMACE
+        algorithm ensures that generated\\n\\nmolecules are valid, owing to the surjective
+        property of SELFIES. Additionally, the MMACE\\n\\nmethod can be applied to both
+        regression and classification models. However, like most XAI\\n\\nmethods for
+        molecular prediction, MMACE does not account for the chemical stability of\\n\\npredicted
+        counterfactuals. To circumvent this drawback, Wellawatte et al. 9 propose an-\\n\\nother
+        approach, which identift counterfactuals through a similarity search on the
+        PubChem\\n\\ndatabase.108\\n\\n\\n\\n\\n\\n                                       13Similarity
+        to adjacent fields\\n\\n\\nTangential examples to counterfactual explanations
+        are adversarial training and matched\\n\\nmolecular pairs.  Adversarial perturbations
+        are used during training to deceive the model\\n\\nto expose the vulnerabilities
+        of a model109,110 whereas counterfactuals are applied post-hoc.\\n\\nTherefore,
+        the main difference between adversarial and counterfactual examples are in the\\n\\napplication,
+        although both are derived from the same optimization problem.100 Grabocka\\n\\net
+        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\\n\\nwhich
+        improves model robustness via ex\\n\\n----\\n\\nQuestion: Are counterfactuals
+        actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -3429,13 +3478,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6140"
+          - "6072"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -3445,7 +3494,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -3459,23 +3508,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xUTW/bMAy951cQOieB434luW3Fup22YeiKDfPgKBJtqZNFQR9pgyL/fZCdJunW
-          Abv4wEc+PT6SfhoBMC3ZEphQPIrOmcmbb9/f04c7efFO3ny8Lj4vFt3b2/Wd/PRVuS9snCtofY8i
-          PldNBXXOYNRkB1h45BEz6+zqrLy4WCzKsgc6kmhyWevi5JwmZVGeT4r5pLjcFyrSAgNbwo8RAMBT
-          /80SrcRHtoRi/BzpMATeIlsekgCYJ5MjjIegQ+Q2svERFGQj2l71arW6D2Qr+1RZgIqF1HXcbyu2
-          hIpdU7IRfcNFTNwAPjrDLc/dBeAeIWtBCVzkEF8bnMKtwi04TxstMx6TjnqDkKxEn3VIbVugBpxH
-          qcWeykoIqW0xRHhQWihokMfkMYDgFtYI3ET0KCESCMVtixAVAqUoqMMp3JAHfOTZ+jFoC0Jhp0P0
-          2/GQnt/koLbSk1O01gKaZAfRBlpPyeUqDh0ZFMlgfueQr40W+6SsRts804AQyKS1Njpuc9c6HGzo
-          Y8CNoYcADXkwJLjJwrIBAicGN/iHm1Hx2NO3KRvXkdSNFs8gARdK4wZBYtDZiBP7phUbD7PzaHCT
-          X6iDII/DDGdFxSq7q+xqtTrdAY9NCjyvoE3G7OO7w1IZap2nddjjh3ijrQ6qzhaQzQsUIjnWo7sR
-          wM9+edOLfWTOU+diHekX2kw4K4v5QMiO93KEF+UejBS5OSk7K/ZL/5Kxlhi5NuHkAJjgQqE81h6v
-          hSep6QQYnfT9t5zXuIfetW3/h/4ICIEuoqyPo3stzWP+n/wr7eBzL5iFbYjY1Y22LXrn9XDSjavn
-          ZzMsLq/kvGSj3eg3AAAA//8DAHMVDZbbBAAA
+          H4sIAAAAAAAAA4xUTY8TMQy991dYOberfsButze0iAMICSEQAga1aeKZMWTiKHFKh9X+d5ROaYvY
+          lbjMwc/vjf1s534EoMiqFSjTajFdcJMX+np/94bizcu3/Hzfvfv18dOX+TLE1+/7z2/VuDB4+x2N
+          /GFdGe6CQyH2A2wiasGiOrtZLGbXt7fT+QHo2KIrtCbI5BlP5tP5s8l0OZleH4ktk8GkVvB1BABw
+          f/iWEr3FvVrBdPwn0mFKukG1OiUBqMiuRJROiZJoL2p8Bg17QX+oerPZfE/sK39feYBKpdx1OvaV
+          WkGl7jh7wVhrI1k7wH1w2uvSXQIdEUotaEGbEtJbh1fwocUeQuQd2YJLJqEdQvYWY6nDkm+AawgR
+          LZmjlLeQctNgEvjZkmmhRi05YgKjPWwRtBOMaEEYTKt9gyAtAmcx3OEVvOIIuNfF+jGQB9NiR0li
+          Px7Syz81tL2NHFrekoE6+6FoB03kHApLQ8cOTXZY/nPKJ0fmmCQM5MtIE0Jil7fkSHqg0sKFC0A+
+          UdMKWIy0Qwt15A7MX2amYlUhHllnJfiBPegU0Egxyjw9gzHoBCSgneOfCWqO4NhoVzwoXhucONyh
+          O3qWQFotB0stRTTieiBfu4zeDIaeh3LytlLjYTEiOtwVzXUyHHFYkNm0UpV/qPxms7lcsIh1Trrs
+          t8/OHeMPp4113ITI23TET/GaPKV2XQxmX7YzCQd1QB9GAN8Ol5H/WnYVIndB1sI/0BfB2Xy6HATV
+          +Rgv4NniiAqLdhfAYj4bPyK5tiiaXLo4L2W0adGeuedb1NkSXwCji8b/recx7aF58s3/yJ8BYzAI
+          2vV5hI+lRSyv1VNpJ6MPBavUJ8FuXZNvMIZIw4NRh/VyMcPp9Y1dztXoYfQbAAD//wMApyqFqjkF
+          AAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1d63f6022ea-SJC
+          - 8ebdedf2ae6117ea-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -3483,14 +3533,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:43 GMT
+          - Mon, 02 Dec 2024 20:05:04 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=STnfSyXPaam5SdHILMuwbp_K.whM_Tzlh7tLtfQ7VIE-1732559923-1.0.1.1-CkPF6ON4C3uJzK3gcwD_QMFyxy49IJrt85EOw_EM7DcB3lrtw1nYbFoo7aavsiFFHuew5A7ALGO95YwN01niuQ;
-            path=/; expires=Mon, 25-Nov-24 19:08:43 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=8qKtEchwziWcNPSdnLM3fvodnhW5YwFMLrEZCWQdupA-1733169904-1.0.1.1-9Hl5J_1w8n3CouCkfo74oKuMSF5OMshJdj_dqilV1izM.TNMTwrZl9lEvUBvybIIDr18jConn7Zk_msjChdALA;
+            path=/; expires=Mon, 02-Dec-24 20:35:04 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=4y7.cC35h1UvgrrYA0HaO9Vc_JaGcQJvJUDP9XF2Qkg-1732559923240-0.0.1.1-604800000;
+          - _cfuvid=tP7L.DWffWgK6_ERdYhk4lK6Ozd9Lrzd8zI8oL0nsBI-1733169904655-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -3503,7 +3553,372 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "1436"
+          - "2027"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998535"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_96e4b24c10499a191b9549f448597223
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 20-22: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\nody,\u2019
+        \u2018floral\u2019 and \u2018herbal\u2019 scents.\\n\\n\\n\\n\\n\\nFigure 5:
+        \ Counterfactual for the 2,4 decadienal molecule.  The counterfactual indicates\\nstructural
+        changes to ethyl benzoate that would result in the model predicting the molecule\\nto
+        not contain the \u2018fruity\u2019 scent. The Tanimoto96 similarity between
+        the counterfactual and\\n2,4 decadienal is also provided. Republished with permission
+        from authors.31\\n\\n\\n   The molecule 2,4-decadienal, which is known to have
+        a \u2018fatty\u2019 scent, is analyzed in Fig-\\n\\nure 5.142,143 The resulting
+        counterfactual, which has a shorter carbon chain and no carbonyl\\n\\ngroups,
+        highlights the influence of these structural features on the \u2018fatty\u2019
+        scent of 2,4 deca-\\n\\ndienal. To generalize to other molecules, Seshadri et
+        al. 31 applied the descriptor attribution\\n\\nmethod to obtain global explanations
+        for the scents. The global explanation for the \u2018fatty\u2019\\n\\nscent
+        was generated by gathering chemical spaces around many \u2018fatty\u2019 scented
+        molecules.\\n\\nThe resulting natural language explanation is: \u201CThe molecular
+        property \u201Cfatty scent\u201D can\\n\\nbe explained by the presence of a
+        heptanyl fragment, two CH2 groups separated by four\\n\\n                                       20bonds,
+        and a C=O double bond, as well as the lack of more than one or two O atoms.\u201D31\\n\\nThe
+        importance of a heptanyl fragment aligns with that reported in the literature,
+        as \u2018fatty\u2019\\n\\nmolecules often have a long carbon chain.144 Furthermore,
+        the importance of a C=O dou-\\n\\nble bond is supported by the findings reported
+        by Licon et al. 145, where in addition to a\\n\\n\u201Clarger carbon-chain skeleton\u201D,
+        they found that \u2018fatty\u2019 molecules also had \u201Caldehyde or acid\\n\\nfunctions\u201D.145
+        For the \u2018pineapple\u2019 scent, the following natural language explanation
+        was ob-\\n\\ntained: \u201CThe molecular property \u201Cpineapple scent\u201D
+        can be explained by the presence of ester,\\n\\nethyl/ether O group, alkene/ether
+        O group, and C=O double bond, as well as the absence of\\n\\nan Aromatic atom.\u201D31
+        Esters, such as ethyl 2-methylbutyrate, are present in many pineap-\\n\\nple
+        volatile compounds.146,147 The combination of a C=O double bond with an ether
+        could\\n\\nalso correspond to an ester group. Additionally, aldehydes and ketones,
+        which contain C=O\\n\\ndouble bonds, are also common in pineapple volatile compounds.146,148\\n\\n\\nDiscussion\\n\\n\\nWe
+        have shown two post-hoc XAI applications based on molecular counterfactual expla-\\n\\nnations9
+        and descriptor explanations.10 These methods can be used to explain black-box\\n\\nmodels
+        whose input is a molecule. These two methods can be applied for both classification\\n\\nand
+        regression tasks. Note that the \u201Ccorrectness\u201D of the explanations
+        strongly depends on\\n\\nthe accuracy of the black-box model.\\n\\n  A molecular
+        counterfactual is one with a minimal distance from a base molecular, but\\n\\nwith
+        contrasting chemical properties.  In the above examples, we used Tanimoto similar-\\n\\nity96
+        of ECFP4 fingreprints97 as distance, although this should be explored in the
+        future.\\n\\nCounterfactual explanations are useful because they are represented
+        as chemical structures\\n\\n(familiar to domain experts), sparse, and are actionable.
+        A few other popular examples of\\n\\ncounterfactual on graph methods are GNNExplainer,
+        MEG and CF-GNNExplainer.69,104,105\\n\\n   The descriptor explanation method
+        developed by Gandhi and White 10 fits a self-explaining\\n\\n\\n\\n                                       21surrogate
+        model to explain the black-box model. This is similar to the GraphLIME87 method,\\n\\nalthough
+        we have the flexibility to use explanation features other than subgraphs. Futher-\\n\\nmore,
+        we show that natural language combined with chemical descriptor attributions
+        can\\n\\ncreate explanations useful for chemists, thus enhancing the accessibility
+        of DL in chemistry.\\n\\nLastly, we examined if XAI can be used beyond interpretation.
+        Work by Seshadri et al. 31 use\\n\\nMMACE and surrogate model explanations to
+        analyze the structure-property relationships\\n\\nof scent. They recovered known
+        structure-property relationships for molecular scent purely\\n\\nfrom explanations,
+        demonstrating the usefulness of a two step process: fit an accurate model\\n\\nand
+        then explain it.\\n\\n   Choosing among the plethora of XAI methods described
+        here is still an open question.\\n\\nIt remains to be seen if there will ever
+        be a consensus benchmark, since this field sits on\\n\\nthe intersection of
+        human-machine interaction, machine learning, and philosophy (i.e., what\\n\\nconstitutes
+        an explanation?). Our current advice is to consider first the audience \u2013
+        domain\\n\\nexperts or ML experts or non-experts \u2013 and what the explanations
+        should accomplish. Are\\n\\nthey meant to inform data selection or model building,
+        how a prediction is used, or how the\\n\\nfeatures can be changed to affect
+        the outcome. The second consideration is what access you\\n\\nhave to the underlying
+        model. The ability to have model derivatives or propagate gradients\\n\\nto
+        the input to models informs the XAI method.\\n\\n\\nConclusion and outlook\\n\\n\\nWe
+        should seek to explain molecular property prediction models because users are
+        more\\n\\nlikely to trus\\n\\n----\\n\\nQuestion: Are counterfactuals actionable?
+        [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "6118"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xUTWsbQQy9+1eIOdvBH8FpfCs5FHpoKQ2U0C22dla7M8l8MZpNbIL/e5mxY69p
+          Ar3sQU/SvvckzesIQOhGrEBIhUnaYCafcbm9e5hJc/vlx8P9i5Jf2+/zX9v5/beH3U8xzhW+fiSZ
+          3qqupLfBUNLeHWAZCRPlrrObxWK2vL2dzgtgfUMml3UhTa79ZD6dX0+mnybT5bFQeS2JxQp+jwAA
+          Xss3U3QNbcUKpuO3iCVm7EisTkkAInqTIwKZNSd0SYzPoPQukSusN5vNI3tXudfKAVSCe2sx7iqx
+          gkrc+d4lii3K1KMB2gaDDrM6BowEDbGMuqYGkAFlBrA2BNpBUgTlN9sEvgXrDcneYIQQqdElFYoH
+          fAX3inalX6QQicmlQ0epyGqJBjjFXqY+Eo/hRWmpSnaLVhuNEZKHxlvULjOkmHgM6JqSwwEj0xgs
+          PmnXZVYWeqa2N9D6CL1rKGZ7mozmouCzMxqN2QGaRDEDJyIh+vwDTQfWUOQp3SmjO5UYksIE8sI1
+          BoXPBAhWO23RQFPmIQna6C0g1Mj05g9B3ScInpmYi38ROX1A4VLVwP6s7NIQeFEeJLqsPadznhEf
+          Ofs8CN3uBkM6G55hlErTcxm3jtSA75P0lviqEuPD1kQy9JxFrVn6SIftua1E5faV22w2w+WL1PaM
+          efddb8wxvj9ts/FdiL7mI36Kt9ppVutIyN7lzeXkgyjofgTwp1xNf3EIIkRvQ1on/0QuN5wtpsez
+          EedDHcDTmyOafEIzAK5PyEXLdUMJteHB6QmJUlFzrj3fKfaN9gNgNBD+L5/3eh/Ea9f9T/szICWF
+          RM36fHrvpUXKL9lHaSejC2HBO05k1612HcUQ9eExacP6pl3WtKC2norRfvQXAAD//wMAuRprvFUF
+          AAA=
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdedf2baa99440-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 20:05:04 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=6X7KW2r0wPUkgxCL_K_HhvKujiKUtis8QG6qcwjcenE-1733169904-1.0.1.1-TDMbnjUA85UvuTKAH_cXf0KTsmxScK6CJ9NLzr.7TlhHvV4JzejfD.pz6FhtE_b0bodPMjf46TRRCXYehoDzMw;
+            path=/; expires=Mon, 02-Dec-24 20:35:04 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=t1.JDDPO2EQo9bT2n9yQp3e8IJWR1Y9aXyH9_YZngmk-1733169904728-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "2093"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998523"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_719aed190552e243935fa8bd10b5cb8a
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 9-12: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\n
+        features. Weber et al. 82 used saliency maps to build an explainable GCN\\n\\narchitecture
+        that gives subgraph importance for small molecule activity prediction. On the\\n\\nother
+        hand, similarity maps compare model predictions for two or more molecules based
+        on\\n\\ntheir chemical fingerprints.83 Similarity maps provide atomic weights
+        or predicted probabil-\\n\\n\\n                                        9ity
+        difference between the molecules by removing one atom at a time. These weights
+        can\\n\\nthen be used to color the molecular graph and give a visual presentation.
+        ChemInformatics\\n\\nModel Explorer (CIME) is an interactive web based toolkit
+        which allows visualization and\\n\\ncomparison of different explanation methods
+        for molecular property prediction models.84\\n\\n\\nSurrogate models\\n\\n\\nOne
+        approach to explain black box predictions is to fit a self-explaining or interpretable\\n\\nmodel
+        to the black box model, in the vicinity of one or a few specific examples. These
+        are\\n\\nknown as surrogate models. Generally, one model per explanation is
+        trained. However, if we\\n\\ncould find one surrogate model that explained the
+        whole DL model, then we would simply\\n\\nhave a globally accurate interpretable
+        model. This means that the black-box model is no\\n\\nlonger needed.79 In the
+        work by White 79, a weighted least squares linear model is used as\\n\\nthe
+        surrogate model. This model provides natural language based descriptor explanations
+        by\\n\\nreplacing input features with chemically interpretable descriptors.
+        This approach is similar\\n\\nto the concept-based explanations approach used
+        by McGrath et al. 85, where human under-\\n\\nstandable concepts were used in
+        place of input features in acquisition of chess knowledge in\\n\\nAlphaZero.
+        Any of the self-explaining models detailed in the Self-explaining models section\\n\\ncan
+        be used as a surrogate model.\\n\\n   The most commonly used surrogate model
+        based method is Locally Interpretable Model\\n\\nExplanations (LIME).35 LIME
+        creates perturbations around the example of interest and fits\\n\\nan interpretable
+        model to these local perturbations. Ribeiro et al. 35 mathematically define\\n\\nan
+        explanation \u03BE for an example \u20D7x using Equation 4.\\n\\n\\n                                   \u03BE(\u20D7x)
+        = arg min L(f, g, \u03C0x) + \u2126(g)                           (4)                                      g\u2208G\\n
+        \  Here f is the black box model and g \u2208G is the interpretable explanation
+        model. G is\\na class of potential interpretable models (e.g.:  linear models).
+        \u03C0x is a similarity measure\\n\\n\\n\\n                                       10between
+        original input \u20D7x and it\u2019s perturbed input \u20D7x\u2032. In context
+        of molecular data, this can\\n\\nbe a chemical similarity metric like Tanimoto86
+        similarity between fingerprints. The goal for\\n\\nLIME is to minimize the loss,
+        L, such that f is closely approximated by g. \u2126is a parameter\\nthat controls
+        the complexity (sparsity) of g. Ribeiro et al. 35 termed the agreement (how
+        low\\n\\nthe loss is) between f and g as the \u201Cfidelity\u201D.\\n\\n   GraphLIME87
+        and LIMEtree88 are modifications to LIME as applicable to graph neural\\n\\nnetworks
+        and regression trees, respectively. LIME has been used in chemistry previously,\\n\\nsuch
+        as Whitmore et al. 89 who used LIME to explain octane number predictions of
+        molecules\\n\\nfrom a random forest classifier. Mehdi and Tiwary 90 used LIME
+        to explain thermodynamic\\n\\ncontributions of features.  Gandhi and White 10
+        use an approach similar to GraphLIME,\\n\\nbut use chemistry specific fragmentation
+        and descriptors to explain molecular property pre-\\n\\ndiction. Some examples
+        are highlighted in the Applications section.  In recent work by\\n\\nMehdi and
+        Tiwary 90, a thermodynamic-based surrogate model approach was used to inter-\\n\\npret
+        black-box models. The authors define an \u201Cinterpretation free energy\u201D
+        which can be\\n\\nachieved by minimizing the surrogate model\u2019s uncertainty
+        and maximizing simplicity.\\n\\n\\nCounterfactual explanations\\n\\n\\nCounterfactual
+        explanations can be found in many fields such as statistics, mathematics and\\n\\nphilosophy.91\u201394
+        According to Woodward and Hitchcock 92, a counterfactual is an example\\n\\nwith
+        minimum deviation from the initial instance but with a contrasting outcome.
+        They\\n\\ncan be used to answer the question, \u201Cwhich smallest change could
+        alter the outcome of an\\n\\ninstance of interest?\u201D While the difference
+        between the two instances is based on the exis-\\n\\ntence of similar worlds
+        in philosophy,95 a distance metric based on molecular similarity is\\n\\nemployed
+        in XAI for chemistry. For example, in the work by Wellawatte et al. 9 distance\\n\\nbetween
+        two molecules is defined as the Tanimoto distance96 between ECFP4 fingerprints.97\\n\\nAdditionally,
+        Mohapatra et al. 98 introduced a chemistry-informed graph representation for\\n\\ncomputing
+        macromolecular similarity. Contrastive explanations are peripheral to counterfac-\\n\\n\\n
+        \                                      11tual explanations. Unlike the counterfactual
+        approach, contrastive approach employ a dual\\n\\noptimization method, which
+        works by generating a similar and a dissimilar (counterfactuals)\\n\\nexample.
+        \ Cont\\n\\n----\\n\\nQuestion: Are counterfactuals actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "6077"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xUTW8rNwy8+1cQOtuGE7tO4lsaNOi79RCgBbqFTUtcrxJJXIjc5xhB/nuh9frj
+          tSnQi4HlkMMRh/THCMB4Z1ZgbINqYxsmj7h8f/p5vn+b4+Pr/YvGXxfPi7tvL088E2vGpYK3r2T1
+          VDW1HNtA6jkdYZsJlQrrzd18frN8eJjd9kBkR6GU7VqdLHhyO7tdTGb3k9lyKGzYWxKzgj9HAAAf
+          /W+RmBy9mxXMxqdIJBHckVmdkwBM5lAiBkW8KCY14wtoOSmlXvVms3kVTlX6qBJAZaSLEfOhMiuo
+          zBN3SSnXaLXDAPTeBkxYXieAmaATcqAMjpRy9IlAGwKJGAKJgm0w7UoMFSx3wQEGpdwncaeWIwHX
+          gAl8Khpt/+lLSxKdwktDh77PFksjTn2l5WSp1ZIqPvqAGfacgxPwCdrGBxZumwNgckCxDXwABOeH
+          BpE0e3thjBzIdoVkIPN6KER/PH6DmjPYhqIXzYcpPHMGesdi8Bh+pxBwj6oEpIBhCo7q0wTO3bak
+          e6IEuudTJxLoxKddn/iCyUcuE/xnxS9Pz78toPZpR7nNPqlM4Uc7jhagLXbgNhCgFM4DtJm/e0dl
+          qH7XaJmLMux7F3pHZHAjEPb2lfHUNWVKevJlDBHfBpWx+Fx3oZ+HI+vFc5oMeJlylxzlot+VSL/Z
+          0GZyvtcm08qMj8uVKdD38sy1WM50XLKHylTps0qbzeZ6RzPVnWA5kdSFMMQ/z0sfeNdm3sqAn+O1
+          T16adSYUTmXBRbk1Pfo5AvirP67uh3sxbebY6lr5jVIhvLn9aXkkNJd7vobvBlRZMVwB8/v5+AvK
+          tSNFH+TqQo1F25C71F7OGTvn+QoYXT3833q+4j4+3qfd/6G/ALacFbn1xbqv0jKVP7z/SjsPuhds
+          5CBKcX21xsWSul3f1cstzanezszoc/Q3AAAA//8DADe/QaR8BQAA
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdedf2b9f1cfd5-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 20:05:06 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=KWoBt4SGNscVLRkwet6JK5XZQ0D7wW7lPLBPmLGEqiw-1733169906-1.0.1.1-SEaGNDdM57N8bV5iljV1.T8JYEgWFw.oYDaqQA6XjzAIvwWS3hjP9nzvx4Xbr0hhcrulwy7gy0oxfpOm.1lAcw;
+            path=/; expires=Mon, 02-Dec-24 20:35:06 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=GeN6FuCUeR8W4bBN0S2EHuN30v_p7fB2WKtDKWeXhMU-1733169906405-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "3749"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -3515,92 +3930,93 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9998"
         x-ratelimit-remaining-tokens:
-          - "29998147"
+          - "29998531"
         x-ratelimit-reset-requests:
-          - 11ms
+          - 6ms
         x-ratelimit-reset-tokens:
-          - 3ms
+          - 2ms
         x-request-id:
-          - req_d45786ea0464807ce95ae4b423d46f7e
+          - req_02de18bd2939c57d7d1836a5bb77b730
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 14-16: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\nd counterfactual examples are in the\n\napplication,
-        although both are derived from the same optimization problem.100 Grabocka\n\net
-        al. 111 have developed a method named Adversarial Training on EXplanations (ATEX)\n\nwhich
-        improves model robustness via exposure to adversarial examples.  While there
-        are\n\nconceptual disparities, we note that the counterfactual and adversarial
-        explanations are\n\nequivalent mathematical objects.\n\n   Matched molecular
-        pairs (MMPs) are pairs of molecules that differ structurally at only\n\none
-        site by a known transformation.112,113 MMPs are widely used in drug discovery
-        and\n\nmedicinal chemistry as these facilitate fast and easy understanding of
-        structure-activity re-\n\nlationships.114\u2013116 Counterfactuals and MMP examples
-        intersect if the structural change is\n\nassociated with a significant change
-        in the properties. In the case the associated changes in\n\nthe properties are
-        non-significant, the two molecules are known as bioisosteres.117,118 The con-\n\nnection
-        between MMPs and adversarial training examples has been explored by van Tilborg\n\net
-        al. 119. MMPs which belong to the counterfactual category are commonly used
-        in outlier\n\nand activity cliff detection.113 This approach is analogous to
-        counterfactual explanations,\n\nas the common objective is to uncover learned
-        knowledge pertaining to structure-property\n\nrelationships.70\n\n\nApplications\n\n\nModel
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 14-16: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\nd
+        counterfactual examples are in the\\n\\napplication, although both are derived
+        from the same optimization problem.100 Grabocka\\n\\net al. 111 have developed
+        a method named Adversarial Training on EXplanations (ATEX)\\n\\nwhich improves
+        model robustness via exposure to adversarial examples.  While there are\\n\\nconceptual
+        disparities, we note that the counterfactual and adversarial explanations are\\n\\nequivalent
+        mathematical objects.\\n\\n   Matched molecular pairs (MMPs) are pairs of molecules
+        that differ structurally at only\\n\\none site by a known transformation.112,113
+        MMPs are widely used in drug discovery and\\n\\nmedicinal chemistry as these
+        facilitate fast and easy understanding of structure-activity re-\\n\\nlationships.114\u2013116
+        Counterfactuals and MMP examples intersect if the structural change is\\n\\nassociated
+        with a significant change in the properties. In the case the associated changes
+        in\\n\\nthe properties are non-significant, the two molecules are known as bioisosteres.117,118
+        The con-\\n\\nnection between MMPs and adversarial training examples has been
+        explored by van Tilborg\\n\\net al. 119. MMPs which belong to the counterfactual
+        category are commonly used in outlier\\n\\nand activity cliff detection.113
+        This approach is analogous to counterfactual explanations,\\n\\nas the common
+        objective is to uncover learned knowledge pertaining to structure-property\\n\\nrelationships.70\\n\\n\\nApplications\\n\\n\\nModel
         interpretation is certainly not new and a common step in ML in chemistry, but
-        XAI for\n\nDL models is becoming more important60,66\u201369,73,88,104,105 Here
-        we illustrate some practical\n\nexamples drawn from our published work on how
-        model-agnostic XAI can be utilized to\n\n\n\n                                       14interpret
-        black-box models and connect the explanations to structure-property relationships.\n\nThe
-        methods are \u201cMolecular Model Agnostic Counterfactual Explanations\u201d
-        (MMACE)9\n\nand \u201cExplaining molecular properties with natural language\u201d.10
-        Then we demonstrate how\n\ncounterfactuals and descriptor explanations can propose
-        structure-property relationships in\n\nthe domain of molecular scent.31\n\n\nBlood-brain
-        barrier permeation prediction\n\n\nThe passive diffusion of drugs from the blood
-        stream to the brain is a critical aspect in drug\n\ndevelopment and discovery.120
-        Small molecule blood-brain barrier (BBB) permeation is a\n\nclassification problem
-        routinely assessed with DL models.121,122 To explain why DL models\n\nwork,
-        we trained two models a random forest (RF) model123 and a Gated Recurrent Unit\n\nRecurrent
-        Neural Network (GRU-RNN). Then we explained the RF model with generated\n\ncounterfactuals
-        explanations using the MMACE9 and the GRU-RNN with descriptor expla-\n\nnations.10
+        XAI for\\n\\nDL models is becoming more important60,66\u201369,73,88,104,105
+        Here we illustrate some practical\\n\\nexamples drawn from our published work
+        on how model-agnostic XAI can be utilized to\\n\\n\\n\\n                                       14interpret
+        black-box models and connect the explanations to structure-property relationships.\\n\\nThe
+        methods are \u201CMolecular Model Agnostic Counterfactual Explanations\u201D
+        (MMACE)9\\n\\nand \u201CExplaining molecular properties with natural language\u201D.10
+        Then we demonstrate how\\n\\ncounterfactuals and descriptor explanations can
+        propose structure-property relationships in\\n\\nthe domain of molecular scent.31\\n\\n\\nBlood-brain
+        barrier permeation prediction\\n\\n\\nThe passive diffusion of drugs from the
+        blood stream to the brain is a critical aspect in drug\\n\\ndevelopment and
+        discovery.120 Small molecule blood-brain barrier (BBB) permeation is a\\n\\nclassification
+        problem routinely assessed with DL models.121,122 To explain why DL models\\n\\nwork,
+        we trained two models a random forest (RF) model123 and a Gated Recurrent Unit\\n\\nRecurrent
+        Neural Network (GRU-RNN). Then we explained the RF model with generated\\n\\ncounterfactuals
+        explanations using the MMACE9 and the GRU-RNN with descriptor expla-\\n\\nnations.10
         Both the models were trained on the dataset developed by Martins et al. 124.
-        The\n\nRF model was implemented in Scikit-learn125 using Mordred molecular descriptors126
-        as the\n\ninput features. The GRU-RNN model was implemented in Keras.127 See
-        Wellawatte et al. 9\n\nand Gandhi and White 10 for more details.\n\n   According
-        to the counterfactuals of the instance molecule in figure 1, we observe that
-        the\n\nmodifications to the carboxylic acid group enable the negative example
-        molecule to permeate\n\nthe BBB. Experimental findings by Fischer et al. 120
-        show that the BBB permeation of\n\nmolecules are governed by hydrophobic interactions
-        and surface area. The carboxylic group is\n\na hydrophilic functional group
-        which hinders hydrophobic interactions and addition of atoms\n\nenhances the
-        surface area. This proves the advantage of using counterfactual explanations,\n\nas
-        they suggest actionable modification to the molecule to make it cross the BBB.\n\n   In
-        Figure 2 we show descriptor explanations generated for Alprozolam, a molecule
-        that\n\npermeates the BBB, using the method described by Gandhi and White 10.
-        We see that\n\npredicted permeability is positively correlated with the aromaticity
-        of the molecule, while\n\n\n                                       15negatively
-        correlated with the number of hydrogen bonds donors and acceptors. A similar\n\nstructure-property
-        relationship for BBB permeability is proposed in more mechanistic stud-\n\nies.128\u2013130
+        The\\n\\nRF model was implemented in Scikit-learn125 using Mordred molecular
+        descriptors126 as the\\n\\ninput features. The GRU-RNN model was implemented
+        in Keras.127 See Wellawatte et al. 9\\n\\nand Gandhi and White 10 for more details.\\n\\n
+        \  According to the counterfactuals of the instance molecule in figure 1, we
+        observe that the\\n\\nmodifications to the carboxylic acid group enable the
+        negative example molecule to permeate\\n\\nthe BBB. Experimental findings by
+        Fischer et al. 120 show that the BBB permeation of\\n\\nmolecules are governed
+        by hydrophobic interactions and surface area. The carboxylic group is\\n\\na
+        hydrophilic functional group which hinders hydrophobic interactions and addition
+        of atoms\\n\\nenhances the surface area. This proves the advantage of using
+        counterfactual explanations,\\n\\nas they suggest actionable modification to
+        the molecule to make it cross the BBB.\\n\\n   In Figure 2 we show descriptor
+        explanations generated for Alprozolam, a molecule that\\n\\npermeates the BBB,
+        using the method described by Gandhi and White 10. We see that\\n\\npredicted
+        permeability is positively correlated with the aromaticity of the molecule,
+        while\\n\\n\\n                                       15negatively correlated
+        with the number of hydrogen bonds donors and acceptors. A similar\\n\\nstructure-property
+        relationship for BBB permeability is proposed in more mechanistic stud-\\n\\nies.128\u2013130
         The substructure attributions indicates a reduction in hydrogen bond donors
-        and\n\nacceptors.  These descriptor explanations are quantitative and interpretable
-        by chemists.\n\nFinally, we can use a natural language model to summarize the
-        findings into a written\n\nexplanation, as shown in the printed text in Figure
-        2.\n\n\n\n\n\nFigure 1: Counterfactuals of a molecule which cannot permeate
-        the blood-brain barrier.\nSimilarity is the Tanimoto similarity of ECFP4 fingerprints.131
-        Red indicates deletions and\ngreen indicates substitutions and addition of atoms.
-        Republished from Ref.9 with permission\nfrom the Royal Society of Chemistry.\n\n\n\nSolubility
-        prediction\n\n\nSmall molecule solubility prediction is a classic cheminformatics
-        regression challenge and is\n\nimportant for chemical process design, drug design
-        and crystallization.133\u2013136 In our previous\n\nworks,9,10 we implemented
-        and trained an RNN\n\n----\n\nQuestion: Are counterfactuals actionable? [yes/no]\n\n"}],
-        "model": "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        and\\n\\nacceptors.  These descriptor explanations are quantitative and interpretable
+        by chemists.\\n\\nFinally, we can use a natural language model to summarize
+        the findings into a written\\n\\nexplanation, as shown in the printed text in
+        Figure 2.\\n\\n\\n\\n\\n\\nFigure 1: Counterfactuals of a molecule which cannot
+        permeate the blood-brain barrier.\\nSimilarity is the Tanimoto similarity of
+        ECFP4 fingerprints.131 Red indicates deletions and\\ngreen indicates substitutions
+        and addition of atoms. Republished from Ref.9 with permission\\nfrom the Royal
+        Society of Chemistry.\\n\\n\\n\\nSolubility prediction\\n\\n\\nSmall molecule
+        solubility prediction is a classic cheminformatics regression challenge and
+        is\\n\\nimportant for chemical process design, drug design and crystallization.133\u2013136
+        In our previous\\n\\nworks,9,10 we implemented and trained an RNN\\n\\n----\\n\\nQuestion:
+        Are counterfactuals actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -3609,13 +4025,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6105"
+          - "6067"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -3625,7 +4041,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -3639,24 +4055,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xU24obSQx991eIekrANh7PTGbHb+uQhCzswsIGsmwHW12l7takutSUqmdthvn3
-          pbo9vuQC+2KMjnR0dErqpwmAYWdWYGyDybadn/36+e8P4VN8++m3Fj///nj/8U96fHDv3U7/+PrO
-          THOFlA9k00vV3ErbeUosYYRtJEyUWa/urpe3t/f3y6sBaMWRz2V1l2Y3MlsuljezxS+zxZtDYSNs
-          Sc0K/pkAADwNv1licLQzK1hMXyItqWJNZnVMAjBRfI4YVGVNGJKZnkArIVEYVG+32weVUISnIgAU
-          Rvu2xbgvzAoK81b6kChWaFOPHmjXeQyYp1PASIA2/8fSE6BCamgP2tc1aYJWHFdsD8lJoBVPtveU
-          8zCBxQCe0GXIkXIkB9InKy3pHN5LBA5Zt6UpcMjcMKjeJZAKSi/iZmVEDlBijEwRXq3X69fQUWxp
-          6DoFeyFfgYPLimhU8J3CoQfGUnZ7zxbQsoM6St8NYukw53GQXHLoRkPter2ew18NK7BCSRZ7pW9J
-          Rz5WaPYuStfw0Ck4aPK7xmNcSrbAWf3osU7h34ZtM9huY28ZPVQSc9OzmeewPj4Bhxpsg6F+sZxC
-          k/0E7bMllKlw7P3Tnt862EV5ZHfx8ByU6ybpoObgDcZLd+eFmY7rFcnTY1axUSuRxjW7L0wRnouw
-          3W7PtzRS1SvmIwm994f483HtvdRdlFIP+DFecWBtNpFQJeQV1ySdGdDnCcCX4bz6i4sxXZS2S5sk
-          Xylkwqvlze1IaE4XfQZfLw9okoT+HLi7m/6AcuMoIXs9u1Fj0TbkTrWng8besZwBk7PBv9fzI+5x
-          eA71/6E/AdZSl8htukiO7eXMp7RI+ZP3s7Sj0YNgo3tN1G4qDjXFLvL41am6zV31pqRrqsqFmTxP
-          /gMAAP//AwAI0+8jfgUAAA==
+          H4sIAAAAAAAAA4xUUY8jNQx+76+w8gTStOp2yy7tGz1xEiCBBPfGoNaTeGZyZOIQZ452V/vfUTK9
+          tsseEi9V5c/+/H2OPc8zAGWN2oLSPSY9BDf/Dh+O7zY/PH7fPa3vPvz19PTz+/DLb6tf/U8/Uq+q
+          XMHNR9Lpc9VC8xAcJct+gnUkTJRZ7x7v7+8eNpvlqgADG3K5rAtpvub5arlaz5ffzpcP58KerSZR
+          W/h9BgDwXH6zRG/oqLawrD5HBhLBjtT2kgSgIrscUShiJaFPqrqCmn0iX1QfDoePwr72z7UHqJWM
+          w4DxVKst1Oodjz5RbFGnER3QMTj0mN0JYCRAnf9j4whQIPV0Ahm7jiTBwMa2Vp+TE8PAjvToKOdh
+          Ao0eHKHJkCGxkQzwmDQPJAt4zxGsz7o1VWB95oai+piAW2gcs5k3Ea2HBmO0FOGr3W73NQSKA5Wu
+          FehX8gWsN1kRTQreKCw9MDZ8PDmrAbU10EUeQxFLZ58XI7nk3I1K7W63W8CH3gpYgYY0jkL/Jp34
+          rEB/MpFDb0snb6DP7xovcW6sBpvVTzOWCv7ure7L2HUctUUHLcfc9MbzAnaXJ7C+u30g3aPvSCqQ
+          MdMIoDElJfFQ7JPv87hBxjwxyp3w7QxD5E/WEIQiTKODbrSmFGY55+FgfD3eRa2qab8iOfqU0/ei
+          OdK0Z5ta1f6l9ofD4XZNI7WjYL4SPzp3jr9c9t5xFyI3csYv8dZ6K/0+Egr7vOOSOKiCvswA/ij3
+          Nb46GRUiDyHtE/9JPhPerdbfTITqetI38P36jCZO6G6Bx031Bcq9oYTWyc2RKo26J3OtvV40jsby
+          DTC7Mf5Wz5e4J/PWd/+H/gpoTSGR2YdIxurXnq9pkfI377/SLoMugpWcJNGwb63vKIZop89OG/aP
+          7UND99Q2SzV7mf0DAAD//wMAY95csn8FAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1d63d6e67fb-SJC
+          - 8ebdedf2bb66aab7-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -3664,14 +4080,14 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:44 GMT
+          - Mon, 02 Dec 2024 20:05:07 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=4Uag1Bn3sBtqDMQtnb4UWl4IobcyhNQR2lgto34zGWs-1732559924-1.0.1.1-MX5ZnR6VWIZKlXPlpWxuBBfnzY0tgQ4QGlKG8HKBufyuCyG2sKcGbK_UnNafnYdTA6M_i5Y.3YDn6jBcWkvOpg;
-            path=/; expires=Mon, 25-Nov-24 19:08:44 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=SVb_CENST7R9CRYDGkPHQOTHRfhXPwgemDF.7SL_vEY-1733169907-1.0.1.1-8poylkWM_ZO3.AK1lWzzlQKEy_3JLT01YoZQOWaTzIFVudhS_e1JeKb8J8jTTFIRe9LJ9I9mOs82uyFjBvYdaw;
+            path=/; expires=Mon, 02-Dec-24 20:35:07 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=lpF8HdNCmnU9y5px86XyU1d8SS6ncR5K94D0me4qbqc-1732559924335-0.0.1.1-604800000;
+          - _cfuvid=PM6oGLL58XG2FXzWXsHz.BAwQ5yn1LDAVhVHWZp3pAo-1733169907194-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -3684,7 +4100,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "2588"
+          - "4551"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -3694,452 +4110,96 @@ interactions:
         x-ratelimit-limit-tokens:
           - "30000000"
         x-ratelimit-remaining-requests:
-          - "9998"
+          - "9999"
         x-ratelimit-remaining-tokens:
           - "29998537"
         x-ratelimit-reset-requests:
-          - 7ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_9984c0c942e149276600a6203a2d77cd
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 20-22: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\nody,\u2019 \u2018floral\u2019 and \u2018herbal\u2019
-        scents.\n\n\n\n\n\nFigure 5:  Counterfactual for the 2,4 decadienal molecule.  The
-        counterfactual indicates\nstructural changes to ethyl benzoate that would result
-        in the model predicting the molecule\nto not contain the \u2018fruity\u2019
-        scent. The Tanimoto96 similarity between the counterfactual and\n2,4 decadienal
-        is also provided. Republished with permission from authors.31\n\n\n   The molecule
-        2,4-decadienal, which is known to have a \u2018fatty\u2019 scent, is analyzed
-        in Fig-\n\nure 5.142,143 The resulting counterfactual, which has a shorter carbon
-        chain and no carbonyl\n\ngroups, highlights the influence of these structural
-        features on the \u2018fatty\u2019 scent of 2,4 deca-\n\ndienal. To generalize
-        to other molecules, Seshadri et al. 31 applied the descriptor attribution\n\nmethod
-        to obtain global explanations for the scents. The global explanation for the
-        \u2018fatty\u2019\n\nscent was generated by gathering chemical spaces around
-        many \u2018fatty\u2019 scented molecules.\n\nThe resulting natural language
-        explanation is: \u201cThe molecular property \u201cfatty scent\u201d can\n\nbe
-        explained by the presence of a heptanyl fragment, two CH2 groups separated by
-        four\n\n                                       20bonds, and a C=O double bond,
-        as well as the lack of more than one or two O atoms.\u201d31\n\nThe importance
-        of a heptanyl fragment aligns with that reported in the literature, as \u2018fatty\u2019\n\nmolecules
-        often have a long carbon chain.144 Furthermore, the importance of a C=O dou-\n\nble
-        bond is supported by the findings reported by Licon et al. 145, where in addition
-        to a\n\n\u201clarger carbon-chain skeleton\u201d, they found that \u2018fatty\u2019
-        molecules also had \u201caldehyde or acid\n\nfunctions\u201d.145 For the \u2018pineapple\u2019
-        scent, the following natural language explanation was ob-\n\ntained: \u201cThe
-        molecular property \u201cpineapple scent\u201d can be explained by the presence
-        of ester,\n\nethyl/ether O group, alkene/ether O group, and C=O double bond,
-        as well as the absence of\n\nan Aromatic atom.\u201d31 Esters, such as ethyl
-        2-methylbutyrate, are present in many pineap-\n\nple volatile compounds.146,147
-        The combination of a C=O double bond with an ether could\n\nalso correspond
-        to an ester group. Additionally, aldehydes and ketones, which contain C=O\n\ndouble
-        bonds, are also common in pineapple volatile compounds.146,148\n\n\nDiscussion\n\n\nWe
-        have shown two post-hoc XAI applications based on molecular counterfactual expla-\n\nnations9
-        and descriptor explanations.10 These methods can be used to explain black-box\n\nmodels
-        whose input is a molecule. These two methods can be applied for both classification\n\nand
-        regression tasks. Note that the \u201ccorrectness\u201d of the explanations
-        strongly depends on\n\nthe accuracy of the black-box model.\n\n  A molecular
-        counterfactual is one with a minimal distance from a base molecular, but\n\nwith
-        contrasting chemical properties.  In the above examples, we used Tanimoto similar-\n\nity96
-        of ECFP4 fingreprints97 as distance, although this should be explored in the
-        future.\n\nCounterfactual explanations are useful because they are represented
-        as chemical structures\n\n(familiar to domain experts), sparse, and are actionable.
-        A few other popular examples of\n\ncounterfactual on graph methods are GNNExplainer,
-        MEG and CF-GNNExplainer.69,104,105\n\n   The descriptor explanation method developed
-        by Gandhi and White 10 fits a self-explaining\n\n\n\n                                       21surrogate
-        model to explain the black-box model. This is similar to the GraphLIME87 method,\n\nalthough
-        we have the flexibility to use explanation features other than subgraphs. Futher-\n\nmore,
-        we show that natural language combined with chemical descriptor attributions
-        can\n\ncreate explanations useful for chemists, thus enhancing the accessibility
-        of DL in chemistry.\n\nLastly, we examined if XAI can be used beyond interpretation.
-        Work by Seshadri et al. 31 use\n\nMMACE and surrogate model explanations to
-        analyze the structure-property relationships\n\nof scent. They recovered known
-        structure-property relationships for molecular scent purely\n\nfrom explanations,
-        demonstrating the usefulness of a two step process: fit an accurate model\n\nand
-        then explain it.\n\n   Choosing among the plethora of XAI methods described
-        here is still an open question.\n\nIt remains to be seen if there will ever
-        be a consensus benchmark, since this field sits on\n\nthe intersection of human-machine
-        interaction, machine learning, and philosophy (i.e., what\n\nconstitutes an
-        explanation?). Our current advice is to consider first the audience \u2013 domain\n\nexperts
-        or ML experts or non-experts \u2013 and what the explanations should accomplish.
-        Are\n\nthey meant to inform data selection or model building, how a prediction
-        is used, or how the\n\nfeatures can be changed to affect the outcome. The second
-        consideration is what access you\n\nhave to the underlying model. The ability
-        to have model derivatives or propagate gradients\n\nto the input to models informs
-        the XAI method.\n\n\nConclusion and outlook\n\n\nWe should seek to explain molecular
-        property prediction models because users are more\n\nlikely to trus\n\n----\n\nQuestion:
-        Are counterfactuals actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6243"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.0
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.0
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xUy24bMQy8+ysIne3AeTe+FTkUOeQQoEUbdAublrheJVpKELlJ3CD/XmjX8QNN
-          gV504HDI4YDU6wjAeGdmYGyDatsUJp9/3H/h29v17eXNNd8+3t3//nbT3Z3x9/v1gzPjwojLB7L6
-          zjqysU2B1EceYJsJlUrV48vTk/Pzq6uT4x5oo6NQaKukk7M4OZmenE2mnybTiw2xid6SmBn8HAEA
-          vPZvkciOXswMpuP3SEsiuCIz2yYBmBxDiRgU8aLIasY70EZW4l71YrF4kMgVv1YMUBnp2hbzujIz
-          qMx17Fgp12i1wwD0kgIylukEMBM4Epv9khygANoC4DIQeAZtCPo2LwqxHqiePa+gjYFsFzBDyuR8
-          z4LeDjmCrw2t+9KZUiYh1qG4baj1FgOI5s5ql0nG8Nx42/TZNbY+eMygEVxs0XPpSFllDMiuz5GE
-          WWgMLT4WGdpQC51Q3QWoY4aOHeXilCtoIaVYTPIYwhowKOUCbIWkHEsDT4Nq6CelNjUo/jdJb0Cn
-          PnhdFwPsgZVSLEo5Pvmh27514leNCizXIE187h3z7FsMYBvkFQkwkSNXZkXbeHoicL6uKRPrR/rG
-          oE0nB3MjpFyalkSNcXCgp4rKUWXGwzJkCvSEbGkuNmYaluKqMhW/VbxYLPZ3KlPdCZaV5i6ETfxt
-          u6QhrlKOS9ng23jt2Uszz4QSuSykaEymR99GAL/6Y+gO9tukHNukc42PxKXg8el0cw1md3978PR4
-          g2pUDHvA2RY5KDl3pOiD7F2UsWgbcjvu7vywcz7uAaO9wf/W81HtYXjPq/8pvwOspaTk5rsz+igt
-          U/mg/pW2NboXbGQtSu289ryinLIf/og6zS/riyWdUr2cmtHb6A8AAAD//wMAzY6ONSwFAAA=
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e83c1d63cd27ae8-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 25 Nov 2024 18:38:44 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=X_4JuF5Hp0zJAXgQFdNopAg2CPKI_iA3xdA67jMtT5I-1732559924-1.0.1.1-3R7kdSZjk9pvieYXaCbmZQA.anFvivV4VZVGZQG2OW9nm.Cmi_w6Lr5kUlu8Da2A_UHk9PK5IMcCVT45Ng7uGg;
-            path=/; expires=Mon, 25-Nov-24 19:08:44 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=KQI3ZOpm5eJOWUCGAIn9SHGQ.xSQlWUyfwbVrD4DfSw-1732559924405-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "2656"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998522"
-        x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
           - 2ms
         x-request-id:
-          - req_29938522284e67b51184b9c0f2f21ebc
+          - req_6e25d3313608f96d31ca17f5062aa8fa
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 25-27: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\nng: machine intelligence approach for
-        drug discovery.\n\n     Molecular diversity 2021, 25, 1315\u20131360.\n\n\n
-        (9) Wellawatte, G. P.; Seshadri, A.; White, A. D. Model agnostic generation
-        of counter-\n\n     factual explanations for molecules. Chemical Science 2022,
-        13, 3697\u20133705.\n\n\n(10) Gandhi, H. A.; White, A. D. Explaining structure-activity
-        relationships using locally\n\n      faithful surrogate models. chemrxiv 2022,\n\n\n(11)
-        Gormley, A. J.; Webb, M. A. Machine learning in combinatorial polymer chemistry.\n\n     Nature
-        Reviews Materials 2021,\n\n\n(12) Gomes, C. P.; Fink, D.; Dover, R. B. V.; Gregoire,
-        J. M. Computational sustainability\n\n     meets materials science. Nature Reviews
-        Materials 2021,\n\n\n(13) On scientific understanding with artificial intelligence.
-        Nature Reviews Physics 2022\n\n     4:12 2022, 4, 761\u2013769.\n\n\n(14) Arrieta,
-        A. B.; D\u00b4\u0131az-Rodr\u00b4\u0131guez, N.; Ser, J. D.; Bennetot, A.; Tabik,
-        S.; Barbado, A.;\n\n     Garcia, S.; Gil-Lopez, S.; Molina, D.; Benjamins, R.;
-        Chatila, R.; Herrera, F. Explain-\n\n     able Artificial Intelligence (XAI):
-        Concepts, Taxonomies, Opportunities and Chal-\n\n     lenges toward Responsible
-        AI. Information Fusion 2019, 58, 82\u2013115.\n\n\n(15) Murdoch, W. J.; Singh,
-        C.; Kumbier, K.; Abbasi-Asl, R.; Yu, B. Interpretable machine\n\n     learning:
-        definitions, methods, and applications. ArXiv 2019, abs/1901.04592.\n\n                                      25(16)
-        Boobier, S.; Osbourn, A.; Mitchell, J. B. Can human experts predict solubility
-        better\n\n     than computers? Journal of cheminformatics 2017, 9, 1\u201314.\n\n\n(17)
-        Lee, J. D.; See, K. A. Trust in automation: Designing for appropriate reliance.
-        Human\n\n     Factors 2004, 46, 50\u201380.\n\n\n(18) Bolukbasi, T.; Chang,
-        K.-W.; Zou, J. Y.; Saligrama, V.; Kalai, A. T. Man is to com-\n\n     puter
-        programmer as woman is to homemaker? debiasing word embeddings. Advances\n\n     in
-        neural information processing systems 2016, 29.\n\n\n(19) Buolamwini, J.; Gebru,
-        T. Gender Shades:  Intersectional Accuracy Disparities in\n\n    Commercial
-        Gender Classification. Proceedings of the 1st Conference on Fairness,\n\n     Accountability
-        and Transparency. 2018; pp 77\u201391.\n\n\n(20) Lapuschkin, S.; W\u00a8aldchen,
-        S.; Binder, A.; Montavon, G.; Samek, W.; M\u00a8uller, K.-R.\n\n    Unmasking
-        Clever Hans predictors and assessing what machines really learn. Nature\n\n     communications
-        2019, 10, 1\u20138.\n\n\n(21) DeGrave, A. J.; Janizek, J. D.; Lee, S.-I. AI
-        for radiographic COVID-19 detection\n\n      selects shortcuts over signal.
-        Nature Machine Intelligence 2021, 3, 610\u2013619.\n\n\n(22) Goodman, B.; Flaxman,
-        S. European Union regulations on algorithmic decision-\n\n    making and a \u201cright
-        to explanation\u201d. AI Magazine 2017, 38, 50\u201357.\n\n\n(23) ACT, A. I.
-        European Commission. On Artificial Intelligence: A European Approach\n\n     to
-        Excellence and Trust. 2021, COM/2021/206.\n\n\n(24) Blueprint for an AI Bill
-        of Rights, The White House. 2022; https://www.whitehouse.\n\n    gov/ostp/ai-bill-of-rights/.\n\n\n(25)
-        Miller, T. Explanation in artificial intelligence: Insights from the social
-        sciences. Ar-\n\n       tificial intelligence 2019, 267, 1\u201338.\n\n\n\n                                      26(26)
-        Murdoch, W. J.; Singh, C.; Kumbier, K.; Abbasi-Asl, R.; Yu, B. Definitions,
-        meth-\n\n     ods, and applications in interpretable machine learning. Proceedings
-        of the National\n\n    Academy of Sciences of the United States of America 2019,
-        116, 22071\u201322080.\n\n\n(27) Gunning, D.; Aha, D. DARPA\u2019s Explainable
-        Artificial Intelligence (XAI) Program.\n\n    AI Magazine 2019, 40, 44\u201358.\n\n\n(28)
-        Biran, O.; Cotton, C. Explanation and justification in machine learning: A survey.\n\n     IJCAI-17
-        workshop on explainable AI (XAI). 2017; pp 8\u201313.\n\n\n(29) Palacio, S.;
-        Lucieri, A.; Munir, M.; Ahmed, S.; Hees, J.; Dengel, A. Xai handbook:\n\n    Towards
-        a unified framework for explainable ai. Proceedings of the IEEE/CVF Inter-\n\n     national
-        Conference on Computer Vision. 2021; pp 3766\u20133775.\n\n\n(30) Kuhn, D. R.;
-        Kacker, R. N.; Lei, Y.; Simos, D. E. Combinatorial Methods for Ex-\n\n     plainable
-        AI. 2020 IEEE International Conference on Software Testing, Verification\n\n    and
-        Validation Workshops (ICSTW) 2020, 167\u2013170.\n\n\n(31) Seshadri, A.; Gandhi,
-        H. A.; Wellawatte, G. P.; White, A. D. Why does that molecule\n\n     smell?
-        ChemRxiv 2022,\n\n\n(32) Das, A.; Rad, P. Opportunities and challenges in explainable
-        artificial intelligence\n\n      (xai): A survey. arXiv preprint arXiv:2006.11371
-        2020,\n\n\n(33) Machlev, R.; Heistrene, L.; Perl, M.; Levy, K. Y.; Belikov,
-        J.; Mannor, S.; Levron, Y.\n\n     Explainable Artificial Intelligence (XAI)
-        techniques for energy and power systems:\n\n     Review, challenges and opportunities.
-        Energy and AI 2022, 9, 100169.\n\n\n(34) Koh, P. W.; Liang, P. Understanding
-        black-box predictions via influence functions.\n\n     International Conference
-        on Machine Learning. 2017; pp 1885\u20131894.\n\n\n(35) Ribeiro, M. T.; Singh,
-        S.; Guestrin, C. \u201d Why should  i trust you?\u201d Explaining the\n\n     predictions
-        of any classifier. Proceedings of the 22nd ACM SIGKDD international\n\n         \n\n----\n\nQuestion:
-        Are counterfactuals actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6231"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.0
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.0
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xUTXMbNwy961dgeMll5ZHXji3rlvrQQz8mM0kn/diOBJHYJWMuyRBYWRqP/3uH
-          u4qltG6nFx7wHh4eSIBPMwDljFqB0hZF98nP3/362/dffrG737+839/b/N07+8OPvfn59s7Wy/eq
-          Khlx+5m0fM260LFPnsTFMME6EwoV1cvbq/rt27u7+noE+mjIl7Quyfw6zutFfT1fLOeLm2OijU4T
-          qxX8MQMAeBrPYjEY2qsVLKqvkZ6YsSO1eiEBqBx9iShkdiwYRFUnUMcgFEbXm83mM8fQhKcmADSK
-          h77HfGjUChr10RLQXlNOAplayhQ0MSA8xvwA2wN8Iu/xEUWogg/EFk12FWAw8Mk6IYgB3vxUOgXs
-          QmRxGjoKlLHcEMQWdByCUG5Ry4AeaJ88hhFlaGOGPnrSgyd+A2nYeseWDLgA95Z6p9HDB+2KqRKr
-          F3V9AR+tY+Ch64iFQSzKfxbBTDDwJCqWYLyavRRvx9qYIWUyTo+ex3fjCh6t0xZcn7yjUoYOoxSO
-          LNz60VHKceeMCx24wK6zwhAzoBfKpf6OuLBOdQyx60LhnCpewP039ifLckilfX+YzEuEIRjK5aUN
-          2PgI2mLoJn0X0iCww+yKLwaNATzhmGVcOz6rQBxEx564gh4fimWx1P+tH0PasYthfqSkHDUxE180
-          qprmJ5OnHQZNa9Yx0zRHy0Y14bkJm83mfAwztQNj2YIweH+MP7/MtY9dynHLR/wl3rrg2K4zIcdQ
-          ZpglJjWizzOAP8f9Gb5ZCZVy7JOsJT5QKIKXN8urSVCdVvYMri+PqERBfwYsF9fVK5JrQ4LO89kS
-          Ko3akjnlnjYWB+PiGTA7a/yffl7Tnpp3ofs/8idAa0pCZn0ar9domcqf9m+0l4seDSs+sFC/bl3o
-          KKfspm+lTevb9mZLV9RuF2r2PPsLAAD//wMA7+8mRV8FAAA=
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e83c1e7b9167ae8-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 25 Nov 2024 18:38:46 GMT
-        Server:
-          - cloudflare
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "2170"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998528"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_6e3da66ea31b18e425689bbee3f90c7e
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 16-20: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\ny prediction\n\n\nSmall molecule solubility
-        prediction is a classic cheminformatics regression challenge and is\n\nimportant
-        for chemical process design, drug design and crystallization.133\u2013136 In
-        our previous\n\nworks,9,10 we implemented and trained an RNN model in Keras
-        to predict solubilities (log\n\nmolarity) of small molecules.127 The AqSolDB
-        curated database137 was used to train the\n\nRNN model.\n\n   In this task,
-        counterfactuals are based on equation 6. Figure 3 illustrates the generated\n\nlocal
-        chemical space and the top four counterfactuals. Based on the counterfactuals,
-        we ob-\n\nserve that the modifications to the ester group and other heteroatoms
-        play an important role\n\nin solubility. These findings align with known experimental
-        and basic chemical intuition.134\n\nFigure 4 shows a quantitative measurement
-        of how substructures are contributing to the pre-\n\n\n\n                                       16Figure
-        2: Descriptor explanations along with natural language explanation obtained
-        for BBB\npermeability of Alprozolam molecule. The green and red bars show descriptors
-        that influ-\nence predictions positively and negatively, respectively. Dotted
-        yellow lines show significance\nthreshold (\u03b1 = 0.05) for the t-statistic.
-        Molecular descriptors show molecule-level proper-\nties that are important for
-        the prediction. ECFP and MACCS descriptors indicate which\nsubstructures influence
-        model predictions. MACCS explanations lead to text explanations\nas shown. Republished
-        from Ref.10 with permission from authors. SMARTS annotations for\nMACCS descriptors
-        were created using SMARTSviewer (smartsview.zbh.uni-hamburg.de,\nCopyright:
-        ZBH, Center for Bioinformatics Hamburg) developed by Schomburg et al. 132.\n\n\n\n\n\n                                       17diction.
-        For example, we see that adding acidic and basic groups as well as hydrogen
-        bond\n\nacceptors, increases solubility. Substructure importance from ECFP97
-        and MACCS138 de-\n\nscriptors indicate that adding heteroatoms increases solubility,
-        while adding rings structures\n\nmakes the molecule less soluble. Although these
-        are established hypotheses, it is interesting\n\nto see they can be derived
-        purely from the data via DL and XAI.\n\n\n\n\n\nFigure 3: Generated chemical
-        space for solubility prediction using the RNN model. The\nchemical space is
-        a 2D projection of the pairwise Tanimoto similarities of the local coun-\nterfactuals.
-        Each data point is colored by solubility. Top 4 counterfactuals are shown here.\nRepublished
-        from Ref.9 with permission from the Royal Society of Chemistry.\n\n\n\nGeneralizing
-        XAI \u2013 interpreting scent-structure relationships\n\n\nIn this example,
-        we show how non-local structure-property relationships can be learned with\n\nXAI
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 16-20: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\ny
+        prediction\\n\\n\\nSmall molecule solubility prediction is a classic cheminformatics
+        regression challenge and is\\n\\nimportant for chemical process design, drug
+        design and crystallization.133\u2013136 In our previous\\n\\nworks,9,10 we implemented
+        and trained an RNN model in Keras to predict solubilities (log\\n\\nmolarity)
+        of small molecules.127 The AqSolDB curated database137 was used to train the\\n\\nRNN
+        model.\\n\\n   In this task, counterfactuals are based on equation 6. Figure
+        3 illustrates the generated\\n\\nlocal chemical space and the top four counterfactuals.
+        Based on the counterfactuals, we ob-\\n\\nserve that the modifications to the
+        ester group and other heteroatoms play an important role\\n\\nin solubility.
+        These findings align with known experimental and basic chemical intuition.134\\n\\nFigure
+        4 shows a quantitative measurement of how substructures are contributing to
+        the pre-\\n\\n\\n\\n                                       16Figure 2: Descriptor
+        explanations along with natural language explanation obtained for BBB\\npermeability
+        of Alprozolam molecule. The green and red bars show descriptors that influ-\\nence
+        predictions positively and negatively, respectively. Dotted yellow lines show
+        significance\\nthreshold (\u03B1 = 0.05) for the t-statistic. Molecular descriptors
+        show molecule-level proper-\\nties that are important for the prediction. ECFP
+        and MACCS descriptors indicate which\\nsubstructures influence model predictions.
+        MACCS explanations lead to text explanations\\nas shown. Republished from Ref.10
+        with permission from authors. SMARTS annotations for\\nMACCS descriptors were
+        created using SMARTSviewer (smartsview.zbh.uni-hamburg.de,\\nCopyright: ZBH,
+        Center for Bioinformatics Hamburg) developed by Schomburg et al. 132.\\n\\n\\n\\n\\n\\n
+        \                                      17diction. For example, we see that adding
+        acidic and basic groups as well as hydrogen bond\\n\\nacceptors, increases solubility.
+        Substructure importance from ECFP97 and MACCS138 de-\\n\\nscriptors indicate
+        that adding heteroatoms increases solubility, while adding rings structures\\n\\nmakes
+        the molecule less soluble. Although these are established hypotheses, it is
+        interesting\\n\\nto see they can be derived purely from the data via DL and
+        XAI.\\n\\n\\n\\n\\n\\nFigure 3: Generated chemical space for solubility prediction
+        using the RNN model. The\\nchemical space is a 2D projection of the pairwise
+        Tanimoto similarities of the local coun-\\nterfactuals. Each data point is colored
+        by solubility. Top 4 counterfactuals are shown here.\\nRepublished from Ref.9
+        with permission from the Royal Society of Chemistry.\\n\\n\\n\\nGeneralizing
+        XAI \u2013 interpreting scent-structure relationships\\n\\n\\nIn this example,
+        we show how non-local structure-property relationships can be learned with\\n\\nXAI
         across multiple molecules. Molecular scent prediction is a multi-label classification
-        task\n\nbecause a molecule can be described by more than one scent. For example,
-        the molecule\n\njasmone can be described as having \u2018jasmine,\u2019 \u2018woody,\u2019
-        \u2018floral,\u2019 and \u2019herbal\u2019 scents.139 The\n\nscent-structure
-        relationship is not very well understood,140 although some relationships are\n\nknown.  For
-        example, molecules with an ester functional group are often associated with\n\n\n                                       18Figure
-        4: Descriptor explanations for solubility prediction model. The green and red
-        bars\nshow descriptors that influence predictions positively and negatively,
-        respectively. Dotted\nyellow lines show significance threshold (\u03b1 = 0.05)
-        for the t-statistic. The MACCS and\nECFP descriptors indicate which substructures
-        influence model predictions. MACCS sub-\nstructures may either be present in
-        the molecule as is or may represent a modification. ECFP\nfingerprints are substructures
-        in the molecule that affect the prediction. MACCS descriptor\nare used to obtain
-        text explanations as shown. Republished from Ref.10 with permission from\nauthors.
-        SMARTS annotations for MACCS descriptors were created using SMARTSviewer\n(smartsview.zbh.uni-hamburg.de,
-        Copyright: ZBH, Center for Bioinformatics Hamburg) de-\nveloped by Schomburg
-        et al. 132.\n\n\n\n\n\n                                       19the \u2018fruity\u2019
-        scent. There are some exceptions though, like tert-amyl acetate which has a\n\n\u2018camphoraceous\u2019
-        rather than \u2018fruity\u2019 scent.140,141\n\n   In Seshadri et al. 31, we
-        trained a GNN model to predict the scent of molecules and utilized\n\ncounterfactuals9
-        and descriptor explanations10 to quantify scent-structure relationships. The\n\nMMACE
+        task\\n\\nbecause a molecule can be described by more than one scent. For example,
+        the molecule\\n\\njasmone can be described as having \u2018jasmine,\u2019 \u2018woody,\u2019
+        \u2018floral,\u2019 and \u2019herbal\u2019 scents.139 The\\n\\nscent-structure
+        relationship is not very well understood,140 although some relationships are\\n\\nknown.
+        \ For example, molecules with an ester functional group are often associated
+        with\\n\\n\\n                                       18Figure 4: Descriptor explanations
+        for solubility prediction model. The green and red bars\\nshow descriptors that
+        influence predictions positively and negatively, respectively. Dotted\\nyellow
+        lines show significance threshold (\u03B1 = 0.05) for the t-statistic. The MACCS
+        and\\nECFP descriptors indicate which substructures influence model predictions.
+        MACCS sub-\\nstructures may either be present in the molecule as is or may represent
+        a modification. ECFP\\nfingerprints are substructures in the molecule that affect
+        the prediction. MACCS descriptor\\nare used to obtain text explanations as shown.
+        Republished from Ref.10 with permission from\\nauthors. SMARTS annotations for
+        MACCS descriptors were created using SMARTSviewer\\n(smartsview.zbh.uni-hamburg.de,
+        Copyright: ZBH, Center for Bioinformatics Hamburg) de-\\nveloped by Schomburg
+        et al. 132.\\n\\n\\n\\n\\n\\n                                       19the \u2018fruity\u2019
+        scent. There are some exceptions though, like tert-amyl acetate which has a\\n\\n\u2018camphoraceous\u2019
+        rather than \u2018fruity\u2019 scent.140,141\\n\\n   In Seshadri et al. 31,
+        we trained a GNN model to predict the scent of molecules and utilized\\n\\ncounterfactuals9
+        and descriptor explanations10 to quantify scent-structure relationships. The\\n\\nMMACE
         method was modified to account for the multi-label aspect of scent prediction.
-        This\n\nmodification defines molecules that differed from the instance molecule
-        by only the selected\n\nscent as counterfactuals. For instance, counterfactuals
-        of the jasmone molecule would be false\n\nfor the \u2018jasmine\u2019 scent
+        This\\n\\nmodification defines molecules that differed from the instance molecule
+        by only the selected\\n\\nscent as counterfactuals. For instance, counterfactuals
+        of the jasmone molecule would be false\\n\\nfor the \u2018jasmine\u2019 scent
         but would still be positive for \u2018woody,\u2019 \u2018floral\u2019 and \u2018herbal\u2019
-        scents.\n\n\n\n\n\nFigure 5:  Counterfactual for the 2,4 decadienal molecule.  The
-        counterfactual indicates\nstructural changes to ethyl benzoate that would result
-        in the model predicting the molecule\nto not contain the \u2018fruity\u2019
-        \n\n----\n\nQuestion: Are counterfactuals actionable? [yes/no]\n\n"}], "model":
-        "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        scents.\\n\\n\\n\\n\\n\\nFigure 5:  Counterfactual for the 2,4 decadienal molecule.
+        \ The counterfactual indicates\\nstructural changes to ethyl benzoate that would
+        result in the model predicting the molecule\\nto not contain the \u2018fruity\u2019
+        \\n\\n----\\n\\nQuestion: Are counterfactuals actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -4148,13 +4208,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6187"
+          - "6087"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -4164,7 +4224,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -4178,24 +4238,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xUTY8bNwy9+1cQOtuG43V2s74lLRIgaHpJEDToFLYscWaYaChBlDZxF/vfC8lf
-          s5stkIsOfOLT4yOp+wmAIqvWoEyvkxmCm73+68u7sF+FP6779x/i649/frhZffn8dsj//v7mWk1L
-          ht99RZNOWXPjh+AwkecDbCLqhIX1xc3V8uXL29vlVQUGb9GVtC6k2crPlovlarZ4NVsceU3vyaCo
-          Nfw9AQC4r2eRyBZ/qDUspqfIgCK6Q7U+XwJQ0bsSUVqEJGlOanoBjeeEXFVvt9uv4rnh+4YBGiV5
-          GHTcN2oNjfrUI+APgzEksCQmi6BA6hGyIPgWjM+cMLbapKydADEM3qHJTkcIES2Z4gXUamUKEtBQ
-          S0Y7t4fWRxDv8o4cpT1otiAGOY0S5/Dbkxd0rI9bSB7IIidq9yApZpNy1A5Mr7mrInUC4tZlZIMj
-          yqIimx60FFVVTA0XQpSEEbrocxDQbYsmEXcjkXP41KMgtMSWuBPQjjqG75R6+Mb+O4PpcSj1AXHK
-          VJjLe12HUqmqrKeuGc0Qor8ji6CrSL1zCMRCXZ9kDm+LU0+smf5E06MLkNliLA0/mjk7eYMQ0R1K
-          7SkI7PZn/4qwR74dSj8+aVyZoZNPxQEqjbYlcEp4rqLdpVEWI909W1sdgtqHqmI8PD5gTIQyb9T0
-          MJsRHd5pNrgR4yMeZvS2UQ0/NLzdbscjHrHNosuGcXbuGH8474zzXYh+J0f8HG+JSfpNRC2ey35I
-          8kFV9GEC8E/dzfxo3VSIfghpk/w35EL4YvnquJzq8h2M4dsjmnzSbgSsFifkEeXGYtLkZLTgymjT
-          o73kXn4DnS35ETAZFf6znue4D8UTd79CfwGMwZDQbi4j+ty1iOW//L9rZ6OrYCV7SThsWuIOY4h0
-          +LLasLlpr3d4he1uoSYPk/8AAAD//wMAVHU92bsFAAA=
+          H4sIAAAAAAAAA4xUy27bMBC8+ysWPNuG82gevrVFA/RS9NBD0aqwKXIlbUORBHeZxgjy7wUlx1Ye
+          BXrRgbM7mlnu8GEGoMiqNSjTaTF9dIv3+uL+hr+/u2o/11/69usHl25/4M3lp+g1qnnpCPVvNPLU
+          tTShjw6Fgh9hk1ALFtaTy7Ozk4vr69W7AeiDRVfa2iiL87A4XZ2eL1ZXi9XFvrELZJDVGn7OAAAe
+          hm+R6C3eqzWs5k8nPTLrFtX6UASgUnDlRGlmYtFe1PwImuAF/aB6u93+5uAr/1B5gEpx7nuddpVa
+          Q6W+dQh4bzBFAUtsMjMySIeQGSE0YEL2gqnRRrJ2DOShDw5NdjpBTGjJlFnA4JbnwBENNWS0czto
+          QgIOLtfkSHagvQU26GXSuISPL/6g0/BzCxKALHqhZlfoB9bS8kIES8pGchp0awHyjcvoDUJMIWIS
+          QgZHt/imlCXcPBM5B9Np3xayAMiCCdoUcuShpUPBFLSEftTJ1PpBl5c5/OnI4ej5hcn5qzF26CJk
+          bzGVq9trWRysQEI3eu0o8hK+dcj4iiSmcEcWgTxT20mZiwTowp/DTLQ72DHag24aNFNh5cJy2yIL
+          +XYcn3S4G4prBD0U6doh1DtoM9lS9vwuJIA2HeEdgkWmhHYy92Wl5uPWJXR4p73BDZuQcNy+60pV
+          /rHy2+12urwJm8y6ZMdn5/bnj4c0uNDGFGre44fzhjxxt0moOfiy+SwhqgF9nAH8GlKXnwVJxRT6
+          KBsJt+gL4cnp1T526hj0KXy5RyWIdhPgfPWEPKPcWBRNjifRVUabDu2x95hznS2FCTCbGH+t5y3u
+          0Tz59n/oj4AxGAXt5rgZb5UlLC/hv8oOgx4EK96xYL9pyLeYYqLxMWri5rK5qPEMm3qlZo+zvwAA
+          AP//AwBmT5tUlQUAAA==
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1e11c4522ea-SJC
+          - 8ebdee0199a217ea-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -4203,7 +4263,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:38:47 GMT
+          - Mon, 02 Dec 2024 20:05:07 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -4217,7 +4277,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "3933"
+          - "2681"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -4229,624 +4289,93 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "29998528"
+          - "29998527"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
           - 2ms
         x-request-id:
-          - req_9f62f5900f82d1cc85ba5020abfd8429
+          - req_5e7ffa0b862feed0682bbcc04a530cc6
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 5-7: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew D.
-        White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\n We present an example evaluation of
-        the SHAP explanation method based on the above\n\nattributes.44 Shapley values
-        were proposed as a local explanation method based on feature\n\nattribution,
-        as they offer a complete explanation - each feature is assigned a fraction of\n\nthe
-        prediction value.44,45 Completeness is a clearly measurable and well-defined
-        metric, but\n\nyields explanations with many components. Yet Shapley values
-        are not actionable nor sparse.\n\nThey are non-sparse as every feature has a
-        non-zero attribution and not-actionable because\n\nthey do not provide a set
-        of features which changes the outcome.46 Ribeiro et al. 35 proposed\n\na surrogate
-        model method that aims to provide sparse/succinct explanations that have high\n\n\n                                        5fidelity
-        to the original model. In Wellawatte et al. 9 we argue that counterfactuals
-        are \u201cbet-\n\nter\u201d explanations because they are actionable and sparse.
-        We highlight that, evaluation of\n\nexplanations is a difficult task because
-        explanations are fundamentally for and by humans.\n\nTherefore, these evaluations
-        are subjective, as they depend on \u201ccomplex human factors and\n\napplication
-        scenarios.\u201d37\n\n\nSelf-explaining models\n\nA self-explanatory model is
-        one that is intrinsically interpretable to an expert.47 Two com-\n\nmon examples
-        found in the literature are linear regression models and decision trees (DT).\n\nIntrinsic
-        models can be found in other XAI applications acting as surrogate models (proxy\n\nmodels)
-        due to their transparent nature.48,49 A linear model is described by the equation\n\n1
-        where, W\u2019s are the weight parameters and x\u2019s are the input features
-        associated with the\n\nprediction \u02c6y. Therefore, we observe that the weights
-        can be used to derive a complete expla-\n\nnation of the model - trained weights
-        quantify the importance of each feature.47 DT models\n\nare another type of
-        self-explaining models which have been used in classification and high-\n\nthroughput
-        screening tasks.  Gajewicz et al. 50 used DT models to classify nanomaterials\n\nthat
-        identify structural features responsible for surface activity. In another study
-        by Han\n\net al. 51, a DT model was developed to filter compounds by their bioactivity
-        based on the\n\nchemical fingerprints.\n\n\n\n                                                              \u02c6y
-        = \u03a3iWixi                                      (1)\n\n\n   Regularization
-        techniques such as EXPO52 and RRR53 are designed to enhance the black-\n\nbox
-        model interpretability.54 Although one can argue that \u201csimplicity\u201d
-        of models are posi-\n\ntively correlated with interpretability, this is based
-        on how the interpretability is evaluated.\n\nFor example, Lipton 55 argue that,
-        from the notion of \u201csimulatability\u201d (the degree to which a\n\nhuman
-        can predict the outcome based on inputs), self-explanatory linear models, rule-based\n\n\n\n                                        6systems,
-        and DT\u2019s can be claimed uninterpretable. A human can predict the outcome
-        given\n\nthe inputs only if the input features are interpretable. Therefore,
-        a linear model which takes\n\nin non-descriptive inputs may not be as transparent.
-        On the other hand, a linear model\n\nis not innately accurate as they fail to
-        capture non-linear relationships in data, limiting is\n\napplicability. Similarly,
-        a DT is a rule-based model and lacks physics informed knowledge.\n\nTherefore,
-        an existing drawback is the trade-off between the degree of understandability
-        and\n\nthe accuracy of a model. For example, an intrinsic model (linear regression
-        or decision trees)\n\ncan be described through the trainable parameters, but
-        it may fail to \u201ccorrectly\u201d capture\n\nnon-linear relations in the
-        data.\n\n\nAttribution methods\n\n\nFeature attribution methods explain black
-        box predictions by assigning each input feature\n\na numerical value, which
-        indicates its importance or contribution to the prediction. Feature\n\nattributions
-        provide local explanations, but can be averaged or combined to explain multi-\n\nple
-        instances. Atom-based numerical assignments are commonly referred to as heatmaps.56\n\nSheridan
-        57 describes an atom-wise attribution method for interpreting QSAR models. Re-\n\ncently,
-        Rasmussen et al. 58 showed that Crippen logP models serve as a benchmark for\n\nheatmap
-        approaches. Other most widely used feature attribution approaches in the litera-\n\nture
-        are gradient based methods,59,60 Shapley Additive exPlanations (SHAP),44 and
-        layer-\n\nwise relevance prorogation.61\n\n   Gradient based approaches are
-        based on the hypothesis that gradients for neural net-\n\nworks are analogous
-        to coefficients for regression models.62 Class activation maps (CAM),63\n\ngradCAM,64
-        smoothGrad,,65 and integrated gradients62 are examples of this method. The\n\nmain
-        idea behind feature attributions with gradients can be represented with equation  2.\n\n\n                                          \u2206\u02c6f(\u20d7x)\n                                                                                           (2)                               \u2206xi  \u2248\u2202\u02c6f(\u20d7x)\u2202xi\n\n\n\n                            \n\n----\n\nQuestion:
-        Are counterfactuals actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6182"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.0
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.0
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xUTW8bRwy961cQc8lFMmQ5sWPd4ksaIEEKtAUaZAuJO8PdGWe+OuQqdgz/92B2
-          ZUlJHaCXPfCRb94jHvdhBqCcUWtQ2qLokP3izd+f3nK7+xBuPt7eXP2L7999u+G/3r/97TLd/q7m
-          dSK1t6TlaepMp5A9iUtxgnUhFKqs51cXq1evrq9XlyMQkiFfx/osi5dpsVquXi6WrxfLy/2gTU4T
-          qzV8ngEAPIzfKjEaulNrWM6fKoGYsSe1PjQBqJJ8rShkdiwYRc2PoE5RKI6qt9vtLafYxIcmAjSK
-          hxCw3DdqDY360xLQnaaSBYxjPTATg3FdR4WiAN1ljxGrXQgkNhmGLhUIyZMePBbIhYzTU0N1zHOw
-          rrfe9VZc7EEsgXfByUjCkDr4w2L2dA879AMxIENMcYEjCbaeAKMZS5yxMJ3BO4FqqCALg1jH8NWJ
-          BZ2GKFQ61DJgffirddoCFgJDrItryVT2Fy2JUHlx6oahJY0DUxV4P878JODp8boioTsBCtkiu29U
-          NaD8/DzkknbOECAwSfXZEcpQDu0YQVuM/fgkpEF0CjSHgF/2ewonEqZ3qa5o2n7qfpTv6taEDEiC
-          loCHMaZuR3MwlCmaSpoi2CFghCoyFR6NYc7e6YmVNUUsLvFZo+ZTPgp52mHUtGGdCk05uW5UEx+b
-          uN1uT2NWqBsYa8rj4P2+/njIrU99LqnlPX6ody46tptCyCnWjLKkrEb0cQbwz3gfww+RV7mkkGUj
-          6QvFSni+Wr6eCNXxJE/g84s9KknQnwAXq/P5M5QbQ4LO88mRKY3akjnOHi8SB+PSCTA7Mf5fPc9x
-          T+Zd7P8P/RHQmrKQ2RzP7rm2QjUMv2o7LHoUrPiehcKmc7Gnkoubfhtd3lx1ly1dUNcu1exx9h0A
-          AP//AwBBL0/lPwUAAA==
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e83c1f679d97ae8-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 25 Nov 2024 18:38:49 GMT
-        Server:
-          - cloudflare
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "2186"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998531"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_7dc0ff1fa32d2e740330fc6a7b8bfd8c
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 9-12: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\n features. Weber et al. 82 used saliency
-        maps to build an explainable GCN\n\narchitecture that gives subgraph importance
-        for small molecule activity prediction. On the\n\nother hand, similarity maps
-        compare model predictions for two or more molecules based on\n\ntheir chemical
-        fingerprints.83 Similarity maps provide atomic weights or predicted probabil-\n\n\n                                        9ity
-        difference between the molecules by removing one atom at a time. These weights
-        can\n\nthen be used to color the molecular graph and give a visual presentation.
-        ChemInformatics\n\nModel Explorer (CIME) is an interactive web based toolkit
-        which allows visualization and\n\ncomparison of different explanation methods
-        for molecular property prediction models.84\n\n\nSurrogate models\n\n\nOne approach
-        to explain black box predictions is to fit a self-explaining or interpretable\n\nmodel
-        to the black box model, in the vicinity of one or a few specific examples. These
-        are\n\nknown as surrogate models. Generally, one model per explanation is trained.
-        However, if we\n\ncould find one surrogate model that explained the whole DL
-        model, then we would simply\n\nhave a globally accurate interpretable model.
-        This means that the black-box model is no\n\nlonger needed.79 In the work by
-        White 79, a weighted least squares linear model is used as\n\nthe surrogate
-        model. This model provides natural language based descriptor explanations by\n\nreplacing
-        input features with chemically interpretable descriptors. This approach is similar\n\nto
-        the concept-based explanations approach used by McGrath et al. 85, where human
-        under-\n\nstandable concepts were used in place of input features in acquisition
-        of chess knowledge in\n\nAlphaZero. Any of the self-explaining models detailed
-        in the Self-explaining models section\n\ncan be used as a surrogate model.\n\n   The
-        most commonly used surrogate model based method is Locally Interpretable Model\n\nExplanations
-        (LIME).35 LIME creates perturbations around the example of interest and fits\n\nan
-        interpretable model to these local perturbations. Ribeiro et al. 35 mathematically
-        define\n\nan explanation \u03be for an example \u20d7x using Equation 4.\n\n\n                                   \u03be(\u20d7x)
-        = arg min L(f, g, \u03c0x) + \u2126(g)                           (4)                                      g\u2208G\n   Here
-        f is the black box model and g \u2208G is the interpretable explanation model.
-        G is\na class of potential interpretable models (e.g.:  linear models). \u03c0x
-        is a similarity measure\n\n\n\n                                       10between
-        original input \u20d7x and it\u2019s perturbed input \u20d7x\u2032. In context
-        of molecular data, this can\n\nbe a chemical similarity metric like Tanimoto86
-        similarity between fingerprints. The goal for\n\nLIME is to minimize the loss,
-        L, such that f is closely approximated by g. \u2126is a parameter\nthat controls
-        the complexity (sparsity) of g. Ribeiro et al. 35 termed the agreement (how
-        low\n\nthe loss is) between f and g as the \u201cfidelity\u201d.\n\n   GraphLIME87
-        and LIMEtree88 are modifications to LIME as applicable to graph neural\n\nnetworks
-        and regression trees, respectively. LIME has been used in chemistry previously,\n\nsuch
-        as Whitmore et al. 89 who used LIME to explain octane number predictions of
-        molecules\n\nfrom a random forest classifier. Mehdi and Tiwary 90 used LIME
-        to explain thermodynamic\n\ncontributions of features.  Gandhi and White 10
-        use an approach similar to GraphLIME,\n\nbut use chemistry specific fragmentation
-        and descriptors to explain molecular property pre-\n\ndiction. Some examples
-        are highlighted in the Applications section.  In recent work by\n\nMehdi and
-        Tiwary 90, a thermodynamic-based surrogate model approach was used to inter-\n\npret
-        black-box models. The authors define an \u201cinterpretation free energy\u201d
-        which can be\n\nachieved by minimizing the surrogate model\u2019s uncertainty
-        and maximizing simplicity.\n\n\nCounterfactual explanations\n\n\nCounterfactual
-        explanations can be found in many fields such as statistics, mathematics and\n\nphilosophy.91\u201394
-        According to Woodward and Hitchcock 92, a counterfactual is an example\n\nwith
-        minimum deviation from the initial instance but with a contrasting outcome.
-        They\n\ncan be used to answer the question, \u201cwhich smallest change could
-        alter the outcome of an\n\ninstance of interest?\u201d While the difference
-        between the two instances is based on the exis-\n\ntence of similar worlds in
-        philosophy,95 a distance metric based on molecular similarity is\n\nemployed
-        in XAI for chemistry. For example, in the work by Wellawatte et al. 9 distance\n\nbetween
-        two molecules is defined as the Tanimoto distance96 between ECFP4 fingerprints.97\n\nAdditionally,
-        Mohapatra et al. 98 introduced a chemistry-informed graph representation for\n\ncomputing
-        macromolecular similarity. Contrastive explanations are peripheral to counterfac-\n\n\n                                       11tual
-        explanations. Unlike the counterfactual approach, contrastive approach employ
-        a dual\n\noptimization method, which works by generating a similar and a dissimilar
-        (counterfactuals)\n\nexample.  Cont\n\n----\n\nQuestion: Are counterfactuals
-        actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06", "stream": false,
-        "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6161"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.0
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.0
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xUTW8bRwy961cQc5YMWbbsWrc2aIMcArRADg2qQqJmubtMZobbIde2Yvi/B7P6
-          WiMt0IuA5SPfPH48vUwAHFduBc63aD52Yfbzn5/fp1/k48M//umb/PGt2X/4LEucp9Atb9y0VMju
-          C3k7VV15iV0gY0kH2GdCo8J6fX+zWC4fHhbXAxClolDKms5mtzJbzBe3s/lPs/ndsbAV9qRuBX9N
-          AABeht8iMVX07FYwn54ikVSxIbc6JwG4LKFEHKqyGiZz0wvoJRmlQfV2u/2iktbpZZ0A1k77GDHv
-          124Fa/dO+mSUa/TWYwB67gImLN0pYCbolSowgYqMcuREYC2BRgyB1MC3mJoSQwMvfagAg1EekqQ3
-          L5FAasAEnIpGP3xyeZLUruBTS/vhnR2WhyQNlV6Sp85KauTEEQNU9MiDLKizxCGLExtjuDCbAPqW
-          6ZEAC4dlVOPUnJRcwYczv9HzwO9biqyW91NAqPjIFMky+4uoKIF8HzCDcuSAmW0/Be19C6gD5SdM
-          HKUM6sSxI3siSvDru99+v4WaU0O5y5xMp8A6Gmx9mmrFdU2ZxsX2JOf+tIyLFbRvGlLT89RHCzws
-          DX2ZFO4CHeXtocvyyBWBduS5Zn/c3IkEEwTCg6CjCjuNTa/Wbno4nUyBHouWjXrJdDihh7Vbp9d1
-          2m634wvMVPeKxQCpD+EYfz2fdJCmy7LTI36O15xY200mVEnlfNWkcwP6OgH4e7BO/8YNrssSO9uY
-          fKVUCK8Xy7sDobu4dQwfneVMDMMIuLk/1b2h3FRkyEFH/nMefUvVpfZiVuwrlhEwGTX+o55/4z40
-          z6n5P/QXwBfTULXpMlXs3/Z8SctU/s7+K+086EGw070axc3oestK6m5zX9/t6Ibq3dxNXiffAQAA
-          //8DAGYbPDJaBQAA
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e83c1d628f3ce78-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 25 Nov 2024 18:38:49 GMT
-        Server:
-          - cloudflare
-        Set-Cookie:
-          - __cf_bm=2Y28RCMOhGtOxwV0eEkgrj9ecK2NcYyPVK1NMAdoH_o-1732559929-1.0.1.1-MlaWMiEKTd5rTNvv_72bmjVk.T9QGqoV0oVFJ._HjtiYt_AQDyjH9RvSXccvmdzpm1Mw8fEuN1etdxWB9DxryQ;
-            path=/; expires=Mon, 25-Nov-24 19:08:49 GMT; domain=.api.openai.com; HttpOnly;
-            Secure; SameSite=None
-          - _cfuvid=fjE_RfgBvewmfzfqephnCodBtJDFaR..jFi76uCfC4w-1732559929679-0.0.1.1-604800000;
-            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "7929"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998531"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_21cb90d41d0e72a37bbcd38a3545143d
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 1-3: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew D.
-        White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\n A Perspective on Explanations of Molecular\n\n              Prediction
-        Models\n\n\nGeemi P. Wellawatte,\u2020   Heta A. Gandhi,\u2021   Aditi Seshadri,\u2021
-        and  Andrew\n\n                           D. White\u2217,\u2021\n\n     \u2020Department
-        of Chemistry, University of Rochester, Rochester, NY, 14627\n\u2021Department
-        of Chemical Engineering, University of Rochester, Rochester, NY, 14627\n             \u00b6Vial
-        Health Technology, Inc., San Francisco, CA 94111\n\n                           E-mail:
-        andrew.white@rochester.edu\n\n\n\n                                 Abstract\n\n\n      Chemists
-        can be skeptical in using deep learning (DL) in decision making, due to\n\n   the
-        lack of interpretability in \u201cblack-box\u201d models.  Explainable artificial
-        intelligence\n\n   (XAI) is a branch of AI which addresses this drawback by
-        providing tools to interpret\n\n  DL models and their predictions. We review
-        the principles of XAI in the domain of\n\n   chemistry and emerging methods
-        for creating and evaluating explanations. Then we\n\n   focus on methods developed
-        by our group and their applications in predicting solubil-\n\n    ity, blood-brain
-        barrier permeability, and the scent of molecules. We show that XAI\n\n   methods
-        like chemical counterfactuals and descriptor explanations can explain DL pre-\n\n   dictions
-        while giving insight into structure-property relationships. Finally, we discuss\n\n   how
-        a two-step process of developing a black-box model and explaining predictions
-        can\n\n   uncover structure-property relationships.\n\n\n\n\n\n                                     1Introduction\n\n\nDeep
-        learning (DL) is advancing the boundaries of computational chemistry because
-        it can\n\naccurately model non-linear structure-function relationships.1\u20133
-        Applications of DL can be\n\nfound in a broad spectrum spanning from quantum
-        computing4,5 to drug discovery6\u201310 to\n\nmaterials design.11,12 According
-        to Kre 13, DL models can contribute to scientific discovery\n\nin three \u201cdimensions\u201d
-        - 1) as a \u2018computational microscope\u2019 to gain insight which are not\n\nattainable
-        through experiments 2) as a \u2018resource of inspiration\u2019 to motivate
-        scientific thinking\n\n3) as an \u2018agent of understanding\u2019 to uncover
-        new observations. However, the rationale of\n\na DL prediction is not always
-        apparent due to the model architecture consisting a large\n\nparameter count.14,15
-        DL models are thus often termed\u201cblack box\u201d models. We can only\n\nreason
-        about the input and output of an DL model, not the underlying cause that leads
-        to\n\na specific prediction.\n\n    It is routine in chemistry now for DL to
-        exceed human level performance \u2014 humans are\n\nnot good at predicting solubility
-        from structure for example161 \u2014 and so understanding how\n\na model makes
-        predictions can guide hypotheses. This is in contrast to a topic like finding\n\na
-        stop sign in an image, where there is little new to be learned about visual
-        perception\n\nby explaining a DL model. However, the black box nature of DL
-        has its own limitations.\n\nUsers are more likely to trust and use predictions
-        from a model if they can understand why\n\nthe prediction was made.17 Explaining
-        predictions can help developers of DL models ensure\n\nthe model is not learning
-        spurious correlations.18,19 Two infamous examples are, 1)neural\n\nnetworks
-        that learned to recognize horses by looking for a photographer\u2019s watermark20
-        and,\n\n2) neural networks that predicted a COVID-19 diagnoses by looking at
-        the font choice\n\non medical images.21 As a result, there is an emerging regulatory
-        framework for when any\n\ncomputer algorithms impact humans.22\u201324 Although
-        we know of no examples yet in chemistry,\n\none can assume the use of AI in
-        predicting toxicity, carcinogenicity, and environmental\n\npersistence will
-        require rationale for the predictions due to regulatory consequences.\n\n   1there
-        does happen to be one human solubility savant, participant 11, who matched machine
-        performance\n\n\n                                        2   EXplainable Artificial
-        Intelligence (XAI) is a field of growing importance that aims to\n\nprovide
-        model interpretations of DL predictions Three terms highly associated with XAI
-        are,\n\ninterpretability, justifications and explainability. Miller 25 defines
-        that interpretability of a\n\nmodel refers to the degree of human understandability
-        intrinsic within the model. Murdoch\n\net al. 26 clarify that interpretability
-        can be perceived as \u201cknowledge\u201d which provide insight\n\nto a particular
-        problem.  Justifications are quantitative metrics tell the users \u201cwhy the\n\nmodel
-        should be trusted,\u201d like test error.27 Justifications are evidence which
-        defend why a\n\nprediction is trustworthy.25 An \u201cexplanation\u201d is a
-        description on why a certain prediction was\n\nmade.9,28 Interpretability and
-        explanation are often used interchangeably. Arrieta et al. 14\n\ndistinguish
-        that interpretability is a passive characteristic of a model, whereas explainability\n\nis
-        an active characteristic which is used to clarify the internal decision-making
-        process.\n\nNamely, an explanation is extra information that gives the context
-        and a cause for one or\n\nmore pre\n\n----\n\nQuestion: Are counterfactuals
-        actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06", "stream": false,
-        "temperature": 0.0}'
-      headers:
-        accept:
-          - application/json
-        accept-encoding:
-          - gzip, deflate
-        connection:
-          - keep-alive
-        content-length:
-          - "6218"
-        content-type:
-          - application/json
-        host:
-          - api.openai.com
-        user-agent:
-          - AsyncOpenAI/Python 1.55.0
-        x-stainless-arch:
-          - arm64
-        x-stainless-async:
-          - async:asyncio
-        x-stainless-lang:
-          - python
-        x-stainless-os:
-          - MacOS
-        x-stainless-package-version:
-          - 1.55.0
-        x-stainless-raw-response:
-          - "true"
-        x-stainless-retry-count:
-          - "0"
-        x-stainless-runtime:
-          - CPython
-        x-stainless-runtime-version:
-          - 3.12.7
-      method: POST
-      uri: https://api.openai.com/v1/chat/completions
-    response:
-      body:
-        string: !!binary |
-          H4sIAAAAAAAAA4xUTW8bOQy9+1cQurQF7MBxvmrfWhRYtChyaYB0sV4YsoYz4kYjCSKV2g3y3wtp
-          3LG7zQJ70UGPfHz8fJoAKGrUCpSxWkwf3ezd1z//eJwv39/ubvnttby//3SXe3d/nr/fftmpafEI
-          23/QyE+vMxP66FAo+AE2CbVgYT2/uVhcXS2Xi2UF+tCgK25dlNllmC3mi8vZ/O1sfn1wtIEMslrB
-          XxMAgKf6Fom+wZ1awXz686dHZt2hWo1GACoFV36UZiYW7UVNj6AJXtBX1U9rD7BWnPtep/1arWCt
-          7iyCTkLGITTEJjMjg1iEzAihBdxFp8nrrRsMWzKkHZAXdI469Abh9dd3H98AeTAWe2JJ+ynEypqd
-          Tm4PbTCZyXcQPPQoNjQMjh5wcDDagQnZC6ZWG8naMWjfQINsEkUJaVDhdSk2g4QaPsWEAg1iBIc6
-          +cL/+sPnN1DrzWdwZ5FxjKepL54xhUdqEMgzdVa4UAVgSdlITjiLKURMsoeEbohnKQ56DqWAD58h
-          JmzIVHgK3ywZCzqVegl6YEQPmuHV1mnzMNuG3StoMpboYpESDJOzA52MJcEaeNA79oJz1yFLaYUW
-          yL7BVFrblCSl5nUiAYz20OWSlt3HUPGDZM854aEiVaIPciwXx5woZAYT0pjvGdxbcliHQHAn0ATk
-          6lcKQIbE7YFFC8I3i2Ix/d69hKCrtjI3UyAB6qOjYbT2YxMetct1ssZutCH9K9uSRgxlhkk7t6+8
-          voMcyyyVvE4rcbZW02HKEzp81N7ghk1IOEz7zVqt/fPpeiRsM+uynT47d/h/HvfNhS6msOUDPv63
-          5IntJqHm4MtusYSoKvo8Afi77nX+ZVVVTKGPspHwgL4Qni8WlwOhOp6SE/ji6oBKEO1+AZbTFyg3
-          DYomxyfHQRltLDZH3+Ml0bmhcAJMThL/Xc9L3EPy5Lv/Q38EjMEo2GyOXXvJLGG5tf9lNha6Cla8
-          Z8F+05LvylWg4dy1cXPTXm/xAtvtXE2eJz8AAAD//wMAg0O20vcFAAA=
-      headers:
-        CF-Cache-Status:
-          - DYNAMIC
-        CF-RAY:
-          - 8e83c204fac07ae8-SJC
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 25 Nov 2024 18:38:51 GMT
-        Server:
-          - cloudflare
-        Transfer-Encoding:
-          - chunked
-        X-Content-Type-Options:
-          - nosniff
-        access-control-expose-headers:
-          - X-Request-ID
-        alt-svc:
-          - h3=":443"; ma=86400
-        openai-organization:
-          - future-house-xr4tdh
-        openai-processing-ms:
-          - "2608"
-        openai-version:
-          - "2020-10-01"
-        strict-transport-security:
-          - max-age=31536000; includeSubDomains; preload
-        x-ratelimit-limit-requests:
-          - "10000"
-        x-ratelimit-limit-tokens:
-          - "30000000"
-        x-ratelimit-remaining-requests:
-          - "9999"
-        x-ratelimit-remaining-tokens:
-          - "29998526"
-        x-ratelimit-reset-requests:
-          - 6ms
-        x-ratelimit-reset-tokens:
-          - 2ms
-        x-request-id:
-          - req_2827cd03b86aa9f6e9114548e638e008
-      status:
-        code: 200
-        message: OK
-  - request:
-      body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 3-5: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew D.
-        White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\npassive characteristic of a model,
-        whereas explainability\n\nis an active characteristic which is used to clarify
-        the internal decision-making process.\n\nNamely, an explanation is extra information
-        that gives the context and a cause for one or\n\nmore predictions.29 We adopt
-        the same nomenclature in this perspective.\n\n   Accuracy and interpretability
-        are two attractive characteristics of DL models. However,\n\nDL models are often
-        highly accurate and less interpretable.28,30 XAI provides a way to avoid\n\nthat
-        trade-off in chemical property prediction. XAI can be viewed as a two-step process.\n\nFirst,
-        we develop an accurate but uninterpretable DL model. Next, we add explanations
-        to\n\npredictions. Ideally, if the DL model has correctly learned the input-output
-        relations, then\n\nthe explanations should give insight into the underlying
-        mechanism.\n\n   In the remainder of this article, we review recent approaches
-        for XAI of chemical property\n\nprediction while drawing specific examples from
-        our recent XAI work.9,10,31 We show how\n\nin various systems these methods
-        yield explanations that are consistent with known and\n\nmechanisms in structure-property
-        relationships.\n\n\n\n\n\n                                        3Theory\n\n\nIn
-        this work, we aim to assemble a common taxonomy for the landscape of XAI while\n\nproviding
-        our perspectives. We utilized the vocabulary proposed by Das and Rad 32 to classify\n\nXAI.
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 3-5: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\npassive
+        characteristic of a model, whereas explainability\\n\\nis an active characteristic
+        which is used to clarify the internal decision-making process.\\n\\nNamely,
+        an explanation is extra information that gives the context and a cause for one
+        or\\n\\nmore predictions.29 We adopt the same nomenclature in this perspective.\\n\\n
+        \  Accuracy and interpretability are two attractive characteristics of DL models.
+        However,\\n\\nDL models are often highly accurate and less interpretable.28,30
+        XAI provides a way to avoid\\n\\nthat trade-off in chemical property prediction.
+        XAI can be viewed as a two-step process.\\n\\nFirst, we develop an accurate
+        but uninterpretable DL model. Next, we add explanations to\\n\\npredictions.
+        Ideally, if the DL model has correctly learned the input-output relations, then\\n\\nthe
+        explanations should give insight into the underlying mechanism.\\n\\n   In the
+        remainder of this article, we review recent approaches for XAI of chemical property\\n\\nprediction
+        while drawing specific examples from our recent XAI work.9,10,31 We show how\\n\\nin
+        various systems these methods yield explanations that are consistent with known
+        and\\n\\nmechanisms in structure-property relationships.\\n\\n\\n\\n\\n\\n                                        3Theory\\n\\n\\nIn
+        this work, we aim to assemble a common taxonomy for the landscape of XAI while\\n\\nproviding
+        our perspectives. We utilized the vocabulary proposed by Das and Rad 32 to classify\\n\\nXAI.
         According to their classification, interpretations can be categorized as global
-        or local\n\ninterpretations on the basis of \u201cwhat is being explained?\u201d.
-        For example, counterfactuals are\n\nlocal interpretations, as these can explain
-        only a given instance. The second classification is\n\nbased on the relation
-        between the model and the interpretation \u2013 is interpretability post-hoc\n\n(extrinsic)
-        or intrinsic to the model?.32,33 An intrinsic XAI method is part of the model\n\nand
+        or local\\n\\ninterpretations on the basis of \u201Cwhat is being explained?\u201D.
+        For example, counterfactuals are\\n\\nlocal interpretations, as these can explain
+        only a given instance. The second classification is\\n\\nbased on the relation
+        between the model and the interpretation \u2013 is interpretability post-hoc\\n\\n(extrinsic)
+        or intrinsic to the model?.32,33 An intrinsic XAI method is part of the model\\n\\nand
         is self-explanatory32 These are also referred to as white-box models to contrast
-        them\n\nwith non-interpretable black box models.28 An extrinsic method is one
-        that can be applied\n\npost-training to any model.33 Post-hoc methods found
-        in the literature focus on interpreting\n\nmodels through 1) training data34
-        and feature attribution,35 2) surrogate models10 and, 3)\n\ncounterfactual9
-        or contrastive explanations.36\n\n   Often, what is a \u201cgood\u201d explanation
-        and what are the required components of an ex-\n\nplanation are debated.32,37,38
-        Palacio et al. 29 state that the lack of a standard framework\n\nhas caused
-        the inability to evaluate the interpretability of a model.  In physical sciences,\n\nwe
-        may instead consider if the explanations somehow reflect and expand our understanding\n\nof
-        physical phenomena.  For example, Oviedo et al. 39 propose that a model explanation\n\ncan
+        them\\n\\nwith non-interpretable black box models.28 An extrinsic method is
+        one that can be applied\\n\\npost-training to any model.33 Post-hoc methods
+        found in the literature focus on interpreting\\n\\nmodels through 1) training
+        data34 and feature attribution,35 2) surrogate models10 and, 3)\\n\\ncounterfactual9
+        or contrastive explanations.36\\n\\n   Often, what is a \u201Cgood\u201D explanation
+        and what are the required components of an ex-\\n\\nplanation are debated.32,37,38
+        Palacio et al. 29 state that the lack of a standard framework\\n\\nhas caused
+        the inability to evaluate the interpretability of a model.  In physical sciences,\\n\\nwe
+        may instead consider if the explanations somehow reflect and expand our understanding\\n\\nof
+        physical phenomena.  For example, Oviedo et al. 39 propose that a model explanation\\n\\ncan
         be evaluated by considering its agreement with physical observations, which
-        they term\n\n\u201ccorrectness.\u201d For example, if an explanation suggests
-        that polarity affects solubility of a\n\nmolecule, and the experimental evidence
-        strengthen the hypothesis, then the explanation\n\nis assumed \u201ccorrect\u201d.
-        In instances where such mechanistic knowledge is sparse, expert bi-\n\nases
+        they term\\n\\n\u201Ccorrectness.\u201D For example, if an explanation suggests
+        that polarity affects solubility of a\\n\\nmolecule, and the experimental evidence
+        strengthen the hypothesis, then the explanation\\n\\nis assumed \u201Ccorrect\u201D.
+        In instances where such mechanistic knowledge is sparse, expert bi-\\n\\nases
         and subjectivity can be used to measure the correctness.40 Other similar metrics
-        of\n\ncorrectness such as \u201cexplanation satisfaction scale\u201d can be
-        found in the literature.41,42 In a\n\nrecent study, Humer et al. 43 introduced
-        CIME an interactive web-based tool that allows the\n\nusers to inspect model
-        explanations. The aim of this study is to bridge the gap between\n\nanalysis
-        of XAI methods. Based on the above discussion, we identify that an agreed upon\n\n\n                                        4evaluation
-        metric is necessary in XAI. We suggest the following attributes can be used
-        to\n\nevaluate explanations. However, the relative importance of each attribute
-        may depend on\n\nthe application - actionability may not be as important as
-        faithfulness when evaluating the\n\ninterpretability of a static physics based
-        model. Therefore, one can select relative importance\n\nof each attribute based
-        on the application.\n\n   \u2022 Actionable. Is it clear how we could change
-        the input features to modify the output?\n\n   \u2022 Complete. Does the explanation
-        completely account for the prediction? Did features\n\n     not included in
-        the explanation really contribute zero effect to the prediction?44\n\n   \u2022
-        Correct. Does the explanation agree with hypothesized or known underlying physical\n\n     mechanism?39\n\n   \u2022
-        Domain Applicable. Does the explanation use language and concepts of domain
-        ex-\n\n      perts?\n\n   \u2022 Fidelity/Faithful. Does the explanation agree
-        with the black box model?\n\n   \u2022 Robust. Does the explanation change significantly
-        with small changes to the model or\n\n      instance being explained?\n\n   \u2022
-        Sparse/Succinct. Is the explanation succinct?\n\n\n  We present an example evaluation
-        of the SHAP explanation method based on the above\n\nattributes.44 Shapley values
-        were proposed as a local explanation method based on feature\n\nattribution,
-        as they offer a complete explanation - each feature is assign\n\n----\n\nQuestion:
-        Are counterfactuals actionable? [yes/no]\n\n"}], "model": "gpt-4o-2024-08-06",
-        "stream": false, "temperature": 0.0}'
+        of\\n\\ncorrectness such as \u201Cexplanation satisfaction scale\u201D can be
+        found in the literature.41,42 In a\\n\\nrecent study, Humer et al. 43 introduced
+        CIME an interactive web-based tool that allows the\\n\\nusers to inspect model
+        explanations. The aim of this study is to bridge the gap between\\n\\nanalysis
+        of XAI methods. Based on the above discussion, we identify that an agreed upon\\n\\n\\n
+        \                                       4evaluation metric is necessary in XAI.
+        We suggest the following attributes can be used to\\n\\nevaluate explanations.
+        However, the relative importance of each attribute may depend on\\n\\nthe application
+        - actionability may not be as important as faithfulness when evaluating the\\n\\ninterpretability
+        of a static physics based model. Therefore, one can select relative importance\\n\\nof
+        each attribute based on the application.\\n\\n   \u2022 Actionable. Is it clear
+        how we could change the input features to modify the output?\\n\\n   \u2022
+        Complete. Does the explanation completely account for the prediction? Did features\\n\\n
+        \    not included in the explanation really contribute zero effect to the prediction?44\\n\\n
+        \  \u2022 Correct. Does the explanation agree with hypothesized or known underlying
+        physical\\n\\n     mechanism?39\\n\\n   \u2022 Domain Applicable. Does the explanation
+        use language and concepts of domain ex-\\n\\n      perts?\\n\\n   \u2022 Fidelity/Faithful.
+        Does the explanation agree with the black box model?\\n\\n   \u2022 Robust.
+        Does the explanation change significantly with small changes to the model or\\n\\n
+        \     instance being explained?\\n\\n   \u2022 Sparse/Succinct. Is the explanation
+        succinct?\\n\\n\\n  We present an example evaluation of the SHAP explanation
+        method based on the above\\n\\nattributes.44 Shapley values were proposed as
+        a local explanation method based on feature\\n\\nattribution, as they offer
+        a complete explanation - each feature is assign\\n\\n----\\n\\nQuestion: Are
+        counterfactuals actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -4855,13 +4384,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6147"
+          - "6079"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -4871,7 +4400,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -4885,24 +4414,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4yUTW/bMAyG7/kVhC7bgKTI0vUrt26HYT3vsGEeElmibXayqIl026Dofx/kpEm6
-          D2AXH/SSLx/KpB4nAIa8WYJxnVXXpzC7/vL14/3Z+9p+vr7afBianxc3729SS03+Gm/MtGRwfYtO
-          n7NOHPcpoBLHrewyWsXi+vbidHF2dnV1Oh+Fnj2GktYmnb3j2WK+eDebX87m57vEjsmhmCV8mwAA
-          PI7fghg9PpgljDbjSY8itkWz3AcBmMyhnBgrQqI2qpkeRMdRMY7U6/X6VjhW8bGKAJWRoe9t3lRm
-          CZX5wENUzI11OtggYDOCR3GZavRgBQI7G4BKUMqotjQuQBG0QxirPChwA/iQgqVo64Bw/Qlef7n+
-          9GYKPdpIsS3Bm+cQkISOGnJAsXA7lBP43CGMVp5RILKO0eRIwwZErSLcd6gdZnB/QbaucJXiU6gH
-          BdoZ9RiLANpZBY5YSAu4Vc1UD4oCyoB3NgylxEgYn3sUeHXk+wruO3IdWPkhQE0pQQIuoM3Q8T1Q
-          TINCg1aHjFIog4cawXU2tuhLnZ49NZsRgAdNg5a+SYD6FKigFMrf2zsYcRTymMt/2WMVkvFyU+Y7
-          8rgDagfy5WaB4winDDYo5i3l2LR1HeEdgqemwYxRC5PjHuWkMtPtqGQMeFd8VuI443ZkLitTxacq
-          rtfr44nL2Axiy8DHIYTd+dN+hAO3KXMtO31/3lAk6VYZrXAs4yrKyYzq0wTg+7gqw4vpNylzn3Sl
-          /ANjMXy7mF9sDc1hO1/IO1VZbTgSThfPeS8sVx7VUpCjfTPOug79IfewnHbwxEfC5KjxP3n+5r1t
-          nmL7P/YHwTlMin6VMnpyL3s+hGUsz9e/wvYXPQIb2Yhiv2ootmXfafuCNGl10ZzXeIpNPTeTp8kv
-          AAAA//8DAEJkEKVKBQAA
+          H4sIAAAAAAAAA4yUTW8cNwyG7/srCF3SALvG2k7sZG+LAi1yKIoAQWAjU+xyJM4MHY2kipy1F4b/
+          e6DZT7cp0Msc9JIvH2pIPU8ADDuzAGM7VNsnP1vizdNvX5fzx7vNH8Pv7VL+pId7ufuM6fPf92Za
+          MmL9QFYPWRc29smTcgw72WZCpeJ6eXt9fXnz8eP8/Sj00ZEvaW3S2bs4u5pfvZvNP8zmN/vELrIl
+          MQv4NgEAeB6/BTE4ejILmE8PJz2JYEtmcQwCMDn6cmJQhEUxqJmeRBuDUhip1+v1g8RQhecqAFRG
+          hr7HvK3MAirzaxyCUm7Q6oBeADOBI7GZa3KAAj5a9MAlKGVSLI0LcADtCMYqTwqxAXpKHjlg7QmW
+          n+CXu+Wnt1PoCQOHtgRvDyEgiSw3bIFD4bYkF/ClIxitXCSBEHWMZsvqtyCKSvDYkXaUwf4EGW3h
+          KsWnUA8KvDfqKRQBtEOFGKiQFnBUzVwPSgIagTboh1JiJAyHHgXenPm+gceObQco3wW4KSVYwHrC
+          DF18BA5pUGgIdcgkhdI7qAlsh6ElV+r00XGzHQHioGnQ0jcLcJ88F5RC+c/2TkYxCDvK5b8csQrJ
+          eLkpxw072gO1A7tysxDDCKcR0CvlHeXYNNqOaUPguGkoU9DCZGNPclGZ6W5UMnnaFJ+V2JhpNzIf
+          KlOFlyqs1+vzicvUDIJl4MPg/f785TjCPrYpx1r2+vG84cDSrTKhxFDGVTQmM6ovE4C/xlUZXk2/
+          STn2SVcav1MohpdX89udoTlt5yt5r2pU9GfC9dUh75XlypEieznbN2PRduROuaflxMFxPBMmZ43/
+          m+dn3rvmObT/x/4kWEtJya1SJsf2dc+nsEzl+fqvsONFj8BGtqLUrxoObdl33r0gTVrdNjc1XVNT
+          z83kZfIDAAD//wMAyyHv60oFAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1e73f2367fb-SJC
+          - 8ebdee01af919440-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -4910,7 +4439,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:39:05 GMT
+          - Mon, 02 Dec 2024 20:05:08 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -4924,7 +4453,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "2029"
+          - "3419"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -4942,85 +4471,90 @@ interactions:
         x-ratelimit-reset-tokens:
           - 2ms
         x-request-id:
-          - req_350134197d16c6abbc627bf446eb0638
+          - req_13af58d6dcdcbdce5597d16a6a644e9c
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Provide a summary of the relevant
-        information that could help answer the question based on the excerpt. Respond
-        with the following JSON format:\n\n{\n  \"summary\": \"...\",\n  \"relevance_score\":
-        \"...\"\n}\n\nwhere `summary` is relevant information from text - about 100
-        words words and `relevance_score` is the relevance of `summary` to answer question
-        (out of 10).\n"}, {"role": "user", "content": "Excerpt from wellawatteUnknownyearaperspectiveon
-        pages 33-35: Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\n----\n\n   metabolic stability of chemical
-        compounds? Journal of Cheminformatics 2021, 13,\n\n     1\u201320.\n\n\n(78)
-        Mastropietro, A.; Pasculli, G.; Feldmann, C.; Rodr\u00b4\u0131guez-P\u00b4erez,
-        R.; Bajorath, J. Edge-\n\n    SHAPer: Bond-Centric Shapley Value-Based Explanation
-        Method for Graph Neural\n\n     Networks. iScience 2022, 25, 105043.\n\n\n(79)
-        White, A. D. Deep learning for molecules and materials. Living Journal of Computa-\n\n      tional
-        Molecular Science 2022, 3.\n\n(80) \u02d8Strumbelj, E.; Kononenko, I. Explaining
-        prediction models and individual predictions\n\n     with feature contributions.
-        Knowledge and Information Systems 2014, 41, 647\u2013665.\n\n\n(81) Erhan, D.;
-        Bengio, Y.; Courville, A.; Vincent, P. Visualizing Higher-Layer Features of\n\n     a
-        Deep Network. Technical Report, Univerist\u00b4e de Montr\u00b4eal 2009,\n\n\n(82)
-        Weber, J. K.; Morrone, J. A.; Bagchi, S.; Pabon, J. D.; gu Kang, S.; Zhang,
-        L.;\n\n     Cornell, W. D. Simplified, interpretable graph convolutional neural
-        networks for small\n\n     molecule activity prediction. Journal of Computer-Aided
-        Molecular Design 2022, 36,\n\n     391\u2013404.\n\n\n(83) Riniker, S.; Landrum,
-        G. A. Similarity maps - A visualization strategy for molecular\n\n     fingerprints
-        and machine-learning methods. Journal of Cheminformatics 2013, 5, 1\u20137.\n\n\n(84)
-        Humer, C.; Heberle, H.; Montanari, F.; Wolf, T.; Huber, F.; Henderson, R.; Hein-\n\n      rich,
-        J.; Streit, M. ChemInformatics Model Explorer (CIME): exploratory analysis of\n\n     chemical
-        model explanations. Journal of Cheminformatics 2022, 14, 1\u201314.\n\n\n(85)
-        McGrath, T.; Kapishnikov, A.; Toma\u02c7sev, N.; Pearce, A.; Wattenberg, M.;
-        Hass-\n\n      abis, D.; Kim, B.; Paquet, U.; Kramnik, V. Acquisition of chess
-        knowledge in Al-\n\n     phaZero. Proceedings of the National Academy of Sciences
-        2022, 119, e2206625119.\n\n\n\n\n                                      33(86)
-        Bajusz, D.; R\u00b4acz, A.; H\u00b4eberger, K. Why is Tanimoto index an appropriate
-        choice for\n\n     fingerprint-based similarity calculations? Journal of Cheminformatics
-        2015, 7, 1\u201313.\n\n\n(87) Huang, Q.; Yamada, M.; Tian, Y.; Singh, D.; Yin,
-        D.; Chang, Y. GraphLIME:\n\n     Local Interpretable Model Explanations for
-        Graph Neural Networks. CoRR 2020,\n\n     abs/2001.06216.\n\n\n(88) Sokol, K.;
-        Flach, P. A. LIMEtree: Interactively Customisable Explanations Based on\n\n     Local
-        Surrogate Multi-output Regression Trees. CoRR 2020, abs/2005.01427.\n\n\n(89)
-        Whitmore, L. S.; George, A.; Hudson, C. M. Mapping chemical performance on molec-\n\n     ular
-        structures using locally interpretable explanations. 2016; https://arxiv.org/\n\n    abs/1611.07443.\n\n\n(90)
-        Mehdi, S.; Tiwary, P. Thermodynamics of Interpretation. 2022,\n\n\n(91) H\u00a8ofler,
-        M. Causal inference based on counterfactuals. BMC Medical Research Method-\n\n     ology
-        2005, 5, 1\u201312.\n\n\n(92) Woodward, J.; Hitchcock, C. Explanatory Generalizations,
-        Part I: A Counterfactual\n\n     Account. No\u02c6us 2003, 37, 1\u201324.\n\n\n(93)
-        Frisch, M. F. Theories, models, and explanation; University of California, Berkeley,\n\n     1998.\n\n\n(94)
-        Reutlinger, A. Is There A Monist Theory of Causal and Non-Causal Explanations?\n\n    The
-        Counterfactual Theory of Scientific Explanation. Philosophy of Science 2016,
-        83,\n\n     733\u2013745.\n\n\n(95) Lewis, D. Causation. The journal of philosophy
-        1974, 70, 556\u2013567.\n\n\n(96) Tanimoto, T. T. Elementary mathematical theory
-        of classification and prediction.\n\n     Internal IBM Technical Report 1958,\n\n\n                                      34
-        (97) Rogers, D.; Hahn, M. Extended-Connectivity Fingerprints. Journal of Chemical
-        In-\n\n      formation and Modeling 2010, 50, 742\u2013754, PMID: 20426451.\n\n\n
-        (98) Mohapatra, S.; An, J.; G\u00b4omez-Bombarelli, R. Chemistry-informed macromolecule\n\n      graph
-        representation for similarity computation, unsupervised and supervised learn-\n\n       ing.
-        Machine Learning: Science and Technology 2022, 3, 015028.\n\n\n (99) Doshi-Velez,
-        F.; Kortz, M.; Budish, R.; Bavitz, C.; Gershman, S.; O\u2019Brien, D.;\n\n       Scott,
-        K.; Schieber, S.; Waldo, J.; Weinberger, D.; Weller, A.; Wood, A. Account-\n\n       ability
-        of AI Under the Law: The Role of Explanation. SSRN Electronic Journal\n\n     2017,\n\n\n(100)
-        Wachter, S.; Mittelstadt, B.; Russell, C. Counterfactual explanations without
-        opening\n\n      the black box: Automated decisions and the GDPR. Harv. JL &
-        Tech. 2017, 31, 841.\n\n\n(101) Jim\u00b4enez-Luna, J.; Grisoni, F.; Schneider,
-        G. Drug discovery with explainable artificial\n\n       intelligence. Nature
-        Machine Intelligence 2020 2:10 2020, 2, 573\u2013584.\n\n\n(102) Fu, T.; Gao,
-        W.; Xiao, C.; Yasonik, J.; Coley, C. W.; Sun, J. Differentiable Scaffold-\n\n      ing
-        Tree for Molecule Optimization. International Conference on Learning Represen-\n\n       tations.
-        2022.\n\n\n(103) Shen, C.; Krenn, M.; Eppel, S.; Aspuru-Guzik, A. Deep molecular
-        dreaming: inverse\n\n     machine learning for de-novo molecular design and
-        interpretability with surjective\n\n      representations. Machine Learning:
-        Science and Technology 2021, 2, 03LT02.\n\n\n(104) Lucic,  A.;   ter  Hoeve,  M.;   Tolomei,  G.;   Rijke,  M.;   Silvestri,  F.  CF-\n\n
-        \n\n----\n\nQuestion: Are counterfactuals actionable? [yes/no]\n\n"}], "model":
-        "gpt-4o-2024-08-06", "stream": false, "temperature": 0.0}'
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 25-27: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\nng:
+        machine intelligence approach for drug discovery.\\n\\n     Molecular diversity
+        2021, 25, 1315\u20131360.\\n\\n\\n (9) Wellawatte, G. P.; Seshadri, A.; White,
+        A. D. Model agnostic generation of counter-\\n\\n     factual explanations for
+        molecules. Chemical Science 2022, 13, 3697\u20133705.\\n\\n\\n(10) Gandhi, H.
+        A.; White, A. D. Explaining structure-activity relationships using locally\\n\\n
+        \     faithful surrogate models. chemrxiv 2022,\\n\\n\\n(11) Gormley, A. J.;
+        Webb, M. A. Machine learning in combinatorial polymer chemistry.\\n\\n     Nature
+        Reviews Materials 2021,\\n\\n\\n(12) Gomes, C. P.; Fink, D.; Dover, R. B. V.;
+        Gregoire, J. M. Computational sustainability\\n\\n     meets materials science.
+        Nature Reviews Materials 2021,\\n\\n\\n(13) On scientific understanding with
+        artificial intelligence. Nature Reviews Physics 2022\\n\\n     4:12 2022, 4,
+        761\u2013769.\\n\\n\\n(14) Arrieta, A. B.; D\xB4\u0131az-Rodr\xB4\u0131guez,
+        N.; Ser, J. D.; Bennetot, A.; Tabik, S.; Barbado, A.;\\n\\n     Garcia, S.;
+        Gil-Lopez, S.; Molina, D.; Benjamins, R.; Chatila, R.; Herrera, F. Explain-\\n\\n
+        \    able Artificial Intelligence (XAI): Concepts, Taxonomies, Opportunities
+        and Chal-\\n\\n     lenges toward Responsible AI. Information Fusion 2019, 58,
+        82\u2013115.\\n\\n\\n(15) Murdoch, W. J.; Singh, C.; Kumbier, K.; Abbasi-Asl,
+        R.; Yu, B. Interpretable machine\\n\\n     learning: definitions, methods, and
+        applications. ArXiv 2019, abs/1901.04592.\\n\\n                                      25(16)
+        Boobier, S.; Osbourn, A.; Mitchell, J. B. Can human experts predict solubility
+        better\\n\\n     than computers? Journal of cheminformatics 2017, 9, 1\u201314.\\n\\n\\n(17)
+        Lee, J. D.; See, K. A. Trust in automation: Designing for appropriate reliance.
+        Human\\n\\n     Factors 2004, 46, 50\u201380.\\n\\n\\n(18) Bolukbasi, T.; Chang,
+        K.-W.; Zou, J. Y.; Saligrama, V.; Kalai, A. T. Man is to com-\\n\\n     puter
+        programmer as woman is to homemaker? debiasing word embeddings. Advances\\n\\n
+        \    in neural information processing systems 2016, 29.\\n\\n\\n(19) Buolamwini,
+        J.; Gebru, T. Gender Shades:  Intersectional Accuracy Disparities in\\n\\n    Commercial
+        Gender Classification. Proceedings of the 1st Conference on Fairness,\\n\\n
+        \    Accountability and Transparency. 2018; pp 77\u201391.\\n\\n\\n(20) Lapuschkin,
+        S.; W\xA8aldchen, S.; Binder, A.; Montavon, G.; Samek, W.; M\xA8uller, K.-R.\\n\\n
+        \   Unmasking Clever Hans predictors and assessing what machines really learn.
+        Nature\\n\\n     communications 2019, 10, 1\u20138.\\n\\n\\n(21) DeGrave, A.
+        J.; Janizek, J. D.; Lee, S.-I. AI for radiographic COVID-19 detection\\n\\n
+        \     selects shortcuts over signal. Nature Machine Intelligence 2021, 3, 610\u2013619.\\n\\n\\n(22)
+        Goodman, B.; Flaxman, S. European Union regulations on algorithmic decision-\\n\\n
+        \   making and a \u201Cright to explanation\u201D. AI Magazine 2017, 38, 50\u201357.\\n\\n\\n(23)
+        ACT, A. I. European Commission. On Artificial Intelligence: A European Approach\\n\\n
+        \    to Excellence and Trust. 2021, COM/2021/206.\\n\\n\\n(24) Blueprint for
+        an AI Bill of Rights, The White House. 2022; https://www.whitehouse.\\n\\n    gov/ostp/ai-bill-of-rights/.\\n\\n\\n(25)
+        Miller, T. Explanation in artificial intelligence: Insights from the social
+        sciences. Ar-\\n\\n       tificial intelligence 2019, 267, 1\u201338.\\n\\n\\n\\n
+        \                                     26(26) Murdoch, W. J.; Singh, C.; Kumbier,
+        K.; Abbasi-Asl, R.; Yu, B. Definitions, meth-\\n\\n     ods, and applications
+        in interpretable machine learning. Proceedings of the National\\n\\n    Academy
+        of Sciences of the United States of America 2019, 116, 22071\u201322080.\\n\\n\\n(27)
+        Gunning, D.; Aha, D. DARPA\u2019s Explainable Artificial Intelligence (XAI)
+        Program.\\n\\n    AI Magazine 2019, 40, 44\u201358.\\n\\n\\n(28) Biran, O.;
+        Cotton, C. Explanation and justification in machine learning: A survey.\\n\\n
+        \    IJCAI-17 workshop on explainable AI (XAI). 2017; pp 8\u201313.\\n\\n\\n(29)
+        Palacio, S.; Lucieri, A.; Munir, M.; Ahmed, S.; Hees, J.; Dengel, A. Xai handbook:\\n\\n
+        \   Towards a unified framework for explainable ai. Proceedings of the IEEE/CVF
+        Inter-\\n\\n     national Conference on Computer Vision. 2021; pp 3766\u20133775.\\n\\n\\n(30)
+        Kuhn, D. R.; Kacker, R. N.; Lei, Y.; Simos, D. E. Combinatorial Methods for
+        Ex-\\n\\n     plainable AI. 2020 IEEE International Conference on Software Testing,
+        Verification\\n\\n    and Validation Workshops (ICSTW) 2020, 167\u2013170.\\n\\n\\n(31)
+        Seshadri, A.; Gandhi, H. A.; Wellawatte, G. P.; White, A. D. Why does that molecule\\n\\n
+        \    smell? ChemRxiv 2022,\\n\\n\\n(32) Das, A.; Rad, P. Opportunities and challenges
+        in explainable artificial intelligence\\n\\n      (xai): A survey. arXiv preprint
+        arXiv:2006.11371 2020,\\n\\n\\n(33) Machlev, R.; Heistrene, L.; Perl, M.; Levy,
+        K. Y.; Belikov, J.; Mannor, S.; Levron, Y.\\n\\n     Explainable Artificial
+        Intelligence (XAI) techniques for energy and power systems:\\n\\n     Review,
+        challenges and opportunities. Energy and AI 2022, 9, 100169.\\n\\n\\n(34) Koh,
+        P. W.; Liang, P. Understanding black-box predictions via influence functions.\\n\\n
+        \    International Conference on Machine Learning. 2017; pp 1885\u20131894.\\n\\n\\n(35)
+        Ribeiro, M. T.; Singh, S.; Guestrin, C. \u201D Why should  i trust you?\u201D
+        Explaining the\\n\\n     predictions of any classifier. Proceedings of the 22nd
+        ACM SIGKDD international\\n\\n         \\n\\n----\\n\\nQuestion: Are counterfactuals
+        actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -5029,13 +4563,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "6224"
+          - "6127"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -5045,7 +4579,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -5059,25 +4593,24 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA4xUwW4bRwy96yuIudQGJEGWJUXWLS1aOAXsNmqKJsgWEneGuzv27HAxnLWtGL7m
-          5/JTxaxkS3YcoJcFlo98fOSQvO8BKGvUApSuMOq6cYO3Hz+d/35z9fdsOf21Xc7z395//BKrd3+8
-          2yzfX6p+iuD8inR8jBpqrhtH0bLfwjoQRkqsJ29Ox9Pp2dn0tANqNuRSWNnEwYQH49F4MhjNB6PZ
-          LrBiq0nUAj73AADuu2+S6A3dqQWM+o+WmkSwJLV4cgJQgV2yKBSxEtFH1d+Dmn0k36ler9dXwj7z
-          95kHyJS0dY1hk6kFZOpDRUB3mkITIVBBgbwmAaEbCujglsO1QCCXSoTIQHeNQ4+pfAEuoGZHunUY
-          oAlkrE4AdJULoDegufWRQoE6tuhkCJccMXebPtgINfkt0XmWZYoLR+En6XICe9DYCjqwfqcKchQy
-          HfKcFI5+vvgFLlJ6dLAkIQy6gguKFRt2XG5gPBpNjztB/zCbWwym+zm3UVea9fVB2scKOWygJJ/a
-          YL/sCr61sQJ8kR9QdwY4uuRvX1tJyU6Ph/DWGJvC0KVyl9RGZ325L9FY0a0ICcSKXnLGipIALkC0
-          TW0qrD5sPhz9WVnHwk3Vef2VvDTBeHQyOx7Ch4qEnj1oW5YkEWKF8bv+YSBoU2+t/0G63WO+eJE+
-          2LpxG+vLpHcDGj3kBNhNAeaOEmHrDYU0nyb5JZqO1/r021TkuSaPw0z1t+MZyNENek0r0RxoO6bz
-          TGX+IfPr9fpwygMVSZFagG+d29kfntbGcdkEzmWHP9kL661Uq0Ao7NOKSORGdehDD+Dfbj3bZxun
-          msB1E1eRr8knwpPZ2WRLqPYX4QCezHdo5IjuAJhPxv1XKFeGIlonBzuuNOqKzD52fxCwNZYPgN5B
-          4d/reY17W7z15f+h3wNaUxPJrPbb/ppboHQyf+T21OhOsJKNRKpXRbccTbDbq1U0qzfFLKdTKvKR
-          6j30/gMAAP//AwAUhGbWvgUAAA==
+          H4sIAAAAAAAAA4xUTW/bOBC9+1cMeOlFDhwn6zi+dbtAT3tpAnTRVWGPqJHIhCIJzsgfDfLfF5Sc
+          2G3TYi8CNG/mzZsvPk0AlK3VCpQ2KLqLbvoeF/uPzX5x//6j/MV/3pl/btpPX7bXn/TtrlJFjgjV
+          A2l5ibrQoYuOxAY/wjoRCmXWy5urq8vF7e1sMQBdqMnlsDbK9DpM57P59XS2nM4Wx0ATrCZWK/h3
+          AgDwNHyzRF/TXq1gVrxYOmLGltTq1QlApeCyRSGzZUEvqjiBOnghP6jebDYPHHzpn0oPUCruuw7T
+          oVQrKNW9IaC9phQFEjWUyGtiQNiF9AjVAT6Tc7hDESrgjthgnWwB6Gv4bKwQBA/v/s6VArY+sFgN
+          LXlKmDsEoQEdei+UGtTSowPaR4d+QBmakKALjnTviN9B7Ctn2VAN1sMHQ53V6OBO2ywq2+az+fwC
+          7o1l4L5tiYVBDMpvk2Ai6HkkFUMwtGYvWdsxNyaIiWqrB83D3LiAnbHagO2is5TT0GGgwsELKzco
+          iilsbW19C9azbY0whATohFLOvyXOXjVpyzb4aYeP2TemoImZ+AI+fKd8VCuHmCt3h1G3BOh9TSkP
+          uQYTdqAN+naktj72AltMNkti0OjBEQ5RtW2GiQqEXnToiAs4KhBD3Q+lYP3Qs2QwJAhRbGe/5b8X
+          8QwVZjkvLTrrGV+Uqhi3K5GjLXpNa9Yh0bhly1KV/rn0m83mfEkTNT1jvhHfO3e0P79uvQttTKHi
+          I/5qb6y3bNaJkIPPG84SohrQ5wnA1+G6+u8ORsUUuihrCY/kM+HlYnk1EqrTQZ/B8z+OqARBdwYs
+          Z8viDcp1TYLW8dmJKo3aUH2KPd0z9rUNZ8DkrPCf9bzFPRZvfft/6E+A1hSF6vVpdG+5Jcov3q/c
+          Xhs9CFZ8YKFu3VjfUorJjo9OE9c3zaKiK2qqmZo8T/4DAAD//wMA3UldLH0FAAA=
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c1fc6b1b22ea-SJC
+          - 8ebdee0c1e7ccfd5-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -5085,7 +4618,7 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:39:24 GMT
+          - Mon, 02 Dec 2024 20:05:08 GMT
         Server:
           - cloudflare
         Transfer-Encoding:
@@ -5099,7 +4632,185 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "2367"
+          - "1982"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998529"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_a021d69f7bbc375514506607495ade9c
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 5-7: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\n
+        We present an example evaluation of the SHAP explanation method based on the
+        above\\n\\nattributes.44 Shapley values were proposed as a local explanation
+        method based on feature\\n\\nattribution, as they offer a complete explanation
+        - each feature is assigned a fraction of\\n\\nthe prediction value.44,45 Completeness
+        is a clearly measurable and well-defined metric, but\\n\\nyields explanations
+        with many components. Yet Shapley values are not actionable nor sparse.\\n\\nThey
+        are non-sparse as every feature has a non-zero attribution and not-actionable
+        because\\n\\nthey do not provide a set of features which changes the outcome.46
+        Ribeiro et al. 35 proposed\\n\\na surrogate model method that aims to provide
+        sparse/succinct explanations that have high\\n\\n\\n                                        5fidelity
+        to the original model. In Wellawatte et al. 9 we argue that counterfactuals
+        are \u201Cbet-\\n\\nter\u201D explanations because they are actionable and sparse.
+        We highlight that, evaluation of\\n\\nexplanations is a difficult task because
+        explanations are fundamentally for and by humans.\\n\\nTherefore, these evaluations
+        are subjective, as they depend on \u201Ccomplex human factors and\\n\\napplication
+        scenarios.\u201D37\\n\\n\\nSelf-explaining models\\n\\nA self-explanatory model
+        is one that is intrinsically interpretable to an expert.47 Two com-\\n\\nmon
+        examples found in the literature are linear regression models and decision trees
+        (DT).\\n\\nIntrinsic models can be found in other XAI applications acting as
+        surrogate models (proxy\\n\\nmodels) due to their transparent nature.48,49 A
+        linear model is described by the equation\\n\\n1 where, W\u2019s are the weight
+        parameters and x\u2019s are the input features associated with the\\n\\nprediction
+        \u02C6y. Therefore, we observe that the weights can be used to derive a complete
+        expla-\\n\\nnation of the model - trained weights quantify the importance of
+        each feature.47 DT models\\n\\nare another type of self-explaining models which
+        have been used in classification and high-\\n\\nthroughput screening tasks.
+        \ Gajewicz et al. 50 used DT models to classify nanomaterials\\n\\nthat identify
+        structural features responsible for surface activity. In another study by Han\\n\\net
+        al. 51, a DT model was developed to filter compounds by their bioactivity based
+        on the\\n\\nchemical fingerprints.\\n\\n\\n\\n                                                              \u02C6y
+        = \u03A3iWixi                                      (1)\\n\\n\\n   Regularization
+        techniques such as EXPO52 and RRR53 are designed to enhance the black-\\n\\nbox
+        model interpretability.54 Although one can argue that \u201Csimplicity\u201D
+        of models are posi-\\n\\ntively correlated with interpretability, this is based
+        on how the interpretability is evaluated.\\n\\nFor example, Lipton 55 argue
+        that, from the notion of \u201Csimulatability\u201D (the degree to which a\\n\\nhuman
+        can predict the outcome based on inputs), self-explanatory linear models, rule-based\\n\\n\\n\\n
+        \                                       6systems, and DT\u2019s can be claimed
+        uninterpretable. A human can predict the outcome given\\n\\nthe inputs only
+        if the input features are interpretable. Therefore, a linear model which takes\\n\\nin
+        non-descriptive inputs may not be as transparent. On the other hand, a linear
+        model\\n\\nis not innately accurate as they fail to capture non-linear relationships
+        in data, limiting is\\n\\napplicability. Similarly, a DT is a rule-based model
+        and lacks physics informed knowledge.\\n\\nTherefore, an existing drawback is
+        the trade-off between the degree of understandability and\\n\\nthe accuracy
+        of a model. For example, an intrinsic model (linear regression or decision trees)\\n\\ncan
+        be described through the trainable parameters, but it may fail to \u201Ccorrectly\u201D
+        capture\\n\\nnon-linear relations in the data.\\n\\n\\nAttribution methods\\n\\n\\nFeature
+        attribution methods explain black box predictions by assigning each input feature\\n\\na
+        numerical value, which indicates its importance or contribution to the prediction.
+        Feature\\n\\nattributions provide local explanations, but can be averaged or
+        combined to explain multi-\\n\\nple instances. Atom-based numerical assignments
+        are commonly referred to as heatmaps.56\\n\\nSheridan 57 describes an atom-wise
+        attribution method for interpreting QSAR models. Re-\\n\\ncently, Rasmussen
+        et al. 58 showed that Crippen logP models serve as a benchmark for\\n\\nheatmap
+        approaches. Other most widely used feature attribution approaches in the litera-\\n\\nture
+        are gradient based methods,59,60 Shapley Additive exPlanations (SHAP),44 and
+        layer-\\n\\nwise relevance prorogation.61\\n\\n   Gradient based approaches
+        are based on the hypothesis that gradients for neural net-\\n\\nworks are analogous
+        to coefficients for regression models.62 Class activation maps (CAM),63\\n\\ngradCAM,64
+        smoothGrad,,65 and integrated gradients62 are examples of this method. The\\n\\nmain
+        idea behind feature attributions with gradients can be represented with equation
+        \ 2.\\n\\n\\n                                          \u2206\u02C6f(\u20D7x)\\n
+        \                                                                                          (2)
+        \                              \u2206xi  \u2248\u2202\u02C6f(\u20D7x)\u2202xi\\n\\n\\n\\n
+        \                           \\n\\n----\\n\\nQuestion: Are counterfactuals actionable?
+        [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "6088"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xUwW7bOBC9+ysGvPQiB44T2I1veyjQAkUvaU+rhT2iRiIbashyyNTeIP++oOTE
+          KpoCe9GBb97Te9QbPS0AlG3VDpQ2mPQQ3PIv3Bw/fjL5fs0P95++fvm8Xa/XH1Jz++PH1qqqMHzz
+          nXR6YV1pPwRHyXqeYB0JExXV6+3NzfXm7m61HYHBt+QKrQ9peeuX69X6drl6v1xtzkTjrSZRO/h7
+          AQDwND6LRW7pqHawql5OBhLBntTudQhARe/KiUIRKwk5qeoCas+JeHR9OBy+i+ean2oGqJXkYcB4
+          qtUOavXVENBRUwwJWis6i5BAa7uOInECOgaHjCUuDJSMbwU6H2HwjnR2GCFEaq2eBkpiqcDY3jjb
+          m2S5h2QwgfaZE8UOdcroBDASaM9iW4rUwruGUqL4bv46gYY0ZiFIhk4jA8fXYOMIkFuQgFHoCr6x
+          sw8E9waDoxM8osskFfw0VpuRx56X0/DIY59mUtVv5kL0j7YlQBBK4DvoCFOOJOcsyKANcj86A5+T
+          9gNVMODDlJeGmfwVlCtOdExAQzAo9t8XISpOcbykX3JbKfrOEfcFazNB8kXXRpA8ttE+EvBoqgLL
+          ncvEmlpoTmDygAwli48yxsUQnNXTJxRNjNF6uapVNdUhkqNHZE170T7SVIu7WtX8XPPhcJi3KlKX
+          BUupOTt3Pn9+ranzfYi+kTP+et5ZtmL2kVA8l0pK8kGN6PMC4J9xHfIvDVch+iGkffIPxEXwer16
+          PwmqywbO4NXmjCaf0M2Am+vb6g3JfUsJrZPZTimN2lB74V4WEHNr/QxYzIL/7uct7Sm85f7/yF8A
+          rSkkaveXLXtrLFIpxZ/GXi96NKzkJImGfWe5pxiinf4SXdhvu01DN9Q1K7V4XvwHAAD//wMAr6rn
+          bi4FAAA=
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdee112c91aab7-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 20:05:09 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "2392"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -5117,82 +4828,90 @@ interactions:
         x-ratelimit-reset-tokens:
           - 2ms
         x-request-id:
-          - req_fa341b72c920af1327ef04d5574e014e
+          - req_77c12b54e952683019fb8e84c5eb144e
       status:
         code: 200
         message: OK
   - request:
       body:
-        '{"messages": [{"role": "system", "content": "Answer in a direct and concise
-        tone. Your audience is an expert, so be highly specific. If there are ambiguous
-        terms or acronyms, first define them."}, {"role": "user", "content": "Answer
-        the question below with the context.\n\nContext (with relevance scores):\n\nwellawatteUnknownyearaperspectiveon
-        pages 12-14: Counterfactual explanations are indeed actionable. They provide
-        intuitive understanding of predictions and suggest which features can be altered
-        to change the outcome. For example, in chemistry, changing a hydrophobic functional
-        group in a molecule to a hydrophilic group can increase solubility. This actionability
-        allows for local, instance-level explanations that can guide modifications to
-        achieve desired predictions.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi
-        Seshadri, and Andrew D. White. A perspective on explanations of molecular prediction
-        models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
-        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon
-        pages 14-16: Counterfactual explanations are actionable as they suggest modifications
-        to molecules that can lead to desired outcomes. For instance, in the context
-        of blood-brain barrier (BBB) permeation, counterfactuals indicate that modifications
-        to the carboxylic acid group can enable a molecule to permeate the BBB. This
-        is because the carboxylic group is hydrophilic and hinders hydrophobic interactions,
-        which are crucial for BBB permeation. By suggesting changes that enhance surface
-        area and hydrophobic interactions, counterfactuals provide actionable insights
-        for molecular modifications.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi
-        Seshadri, and Andrew D. White. A perspective on explanations of molecular prediction
-        models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
-        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon
-        pages 16-20: The excerpt discusses the use of counterfactuals in molecular prediction
-        models, specifically for solubility and scent prediction. Counterfactuals are
-        used to identify structural changes that influence predictions, such as modifications
-        to ester groups affecting solubility. These findings align with known chemical
-        intuition, suggesting that counterfactuals can provide actionable insights.
-        For scent prediction, counterfactuals help understand scent-structure relationships
-        by identifying changes that affect scent classification. This indicates that
-        counterfactuals can be used to derive actionable insights for modifying molecular
-        properties.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew
-        D. White. A perspective on explanations of molecular prediction models. ChemRxiv,
-        Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon pages 20-22:
-        Counterfactual explanations are described as actionable in the context of explaining
-        molecular prediction models. They are represented as chemical structures, which
-        are familiar to domain experts, and are sparse, making them useful for understanding
-        and potentially altering chemical properties. The text emphasizes the utility
-        of counterfactuals in providing actionable insights by showing minimal changes
-        needed to achieve different chemical properties, thus making them a practical
-        tool for chemists.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri,
-        and Andrew D. White. A perspective on explanations of molecular prediction models.
-        ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
-        This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon pages 5-7:
-        The excerpt discusses different explanation methods for molecular prediction
-        models, highlighting the limitations of Shapley values as non-actionable and
-        non-sparse. It contrasts this with counterfactuals, which are described as ''better''
-        explanations because they are actionable and sparse. The text emphasizes that
-        counterfactuals provide a set of features that can change the outcome, making
-        them actionable. The evaluation of explanations is noted to be subjective, depending
-        on human factors and application scenarios.\nFrom Geemi P. Wellawatte, Heta
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 33-35: Geemi P. Wellawatte, Heta
         A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
         of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
-        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nValid Keys:
-        wellawatteUnknownyearaperspectiveon pages 12-14, wellawatteUnknownyearaperspectiveon
-        pages 14-16, wellawatteUnknownyearaperspectiveon pages 16-20, wellawatteUnknownyearaperspectiveon
-        pages 20-22, wellawatteUnknownyearaperspectiveon pages 5-7\n\n----\n\nQuestion:
-        Are counterfactuals actionable? [yes/no]\n\nWrite an answer based on the context.
-        If the context provides insufficient information reply \"I cannot answer.\"
-        For each part of your answer, indicate which sources most support it via citation
-        keys at the end of sentences, like (Example2012Example pages 3-4). Only cite
-        from the context below and only use the valid keys. Write in the style of a
-        Wikipedia article, with concise sentences and coherent paragraphs. The context
-        comes from a variety of sources and is only a summary, so there may inaccuracies
-        or ambiguities. If quotes are present and relevant, use them in the answer.
-        This answer will go directly onto Wikipedia, so do not add any extraneous information.\n\nAnswer
-        (about 200 words, but can be longer):"}], "model": "gpt-4o-2024-08-06", "stream":
-        false, "temperature": 0.0}'
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\n
+        \  metabolic stability of chemical compounds? Journal of Cheminformatics 2021,
+        13,\\n\\n     1\u201320.\\n\\n\\n(78) Mastropietro, A.; Pasculli, G.; Feldmann,
+        C.; Rodr\xB4\u0131guez-P\xB4erez, R.; Bajorath, J. Edge-\\n\\n    SHAPer: Bond-Centric
+        Shapley Value-Based Explanation Method for Graph Neural\\n\\n     Networks.
+        iScience 2022, 25, 105043.\\n\\n\\n(79) White, A. D. Deep learning for molecules
+        and materials. Living Journal of Computa-\\n\\n      tional Molecular Science
+        2022, 3.\\n\\n(80) \u02D8Strumbelj, E.; Kononenko, I. Explaining prediction
+        models and individual predictions\\n\\n     with feature contributions. Knowledge
+        and Information Systems 2014, 41, 647\u2013665.\\n\\n\\n(81) Erhan, D.; Bengio,
+        Y.; Courville, A.; Vincent, P. Visualizing Higher-Layer Features of\\n\\n     a
+        Deep Network. Technical Report, Univerist\xB4e de Montr\xB4eal 2009,\\n\\n\\n(82)
+        Weber, J. K.; Morrone, J. A.; Bagchi, S.; Pabon, J. D.; gu Kang, S.; Zhang,
+        L.;\\n\\n     Cornell, W. D. Simplified, interpretable graph convolutional neural
+        networks for small\\n\\n     molecule activity prediction. Journal of Computer-Aided
+        Molecular Design 2022, 36,\\n\\n     391\u2013404.\\n\\n\\n(83) Riniker, S.;
+        Landrum, G. A. Similarity maps - A visualization strategy for molecular\\n\\n
+        \    fingerprints and machine-learning methods. Journal of Cheminformatics 2013,
+        5, 1\u20137.\\n\\n\\n(84) Humer, C.; Heberle, H.; Montanari, F.; Wolf, T.; Huber,
+        F.; Henderson, R.; Hein-\\n\\n      rich, J.; Streit, M. ChemInformatics Model
+        Explorer (CIME): exploratory analysis of\\n\\n     chemical model explanations.
+        Journal of Cheminformatics 2022, 14, 1\u201314.\\n\\n\\n(85) McGrath, T.; Kapishnikov,
+        A.; Toma\u02C7sev, N.; Pearce, A.; Wattenberg, M.; Hass-\\n\\n      abis, D.;
+        Kim, B.; Paquet, U.; Kramnik, V. Acquisition of chess knowledge in Al-\\n\\n
+        \    phaZero. Proceedings of the National Academy of Sciences 2022, 119, e2206625119.\\n\\n\\n\\n\\n
+        \                                     33(86) Bajusz, D.; R\xB4acz, A.; H\xB4eberger,
+        K. Why is Tanimoto index an appropriate choice for\\n\\n     fingerprint-based
+        similarity calculations? Journal of Cheminformatics 2015, 7, 1\u201313.\\n\\n\\n(87)
+        Huang, Q.; Yamada, M.; Tian, Y.; Singh, D.; Yin, D.; Chang, Y. GraphLIME:\\n\\n
+        \    Local Interpretable Model Explanations for Graph Neural Networks. CoRR
+        2020,\\n\\n     abs/2001.06216.\\n\\n\\n(88) Sokol, K.; Flach, P. A. LIMEtree:
+        Interactively Customisable Explanations Based on\\n\\n     Local Surrogate Multi-output
+        Regression Trees. CoRR 2020, abs/2005.01427.\\n\\n\\n(89) Whitmore, L. S.; George,
+        A.; Hudson, C. M. Mapping chemical performance on molec-\\n\\n     ular structures
+        using locally interpretable explanations. 2016; https://arxiv.org/\\n\\n    abs/1611.07443.\\n\\n\\n(90)
+        Mehdi, S.; Tiwary, P. Thermodynamics of Interpretation. 2022,\\n\\n\\n(91) H\xA8ofler,
+        M. Causal inference based on counterfactuals. BMC Medical Research Method-\\n\\n
+        \    ology 2005, 5, 1\u201312.\\n\\n\\n(92) Woodward, J.; Hitchcock, C. Explanatory
+        Generalizations, Part I: A Counterfactual\\n\\n     Account. No\u02C6us 2003,
+        37, 1\u201324.\\n\\n\\n(93) Frisch, M. F. Theories, models, and explanation;
+        University of California, Berkeley,\\n\\n     1998.\\n\\n\\n(94) Reutlinger,
+        A. Is There A Monist Theory of Causal and Non-Causal Explanations?\\n\\n    The
+        Counterfactual Theory of Scientific Explanation. Philosophy of Science 2016,
+        83,\\n\\n     733\u2013745.\\n\\n\\n(95) Lewis, D. Causation. The journal of
+        philosophy 1974, 70, 556\u2013567.\\n\\n\\n(96) Tanimoto, T. T. Elementary mathematical
+        theory of classification and prediction.\\n\\n     Internal IBM Technical Report
+        1958,\\n\\n\\n                                      34 (97) Rogers, D.; Hahn,
+        M. Extended-Connectivity Fingerprints. Journal of Chemical In-\\n\\n      formation
+        and Modeling 2010, 50, 742\u2013754, PMID: 20426451.\\n\\n\\n (98) Mohapatra,
+        S.; An, J.; G\xB4omez-Bombarelli, R. Chemistry-informed macromolecule\\n\\n
+        \     graph representation for similarity computation, unsupervised and supervised
+        learn-\\n\\n       ing. Machine Learning: Science and Technology 2022, 3, 015028.\\n\\n\\n
+        (99) Doshi-Velez, F.; Kortz, M.; Budish, R.; Bavitz, C.; Gershman, S.; O\u2019Brien,
+        D.;\\n\\n       Scott, K.; Schieber, S.; Waldo, J.; Weinberger, D.; Weller,
+        A.; Wood, A. Account-\\n\\n       ability of AI Under the Law: The Role of Explanation.
+        SSRN Electronic Journal\\n\\n     2017,\\n\\n\\n(100) Wachter, S.; Mittelstadt,
+        B.; Russell, C. Counterfactual explanations without opening\\n\\n      the black
+        box: Automated decisions and the GDPR. Harv. JL & Tech. 2017, 31, 841.\\n\\n\\n(101)
+        Jim\xB4enez-Luna, J.; Grisoni, F.; Schneider, G. Drug discovery with explainable
+        artificial\\n\\n       intelligence. Nature Machine Intelligence 2020 2:10 2020,
+        2, 573\u2013584.\\n\\n\\n(102) Fu, T.; Gao, W.; Xiao, C.; Yasonik, J.; Coley,
+        C. W.; Sun, J. Differentiable Scaffold-\\n\\n      ing Tree for Molecule Optimization.
+        International Conference on Learning Represen-\\n\\n       tations. 2022.\\n\\n\\n(103)
+        Shen, C.; Krenn, M.; Eppel, S.; Aspuru-Guzik, A. Deep molecular dreaming: inverse\\n\\n
+        \    machine learning for de-novo molecular design and interpretability with
+        surjective\\n\\n      representations. Machine Learning: Science and Technology
+        2021, 2, 03LT02.\\n\\n\\n(104) Lucic,  A.;   ter  Hoeve,  M.;   Tolomei,  G.;
+        \  Rijke,  M.;   Silvestri,  F.  CF-\\n\\n \\n\\n----\\n\\nQuestion: Are counterfactuals
+        actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
       headers:
         accept:
           - application/json
@@ -5201,13 +4920,13 @@ interactions:
         connection:
           - keep-alive
         content-length:
-          - "5764"
+          - "6119"
         content-type:
           - application/json
         host:
           - api.openai.com
         user-agent:
-          - AsyncOpenAI/Python 1.55.0
+          - AsyncOpenAI/Python 1.56.0
         x-stainless-arch:
           - arm64
         x-stainless-async:
@@ -5217,7 +4936,7 @@ interactions:
         x-stainless-os:
           - MacOS
         x-stainless-package-version:
-          - 1.55.0
+          - 1.56.0
         x-stainless-raw-response:
           - "true"
         x-stainless-retry-count:
@@ -5231,29 +4950,25 @@ interactions:
     response:
       body:
         string: !!binary |
-          H4sIAAAAAAAAA5xW224bNxB911cM9ikGJEGSLcvxW9U0SNGHAEXTNmgKYZY7uzs1lyTIoa1F4H8v
-          yF1dfCna9EWCOBfOOTwzo68TgIKr4hYK1aKozunZd79//vDr5f0PP3/qfvp486H87Xq5x/pGv3u3
-          cZfFNEXY8i9ScoiaK9s5TcLWDGblCYVS1uXmcrVev317vc6GzlakU1jjZHZlZ6vF6mq2uJktrsfA
-          1rKiUNzCHxMAgK/5M5VoKtoXt7CYHk46CgEbKm6PTgCFtzqdFBgCB0EjxfRkVNYImVz1ZwpTUDYa
-          IV+jkog6AHoCVAkFlprm8EtLPThv77kiYCORhe8JoqnIp+QVmwZsDc5TxTkuAJoKQmwaCgIPLasW
-          akKJngIoNFASoBbyVIFYUC2ahkBaAhtF2Y7m8KPJv3Ote0npO6tJRY3+7CLIRL7AALR3Gg2OtXgC
-          h144R+seYqA6aihJYQz53h5sXZM/gw1sAjetBCh7YFOxQkk4gyPFNat0c/oe75AWJSPThBlTRYET
-          vBFQmMN764H2mBQyBTagWuo4iO+nAwEpO0LbV9661pasoI5mqEdD4210KQoPPFC65ejPmtXolKpg
-          k6QXCILVsWTN0k+hos6aIH4Aktg9wM0OiePnUmADTeT8wM/wWkDVMt3TEen58795IK3xAUXok7kz
-          9sH0hB4d+cRfko814LChAMvVbHl1Mf9ivpj30UtLvrOe/k2VqbJn+ii1tdWs9MgGSvSeycOb7XZ7
-          AY58R7nwUcwHZb7AlFOiL+2+T4Si4mpgdTqqOJFLQwVPX2K8Y1DxdrtNsiHTolGJvPNX5QRrQJKE
-          66Ni1FBbn8NOtX4TiVez5fXFHL5/TpoOFlrSWTpPGzYoMjIL4qNKfQme9MBDy24QfUVGuO6T89Ch
-          o8yxrknJkACUTjPmQOIUpI1hHBZZ0K80VIKame8HXZ3a2jrywvRt+rmerRaDfj7ek0etX9eOJ+cp
-          kBGqAMPQfQo1HBkIUGPHmtHn/rVdEhLtU0nDPEtZgkMfaAod3o1N1IHLr5lyibV6wDc2dxbVifec
-          xtk0fRm17ocheKrl/zGwWsxWq4v5+Yj3VMeAacOYqPV4/njcGdo2ztsyjPbjec2GQ7tLo8OatB+C
-          WFdk6+ME4M+8m+KTdVM4bzsnO7F3ZFLC5WpzMyQsTuvwZF5tNqNVrKA+i1uv19NXUu4qEmQdzhZc
-          oVC1VJ1iT9sQY8X2zDA5A/6yntdyD+DZNP8l/cmgFDmhaneagq+5eUr/F/7J7Uh0LrgIfRDqdjWb
-          hrzzPKzs2u029XVJl1SXi2LyOPkbAAD//wMAJ+CfLrsIAAA=
+          H4sIAAAAAAAAA3xUTW/bOBC9+1cMeOkGsA0lTpTEtwLFbtqi2EW3RYtWhUGTI5ENRQqcUWJvkP9e
+          kHJsuWn3IkDz5uO94cw8TACE1WIJQhnJqu3c7KUsN68///0xvDGvjLko/3z3Jfjrt4vzmzdeimmK
+          COvvqPgpaq5C2zlkG/wAq4iSMWU9vVwsTsvr6+IqA23Q6FJY0/HsPMzOirPzWXE1K8pdoAlWIYkl
+          fJ0AADzkb6LoNW7EEorpk6VFItmgWO6dAEQMLlmEJLLE0rOYHkAVPKPPrB8qD1AJ6ttWxm0lllCJ
+          DwYBNwpjxxCxxoheIQHhHUbp4D7EW4KILikDDqBC7xljLRX30gFuOie9TE0gkF4DG7QREiOwHkhZ
+          9GxrqzLosJEOMqMN0xz+7VAlUDq3nYJlaJN3SnVTVZUItcP4gjIJCB6U7Ek6sH5HE9aSUGfkiBXB
+          H2dFcXGSa34KQd/LqPPPjWVlVFC3LwikylEQ6r2KELfQoE/K7X87UT1Z3/yywOJkDi+1tslvUPAe
+          e3bWN5m1tqR6Iht8YsgGf+4dG0wFQz1u06ihqchpuVMhlWGMgAzSzcc9+Z/3sE9lc79TIdlzaPNT
+          alSW9q/216t/3udylycgI4IPjHoOHwwSHo1F3zRIDGwkP+tJCuxpGJMuhjur8fl8WE+2MUxTuDdW
+          GbBt5yxSIroFJT2sEaTKLV0PM9R7jTGNtU4PkXI8cZ+18jbZuhgUEiHNKzEdZjyiwzvpFa5IhYjD
+          rF9VovKP4+WIWKeREkvwvXM7++N+21xouhjWtMP39tp6S2YVUVLwabOIQycy+jgB+Ja3uj9aVNHF
+          0Ha84nCLPiU8La/Ph4TicEhG8EW5QzmwdCPg6mJ3Do5TrjSytI5Gp0EoqQzqcdJFuRche23DASsm
+          I+3PKf0q/aDf+maU5bfpD4BS2DHqVRdRW3Us++AWMR3b37nte50JC9oSY7uq8+510Q73ru5Wl3W5
+          xgXW60JMHic/AAAA//8DAGDHo0T4BQAA
       headers:
         CF-Cache-Status:
           - DYNAMIC
         CF-RAY:
-          - 8e83c2e42e2215ba-SJC
+          - 8ebdee13daea17ea-SJC
         Connection:
           - keep-alive
         Content-Encoding:
@@ -5261,14 +4976,368 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Mon, 25 Nov 2024 18:39:31 GMT
+          - Mon, 02 Dec 2024 20:05:10 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "2332"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998531"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_d0035d9506c4c0203a96a235369cdf3a
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        "{\"messages\":[{\"role\":\"system\",\"content\":\"Provide a summary of
+        the relevant information that could help answer the question based on the excerpt.
+        Respond with the following JSON format:\\n\\n{\\n  \\\"summary\\\": \\\"...\\\",\\n
+        \ \\\"relevance_score\\\": \\\"...\\\"\\n}\\n\\nwhere `summary` is relevant
+        information from text - about 100 words words and `relevance_score` is the relevance
+        of `summary` to answer question (out of 10).\\n\"},{\"role\":\"user\",\"content\":\"Excerpt
+        from wellawatteUnknownyearaperspectiveon pages 1-3: Geemi P. Wellawatte, Heta
+        A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\\n\\n----\\n\\n
+        A Perspective on Explanations of Molecular\\n\\n              Prediction Models\\n\\n\\nGeemi
+        P. Wellawatte,\u2020   Heta A. Gandhi,\u2021   Aditi Seshadri,\u2021 and  Andrew\\n\\n
+        \                          D. White\u2217,\u2021\\n\\n     \u2020Department
+        of Chemistry, University of Rochester, Rochester, NY, 14627\\n\u2021Department
+        of Chemical Engineering, University of Rochester, Rochester, NY, 14627\\n             \xB6Vial
+        Health Technology, Inc., San Francisco, CA 94111\\n\\n                           E-mail:
+        andrew.white@rochester.edu\\n\\n\\n\\n                                 Abstract\\n\\n\\n
+        \     Chemists can be skeptical in using deep learning (DL) in decision making,
+        due to\\n\\n   the lack of interpretability in \u201Cblack-box\u201D models.
+        \ Explainable artificial intelligence\\n\\n   (XAI) is a branch of AI which
+        addresses this drawback by providing tools to interpret\\n\\n  DL models and
+        their predictions. We review the principles of XAI in the domain of\\n\\n   chemistry
+        and emerging methods for creating and evaluating explanations. Then we\\n\\n
+        \  focus on methods developed by our group and their applications in predicting
+        solubil-\\n\\n    ity, blood-brain barrier permeability, and the scent of molecules.
+        We show that XAI\\n\\n   methods like chemical counterfactuals and descriptor
+        explanations can explain DL pre-\\n\\n   dictions while giving insight into
+        structure-property relationships. Finally, we discuss\\n\\n   how a two-step
+        process of developing a black-box model and explaining predictions can\\n\\n
+        \  uncover structure-property relationships.\\n\\n\\n\\n\\n\\n                                     1Introduction\\n\\n\\nDeep
+        learning (DL) is advancing the boundaries of computational chemistry because
+        it can\\n\\naccurately model non-linear structure-function relationships.1\u20133
+        Applications of DL can be\\n\\nfound in a broad spectrum spanning from quantum
+        computing4,5 to drug discovery6\u201310 to\\n\\nmaterials design.11,12 According
+        to Kre 13, DL models can contribute to scientific discovery\\n\\nin three \u201Cdimensions\u201D
+        - 1) as a \u2018computational microscope\u2019 to gain insight which are not\\n\\nattainable
+        through experiments 2) as a \u2018resource of inspiration\u2019 to motivate
+        scientific thinking\\n\\n3) as an \u2018agent of understanding\u2019 to uncover
+        new observations. However, the rationale of\\n\\na DL prediction is not always
+        apparent due to the model architecture consisting a large\\n\\nparameter count.14,15
+        DL models are thus often termed\u201Cblack box\u201D models. We can only\\n\\nreason
+        about the input and output of an DL model, not the underlying cause that leads
+        to\\n\\na specific prediction.\\n\\n    It is routine in chemistry now for DL
+        to exceed human level performance \u2014 humans are\\n\\nnot good at predicting
+        solubility from structure for example161 \u2014 and so understanding how\\n\\na
+        model makes predictions can guide hypotheses. This is in contrast to a topic
+        like finding\\n\\na stop sign in an image, where there is little new to be learned
+        about visual perception\\n\\nby explaining a DL model. However, the black box
+        nature of DL has its own limitations.\\n\\nUsers are more likely to trust and
+        use predictions from a model if they can understand why\\n\\nthe prediction
+        was made.17 Explaining predictions can help developers of DL models ensure\\n\\nthe
+        model is not learning spurious correlations.18,19 Two infamous examples are,
+        1)neural\\n\\nnetworks that learned to recognize horses by looking for a photographer\u2019s
+        watermark20 and,\\n\\n2) neural networks that predicted a COVID-19 diagnoses
+        by looking at the font choice\\n\\non medical images.21 As a result, there is
+        an emerging regulatory framework for when any\\n\\ncomputer algorithms impact
+        humans.22\u201324 Although we know of no examples yet in chemistry,\\n\\none
+        can assume the use of AI in predicting toxicity, carcinogenicity, and environmental\\n\\npersistence
+        will require rationale for the predictions due to regulatory consequences.\\n\\n
+        \  1there does happen to be one human solubility savant, participant 11, who
+        matched machine performance\\n\\n\\n                                        2
+        \  EXplainable Artificial Intelligence (XAI) is a field of growing importance
+        that aims to\\n\\nprovide model interpretations of DL predictions Three terms
+        highly associated with XAI are,\\n\\ninterpretability, justifications and explainability.
+        Miller 25 defines that interpretability of a\\n\\nmodel refers to the degree
+        of human understandability intrinsic within the model. Murdoch\\n\\net al. 26
+        clarify that interpretability can be perceived as \u201Cknowledge\u201D which
+        provide insight\\n\\nto a particular problem.  Justifications are quantitative
+        metrics tell the users \u201Cwhy the\\n\\nmodel should be trusted,\u201D like
+        test error.27 Justifications are evidence which defend why a\\n\\nprediction
+        is trustworthy.25 An \u201Cexplanation\u201D is a description on why a certain
+        prediction was\\n\\nmade.9,28 Interpretability and explanation are often used
+        interchangeably. Arrieta et al. 14\\n\\ndistinguish that interpretability is
+        a passive characteristic of a model, whereas explainability\\n\\nis an active
+        characteristic which is used to clarify the internal decision-making process.\\n\\nNamely,
+        an explanation is extra information that gives the context and a cause for one
+        or\\n\\nmore pre\\n\\n----\\n\\nQuestion: Are counterfactuals actionable? [yes/no]\\n\\n\"}],\"model\":\"gpt-4o-2024-08-06\",\"stream\":false,\"temperature\":0.0}"
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "6107"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xUTW8bNxC961cMeEkCSIYku4qimxEHiIEARVAf0kSFQJGjJWMuyc4MbS0M//eC
+          u7KkIi7Qyx7mzXt887VPIwDlrVqBMk6LaXOYXOvF/taU3//uuj/k67cbXP756frj3aevt9+3H9W4
+          MtL2Jxp5YV2Y1OaA4lMcYEOoBavq7P3l5Wzx4cN02QNtshgqrckyuUqT+XR+NZkuJ9PFgeiSN8hq
+          BT9GAABP/bdajBb3agXT8UukRWbdoFodkwAUpVAjSjN7Fh1FjU+gSVEw9q6f1hFgrbi0raZurVaw
+          VncOQZN4ExCsZ1OYkUEcQmGEtAPc56B91NswJO688TqAj4Ih+AajQXj77fr2HfgIxmHrWagbQ+5V
+          S9AUOtglU9jHBlKEFsUlyxD8PQ4EowOYVKIg7bSRogODjhYssiGfJdHgIurabAZJ/fOUCQUsYoaA
+          mmLVf3vz5R30/eYLuHPIeHxP+7YyM6UHbxF8ZN844SqVgIWKkUI4yZQyknRAGIb3nM+Dn0Mr4OYL
+          ZELrTQ+P4dF540BT7ZdgBEaMoBnebIM295Nt2r85eAJbsJoQh55gWKA9aDLOC/bv966PE+HSNMhS
+          B6IFSrRIdcC2lip9dWdGwOgITanFuS6nHj8Yj1wIXzxUozHJqWmcC/lUGEyiY9UX8Dk94gPSGLyA
+          Tcg9qfbAGy+hAxYtCI8OxSH9OkBC0L2xujoXazUeto8w4IOOBjdsEuGwhYu1Wsfn87Ul3BXW9Wpi
+          CeEQfz7eQUhNprTlA36M73z07DaEmlOsO8+SsurR5xHAX/29lX+dkMqU2iwbSfcYq+BsPr8aBNXp
+          xM/h2QGVJDqcAZdXv41fkdxYFO0Dnx2tMto4tCfu6cJ1sT6dAaOzwn/185r2ULyPzf+RPwHGYBa0
+          m9NGvZZGWP+B/5V2bHRvWHHHgu1m52NTr9UPv6Fd3iwvZzhdvLfLuRo9j/4BAAD//wMAMkcUxY8F
+          AAA=
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdee189ba19440-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 20:05:11 GMT
+        Server:
+          - cloudflare
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "2309"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29998526"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_2ce78e12766d2800bd0978a834c15ff7
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"messages":[{"role":"system","content":"Answer in a direct and concise
+        tone. Your audience is an expert, so be highly specific. If there are ambiguous
+        terms or acronyms, first define them."},{"role":"user","content":"Answer the
+        question below with the context.\n\nContext (with relevance scores):\n\nwellawatteUnknownyearaperspectiveon
+        pages 12-14: Counterfactual explanations are indeed actionable. They provide
+        intuitive understanding of predictions and suggest which features can be altered
+        to change the outcome. For example, in chemistry, changing a hydrophobic functional
+        group in a molecule to a hydrophilic group to increase solubility is an actionable
+        insight derived from counterfactuals. This actionability is a key aspect of
+        counterfactual explanations, as it allows for local, instance-level changes
+        that can directly influence the prediction outcome.\nFrom Geemi P. Wellawatte,
+        Heta A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon
+        pages 14-16: Counterfactual explanations are actionable as they suggest modifications
+        to molecules that can lead to desired outcomes. For instance, in the context
+        of blood-brain barrier (BBB) permeation, counterfactuals indicate that modifications
+        to the carboxylic acid group can enable a molecule to permeate the BBB. This
+        is because the carboxylic group is hydrophilic and hinders hydrophobic interactions,
+        which are crucial for BBB permeation. By suggesting actionable changes, such
+        as adding atoms to enhance surface area, counterfactuals provide practical guidance
+        for molecular modifications.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi
+        Seshadri, and Andrew D. White. A perspective on explanations of molecular prediction
+        models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon
+        pages 16-20: The excerpt discusses the use of counterfactuals in molecular prediction
+        models, specifically for solubility and scent prediction. Counterfactuals are
+        used to identify modifications in molecular structures that influence properties
+        like solubility and scent. For solubility, changes to ester groups and heteroatoms
+        are significant, while for scent prediction, counterfactuals help understand
+        scent-structure relationships. These counterfactuals provide insights into how
+        structural changes can affect predictions, suggesting that they can be actionable
+        by guiding modifications to achieve desired properties.\nFrom Geemi P. Wellawatte,
+        Heta A. Gandhi, Aditi Seshadri, and Andrew D. White. A perspective on explanations
+        of molecular prediction models. ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02,
+        doi:10.26434/chemrxiv-2022-qfv02. This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon
+        pages 20-22: Counterfactual explanations are described as actionable in the
+        context of molecular prediction models. They are represented as chemical structures,
+        which are familiar to domain experts, and are sparse, making them useful for
+        understanding and potentially altering chemical properties. The text highlights
+        that counterfactuals have a minimal distance from a base molecule but possess
+        contrasting chemical properties, making them actionable for domain experts who
+        can use these insights to modify molecular structures to achieve desired outcomes.\nFrom
+        Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri, and Andrew D. White. A
+        perspective on explanations of molecular prediction models. ChemRxiv, Unknown
+        year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
+        This article has 1 citations.\n\nwellawatteUnknownyearaperspectiveon pages 5-7:
+        The excerpt discusses different explanation methods for molecular prediction
+        models, highlighting that counterfactuals are considered ''better'' explanations
+        because they are actionable and sparse. Unlike Shapley values, which are non-sparse
+        and not actionable, counterfactuals provide a set of features that can change
+        the outcome, making them actionable. The text emphasizes that evaluating explanations
+        is challenging due to their subjective nature, influenced by human factors and
+        application scenarios.\nFrom Geemi P. Wellawatte, Heta A. Gandhi, Aditi Seshadri,
+        and Andrew D. White. A perspective on explanations of molecular prediction models.
+        ChemRxiv, Unknown year. URL: https://doi.org/10.26434/chemrxiv-2022-qfv02, doi:10.26434/chemrxiv-2022-qfv02.
+        This article has 1 citations.\n\nValid Keys: wellawatteUnknownyearaperspectiveon
+        pages 12-14, wellawatteUnknownyearaperspectiveon pages 14-16, wellawatteUnknownyearaperspectiveon
+        pages 16-20, wellawatteUnknownyearaperspectiveon pages 20-22, wellawatteUnknownyearaperspectiveon
+        pages 5-7\n\n----\n\nQuestion: Are counterfactuals actionable? [yes/no]\n\nWrite
+        an answer based on the context. If the context provides insufficient information
+        reply \"I cannot answer.\" For each part of your answer, indicate which sources
+        most support it via citation keys at the end of sentences, like (Example2012Example
+        pages 3-4). Only cite from the context below and only use the valid keys. Write
+        in the style of a Wikipedia article, with concise sentences and coherent paragraphs.
+        The context comes from a variety of sources and is only a summary, so there
+        may inaccuracies or ambiguities. If quotes are present and relevant, use them
+        in the answer. This answer will go directly onto Wikipedia, so do not add any
+        extraneous information.\n\nAnswer (about 200 words, but can be longer):"}],"model":"gpt-4o-2024-08-06","stream":false,"temperature":0.0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "5830"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.56.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.56.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.7
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA5RW34sbNxB+918x7FMP1sb2XX25e2tLA4FCC0kITVPMrDS7OzmtJCTtnZdw/3sZ
+          eW3vYYf0HmyD5ofm++Ybjb/NAArWxT0UqsWkOm/mv+Bm98e7z/jh49ff6dPbz+uWVRP8X5/W9c1Q
+          lBLhqq+k0iFqoVznDSV2dm9WgTCRZF3dXl+vNnd3q1U2dE6TkbDGp/mNm6+X65v58s18uRkDW8eK
+          YnEP/8wAAL7lbynRatoV97AsDycdxYgNFfdHJ4AiOCMnBcbIMaFNRXkyKmcT2Vz13xRLUK63iUKN
+          KvVoImAgQCUosDK0gHcWUkuQw3YJXA2dM6R6gwF8IM3ZFzKms3RAO2/QorhE8ME9sp6mB7aRmzZF
+          qAaIfdNQTGwbiJ4U16wkrfyOCZKbXB5T6FXqA0VILSZQaMEQavHSFDmQBtcn5TqKC3jrAtAOpUOl
+          ABqyP1styQlUi7ahfEPd2319Bprgeh+BLeDhYhIXNIkEvfMUElOE2KsWMEJ0pq/YcBrABaiMc3pe
+          BWQLFYbAEkShowxnAb8O+3sFMUI76OB86ypWZzXkSw8ebFiBs1ROrxM0lfApqoukS9DUORtTwMyo
+          9PDA+1hgfdZ7tqBa6jimMMBPT2QMPmFK9NE+WPdkB8KAnoJ0J/EjOQsehbXVer66uVrAe+7YYDBD
+          CfUP8Z9LbxTAedOzADFUbjcIdlSsT7yQbdEqGjPvwZXSjNRyHN1amZwQwZKSgQnDC7ZZqtiTE18F
+          +2a+2lwtvtgv9rdLU2Sigz5SVmSfC0hoNcgnQxymEjL8QBAV2ZQdJq2tBmBNNnE95NngxmZ6bDrO
+          AJqDgsujFrNITxxSFM2OipYbWkoUHCbXvQ70Zr5eXi3gQ0uRXs73y6cDKlLYR9pPm9gC+UCRbCIt
+          BWapKTTTSa6xY8MY8hC7TpRDO6EoloDGuCdhQLTlc8MkGr03o1hEwHtmxe3yU+EAVcv0SKdH5ljI
+          pB2vYGS9nK/XVwv485ECGnP5SVXORtYkj1LsPQV2GaNLLYUpi9BRap2e9PF9i97QAI9oeumv7mmc
+          CQ5Tui0Kwr14PIYo0nkFip/nt1eL6aIIVPcRZU/Z3pjx/Pm4eYxrfHBVHO3H85otx3Yrr5CzsmVi
+          cr7I1ucZwL95w/Uvllbhg+t82ib3QFYSrtZ3b/YJi9NSPZmvl9ejNbmEZhK3Wa7KCym3mhKyiZM1
+          WShULelT7GmnYq/ZTQyzCfDzei7l3oNn2/yf9CeDUuQT6e1prV5yCyT/Or7ndiQ6F1zEISbqtjXb
+          hoIPvF/8td/e1puKrqmulsXsefYfAAAA//8DAPXxUvYBCQAA
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 8ebdee28eb156428-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 20:05:16 GMT
         Server:
           - cloudflare
         Set-Cookie:
-          - __cf_bm=oKnzG6Qck8Xla.QVOtA50KxYXqbnc4KQIbg7I9Q1304-1732559971-1.0.1.1-ppvA4EaQbiWyIf6ctSdZk5v7cyMT7WGhEDu619KwErYYNL2nq0OP8mS9IecaTqIt8AwGLwov_87VmfoTjhPLUA;
-            path=/; expires=Mon, 25-Nov-24 19:09:31 GMT; domain=.api.openai.com; HttpOnly;
+          - __cf_bm=2TXt.GQ90cL38Z4iukWM5DJcG3r0zo95LcmCGZwTYN4-1733169916-1.0.1.1-GNB_JoqfxWRN3FIQQvqP3QLO0M_o4kuyunlGL6Z4_pz04anWrxUTn6z.8Kd2tudpI7P6Gfn0DznmkoRc67v_Iw;
+            path=/; expires=Mon, 02-Dec-24 20:35:16 GMT; domain=.api.openai.com; HttpOnly;
             Secure; SameSite=None
-          - _cfuvid=NAlCpDMmZQflEd9fiTWGv2OiEMaL.xgketT3rTE5KwA-1732559971993-0.0.1.1-604800000;
+          - _cfuvid=cpIpfP1Lg.BWfwFLSqFUwAjpLqLsaHDXx59h9dThkCg-1733169916484-0.0.1.1-604800000;
             path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
         Transfer-Encoding:
           - chunked
@@ -5281,7 +5350,7 @@ interactions:
         openai-organization:
           - future-house-xr4tdh
         openai-processing-ms:
-          - "7057"
+          - "4983"
         openai-version:
           - "2020-10-01"
         strict-transport-security:
@@ -5293,13 +5362,13 @@ interactions:
         x-ratelimit-remaining-requests:
           - "9999"
         x-ratelimit-remaining-tokens:
-          - "29998584"
+          - "29998565"
         x-ratelimit-reset-requests:
           - 6ms
         x-ratelimit-reset-tokens:
           - 2ms
         x-request-id:
-          - req_f6e5f0e1469ee79302fd125ad7721c90
+          - req_0246fade9b910ac7aef7d3ca106c584f
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_s2_only_fields_filtering.yaml
+++ b/tests/cassettes/test_s2_only_fields_filtering.yaml
@@ -15,7 +15,7 @@ interactions:
           "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773", "name": "Oliver
           Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"}, {"authorId":
           "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853", "name":
-          "P. Schwaller"}], "matchScore": 176.3838}]}
+          "P. Schwaller"}], "matchScore": 178.39174}]}
 
           '
       headers:
@@ -24,31 +24,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "683"
+          - "684"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         Via:
-          - 1.1 ad0f81beb11a40b80a59b548e3794d00.cloudfront.net (CloudFront)
+          - 1.1 0cb53c06b4d3d66446893feb6331dc78.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - C5O8FHg7UWH8wLxYj5DYy9jhgtRXBan_-55nXKdGb8xm2QK_I9JAHg==
+          - lOye08SjJjwiciQPbYc3xBniCMKIlnXYUGyU0a4EVkI1J26y7J5fgg==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PzHJKPHcEcmw=
+          - CLbZTEN7vHcEMVQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "683"
+          - "684"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:27 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 77671f8c-1de9-42b7-ab76-60f2e52c2df4
+          - 1b680ca8-bbbe-4ce8-a30f-ddf50cfc4ceb
       status:
         code: 200
         message: OK
@@ -73,7 +73,7 @@ interactions:
         Content-Type:
           - text/plain;charset=utf-8
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:28 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_title_search[paper_attributes0].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes0].yaml
@@ -3,68 +3,14 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/search?query=Effect%20of%20native%20oxide%20layers%20on%20copper%20thin-film%20tensile%20properties:%20A%20reactive%20molecular%20dynamics%20study&email=example@papercrow.ai
-    response:
-      body:
-        string:
-          '{"elapsed_seconds":0.306,"results":[{"response":{"best_oa_location":null,"data_standard":2,"doi":"10.1063/1.4938384","doi_url":"https://doi.org/10.1063/1.4938384","first_oa_location":null,"genre":"journal-article","has_repository_copy":false,"is_oa":false,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"0021-8979","journal_issns":"0021-8979,1089-7550","journal_name":"Journal
-          of Applied Physics","oa_locations":[],"oa_locations_embargoed":[],"oa_status":"closed","published_date":"2015-12-21","publisher":"AIP
-          Publishing","title":"Effect of native oxide layers on copper thin-film tensile
-          properties: A reactive molecular dynamics study","updated":"2023-07-31T05:28:57.007821","year":2015,"z_authors":[{"affiliation":[{"name":"University
-          of Rochester 1 Materials Science Program, , Rochester, New York 14627, USA"}],"family":"Skarlinski","given":"Michael
-          D.","sequence":"first"},{"affiliation":[{"name":"University of Rochester 1
-          Materials Science Program, , Rochester, New York 14627, USA"},{"name":"University
-          of Rochester 2 Department of Mechanical Engineering, , Rochester, New York
-          14627, USA"}],"family":"Quesnel","given":"David J.","sequence":"additional"}]},"score":0.009231734,"snippet":"<b>Effect</b>
-          of <b>native</b> <b>oxide</b> <b>layers</b> on <b>copper</b> <b>thin</b>-<b>film</b>
-          <b>tensile</b> <b>properties</b>: A <b>reactive</b> <b>molecular</b> <b>dynamics</b>
-          <b>study</b>"}]}
-
-          '
-      headers:
-        Access-Control-Allow-Headers:
-          - origin, content-type, accept, x-requested-with
-        Access-Control-Allow-Methods:
-          - POST, GET, OPTIONS, PUT, DELETE, PATCH
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "706"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
-        Nel:
-          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
-        Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D"}]}'
-        Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D
-        Server:
-          - gunicorn
-        Vary:
-          - Accept-Encoding
-        Via:
-          - 1.1 vegur
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
       uri: https://api.openalex.org/works?filter=title.search:Effect+of+native+oxide+layers+on+copper+thin-film+tensile+properties:+A+reactive+molecular+dynamics+study
     response:
       body:
         string:
-          '{"meta":{"count":1,"db_response_time_ms":528,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W2277923667","doi":"https://doi.org/10.1063/1.4938384","title":"Effect
+          '{"meta":{"count":1,"db_response_time_ms":272,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W2277923667","doi":"https://doi.org/10.1063/1.4938384","title":"Effect
           of native oxide layers on copper thin-film tensile properties: A reactive
           molecular dynamics study","display_name":"Effect of native oxide layers on
-          copper thin-film tensile properties: A reactive molecular dynamics study","relevance_score":780.78485,"publication_year":2015,"publication_date":"2015-12-21","ids":{"openalex":"https://openalex.org/W2277923667","doi":"https://doi.org/10.1063/1.4938384","mag":"2277923667"},"language":"en","primary_location":{"is_oa":false,"landing_page_url":"https://doi.org/10.1063/1.4938384","pdf_url":null,"source":{"id":"https://openalex.org/S187991544","display_name":"Journal
+          copper thin-film tensile properties: A reactive molecular dynamics study","relevance_score":762.2231,"publication_year":2015,"publication_date":"2015-12-21","ids":{"openalex":"https://openalex.org/W2277923667","doi":"https://doi.org/10.1063/1.4938384","mag":"2277923667"},"language":"en","primary_location":{"is_oa":false,"landing_page_url":"https://doi.org/10.1063/1.4938384","pdf_url":null,"source":{"id":"https://openalex.org/S187991544","display_name":"Journal
           of Applied Physics","issn_l":"0021-8979","issn":["0021-8979","1089-7550","1520-8850"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310320257","host_organization_name":"American
           Institute of Physics","host_organization_lineage":["https://openalex.org/P4310320257"],"host_organization_lineage_names":["American
           Institute of Physics"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false},"type":"article","type_crossref":"journal-article","indexed_in":["crossref"],"open_access":{"is_oa":false,"oa_status":"closed","oa_url":null,"any_repository_has_fulltext":false},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5015270557","display_name":"Michael
@@ -80,7 +26,7 @@ interactions:
           2 Department of Mechanical Engineering, , Rochester, New York 14627, USA"],"affiliations":[{"raw_affiliation_string":"University
           of Rochester 2 Department of Mechanical Engineering, , Rochester, New York
           14627, USA","institution_ids":["https://openalex.org/I5388228"]},{"raw_affiliation_string":"University
-          of Rochester 1 Materials Science Program, , Rochester, New York 14627, USA","institution_ids":["https://openalex.org/I5388228"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":{"value":3500,"currency":"USD","value_usd":3500,"provenance":"doaj"},"apc_paid":null,"fwci":0.386,"has_fulltext":true,"fulltext_origin":"ngrams","cited_by_count":8,"citation_normalized_percentile":{"value":0.665083,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":84,"max":85},"biblio":{"volume":"118","issue":"23","first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11661","display_name":"Low
+          of Rochester 1 Materials Science Program, , Rochester, New York 14627, USA","institution_ids":["https://openalex.org/I5388228"]}]}],"institution_assertions":[],"countries_distinct_count":1,"institutions_distinct_count":1,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":{"value":3500,"currency":"USD","value_usd":3500,"provenance":"doaj"},"apc_paid":null,"fwci":0.379,"has_fulltext":true,"fulltext_origin":"ngrams","cited_by_count":8,"citation_normalized_percentile":{"value":0.657628,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":84,"max":85},"biblio":{"volume":"118","issue":"23","first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11661","display_name":"Low
           Dielectric Constant Materials for Microelectronics","score":0.9985,"subfield":{"id":"https://openalex.org/subfields/2504","display_name":"Electronic,
           Optical and Magnetic Materials"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
           Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
@@ -110,9 +56,9 @@ interactions:
           chemistry","level":1,"score":0.0}],"mesh":[],"locations_count":1,"locations":[{"is_oa":false,"landing_page_url":"https://doi.org/10.1063/1.4938384","pdf_url":null,"source":{"id":"https://openalex.org/S187991544","display_name":"Journal
           of Applied Physics","issn_l":"0021-8979","issn":["0021-8979","1089-7550","1520-8850"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310320257","host_organization_name":"American
           Institute of Physics","host_organization_lineage":["https://openalex.org/P4310320257"],"host_organization_lineage_names":["American
-          Institute of Physics"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"id":"https://metadata.un.org/sdg/15","score":0.6,"display_name":"Life
-          on land"}],"grants":[{"funder":"https://openalex.org/F4320337345","funder_display_name":"Office
-          of Naval Research","award_id":"N00014-12-1-0542"}],"datasets":[],"versions":[],"referenced_works_count":58,"referenced_works":["https://openalex.org/W1964561108","https://openalex.org/W1966577027","https://openalex.org/W1967370996","https://openalex.org/W1969763275","https://openalex.org/W1972295667","https://openalex.org/W1972758026","https://openalex.org/W1973496772","https://openalex.org/W1975415324","https://openalex.org/W1979198964","https://openalex.org/W1980718691","https://openalex.org/W1998250010","https://openalex.org/W2000148778","https://openalex.org/W2002958700","https://openalex.org/W2004635538","https://openalex.org/W2005223231","https://openalex.org/W2015240911","https://openalex.org/W2015427003","https://openalex.org/W2019465613","https://openalex.org/W2024438921","https://openalex.org/W2025448774","https://openalex.org/W2033010856","https://openalex.org/W2035858373","https://openalex.org/W2037530567","https://openalex.org/W2042894263","https://openalex.org/W2047968138","https://openalex.org/W2048410032","https://openalex.org/W2051407701","https://openalex.org/W2052281371","https://openalex.org/W2055302323","https://openalex.org/W2060383028","https://openalex.org/W2061811424","https://openalex.org/W2067319108","https://openalex.org/W2067867161","https://openalex.org/W2068128554","https://openalex.org/W2068954018","https://openalex.org/W2075147729","https://openalex.org/W2082154123","https://openalex.org/W2082164550","https://openalex.org/W2082730101","https://openalex.org/W2103591835","https://openalex.org/W2112144973","https://openalex.org/W2113676282","https://openalex.org/W2118785939","https://openalex.org/W2125614899","https://openalex.org/W2129814046","https://openalex.org/W2129831264","https://openalex.org/W2155155530","https://openalex.org/W2158386952","https://openalex.org/W2163762820","https://openalex.org/W2316209218","https://openalex.org/W2317838033","https://openalex.org/W2323178299","https://openalex.org/W282450671","https://openalex.org/W3103133276","https://openalex.org/W3104017686","https://openalex.org/W3104324287","https://openalex.org/W4250102497","https://openalex.org/W4255450160"],"related_works":["https://openalex.org/W4313886759","https://openalex.org/W4289780727","https://openalex.org/W3196590631","https://openalex.org/W2363424936","https://openalex.org/W2334739780","https://openalex.org/W2189903790","https://openalex.org/W2067018196","https://openalex.org/W2014598323","https://openalex.org/W1987421019","https://openalex.org/W1495724091"],"abstract_inverted_index":{"Metal-oxide":[0],"layers":[1,94,146,212,242],"are":[2,79,107,136,264],"likely":[3],"to":[4,11,81,119,175,232,254,266],"be":[5,233],"present":[6],"on":[7,96,109,271],"metallic":[8,47],"nano-structures":[9],"due":[10],"either":[12],"environmental":[13],"exposure":[14],"during":[15,259],"use,":[16],"or":[17],"high":[18],"temperature":[19],"processing":[20],"techniques":[21],"such":[22],"as":[23],"annealing.":[24],"It":[25,167],"is":[26,168,230],"well":[27],"known":[28],"that":[29,92,131,170,278],"nano-structured":[30],"metals":[31],"have":[32,51,95,147],"vastly":[33],"different":[34,113],"mechanical":[35,98,134,262],"properties":[36,99,135,263],"from":[37],"bulk":[38,156],"metals;":[39],"however,":[40],"difficulties":[41],"in":[42,122],"modeling":[43],"the":[44,53,57,90,97,176,180,210,221,244,250,279,282,285],"transition":[45,258],"between":[46],"and":[48,116,126,158,163,192,197,237],"ionic":[49],"bonding":[50],"prevented":[52],"computational":[54],"investigation":[55],"of":[56,59,100,161,179,218,281],"effects":[58,91],"oxide":[60,117,141,145,211,241],"surface":[61],"layers.":[62,142],"Newly":[63],"developed":[64],"charge-optimized":[65],"many":[66],"body":[67],"[Liang":[68],"et":[69],"al.,":[70],"Mater.":[71],"Sci.":[72],"Eng.,":[73],"R":[74],"74,":[75],"255":[76],"(2013)]":[77],"potentials":[78],"used":[80],"perform":[82],"fully":[83],"reactive":[84],"molecular":[85],"dynamics":[86],"simulations":[87],"which":[88],"elucidate":[89],"metal-oxide":[93],"a":[101,159,184,198,234,267],"copper":[102,226,252],"thin-film.":[103],"Simulated":[104],"tensile":[105],"tests":[106],"performed":[108],"thin-films":[110],"while":[111],"using":[112],"strain-rates,":[114],"temperatures,":[115],"thicknesses":[118],"evaluate":[120],"changes":[121],"yield":[123],"stress,":[124],"modulus,":[125],"failure":[127],"mechanisms.":[128],"Findings":[129],"indicate":[130],"copper-thin":[132],"film":[133],"strongly":[137],"affected":[138],"by":[139],"native":[140],"The":[143,224,240,261,275],"formed":[144],"an":[148,256],"amorphous":[149],"structure":[150],"with":[151],"lower":[152],"Cu-O":[153],"bond-densities":[154],"than":[155],"CuO,":[157],"mixture":[160],"Cu2O":[162],"CuO":[164],"charge":[165],"character.":[166],"found":[169,231],"oxidation":[171,280],"will":[172],"cause":[173],"modifications":[174],"strain":[177,194],"response":[178],"elastic":[181],"modulii,":[182],"producing":[183],"stiffened":[185],"modulii":[186,200],"at":[187,201],"low":[188,193],"temperatures":[189],"(&amp;lt;75":[190],"K)":[191],"values":[195],"(&amp;lt;5%),":[196],"softened":[199],"higher":[202],"temperatures.":[203],"While":[204],"under":[205],"strain,":[206],"structural":[207],"reorganization":[208],"within":[209],"facilitates":[213],"brittle":[214],"yielding":[215,228,246],"through":[216],"nucleation":[217,273],"defects":[219],"across":[220],"oxide/metal":[222],"interface.":[223],"oxide-free":[225],"thin-film":[227,253],"mechanism":[229],"tensile-axis":[235],"reorientation":[236],"grain":[238],"creation.":[239],"change":[243],"observed":[245],"mechanism,":[247],"allowing":[248],"for":[249,288],"inner":[251],"sustain":[255],"FCC-to-BCC":[257],"yielding.":[260,289],"fit":[265,276],"thermodynamic":[268],"model":[269],"based":[270],"classical":[272],"theory.":[274],"implies":[277],"films":[283],"reduces":[284],"activation":[286],"volume":[287]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W2277923667","counts_by_year":[{"year":2023,"cited_by_count":1},{"year":2022,"cited_by_count":1},{"year":2020,"cited_by_count":1},{"year":2019,"cited_by_count":1},{"year":2018,"cited_by_count":1},{"year":2017,"cited_by_count":2},{"year":2016,"cited_by_count":1}],"updated_date":"2024-10-17T11:09:41.116536","created_date":"2016-06-24"}],"group_by":[]}
+          Institute of Physics"],"type":"journal"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":null,"sustainable_development_goals":[{"id":"https://metadata.un.org/sdg/15","display_name":"Life
+          on land","score":0.6}],"grants":[{"funder":"https://openalex.org/F4320337345","funder_display_name":"Office
+          of Naval Research","award_id":"N00014-12-1-0542"}],"datasets":[],"versions":[],"referenced_works_count":58,"referenced_works":["https://openalex.org/W1964561108","https://openalex.org/W1966577027","https://openalex.org/W1967370996","https://openalex.org/W1969763275","https://openalex.org/W1972295667","https://openalex.org/W1972758026","https://openalex.org/W1973496772","https://openalex.org/W1975415324","https://openalex.org/W1979198964","https://openalex.org/W1980718691","https://openalex.org/W1998250010","https://openalex.org/W2000148778","https://openalex.org/W2002958700","https://openalex.org/W2004635538","https://openalex.org/W2005223231","https://openalex.org/W2015240911","https://openalex.org/W2015427003","https://openalex.org/W2019465613","https://openalex.org/W2024438921","https://openalex.org/W2025448774","https://openalex.org/W2033010856","https://openalex.org/W2035858373","https://openalex.org/W2037530567","https://openalex.org/W2042894263","https://openalex.org/W2047968138","https://openalex.org/W2048410032","https://openalex.org/W2051407701","https://openalex.org/W2052281371","https://openalex.org/W2055302323","https://openalex.org/W2060383028","https://openalex.org/W2061811424","https://openalex.org/W2067319108","https://openalex.org/W2067867161","https://openalex.org/W2068128554","https://openalex.org/W2068954018","https://openalex.org/W2075147729","https://openalex.org/W2082154123","https://openalex.org/W2082164550","https://openalex.org/W2082730101","https://openalex.org/W2103591835","https://openalex.org/W2112144973","https://openalex.org/W2113676282","https://openalex.org/W2118785939","https://openalex.org/W2125614899","https://openalex.org/W2129814046","https://openalex.org/W2129831264","https://openalex.org/W2155155530","https://openalex.org/W2158386952","https://openalex.org/W2163762820","https://openalex.org/W2316209218","https://openalex.org/W2317838033","https://openalex.org/W2323178299","https://openalex.org/W282450671","https://openalex.org/W3103133276","https://openalex.org/W3104017686","https://openalex.org/W3104324287","https://openalex.org/W4250102497","https://openalex.org/W4255450160"],"related_works":["https://openalex.org/W4313886759","https://openalex.org/W4289780727","https://openalex.org/W3196590631","https://openalex.org/W2363424936","https://openalex.org/W2334739780","https://openalex.org/W2189903790","https://openalex.org/W2067018196","https://openalex.org/W2014598323","https://openalex.org/W1987421019","https://openalex.org/W1495724091"],"abstract_inverted_index":{"Metal-oxide":[0],"layers":[1,94,146,212,242],"are":[2,79,107,136,264],"likely":[3],"to":[4,11,81,119,175,232,254,266],"be":[5,233],"present":[6],"on":[7,96,109,271],"metallic":[8,47],"nano-structures":[9],"due":[10],"either":[12],"environmental":[13],"exposure":[14],"during":[15,259],"use,":[16],"or":[17],"high":[18],"temperature":[19],"processing":[20],"techniques":[21],"such":[22],"as":[23],"annealing.":[24],"It":[25,167],"is":[26,168,230],"well":[27],"known":[28],"that":[29,92,131,170,278],"nano-structured":[30],"metals":[31],"have":[32,51,95,147],"vastly":[33],"different":[34,113],"mechanical":[35,98,134,262],"properties":[36,99,135,263],"from":[37],"bulk":[38,156],"metals;":[39],"however,":[40],"difficulties":[41],"in":[42,122],"modeling":[43],"the":[44,53,57,90,97,176,180,210,221,244,250,279,282,285],"transition":[45,258],"between":[46],"and":[48,116,126,158,163,192,197,237],"ionic":[49],"bonding":[50],"prevented":[52],"computational":[54],"investigation":[55],"of":[56,59,100,161,179,218,281],"effects":[58,91],"oxide":[60,117,141,145,211,241],"surface":[61],"layers.":[62,142],"Newly":[63],"developed":[64],"charge-optimized":[65],"many":[66],"body":[67],"[Liang":[68],"et":[69],"al.,":[70],"Mater.":[71],"Sci.":[72],"Eng.,":[73],"R":[74],"74,":[75],"255":[76],"(2013)]":[77],"potentials":[78],"used":[80],"perform":[82],"fully":[83],"reactive":[84],"molecular":[85],"dynamics":[86],"simulations":[87],"which":[88],"elucidate":[89],"metal-oxide":[93],"a":[101,159,184,198,234,267],"copper":[102,226,252],"thin-film.":[103],"Simulated":[104],"tensile":[105],"tests":[106],"performed":[108],"thin-films":[110],"while":[111],"using":[112],"strain-rates,":[114],"temperatures,":[115],"thicknesses":[118],"evaluate":[120],"changes":[121],"yield":[123],"stress,":[124],"modulus,":[125],"failure":[127],"mechanisms.":[128],"Findings":[129],"indicate":[130],"copper-thin":[132],"film":[133],"strongly":[137],"affected":[138],"by":[139],"native":[140],"The":[143,224,240,261,275],"formed":[144],"an":[148,256],"amorphous":[149],"structure":[150],"with":[151],"lower":[152],"Cu-O":[153],"bond-densities":[154],"than":[155],"CuO,":[157],"mixture":[160],"Cu2O":[162],"CuO":[164],"charge":[165],"character.":[166],"found":[169,231],"oxidation":[171,280],"will":[172],"cause":[173],"modifications":[174],"strain":[177,194],"response":[178],"elastic":[181],"modulii,":[182],"producing":[183],"stiffened":[185],"modulii":[186,200],"at":[187,201],"low":[188,193],"temperatures":[189],"(&amp;lt;75":[190],"K)":[191],"values":[195],"(&amp;lt;5%),":[196],"softened":[199],"higher":[202],"temperatures.":[203],"While":[204],"under":[205],"strain,":[206],"structural":[207],"reorganization":[208],"within":[209],"facilitates":[213],"brittle":[214],"yielding":[215,228,246],"through":[216],"nucleation":[217,273],"defects":[219],"across":[220],"oxide/metal":[222],"interface.":[223],"oxide-free":[225],"thin-film":[227,253],"mechanism":[229],"tensile-axis":[235],"reorientation":[236],"grain":[238],"creation.":[239],"change":[243],"observed":[245],"mechanism,":[247],"allowing":[248],"for":[249,288],"inner":[251],"sustain":[255],"FCC-to-BCC":[257],"yielding.":[260,289],"fit":[265,276],"thermodynamic":[268],"model":[269],"based":[270],"classical":[272],"theory.":[274],"implies":[277],"films":[283],"reduces":[284],"activation":[286],"volume":[287]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W2277923667","counts_by_year":[{"year":2023,"cited_by_count":1},{"year":2022,"cited_by_count":1},{"year":2020,"cited_by_count":1},{"year":2019,"cited_by_count":1},{"year":2018,"cited_by_count":1},{"year":2017,"cited_by_count":2},{"year":2016,"cited_by_count":1}],"updated_date":"2024-11-19T02:35:40.795640","created_date":"2016-06-24"}],"group_by":[]}
 
           '
       headers:
@@ -138,15 +84,15 @@ interactions:
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:29 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Referrer-Policy:
           - strict-origin-when-cross-origin
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168189&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=zzd5vuiAqh%2BuPOazDCjSK4%2BTxOdG%2FypO1xLt1DPjzAI%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168189&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=zzd5vuiAqh%2BuPOazDCjSK4%2BTxOdG%2FypO1xLt1DPjzAI%3D
         Server:
           - gunicorn
         Strict-Transport-Security:
@@ -163,6 +109,60 @@ interactions:
           - SAMEORIGIN
         X-Xss-Protection:
           - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.unpaywall.org/v2/search?query=Effect%20of%20native%20oxide%20layers%20on%20copper%20thin-film%20tensile%20properties:%20A%20reactive%20molecular%20dynamics%20study&email=example@papercrow.ai
+    response:
+      body:
+        string:
+          '{"elapsed_seconds":0.365,"results":[{"response":{"best_oa_location":null,"data_standard":2,"doi":"10.1063/1.4938384","doi_url":"https://doi.org/10.1063/1.4938384","first_oa_location":null,"genre":"journal-article","has_repository_copy":false,"is_oa":false,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"0021-8979","journal_issns":"0021-8979,1089-7550","journal_name":"Journal
+          of Applied Physics","oa_locations":[],"oa_locations_embargoed":[],"oa_status":"closed","published_date":"2015-12-21","publisher":"AIP
+          Publishing","title":"Effect of native oxide layers on copper thin-film tensile
+          properties: A reactive molecular dynamics study","updated":"2023-07-31T05:28:57.007821","year":2015,"z_authors":[{"affiliation":[{"name":"University
+          of Rochester 1 Materials Science Program, , Rochester, New York 14627, USA"}],"family":"Skarlinski","given":"Michael
+          D.","sequence":"first"},{"affiliation":[{"name":"University of Rochester 1
+          Materials Science Program, , Rochester, New York 14627, USA"},{"name":"University
+          of Rochester 2 Department of Mechanical Engineering, , Rochester, New York
+          14627, USA"}],"family":"Quesnel","given":"David J.","sequence":"additional"}]},"score":0.009231734,"snippet":"<b>Effect</b>
+          of <b>native</b> <b>oxide</b> <b>layers</b> on <b>copper</b> <b>thin</b>-<b>film</b>
+          <b>tensile</b> <b>properties</b>: A <b>reactive</b> <b>molecular</b> <b>dynamics</b>
+          <b>study</b>"}]}
+
+          '
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "707"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:29 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168189&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=jvHe7mLcg0TdhFD7ncV2ILt8klA3O64V%2Fr0oqzgnbqc%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168189&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=jvHe7mLcg0TdhFD7ncV2ILt8klA3O64V%2Fr0oqzgnbqc%3D
+        Server:
+          - gunicorn
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
       status:
         code: 200
         message: OK
@@ -188,7 +188,7 @@ interactions:
           tensile properties: A reactive molecular dynamics study},\n volume = {118},\n
           year = {2015}\n}\n"}, "authors": [{"authorId": "9821934", "name": "Michael
           Skarlinski"}, {"authorId": "37723150", "name": "D. Quesnel"}], "matchScore":
-          283.3764}]}
+          283.47464}]}
 
           '
       headers:
@@ -197,31 +197,31 @@ interactions:
         Connection:
           - keep-alive
         Content-Length:
-          - "1108"
+          - "1109"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Via:
-          - 1.1 97354ec70bdda7ac06cc29aed9bfdb3c.cloudfront.net (CloudFront)
+          - 1.1 fd0518257f901c4d9c7dc3b36830c8be.cloudfront.net (CloudFront)
         X-Amz-Cf-Id:
-          - FGhLUmMRMcd_XINPLPH4yZ3nUSbCRsrlBTXkWUOl5uKNRPJ8LuVuWQ==
+          - HSJoQyT_9oznW6T-xlgebcf7YpC2gPMNse_pbCXihztqahCYlKz7Gw==
         X-Amz-Cf-Pop:
           - SFO53-P7
         X-Cache:
           - Miss from cloudfront
         x-amz-apigw-id:
-          - A81PnESLvHcESNw=
+          - CLbZoFaUvHcEhcQ=
         x-amzn-Remapped-Connection:
           - keep-alive
         x-amzn-Remapped-Content-Length:
-          - "1108"
+          - "1109"
         x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         x-amzn-Remapped-Server:
           - gunicorn
         x-amzn-RequestId:
-          - 6c77e59a-36c6-41a4-84c0-c18ad4b90a4a
+          - 2c2e09cc-9716-4a51-9e02-6541f0d4c466
       status:
         code: 200
         message: OK
@@ -233,7 +233,7 @@ interactions:
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":11962693,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":12022430,"items":[{"indexed":{"date-parts":[[2023,9,29]],"date-time":"2023-09-29T22:47:50Z","timestamp":1696027670718},"reference-count":57,"publisher":"AIP
           Publishing","issue":"23","funder":[{"DOI":"10.13039\/100000006","name":"Office
           of Naval Research","doi-asserted-by":"publisher","award":["N00014-12-1-0542"],"id":[{"id":"10.13039\/100000006","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["pubs.aip.org"],"crossmark-restriction":true},"published-print":{"date-parts":[[2015,12,21]]},"abstract":"<jats:p>Metal-oxide
           layers are likely to be present on metallic nano-structures due to either
@@ -327,7 +327,7 @@ interactions:
           Sci. Eng. A"},{"key":"2023062402360541600_c55","doi-asserted-by":"publisher","first-page":"057129","DOI":"10.1063\/1.4880241","volume":"4","year":"2014","journal-title":"AIP
           Adv."},{"key":"2023062402360541600_c56","doi-asserted-by":"publisher","first-page":"94","DOI":"10.1016\/j.susc.2014.10.017","volume":"633","year":"2015","journal-title":"Surf.
           Sci."},{"key":"2023062402360541600_c57","doi-asserted-by":"publisher","first-page":"710","DOI":"10.1016\/j.pmatsci.2010.04.001","volume":"55","year":"2010","journal-title":"Prog.
-          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":63.98746,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Mater. Sci."}],"container-title":["Journal of Applied Physics"],"language":"en","link":[{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/pubs.aip.org\/aip\/jap\/article-pdf\/doi\/10.1063\/1.4938384\/15174088\/235306_1_online.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2023,6,24]],"date-time":"2023-06-24T15:07:33Z","timestamp":1687619253000},"score":64.01677,"resource":{"primary":{"URL":"https:\/\/pubs.aip.org\/jap\/article\/118\/23\/235306\/141678\/Effect-of-native-oxide-layers-on-copper-thin-film"}},"issued":{"date-parts":[[2015,12,21]]},"references-count":57,"journal-issue":{"issue":"23","published-print":{"date-parts":[[2015,12,21]]}},"URL":"http:\/\/dx.doi.org\/10.1063\/1.4938384","ISSN":["0021-8979","1089-7550"],"issn-type":[{"value":"0021-8979","type":"print"},{"value":"1089-7550","type":"electronic"}],"published-other":{"date-parts":[[2015,12,21]]},"published":{"date-parts":[[2015,12,21]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -341,11 +341,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3946"
+          - "3944"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:30 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -392,7 +392,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:

--- a/tests/cassettes/test_title_search[paper_attributes1].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes1].yaml
@@ -3,51 +3,13 @@ interactions:
       body: null
       headers: {}
       method: GET
-      uri: https://api.unpaywall.org/v2/search?query=PaperQA:%20Retrieval-Augmented%20Generative%20Agent%20for%20Scientific%20Research&email=example@papercrow.ai
-    response:
-      body:
-        string: '{"elapsed_seconds":0.023,"results":[]}
-
-          '
-      headers:
-        Access-Control-Allow-Headers:
-          - origin, content-type, accept, x-requested-with
-        Access-Control-Allow-Methods:
-          - POST, GET, OPTIONS, PUT, DELETE, PATCH
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "39"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Nel:
-          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
-        Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107839&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=XFcI6L69f0FCYAtbCfIpvvg1RbSo02xhP0uUA0yPr58%3D"}]}'
-        Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107839&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=XFcI6L69f0FCYAtbCfIpvvg1RbSo02xhP0uUA0yPr58%3D
-        Server:
-          - gunicorn
-        Via:
-          - 1.1 vegur
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
       uri: https://api.openalex.org/works?filter=title.search:PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research
     response:
       body:
         string:
-          '{"meta":{"count":1,"db_response_time_ms":361,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W4389761608","doi":"https://doi.org/10.48550/arxiv.2312.07559","title":"PaperQA:
+          '{"meta":{"count":1,"db_response_time_ms":80,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W4389761608","doi":"https://doi.org/10.48550/arxiv.2312.07559","title":"PaperQA:
           Retrieval-Augmented Generative Agent for Scientific Research","display_name":"PaperQA:
-          Retrieval-Augmented Generative Agent for Scientific Research","relevance_score":715.43823,"publication_year":2023,"publication_date":"2023-01-01","ids":{"openalex":"https://openalex.org/W4389761608","doi":"https://doi.org/10.48550/arxiv.2312.07559"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2312.07559","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
+          Retrieval-Augmented Generative Agent for Scientific Research","relevance_score":725.4885,"publication_year":2023,"publication_date":"2023-01-01","ids":{"openalex":"https://openalex.org/W4389761608","doi":"https://doi.org/10.48550/arxiv.2312.07559"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2312.07559","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
           (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
           University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
           University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"type":"preprint","type_crossref":"posted-content","indexed_in":["arxiv","datacite"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://arxiv.org/abs/2312.07559","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5092171854","display_name":"Jakub
@@ -62,7 +24,7 @@ interactions:
           G. Rodriques","orcid":"https://orcid.org/0000-0002-2509-0861"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Rodriques,
           Samuel G.","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"last","author":{"id":"https://openalex.org/A5103115676","display_name":"Andrew
           Dickson White","orcid":"https://orcid.org/0000-0002-6647-3965"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"White,
-          Andrew D.","raw_affiliation_strings":[],"affiliations":[]}],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":false,"cited_by_count":10,"citation_normalized_percentile":{"value":0.836334,"is_in_top_1_percent":false,"is_in_top_10_percent":false},"cited_by_percentile_year":{"min":96,"max":97},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T10028","display_name":"Natural
+          Andrew D.","raw_affiliation_strings":[],"affiliations":[]}],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":false,"cited_by_count":10,"citation_normalized_percentile":{"value":0.999951,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":96,"max":97},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T10028","display_name":"Natural
           Language Processing","score":0.9996,"subfield":{"id":"https://openalex.org/subfields/1702","display_name":"Artificial
           Intelligence"},"field":{"id":"https://openalex.org/fields/17","display_name":"Computer
           Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
@@ -105,8 +67,8 @@ interactions:
           API","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I4210145204","host_organization_name":"DataCite","host_organization_lineage":["https://openalex.org/I4210145204"],"host_organization_lineage_names":["DataCite"],"type":"metadata"},"license":null,"license_id":null,"version":null}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2312.07559","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
           (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
           University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
-          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[{"score":0.86,"display_name":"Quality
-          education","id":"https://metadata.un.org/sdg/4"}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":0,"referenced_works":[],"related_works":["https://openalex.org/W972276598","https://openalex.org/W4321353415","https://openalex.org/W2745001401","https://openalex.org/W2387743295","https://openalex.org/W2384605597","https://openalex.org/W2378211422","https://openalex.org/W2130974462","https://openalex.org/W2087343574","https://openalex.org/W2086519370","https://openalex.org/W2028665553"],"abstract_inverted_index":{"Large":[0],"Language":[1],"Models":[2],"(LLMs)":[3],"generalize":[4],"well":[5],"across":[6,79,152],"language":[7],"tasks,":[8],"but":[9],"suffer":[10],"from":[11,148],"hallucinations":[12,33],"and":[13,34,88,90,112,144],"uninterpretability,":[14],"making":[15],"it":[16,106],"difficult":[17],"to":[18,31,46,93,125],"assess":[19],"their":[20],"accuracy":[21],"without":[22],"ground-truth.":[23],"Retrieval-Augmented":[24],"Generation":[25],"(RAG)":[26],"models":[27,45],"have":[28],"been":[29],"proposed":[30],"reduce":[32],"provide":[35,94],"provenance":[36],"for":[37,64],"how":[38,126],"an":[39,73],"answer":[40],"was":[41],"generated.":[42],"Applying":[43],"such":[44],"the":[47,68,84,122,153],"scientific":[48,56,69,81,131,150],"literature":[49],"may":[50],"enable":[51],"large-scale,":[52],"systematic":[53],"processing":[54],"of":[55,86,109,146],"knowledge.":[57],"We":[58],"present":[59],"PaperQA,":[60],"a":[61,100,137],"RAG":[62,92],"agent":[63,74,98],"answering":[65,102],"questions":[66],"over":[67],"literature.":[70,154],"PaperQA":[71],"is":[72],"that":[75,141],"performs":[76],"information":[77,147],"retrieval":[78,143],"full-text":[80,149],"articles,":[82],"assesses":[83],"relevance":[85],"sources":[87],"passages,":[89],"uses":[91],"answers.":[95],"Viewing":[96],"this":[97],"as":[99],"question":[101],"model,":[103],"we":[104,133,156],"find":[105],"exceeds":[107],"performance":[108],"existing":[110],"LLMs":[111],"LLM":[113],"agents":[114],"on":[115,130,163],"current":[116],"science":[117],"QA":[118],"benchmarks.":[119],"To":[120],"push":[121],"field":[123],"closer":[124],"humans":[127],"perform":[128],"research":[129],"literature,":[132],"also":[134],"introduce":[135],"LitQA,":[136],"more":[138],"complex":[139],"benchmark":[140],"requires":[142],"synthesis":[145],"papers":[151],"Finally,":[155],"demonstrate":[157],"PaperQA''s":[158],"matches":[159],"expert":[160],"human":[161],"researchers":[162],"LitQA.":[164]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4389761608","counts_by_year":[{"year":2024,"cited_by_count":8},{"year":2023,"cited_by_count":1}],"updated_date":"2024-11-08T04:07:37.813635","created_date":"2023-12-15"}],"group_by":[]}
+          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[{"display_name":"Quality
+          education","score":0.86,"id":"https://metadata.un.org/sdg/4"}],"grants":[],"datasets":[],"versions":[],"referenced_works_count":0,"referenced_works":[],"related_works":["https://openalex.org/W972276598","https://openalex.org/W4321353415","https://openalex.org/W2745001401","https://openalex.org/W2387743295","https://openalex.org/W2384605597","https://openalex.org/W2378211422","https://openalex.org/W2130974462","https://openalex.org/W2087343574","https://openalex.org/W2086519370","https://openalex.org/W2028665553"],"abstract_inverted_index":{"Large":[0],"Language":[1],"Models":[2],"(LLMs)":[3],"generalize":[4],"well":[5],"across":[6,79,152],"language":[7],"tasks,":[8],"but":[9],"suffer":[10],"from":[11,148],"hallucinations":[12,33],"and":[13,34,88,90,112,144],"uninterpretability,":[14],"making":[15],"it":[16,106],"difficult":[17],"to":[18,31,46,93,125],"assess":[19],"their":[20],"accuracy":[21],"without":[22],"ground-truth.":[23],"Retrieval-Augmented":[24],"Generation":[25],"(RAG)":[26],"models":[27,45],"have":[28],"been":[29],"proposed":[30],"reduce":[32],"provide":[35,94],"provenance":[36],"for":[37,64],"how":[38,126],"an":[39,73],"answer":[40],"was":[41],"generated.":[42],"Applying":[43],"such":[44],"the":[47,68,84,122,153],"scientific":[48,56,69,81,131,150],"literature":[49],"may":[50],"enable":[51],"large-scale,":[52],"systematic":[53],"processing":[54],"of":[55,86,109,146],"knowledge.":[57],"We":[58],"present":[59],"PaperQA,":[60],"a":[61,100,137],"RAG":[62,92],"agent":[63,74,98],"answering":[65,102],"questions":[66],"over":[67],"literature.":[70,154],"PaperQA":[71],"is":[72],"that":[75,141],"performs":[76],"information":[77,147],"retrieval":[78,143],"full-text":[80,149],"articles,":[82],"assesses":[83],"relevance":[85],"sources":[87],"passages,":[89],"uses":[91],"answers.":[95],"Viewing":[96],"this":[97],"as":[99],"question":[101],"model,":[103],"we":[104,133,156],"find":[105],"exceeds":[107],"performance":[108],"existing":[110],"LLMs":[111],"LLM":[113],"agents":[114],"on":[115,130,163],"current":[116],"science":[117],"QA":[118],"benchmarks.":[119],"To":[120],"push":[121],"field":[123],"closer":[124],"humans":[127],"perform":[128],"research":[129],"literature,":[132],"also":[134],"introduce":[135],"LitQA,":[136],"more":[138],"complex":[139],"benchmark":[140],"requires":[142],"synthesis":[145],"papers":[151],"Finally,":[155],"demonstrate":[157],"PaperQA''s":[158],"matches":[159],"expert":[160],"human":[161],"researchers":[162],"LitQA.":[164]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4389761608","counts_by_year":[{"year":2024,"cited_by_count":8},{"year":2023,"cited_by_count":1}],"updated_date":"2024-11-17T20:34:48.228663","created_date":"2023-12-15"}],"group_by":[]}
 
           '
       headers:
@@ -126,21 +88,21 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "3491"
+          - "3487"
         Content-Security-Policy:
           - default-src 'self'; object-src 'none'
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:31 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Referrer-Policy:
           - strict-origin-when-cross-origin
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107839&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=savWMBIX%2FuigNk%2BB3oRRW5YgYPj3kIdhOkW0Tn87mXQ%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168191&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=voCezOGfcA%2BpZtA0pQ8xmxehXw7u0GuZsZo1Usd1FUQ%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107839&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=savWMBIX%2FuigNk%2BB3oRRW5YgYPj3kIdhOkW0Tn87mXQ%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168191&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=voCezOGfcA%2BpZtA0pQ8xmxehXw7u0GuZsZo1Usd1FUQ%3D
         Server:
           - gunicorn
         Strict-Transport-Security:
@@ -164,11 +126,110 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.unpaywall.org/v2/search?query=PaperQA:%20Retrieval-Augmented%20Generative%20Agent%20for%20Scientific%20Research&email=example@papercrow.ai
+    response:
+      body:
+        string: '{"elapsed_seconds":0.038,"results":[]}
+
+          '
+      headers:
+        Access-Control-Allow-Headers:
+          - origin, content-type, accept, x-requested-with
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "39"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:31 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168191&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=amaDfjIUHQ8kon3Kkq6Ky1tetGeiggwyv09JT1WA51E%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168191&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=amaDfjIUHQ8kon3Kkq6Ky1tetGeiggwyv09JT1WA51E%3D
+        Server:
+          - gunicorn
+        Via:
+          - 1.1 vegur
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "7e55d8701785818776323b4147cb13354c820469", "externalIds":
+          {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
+          "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
+          "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
+          "venue": "arXiv.org", "year": 2023, "citationCount": 38, "influentialCitationCount":
+          1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
+          "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
+          "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
+          L''ala and Odhran O''Donoghue and Aleksandar Shtedritski and Sam Cox and Samuel
+          G. Rodriques and Andrew D. White},\n booktitle = {arXiv.org},\n journal =
+          {ArXiv},\n title = {PaperQA: Retrieval-Augmented Generative Agent for Scientific
+          Research},\n volume = {abs/2312.07559},\n year = {2023}\n}\n"}, "authors":
+          [{"authorId": "2219926382", "name": "Jakub L''ala"}, {"authorId": "2258961056",
+          "name": "Odhran O''Donoghue"}, {"authorId": "2258961451", "name": "Aleksandar
+          Shtedritski"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId":
+          "2258964497", "name": "Samuel G. Rodriques"}, {"authorId": "2273941271", "name":
+          "Andrew D. White"}], "matchScore": 247.75336}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1386"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:31 GMT
+        Via:
+          - 1.1 1401c4844b3ea759244fef5091fc307a.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - g5qtBr5Pt2WSYiakHslP3mQOwUSbwOO74xzFE8cNAUVRPvBLz1AEsg==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbZ8GiIPHcEGeQ=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1386"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:31 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 191cb665-c787-4cdf-b9c4-d583ce3ebc31
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2053545,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2066122,"items":[{"indexed":{"date-parts":[[2024,3,8]],"date-time":"2024-03-08T00:26:06Z","timestamp":1709857566241},"reference-count":48,"publisher":"Oxford
           University Press (OUP)","issue":"1","license":[{"start":{"date-parts":[[2024,2,21]],"date-time":"2024-02-21T00:00:00Z","timestamp":1708473600000},"content-version":"vor","delay-in-days":48,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0\/"}],"funder":[{"DOI":"10.13039\/100000092","name":"National
           Library of Medicine","doi-asserted-by":"publisher","award":["R01LM009886","R01LM014344"],"id":[{"id":"10.13039\/100000092","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100006108","name":"National
           Center for Advancing Translational Sciences","doi-asserted-by":"publisher","award":["UL1TR001873"],"id":[{"id":"10.13039\/100006108","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000002","name":"National
@@ -255,7 +316,7 @@ interactions:
           gain-based evaluation of IR techniques","volume":"20","author":"J\u00e4rvelin","year":"2002","journal-title":"ACM
           Trans Inf Syst"},{"key":"2024030720490192400_ooae021-B46","volume-title":"Evidence-Based
           Practice in Nursing & Healthcare: A Guide to Best Practice","author":"Melnyk","year":"2022"},{"key":"2024030720490192400_ooae021-B47","first-page":"206","author":"Gupta","year":"2017"},{"key":"2024030720490192400_ooae021-B48","first-page":"1","author":"Park","year":"2012"}],"container-title":["JAMIA
-          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":27.876652,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
+          Open"],"language":"en","link":[{"URL":"https:\/\/academic.oup.com\/jamiaopen\/advance-article-pdf\/doi\/10.1093\/jamiaopen\/ooae021\/56732770\/ooae021.pdf","content-type":"application\/pdf","content-version":"am","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"syndication"},{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article-pdf\/7\/1\/ooae021\/56904263\/ooae021.pdf","content-type":"unspecified","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,3,7]],"date-time":"2024-03-07T20:49:23Z","timestamp":1709844563000},"score":27.892555,"resource":{"primary":{"URL":"https:\/\/academic.oup.com\/jamiaopen\/article\/doi\/10.1093\/jamiaopen\/ooae021\/7612234"}},"issued":{"date-parts":[[2024,1,4]]},"references-count":48,"journal-issue":{"issue":"1","published-print":{"date-parts":[[2024,1,4]]}},"URL":"http:\/\/dx.doi.org\/10.1093\/jamiaopen\/ooae021","ISSN":["2574-2531"],"issn-type":[{"value":"2574-2531","type":"electronic"}],"published-other":{"date-parts":[[2024,4,1]]},"published":{"date-parts":[[2024,1,4]]}}],"items-per-page":1,"query":{"start-index":0,"search-terms":null}}}'
       headers:
         Access-Control-Allow-Headers:
           - X-Requested-With, Accept, Accept-Encoding, Accept-Charset, Accept-Language,
@@ -269,11 +330,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "4503"
+          - "4502"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -290,67 +351,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=PaperQA:+Retrieval-Augmented+Generative+Agent+for+Scientific+Research&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "7e55d8701785818776323b4147cb13354c820469", "externalIds":
-          {"ArXiv": "2312.07559", "DBLP": "journals/corr/abs-2312-07559", "DOI": "10.48550/arXiv.2312.07559",
-          "CorpusId": 266191420}, "url": "https://www.semanticscholar.org/paper/7e55d8701785818776323b4147cb13354c820469",
-          "title": "PaperQA: Retrieval-Augmented Generative Agent for Scientific Research",
-          "venue": "arXiv.org", "year": 2023, "citationCount": 37, "influentialCitationCount":
-          1, "isOpenAccess": false, "openAccessPdf": null, "publicationTypes": ["JournalArticle"],
-          "publicationDate": "2023-12-08", "journal": {"name": "ArXiv", "volume": "abs/2312.07559"},
-          "citationStyles": {"bibtex": "@Article{L''ala2023PaperQARG,\n author = {Jakub
-          L''ala and Odhran O''Donoghue and Aleksandar Shtedritski and Sam Cox and Samuel
-          G. Rodriques and Andrew D. White},\n booktitle = {arXiv.org},\n journal =
-          {ArXiv},\n title = {PaperQA: Retrieval-Augmented Generative Agent for Scientific
-          Research},\n volume = {abs/2312.07559},\n year = {2023}\n}\n"}, "authors":
-          [{"authorId": "2219926382", "name": "Jakub L''ala"}, {"authorId": "2258961056",
-          "name": "Odhran O''Donoghue"}, {"authorId": "2258961451", "name": "Aleksandar
-          Shtedritski"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId":
-          "2258964497", "name": "Samuel G. Rodriques"}, {"authorId": "2273941271", "name":
-          "Andrew D. White"}], "matchScore": 242.62341}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1386"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Via:
-          - 1.1 6b6864bce40e8c6517571357636f0dbe.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - SK1ES23hj6VIH1SsehqMda1G0Y_Wb12dFX9CGOQ7sG2QtAzGC3iYwg==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81P8EItvHcEtnw=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1386"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 3b1a8226-4400-4ab8-b0d0-71c1c6b6b949
       status:
         code: 200
         message: OK

--- a/tests/cassettes/test_title_search[paper_attributes2].yaml
+++ b/tests/cassettes/test_title_search[paper_attributes2].yaml
@@ -3,16 +3,192 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.openalex.org/works?filter=title.search:Augmenting+large+language+models+with+chemistry+tools
+    response:
+      body:
+        string:
+          '{"meta":{"count":2,"db_response_time_ms":128,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W4365597205","doi":"https://doi.org/10.48550/arxiv.2304.05376","title":"ChemCrow:
+          Augmenting large-language models with chemistry tools","display_name":"ChemCrow:
+          Augmenting large-language models with chemistry tools","relevance_score":1135.6461,"publication_year":2023,"publication_date":"2023-01-01","ids":{"openalex":"https://openalex.org/W4365597205","doi":"https://doi.org/10.48550/arxiv.2304.05376"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
+          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
+          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
+          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"type":"preprint","type_crossref":"posted-content","indexed_in":["arxiv","datacite"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://arxiv.org/abs/2304.05376","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5055903035","display_name":"Andres
+          M Bran","orcid":"https://orcid.org/0000-0002-4432-3667"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Bran,
+          Andres M","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"middle","author":{"id":"https://openalex.org/A5101971357","display_name":"Sam
+          Cox","orcid":"https://orcid.org/0000-0002-4441-9327"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Cox,
+          Sam","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"middle","author":{"id":"https://openalex.org/A5103115676","display_name":"Andrew
+          Dickson White","orcid":"https://orcid.org/0000-0002-6647-3965"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"White,
+          Andrew D","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"last","author":{"id":"https://openalex.org/A5028051805","display_name":"Philippe
+          Schwaller","orcid":"https://orcid.org/0000-0003-3046-6576"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Schwaller,
+          Philippe","raw_affiliation_strings":[],"affiliations":[]}],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":false,"cited_by_count":84,"citation_normalized_percentile":{"value":0.999834,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":99,"max":100},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11948","display_name":"Accelerating
+          Materials Innovation through Informatics","score":0.9995,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
+          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}},"topics":[{"id":"https://openalex.org/T11948","display_name":"Accelerating
+          Materials Innovation through Informatics","score":0.9995,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
+          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/limiting","display_name":"Limiting","score":0.706134},{"id":"https://openalex.org/keywords/computational-chemistry","display_name":"Computational
+          Chemistry","score":0.518176}],"concepts":[{"id":"https://openalex.org/C188198153","wikidata":"https://www.wikidata.org/wiki/Q1613840","display_name":"Limiting","level":2,"score":0.706134},{"id":"https://openalex.org/C174348530","wikidata":"https://www.wikidata.org/wiki/Q188635","display_name":"Bridging
+          (networking)","level":2,"score":0.67967176},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
+          science","level":0,"score":0.6176928},{"id":"https://openalex.org/C177264268","wikidata":"https://www.wikidata.org/wiki/Q1514741","display_name":"Set
+          (abstract data type)","level":2,"score":0.47735333},{"id":"https://openalex.org/C74187038","wikidata":"https://www.wikidata.org/wiki/Q1418791","display_name":"Drug
+          discovery","level":2,"score":0.4398606},{"id":"https://openalex.org/C185592680","wikidata":"https://www.wikidata.org/wiki/Q2329","display_name":"Chemistry","level":0,"score":0.3678416},{"id":"https://openalex.org/C2522767166","wikidata":"https://www.wikidata.org/wiki/Q2374463","display_name":"Data
+          science","level":1,"score":0.34021586},{"id":"https://openalex.org/C171250308","wikidata":"https://www.wikidata.org/wiki/Q11468","display_name":"Nanotechnology","level":1,"score":0.3370079},{"id":"https://openalex.org/C154945302","wikidata":"https://www.wikidata.org/wiki/Q11660","display_name":"Artificial
+          intelligence","level":1,"score":0.33441877},{"id":"https://openalex.org/C127413603","wikidata":"https://www.wikidata.org/wiki/Q11023","display_name":"Engineering","level":0,"score":0.19605169},{"id":"https://openalex.org/C199360897","wikidata":"https://www.wikidata.org/wiki/Q9143","display_name":"Programming
+          language","level":1,"score":0.13234842},{"id":"https://openalex.org/C78519656","wikidata":"https://www.wikidata.org/wiki/Q101333","display_name":"Mechanical
+          engineering","level":1,"score":0.0},{"id":"https://openalex.org/C31258907","wikidata":"https://www.wikidata.org/wiki/Q1301371","display_name":"Computer
+          network","level":1,"score":0.0},{"id":"https://openalex.org/C55493867","wikidata":"https://www.wikidata.org/wiki/Q7094","display_name":"Biochemistry","level":1,"score":0.0},{"id":"https://openalex.org/C192562407","wikidata":"https://www.wikidata.org/wiki/Q228736","display_name":"Materials
+          science","level":0,"score":0.0}],"mesh":[],"locations_count":2,"locations":[{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
+          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
+          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
+          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},{"is_oa":false,"landing_page_url":"https://api.datacite.org/dois/10.48550/arxiv.2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4393179698","display_name":"DataCite
+          API","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I4210145204","host_organization_name":"DataCite","host_organization_lineage":["https://openalex.org/I4210145204"],"host_organization_lineage_names":["DataCite"],"type":"metadata"},"license":null,"license_id":null,"version":null}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
+          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
+          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
+          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[],"grants":[],"datasets":[],"versions":[],"referenced_works_count":0,"referenced_works":[],"related_works":["https://openalex.org/W4388870064","https://openalex.org/W4248308508","https://openalex.org/W4235186151","https://openalex.org/W2667588871","https://openalex.org/W2272354214","https://openalex.org/W2210139803","https://openalex.org/W2084768720","https://openalex.org/W2056057048","https://openalex.org/W2054685365","https://openalex.org/W2043010663"],"abstract_inverted_index":{"Over":[0],"the":[1,92,107,117,179],"last":[2],"decades,":[3],"excellent":[4],"computational":[5,184],"chemistry":[6,71],"tools":[7],"have":[8,35],"been":[9],"developed.":[10],"Integrating":[11],"them":[12],"into":[13],"a":[14,120,136],"single":[15],"platform":[16],"with":[17,45],"enhanced":[18],"accessibility":[19],"could":[20],"help":[21],"reaching":[22],"their":[23,58],"full":[24],"potential":[25],"by":[26,177],"overcoming":[27],"steep":[28],"learning":[29],"curves.":[30],"Recently,":[31],"large-language":[32],"models":[33,50],"(LLMs)":[34],"shown":[36],"strong":[37],"performance":[38,94],"in":[39,60,95,134],"tasks":[40,76],"across":[41,77],"domains,":[42],"but":[43,172],"struggle":[44],"chemistry-related":[46],"problems.":[47],"Moreover,":[48],"these":[49],"lack":[51],"access":[52],"to":[53,74],"external":[54],"knowledge":[55],"sources,":[56],"limiting":[57],"usefulness":[59],"scientific":[61,175],"applications.":[62],"In":[63],"this":[64],"study,":[65],"we":[66,143],"introduce":[67],"ChemCrow,":[68],"an":[69,110,148],"LLM":[70,93,127],"agent":[72,102],"designed":[73],"accomplish":[75],"organic":[78],"synthesis,":[79],"drug":[80],"discovery,":[81],"and":[82,97,105,115,128,157,167,183],"materials":[83],"design.":[84],"By":[85],"integrating":[86],"18":[87],"expert-designed":[88],"tools,":[89],"ChemCrow":[90],"augments":[91],"chemistry,":[96],"new":[98],"capabilities":[99],"emerge.":[100],"Our":[101,123,160],"autonomously":[103],"planned":[104],"executed":[106],"syntheses":[108],"of":[109,119,139],"insect":[111],"repellent,":[112],"three":[113],"organocatalysts,":[114],"guided":[116],"discovery":[118],"novel":[121],"chromophore.":[122],"evaluation,":[124],"including":[125],"both":[126],"expert":[129,165],"assessments,":[130],"demonstrates":[131],"ChemCrow''s":[132],"effectiveness":[133],"automating":[135],"diverse":[137],"set":[138],"chemical":[140],"tasks.":[141],"Surprisingly,":[142],"find":[144],"that":[145],"GPT-4":[146,155],"as":[147],"evaluator":[149],"cannot":[150],"distinguish":[151],"between":[152,181],"clearly":[153],"wrong":[154],"completions":[156],"Chemcrow''s":[158],"performance.":[159],"work":[161],"not":[162],"only":[163],"aids":[164],"chemists":[166],"lowers":[168],"barriers":[169],"for":[170],"non-experts,":[171],"also":[173],"fosters":[174],"advancement":[176],"bridging":[178],"gap":[180],"experimental":[182],"chemistry.":[185]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4365597205","counts_by_year":[{"year":2024,"cited_by_count":46},{"year":2023,"cited_by_count":32}],"updated_date":"2024-11-28T14:13:52.508530","created_date":"2023-04-15"},{"id":"https://openalex.org/W4396723768","doi":"https://doi.org/10.1038/s42256-024-00832-8","title":"Augmenting
+          large language models with chemistry tools","display_name":"Augmenting large
+          language models with chemistry tools","relevance_score":942.8967,"publication_year":2024,"publication_date":"2024-05-08","ids":{"openalex":"https://openalex.org/W4396723768","doi":"https://doi.org/10.1038/s42256-024-00832-8","pmid":"https://pubmed.ncbi.nlm.nih.gov/38799228"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
+          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
+          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
+          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},"type":"article","type_crossref":"journal-article","indexed_in":["crossref","pubmed"],"open_access":{"is_oa":true,"oa_status":"hybrid","oa_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5031480183","display_name":"Andres
+          M. Bran","orcid":null},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
+          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Andres
+          M. Bran","raw_affiliation_strings":["Laboratory of Artificial Chemical Intelligence
+          (LIAC), ISIC, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"Laboratory
+          of Artificial Chemical Intelligence (LIAC), ISIC, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5101971357","display_name":"Sam
+          Cox","orcid":"https://orcid.org/0000-0002-4441-9327"},"institutions":[{"id":"https://openalex.org/I5388228","display_name":"University
+          of Rochester","ror":"https://ror.org/022kthw22","country_code":"US","type":"education","lineage":["https://openalex.org/I5388228"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Sam
+          Cox","raw_affiliation_strings":["Department of Chemical Engineering, University
+          of Rochester, Rochester, NY, USA"],"affiliations":[{"raw_affiliation_string":"Department
+          of Chemical Engineering, University of Rochester, Rochester, NY, USA","institution_ids":["https://openalex.org/I5388228"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5075449407","display_name":"Oliver
+          Schilter","orcid":"https://orcid.org/0000-0003-0310-0851"},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
+          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Oliver
+          Schilter","raw_affiliation_strings":["Laboratory of Artificial Chemical Intelligence
+          (LIAC), ISIC, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"Laboratory
+          of Artificial Chemical Intelligence (LIAC), ISIC, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5092630105","display_name":"Carlo
+          Baldassari","orcid":"https://orcid.org/0009-0008-1199-7113"},"institutions":[{"id":"https://openalex.org/I4210126328","display_name":"IBM
+          Research - Zurich","ror":"https://ror.org/02js37d36","country_code":"CH","type":"facility","lineage":["https://openalex.org/I1341412227","https://openalex.org/I4210114115","https://openalex.org/I4210126328"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Carlo
+          Baldassari","raw_affiliation_strings":["Accelerated Discovery, IBM Research
+          \u2013 Europe, R\u00fcschlikon, Switzerland"],"affiliations":[{"raw_affiliation_string":"Accelerated
+          Discovery, IBM Research \u2013 Europe, R\u00fcschlikon, Switzerland","institution_ids":["https://openalex.org/I4210126328"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5103115676","display_name":"Andrew
+          Dickson White","orcid":"https://orcid.org/0000-0002-6647-3965"},"institutions":[{"id":"https://openalex.org/I5388228","display_name":"University
+          of Rochester","ror":"https://ror.org/022kthw22","country_code":"US","type":"education","lineage":["https://openalex.org/I5388228"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Andrew
+          D. White","raw_affiliation_strings":["Department of Chemical Engineering,
+          University of Rochester, Rochester, NY, USA"],"affiliations":[{"raw_affiliation_string":"Department
+          of Chemical Engineering, University of Rochester, Rochester, NY, USA","institution_ids":["https://openalex.org/I5388228"]}]},{"author_position":"last","author":{"id":"https://openalex.org/A5028051805","display_name":"Philippe
+          Schwaller","orcid":"https://orcid.org/0000-0003-3046-6576"},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
+          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Philippe
+          Schwaller","raw_affiliation_strings":["National Centre of Competence in Research
+          (NCCR) Catalysis, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"National
+          Centre of Competence in Research (NCCR) Catalysis, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]}],"institution_assertions":[],"countries_distinct_count":2,"institutions_distinct_count":3,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":{"value":9750,"currency":"EUR","value_usd":11690,"provenance":"doaj"},"apc_paid":{"value":9750,"currency":"EUR","value_usd":11690,"provenance":"doaj"},"fwci":49.07,"has_fulltext":true,"fulltext_origin":"pdf","cited_by_count":52,"citation_normalized_percentile":{"value":0.999965,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":99,"max":100},"biblio":{"volume":"6","issue":"5","first_page":"525","last_page":"535"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11948","display_name":"Accelerating
+          Materials Innovation through Informatics","score":0.9998,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
+          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}},"topics":[{"id":"https://openalex.org/T11948","display_name":"Accelerating
+          Materials Innovation through Informatics","score":0.9998,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
+          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}},{"id":"https://openalex.org/T10028","display_name":"Natural Language
+          Processing","score":0.9888,"subfield":{"id":"https://openalex.org/subfields/1702","display_name":"Artificial
+          Intelligence"},"field":{"id":"https://openalex.org/fields/17","display_name":"Computer
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}},{"id":"https://openalex.org/T10260","display_name":"Empirical
+          Studies in Software Engineering","score":0.9806,"subfield":{"id":"https://openalex.org/subfields/1710","display_name":"Information
+          Systems"},"field":{"id":"https://openalex.org/fields/17","display_name":"Computer
+          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/limiting","display_name":"Limiting","score":0.75848544},{"id":"https://openalex.org/keywords/computational-chemistry","display_name":"Computational
+          Chemistry","score":0.503028}],"concepts":[{"id":"https://openalex.org/C188198153","wikidata":"https://www.wikidata.org/wiki/Q1613840","display_name":"Limiting","level":2,"score":0.75848544},{"id":"https://openalex.org/C174348530","wikidata":"https://www.wikidata.org/wiki/Q188635","display_name":"Bridging
+          (networking)","level":2,"score":0.7373165},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
+          science","level":0,"score":0.6407423},{"id":"https://openalex.org/C177264268","wikidata":"https://www.wikidata.org/wiki/Q1514741","display_name":"Set
+          (abstract data type)","level":2,"score":0.44978535},{"id":"https://openalex.org/C74187038","wikidata":"https://www.wikidata.org/wiki/Q1418791","display_name":"Drug
+          discovery","level":2,"score":0.41493544},{"id":"https://openalex.org/C171250308","wikidata":"https://www.wikidata.org/wiki/Q11468","display_name":"Nanotechnology","level":1,"score":0.34248286},{"id":"https://openalex.org/C2522767166","wikidata":"https://www.wikidata.org/wiki/Q2374463","display_name":"Data
+          science","level":1,"score":0.3251446},{"id":"https://openalex.org/C185592680","wikidata":"https://www.wikidata.org/wiki/Q2329","display_name":"Chemistry","level":0,"score":0.3200932},{"id":"https://openalex.org/C127413603","wikidata":"https://www.wikidata.org/wiki/Q11023","display_name":"Engineering","level":0,"score":0.16270861},{"id":"https://openalex.org/C199360897","wikidata":"https://www.wikidata.org/wiki/Q9143","display_name":"Programming
+          language","level":1,"score":0.108196944},{"id":"https://openalex.org/C78519656","wikidata":"https://www.wikidata.org/wiki/Q101333","display_name":"Mechanical
+          engineering","level":1,"score":0.0},{"id":"https://openalex.org/C31258907","wikidata":"https://www.wikidata.org/wiki/Q1301371","display_name":"Computer
+          network","level":1,"score":0.0},{"id":"https://openalex.org/C55493867","wikidata":"https://www.wikidata.org/wiki/Q7094","display_name":"Biochemistry","level":1,"score":0.0},{"id":"https://openalex.org/C192562407","wikidata":"https://www.wikidata.org/wiki/Q228736","display_name":"Materials
+          science","level":0,"score":0.0}],"mesh":[],"locations_count":3,"locations":[{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
+          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
+          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
+          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},{"is_oa":true,"landing_page_url":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","pdf_url":null,"source":{"id":"https://openalex.org/S2764455111","display_name":"PubMed
+          Central","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I1299303238","host_organization_name":"National
+          Institutes of Health","host_organization_lineage":["https://openalex.org/I1299303238"],"host_organization_lineage_names":["National
+          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":"publishedVersion","is_accepted":true,"is_published":true},{"is_oa":false,"landing_page_url":"https://pubmed.ncbi.nlm.nih.gov/38799228","pdf_url":null,"source":{"id":"https://openalex.org/S4306525036","display_name":"PubMed","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I1299303238","host_organization_name":"National
+          Institutes of Health","host_organization_lineage":["https://openalex.org/I1299303238"],"host_organization_lineage_names":["National
+          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
+          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
+          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
+          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},"sustainable_development_goals":[{"id":"https://metadata.un.org/sdg/4","score":0.49,"display_name":"Quality
+          education"}],"grants":[{"funder":"https://openalex.org/F4320306076","funder_display_name":"National
+          Science Foundation","award_id":"1751471"},{"funder":"https://openalex.org/F4320320924","funder_display_name":"Schweizerischer
+          Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","award_id":"180544"}],"datasets":[],"versions":[],"referenced_works_count":57,"referenced_works":["https://openalex.org/W1964666522","https://openalex.org/W1972905466","https://openalex.org/W1988037271","https://openalex.org/W1995396482","https://openalex.org/W2034354062","https://openalex.org/W2037825667","https://openalex.org/W2119396661","https://openalex.org/W2126363023","https://openalex.org/W2189911347","https://openalex.org/W2324964582","https://openalex.org/W2478294658","https://openalex.org/W2529996553","https://openalex.org/W2594183968","https://openalex.org/W2606363443","https://openalex.org/W2747592475","https://openalex.org/W2903262661","https://openalex.org/W2966357564","https://openalex.org/W2968071222","https://openalex.org/W2970764640","https://openalex.org/W2987091515","https://openalex.org/W2998702515","https://openalex.org/W3010145447","https://openalex.org/W3014089210","https://openalex.org/W3023658436","https://openalex.org/W3088999551","https://openalex.org/W3094640617","https://openalex.org/W3094686696","https://openalex.org/W3097758405","https://openalex.org/W3098269892","https://openalex.org/W3101155908","https://openalex.org/W3103092523","https://openalex.org/W3121024033","https://openalex.org/W3123901912","https://openalex.org/W3128474010","https://openalex.org/W3129039627","https://openalex.org/W3157679602","https://openalex.org/W3179394107","https://openalex.org/W3198449425","https://openalex.org/W4220681836","https://openalex.org/W4220715560","https://openalex.org/W4220747243","https://openalex.org/W4225876201","https://openalex.org/W4226159083","https://openalex.org/W4281669078","https://openalex.org/W4283034548","https://openalex.org/W4285093994","https://openalex.org/W4306845856","https://openalex.org/W4310603653","https://openalex.org/W4319996831","https://openalex.org/W4327564965","https://openalex.org/W4365794116","https://openalex.org/W4385571219","https://openalex.org/W4387567938","https://openalex.org/W4389519254","https://openalex.org/W4389520103","https://openalex.org/W4389991792","https://openalex.org/W4391561379"],"related_works":["https://openalex.org/W4388870064","https://openalex.org/W4248308508","https://openalex.org/W4235186151","https://openalex.org/W2667588871","https://openalex.org/W2272354214","https://openalex.org/W2210139803","https://openalex.org/W2084768720","https://openalex.org/W2056057048","https://openalex.org/W2054685365","https://openalex.org/W2043010663"],"abstract_inverted_index":{"Abstract":[0],"Large":[1],"language":[2],"models":[3,19],"(LLMs)":[4],"have":[5],"shown":[6],"strong":[7],"performance":[8,67],"in":[9,30,68,108],"tasks":[10,43],"across":[11,44],"domains":[12],"but":[13,128],"struggle":[14],"with":[15],"chemistry-related":[16],"problems.":[17],"These":[18],"also":[20,129],"lack":[21],"access":[22],"to":[23,41],"external":[24],"knowledge":[25],"sources,":[26],"limiting":[27],"their":[28],"usefulness":[29],"scientific":[31,131],"applications.":[32],"We":[33],"introduce":[34],"ChemCrow,":[35],"an":[36,83],"LLM":[37,66,101],"chemistry":[38],"agent":[39,75],"designed":[40],"accomplish":[42],"organic":[45],"synthesis,":[46],"drug":[47],"discovery":[48,92],"and":[49,57,70,78,86,89,102,123,139],"materials":[50],"design.":[51],"By":[52],"integrating":[53],"18":[54],"expert-designed":[55],"tools":[56],"using":[58],"GPT-4":[59],"as":[60],"the":[61,65,80,91,135],"LLM,":[62],"ChemCrow":[63],"augments":[64],"chemistry,":[69],"new":[71],"capabilities":[72],"emerge.":[73],"Our":[74,97,116],"autonomously":[76],"planned":[77],"executed":[79],"syntheses":[81],"of":[82,93,113],"insect":[84],"repellent":[85],"three":[87],"organocatalysts":[88],"guided":[90],"a":[94,110],"novel":[95],"chromophore.":[96],"evaluation,":[98],"including":[99],"both":[100],"expert":[103,121],"assessments,":[104],"demonstrates":[105],"ChemCrow\u2019s":[106],"effectiveness":[107],"automating":[109],"diverse":[111],"set":[112],"chemical":[114],"tasks.":[115],"work":[117],"not":[118],"only":[119],"aids":[120],"chemists":[122],"lowers":[124],"barriers":[125],"for":[126],"non-experts":[127],"fosters":[130],"advancement":[132],"by":[133],"bridging":[134],"gap":[136],"between":[137],"experimental":[138],"computational":[140],"chemistry.":[141]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4396723768","counts_by_year":[{"year":2024,"cited_by_count":46},{"year":2023,"cited_by_count":3}],"updated_date":"2024-11-24T08:11:26.056676","created_date":"2024-05-09"}],"group_by":[]}
+
+          '
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Authorization,
+            Cache-Control
+        Access-Control-Allow-Methods:
+          - POST, GET, OPTIONS, PUT, DELETE, PATCH
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - Authorization, Cache-Control
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Length:
+          - "5987"
+        Content-Security-Policy:
+          - default-src 'self'; object-src 'none'
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:32 GMT
+        Nel:
+          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        Report-To:
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168192&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=WzrrO0uMYZrwdXF6nTj390M%2F%2BiRzDIOCZJwZqsf96HM%3D"}]}'
+        Reporting-Endpoints:
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168192&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=WzrrO0uMYZrwdXF6nTj390M%2F%2BiRzDIOCZJwZqsf96HM%3D
+        Server:
+          - gunicorn
+        Strict-Transport-Security:
+          - max-age=31556926; includeSubDomains
+        Vary:
+          - Accept-Encoding
+        Via:
+          - 1.1 vegur
+        X-Api-Pool:
+          - common
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Xss-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.unpaywall.org/v2/search?query=Augmenting%20large%20language%20models%20with%20chemistry%20tools&email=example@papercrow.ai
     response:
       body:
         string:
-          '{"elapsed_seconds":0.228,"results":[{"response":{"best_oa_location":{"endpoint_id":null,"evidence":"open
-          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-10-19T14:56:04.324106","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"data_standard":2,"doi":"10.1038/s42256-024-00832-8","doi_url":"https://doi.org/10.1038/s42256-024-00832-8","first_oa_location":{"endpoint_id":null,"evidence":"open
-          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-10-19T14:56:04.324106","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"genre":"journal-article","has_repository_copy":true,"is_oa":true,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"2522-5839","journal_issns":"2522-5839","journal_name":"Nature
+          '{"elapsed_seconds":0.239,"results":[{"response":{"best_oa_location":{"endpoint_id":null,"evidence":"open
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-11-21T12:13:19.078817","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"data_standard":2,"doi":"10.1038/s42256-024-00832-8","doi_url":"https://doi.org/10.1038/s42256-024-00832-8","first_oa_location":{"endpoint_id":null,"evidence":"open
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-11-21T12:13:19.078817","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},"genre":"journal-article","has_repository_copy":true,"is_oa":true,"is_paratext":false,"journal_is_in_doaj":false,"journal_is_oa":false,"journal_issn_l":"2522-5839","journal_issns":"2522-5839","journal_name":"Nature
           Machine Intelligence","oa_locations":[{"endpoint_id":null,"evidence":"open
-          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-10-19T14:56:04.324106","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},{"endpoint_id":null,"evidence":"oa
-          repository (via pmcid lookup)","host_type":"repository","is_best":false,"license":null,"oa_date":null,"pmh_id":null,"repository_institution":null,"updated":"2024-10-19T14:56:04.324216","url":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_landing_page":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_pdf":null,"version":"publishedVersion"}],"oa_locations_embargoed":[],"oa_status":"hybrid","published_date":"2024-05-08","publisher":"Springer
+          (via crossref license)","host_type":"publisher","is_best":true,"license":"cc-by","oa_date":"2024-05-08","pmh_id":null,"repository_institution":null,"updated":"2024-11-21T12:13:19.078817","url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","url_for_landing_page":"https://doi.org/10.1038/s42256-024-00832-8","url_for_pdf":"https://www.nature.com/articles/s42256-024-00832-8.pdf","version":"publishedVersion"},{"endpoint_id":null,"evidence":"oa
+          repository (via pmcid lookup)","host_type":"repository","is_best":false,"license":null,"oa_date":null,"pmh_id":null,"repository_institution":null,"updated":"2024-11-21T12:13:19.078975","url":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_landing_page":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","url_for_pdf":null,"version":"publishedVersion"}],"oa_locations_embargoed":[],"oa_status":"hybrid","published_date":"2024-05-08","publisher":"Springer
           Science and Business Media LLC","title":"Augmenting large language models
           with chemistry tools","updated":"2024-05-09T06:24:40.646053","year":2024,"z_authors":[{"family":"M.
           Bran","given":"Andres","sequence":"first"},{"family":"Cox","given":"Sam","sequence":"additional"},{"ORCID":"http://orcid.org/0000-0003-0310-0851","authenticated-orcid":false,"family":"Schilter","given":"Oliver","sequence":"additional"},{"family":"Baldassari","given":"Carlo","sequence":"additional"},{"ORCID":"http://orcid.org/0000-0002-6647-3965","authenticated-orcid":false,"family":"White","given":"Andrew
@@ -1578,17 +1754,17 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "39651"
+          - "39650"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:32 GMT
         Nel:
           - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
         Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D"}]}'
+          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1733168192&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=LqmqL4E3lYtXOy34G1aDK6FyQcvHdt1Jyr1ojaUWRDc%3D"}]}'
         Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=%2F052tL2z%2BdNzdHoagC3cvjHVq4tmR4dL6T%2F3i5Ta%2FHY%3D
+          - heroku-nel=https://nel.heroku.com/reports?ts=1733168192&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&s=LqmqL4E3lYtXOy34G1aDK6FyQcvHdt1Jyr1ojaUWRDc%3D
         Server:
           - gunicorn
         Vary:
@@ -1602,11 +1778,74 @@ interactions:
       body: null
       headers: {}
       method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
+    response:
+      body:
+        string:
+          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
+          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
+          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
+          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
+          "title": "Augmenting large language models with chemistry tools", "venue":
+          "Nat. Mac. Intell.", "year": 2023, "citationCount": 230, "influentialCitationCount":
+          12, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
+          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
+          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
+          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
+          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
+          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
+          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
+          {Augmenting large language models with chemistry tools},\n volume = {6},\n
+          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
+          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
+          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
+          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
+          "name": "P. Schwaller"}], "matchScore": 176.67178}]}
+
+          '
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1551"
+        Content-Type:
+          - application/json
+        Date:
+          - Mon, 02 Dec 2024 19:36:32 GMT
+        Via:
+          - 1.1 29474fd3a24c6552dfdc04ee03c03aa2.cloudfront.net (CloudFront)
+        X-Amz-Cf-Id:
+          - Cq6VVVw4HEYTOo0LupLQHHcU7OQuxt8d8DeniFdB7bPHbBQdTExPgw==
+        X-Amz-Cf-Pop:
+          - SFO53-P7
+        X-Cache:
+          - Miss from cloudfront
+        x-amz-apigw-id:
+          - CLbaGHmVPHcEBDw=
+        x-amzn-Remapped-Connection:
+          - keep-alive
+        x-amzn-Remapped-Content-Length:
+          - "1551"
+        x-amzn-Remapped-Date:
+          - Mon, 02 Dec 2024 19:36:32 GMT
+        x-amzn-Remapped-Server:
+          - gunicorn
+        x-amzn-RequestId:
+          - 3ee9e3a2-88d4-45db-911c-0e3f3e5977e0
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers: {}
+      method: GET
       uri: https://api.crossref.org/works?mailto=example@papercrow.ai&query.title=Augmenting+large+language+models+with+chemistry+tools&rows=1
     response:
       body:
         string:
-          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2335032,"items":[{"indexed":{"date-parts":[[2024,9,20]],"date-time":"2024-09-20T17:08:43Z","timestamp":1726852123984},"reference-count":103,"publisher":"Springer
+          '{"status":"ok","message-type":"work-list","message-version":"1.0.0","message":{"facets":{},"total-results":2349040,"items":[{"indexed":{"date-parts":[[2024,11,19]],"date-time":"2024-11-19T19:11:02Z","timestamp":1732043462673},"reference-count":103,"publisher":"Springer
           Science and Business Media LLC","issue":"5","license":[{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"tdm","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"},{"start":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T00:00:00Z","timestamp":1715126400000},"content-version":"vor","delay-in-days":0,"URL":"https:\/\/creativecommons.org\/licenses\/by\/4.0"}],"funder":[{"DOI":"10.13039\/501100001711","name":"Schweizerischer
           Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","doi-asserted-by":"publisher","award":["180544","180544","180544"],"id":[{"id":"10.13039\/501100001711","id-type":"DOI","asserted-by":"publisher"}]},{"DOI":"10.13039\/100000001","name":"National
           Science Foundation","doi-asserted-by":"publisher","award":["1751471","1751471"],"id":[{"id":"10.13039\/100000001","id-type":"DOI","asserted-by":"publisher"}]}],"content-domain":{"domain":["link.springer.com"],"crossmark-restriction":false},"short-container-title":["Nat
@@ -1623,7 +1862,7 @@ interactions:
           both LLM and expert assessments, demonstrates ChemCrow\u2019s effectiveness
           in automating a diverse set of chemical tasks. Our work not only aids expert
           chemists and lowers barriers for non-experts but also fosters scientific advancement
-          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":21,"title":["Augmenting
+          by bridging the gap between experimental and computational chemistry.<\/jats:p>","DOI":"10.1038\/s42256-024-00832-8","type":"journal-article","created":{"date-parts":[[2024,5,8]],"date-time":"2024-05-08T10:03:31Z","timestamp":1715162611000},"page":"525-535","update-policy":"http:\/\/dx.doi.org\/10.1007\/springer_crossmark_policy","source":"Crossref","is-referenced-by-count":36,"title":["Augmenting
           large language models with chemistry tools"],"prefix":"10.1038","volume":"6","author":[{"given":"Andres","family":"M.
           Bran","sequence":"first","affiliation":[]},{"given":"Sam","family":"Cox","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-0310-0851","authenticated-orcid":false,"given":"Oliver","family":"Schilter","sequence":"additional","affiliation":[]},{"given":"Carlo","family":"Baldassari","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0002-6647-3965","authenticated-orcid":false,"given":"Andrew
           D.","family":"White","sequence":"additional","affiliation":[]},{"ORCID":"http:\/\/orcid.org\/0000-0003-3046-6576","authenticated-orcid":false,"given":"Philippe","family":"Schwaller","sequence":"additional","affiliation":[]}],"member":"297","published-online":{"date-parts":[[2024,5,8]]},"reference":[{"key":"832_CR1","unstructured":"Devlin,
@@ -1912,7 +2151,7 @@ interactions:
           (2024).","DOI":"10.5281\/zenodo.10884645"},{"key":"832_CR103","doi-asserted-by":"publisher","unstructured":"Bran,
           A., Cox, S., White, A. & Schwaller, P. ur-whitelab\/chemcrow-public: v0.3.24.
           Zenodo https:\/\/doi.org\/10.5281\/zenodo.10884639 (2024).","DOI":"10.5281\/zenodo.10884639"}],"container-title":["Nature
-          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.40466,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
+          Machine Intelligence"],"language":"en","link":[{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8","content-type":"text\/html","content-version":"vor","intended-application":"text-mining"},{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8.pdf","content-type":"application\/pdf","content-version":"vor","intended-application":"similarity-checking"}],"deposited":{"date-parts":[[2024,5,23]],"date-time":"2024-05-23T23:03:31Z","timestamp":1716505411000},"score":46.434135,"resource":{"primary":{"URL":"https:\/\/www.nature.com\/articles\/s42256-024-00832-8"}},"issued":{"date-parts":[[2024,5,8]]},"references-count":103,"journal-issue":{"issue":"5","published-online":{"date-parts":[[2024,5]]}},"alternative-id":["832"],"URL":"http:\/\/dx.doi.org\/10.1038\/s42256-024-00832-8","ISSN":["2522-5839"],"issn-type":[{"value":"2522-5839","type":"electronic"}],"published":{"date-parts":[[2024,5,8]]},"assertion":[{"value":"13
           September 2023","order":1,"name":"received","label":"Received","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"27 March 2024","order":2,"name":"accepted","label":"Accepted","group":{"name":"ArticleHistory","label":"Article
           History"}},{"value":"8 May 2024","order":3,"name":"first_online","label":"First
@@ -1933,11 +2172,11 @@ interactions:
         Content-Encoding:
           - gzip
         Content-Length:
-          - "10574"
+          - "10576"
         Content-Type:
           - application/json
         Date:
-          - Fri, 08 Nov 2024 23:17:17 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Vary:
@@ -1954,182 +2193,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.openalex.org/works?filter=title.search:Augmenting+large+language+models+with+chemistry+tools
-    response:
-      body:
-        string:
-          '{"meta":{"count":2,"db_response_time_ms":273,"page":1,"per_page":25,"groups_count":null},"results":[{"id":"https://openalex.org/W4365597205","doi":"https://doi.org/10.48550/arxiv.2304.05376","title":"ChemCrow:
-          Augmenting large-language models with chemistry tools","display_name":"ChemCrow:
-          Augmenting large-language models with chemistry tools","relevance_score":1116.1659,"publication_year":2023,"publication_date":"2023-01-01","ids":{"openalex":"https://openalex.org/W4365597205","doi":"https://doi.org/10.48550/arxiv.2304.05376"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
-          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
-          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
-          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"type":"preprint","type_crossref":"posted-content","indexed_in":["arxiv","datacite"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://arxiv.org/abs/2304.05376","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5055903035","display_name":"Andres
-          M Bran","orcid":"https://orcid.org/0000-0002-4432-3667"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Bran,
-          Andres M","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"middle","author":{"id":"https://openalex.org/A5101971357","display_name":"Sam
-          Cox","orcid":"https://orcid.org/0000-0002-4441-9327"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Cox,
-          Sam","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"middle","author":{"id":"https://openalex.org/A5103115676","display_name":"Andrew
-          Dickson White","orcid":"https://orcid.org/0000-0002-6647-3965"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"White,
-          Andrew D","raw_affiliation_strings":[],"affiliations":[]},{"author_position":"last","author":{"id":"https://openalex.org/A5028051805","display_name":"Philippe
-          Schwaller","orcid":"https://orcid.org/0000-0003-3046-6576"},"institutions":[],"countries":[],"is_corresponding":false,"raw_author_name":"Schwaller,
-          Philippe","raw_affiliation_strings":[],"affiliations":[]}],"institution_assertions":[],"countries_distinct_count":0,"institutions_distinct_count":0,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":null,"has_fulltext":false,"cited_by_count":81,"citation_normalized_percentile":{"value":0.999852,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":99,"max":100},"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11948","display_name":"Accelerating
-          Materials Innovation through Informatics","score":0.9995,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
-          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}},"topics":[{"id":"https://openalex.org/T11948","display_name":"Accelerating
-          Materials Innovation through Informatics","score":0.9995,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
-          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/limiting","display_name":"Limiting","score":0.706134},{"id":"https://openalex.org/keywords/computational-chemistry","display_name":"Computational
-          Chemistry","score":0.518176}],"concepts":[{"id":"https://openalex.org/C188198153","wikidata":"https://www.wikidata.org/wiki/Q1613840","display_name":"Limiting","level":2,"score":0.706134},{"id":"https://openalex.org/C174348530","wikidata":"https://www.wikidata.org/wiki/Q188635","display_name":"Bridging
-          (networking)","level":2,"score":0.67967176},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
-          science","level":0,"score":0.6176928},{"id":"https://openalex.org/C177264268","wikidata":"https://www.wikidata.org/wiki/Q1514741","display_name":"Set
-          (abstract data type)","level":2,"score":0.47735333},{"id":"https://openalex.org/C74187038","wikidata":"https://www.wikidata.org/wiki/Q1418791","display_name":"Drug
-          discovery","level":2,"score":0.4398606},{"id":"https://openalex.org/C185592680","wikidata":"https://www.wikidata.org/wiki/Q2329","display_name":"Chemistry","level":0,"score":0.3678416},{"id":"https://openalex.org/C2522767166","wikidata":"https://www.wikidata.org/wiki/Q2374463","display_name":"Data
-          science","level":1,"score":0.34021586},{"id":"https://openalex.org/C171250308","wikidata":"https://www.wikidata.org/wiki/Q11468","display_name":"Nanotechnology","level":1,"score":0.3370079},{"id":"https://openalex.org/C154945302","wikidata":"https://www.wikidata.org/wiki/Q11660","display_name":"Artificial
-          intelligence","level":1,"score":0.33441877},{"id":"https://openalex.org/C127413603","wikidata":"https://www.wikidata.org/wiki/Q11023","display_name":"Engineering","level":0,"score":0.19605169},{"id":"https://openalex.org/C199360897","wikidata":"https://www.wikidata.org/wiki/Q9143","display_name":"Programming
-          language","level":1,"score":0.13234842},{"id":"https://openalex.org/C78519656","wikidata":"https://www.wikidata.org/wiki/Q101333","display_name":"Mechanical
-          engineering","level":1,"score":0.0},{"id":"https://openalex.org/C31258907","wikidata":"https://www.wikidata.org/wiki/Q1301371","display_name":"Computer
-          network","level":1,"score":0.0},{"id":"https://openalex.org/C55493867","wikidata":"https://www.wikidata.org/wiki/Q7094","display_name":"Biochemistry","level":1,"score":0.0},{"id":"https://openalex.org/C192562407","wikidata":"https://www.wikidata.org/wiki/Q228736","display_name":"Materials
-          science","level":0,"score":0.0}],"mesh":[],"locations_count":2,"locations":[{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
-          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
-          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
-          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},{"is_oa":false,"landing_page_url":"https://api.datacite.org/dois/10.48550/arxiv.2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4393179698","display_name":"DataCite
-          API","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I4210145204","host_organization_name":"DataCite","host_organization_lineage":["https://openalex.org/I4210145204"],"host_organization_lineage_names":["DataCite"],"type":"metadata"},"license":null,"license_id":null,"version":null}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://arxiv.org/abs/2304.05376","pdf_url":null,"source":{"id":"https://openalex.org/S4306400194","display_name":"arXiv
-          (Cornell University)","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I205783295","host_organization_name":"Cornell
-          University","host_organization_lineage":["https://openalex.org/I205783295"],"host_organization_lineage_names":["Cornell
-          University"],"type":"repository"},"license":"other-oa","license_id":"https://openalex.org/licenses/other-oa","version":"submittedVersion","is_accepted":false,"is_published":false},"sustainable_development_goals":[],"grants":[],"datasets":[],"versions":[],"referenced_works_count":0,"referenced_works":[],"related_works":["https://openalex.org/W4388870064","https://openalex.org/W4248308508","https://openalex.org/W4235186151","https://openalex.org/W2667588871","https://openalex.org/W2272354214","https://openalex.org/W2210139803","https://openalex.org/W2084768720","https://openalex.org/W2056057048","https://openalex.org/W2054685365","https://openalex.org/W2043010663"],"abstract_inverted_index":{"Over":[0],"the":[1,92,107,117,179],"last":[2],"decades,":[3],"excellent":[4],"computational":[5,184],"chemistry":[6,71],"tools":[7],"have":[8,35],"been":[9],"developed.":[10],"Integrating":[11],"them":[12],"into":[13],"a":[14,120,136],"single":[15],"platform":[16],"with":[17,45],"enhanced":[18],"accessibility":[19],"could":[20],"help":[21],"reaching":[22],"their":[23,58],"full":[24],"potential":[25],"by":[26,177],"overcoming":[27],"steep":[28],"learning":[29],"curves.":[30],"Recently,":[31],"large-language":[32],"models":[33,50],"(LLMs)":[34],"shown":[36],"strong":[37],"performance":[38,94],"in":[39,60,95,134],"tasks":[40,76],"across":[41,77],"domains,":[42],"but":[43,172],"struggle":[44],"chemistry-related":[46],"problems.":[47],"Moreover,":[48],"these":[49],"lack":[51],"access":[52],"to":[53,74],"external":[54],"knowledge":[55],"sources,":[56],"limiting":[57],"usefulness":[59],"scientific":[61,175],"applications.":[62],"In":[63],"this":[64],"study,":[65],"we":[66,143],"introduce":[67],"ChemCrow,":[68],"an":[69,110,148],"LLM":[70,93,127],"agent":[72,102],"designed":[73],"accomplish":[75],"organic":[78],"synthesis,":[79],"drug":[80],"discovery,":[81],"and":[82,97,105,115,128,157,167,183],"materials":[83],"design.":[84],"By":[85],"integrating":[86],"18":[87],"expert-designed":[88],"tools,":[89],"ChemCrow":[90],"augments":[91],"chemistry,":[96],"new":[98],"capabilities":[99],"emerge.":[100],"Our":[101,123,160],"autonomously":[103],"planned":[104],"executed":[106],"syntheses":[108],"of":[109,119,139],"insect":[111],"repellent,":[112],"three":[113],"organocatalysts,":[114],"guided":[116],"discovery":[118],"novel":[121],"chromophore.":[122],"evaluation,":[124],"including":[125],"both":[126],"expert":[129,165],"assessments,":[130],"demonstrates":[131],"ChemCrow''s":[132],"effectiveness":[133],"automating":[135],"diverse":[137],"set":[138],"chemical":[140],"tasks.":[141],"Surprisingly,":[142],"find":[144],"that":[145],"GPT-4":[146,155],"as":[147],"evaluator":[149],"cannot":[150],"distinguish":[151],"between":[152,181],"clearly":[153],"wrong":[154],"completions":[156],"Chemcrow''s":[158],"performance.":[159],"work":[161],"not":[162],"only":[163],"aids":[164],"chemists":[166],"lowers":[168],"barriers":[169],"for":[170],"non-experts,":[171],"also":[173],"fosters":[174],"advancement":[176],"bridging":[178],"gap":[180],"experimental":[182],"chemistry.":[185]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4365597205","counts_by_year":[{"year":2024,"cited_by_count":46},{"year":2023,"cited_by_count":32}],"updated_date":"2024-11-07T22:02:28.117373","created_date":"2023-04-15"},{"id":"https://openalex.org/W4396723768","doi":"https://doi.org/10.1038/s42256-024-00832-8","title":"Augmenting
-          large language models with chemistry tools","display_name":"Augmenting large
-          language models with chemistry tools","relevance_score":927.8963,"publication_year":2024,"publication_date":"2024-05-08","ids":{"openalex":"https://openalex.org/W4396723768","doi":"https://doi.org/10.1038/s42256-024-00832-8","pmid":"https://pubmed.ncbi.nlm.nih.gov/38799228"},"language":"en","primary_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
-          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
-          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
-          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},"type":"article","type_crossref":"journal-article","indexed_in":["crossref","pubmed"],"open_access":{"is_oa":true,"oa_status":"hybrid","oa_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","any_repository_has_fulltext":true},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5031480183","display_name":"Andres
-          M. Bran","orcid":null},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
-          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Andres
-          M. Bran","raw_affiliation_strings":["Laboratory of Artificial Chemical Intelligence
-          (LIAC), ISIC, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"Laboratory
-          of Artificial Chemical Intelligence (LIAC), ISIC, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5101971357","display_name":"Sam
-          Cox","orcid":"https://orcid.org/0000-0002-4441-9327"},"institutions":[{"id":"https://openalex.org/I5388228","display_name":"University
-          of Rochester","ror":"https://ror.org/022kthw22","country_code":"US","type":"education","lineage":["https://openalex.org/I5388228"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Sam
-          Cox","raw_affiliation_strings":["Department of Chemical Engineering, University
-          of Rochester, Rochester, NY, USA"],"affiliations":[{"raw_affiliation_string":"Department
-          of Chemical Engineering, University of Rochester, Rochester, NY, USA","institution_ids":["https://openalex.org/I5388228"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5075449407","display_name":"Oliver
-          Schilter","orcid":"https://orcid.org/0000-0003-0310-0851"},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
-          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Oliver
-          Schilter","raw_affiliation_strings":["Laboratory of Artificial Chemical Intelligence
-          (LIAC), ISIC, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"Laboratory
-          of Artificial Chemical Intelligence (LIAC), ISIC, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5092630105","display_name":"Carlo
-          Baldassari","orcid":"https://orcid.org/0009-0008-1199-7113"},"institutions":[{"id":"https://openalex.org/I4210126328","display_name":"IBM
-          Research - Zurich","ror":"https://ror.org/02js37d36","country_code":"CH","type":"facility","lineage":["https://openalex.org/I1341412227","https://openalex.org/I4210114115","https://openalex.org/I4210126328"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Carlo
-          Baldassari","raw_affiliation_strings":["Accelerated Discovery, IBM Research
-          \u2013 Europe, R\u00fcschlikon, Switzerland"],"affiliations":[{"raw_affiliation_string":"Accelerated
-          Discovery, IBM Research \u2013 Europe, R\u00fcschlikon, Switzerland","institution_ids":["https://openalex.org/I4210126328"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5103115676","display_name":"Andrew
-          Dickson White","orcid":"https://orcid.org/0000-0002-6647-3965"},"institutions":[{"id":"https://openalex.org/I5388228","display_name":"University
-          of Rochester","ror":"https://ror.org/022kthw22","country_code":"US","type":"education","lineage":["https://openalex.org/I5388228"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Andrew
-          D. White","raw_affiliation_strings":["Department of Chemical Engineering,
-          University of Rochester, Rochester, NY, USA"],"affiliations":[{"raw_affiliation_string":"Department
-          of Chemical Engineering, University of Rochester, Rochester, NY, USA","institution_ids":["https://openalex.org/I5388228"]}]},{"author_position":"last","author":{"id":"https://openalex.org/A5028051805","display_name":"Philippe
-          Schwaller","orcid":"https://orcid.org/0000-0003-3046-6576"},"institutions":[{"id":"https://openalex.org/I5124864","display_name":"\u00c9cole
-          Polytechnique F\u00e9d\u00e9rale de Lausanne","ror":"https://ror.org/02s376052","country_code":"CH","type":"education","lineage":["https://openalex.org/I2799323385","https://openalex.org/I5124864"]}],"countries":["CH"],"is_corresponding":false,"raw_author_name":"Philippe
-          Schwaller","raw_affiliation_strings":["National Centre of Competence in Research
-          (NCCR) Catalysis, EPFL, Lausanne, Switzerland"],"affiliations":[{"raw_affiliation_string":"National
-          Centre of Competence in Research (NCCR) Catalysis, EPFL, Lausanne, Switzerland","institution_ids":["https://openalex.org/I5124864"]}]}],"institution_assertions":[],"countries_distinct_count":2,"institutions_distinct_count":3,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":{"value":9750,"currency":"EUR","value_usd":11690,"provenance":"doaj"},"apc_paid":{"value":9750,"currency":"EUR","value_usd":11690,"provenance":"doaj"},"fwci":12.752,"has_fulltext":true,"fulltext_origin":"pdf","cited_by_count":50,"citation_normalized_percentile":{"value":0.999956,"is_in_top_1_percent":true,"is_in_top_10_percent":true},"cited_by_percentile_year":{"min":99,"max":100},"biblio":{"volume":"6","issue":"5","first_page":"525","last_page":"535"},"is_retracted":false,"is_paratext":false,"primary_topic":{"id":"https://openalex.org/T11948","display_name":"Accelerating
-          Materials Innovation through Informatics","score":0.9998,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
-          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}},"topics":[{"id":"https://openalex.org/T11948","display_name":"Accelerating
-          Materials Innovation through Informatics","score":0.9998,"subfield":{"id":"https://openalex.org/subfields/2505","display_name":"Materials
-          Chemistry"},"field":{"id":"https://openalex.org/fields/25","display_name":"Materials
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}},{"id":"https://openalex.org/T10028","display_name":"Natural Language
-          Processing","score":0.9888,"subfield":{"id":"https://openalex.org/subfields/1702","display_name":"Artificial
-          Intelligence"},"field":{"id":"https://openalex.org/fields/17","display_name":"Computer
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}},{"id":"https://openalex.org/T10260","display_name":"Empirical
-          Studies in Software Engineering","score":0.9806,"subfield":{"id":"https://openalex.org/subfields/1710","display_name":"Information
-          Systems"},"field":{"id":"https://openalex.org/fields/17","display_name":"Computer
-          Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
-          Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/limiting","display_name":"Limiting","score":0.75848544},{"id":"https://openalex.org/keywords/computational-chemistry","display_name":"Computational
-          Chemistry","score":0.503028}],"concepts":[{"id":"https://openalex.org/C188198153","wikidata":"https://www.wikidata.org/wiki/Q1613840","display_name":"Limiting","level":2,"score":0.75848544},{"id":"https://openalex.org/C174348530","wikidata":"https://www.wikidata.org/wiki/Q188635","display_name":"Bridging
-          (networking)","level":2,"score":0.7373165},{"id":"https://openalex.org/C41008148","wikidata":"https://www.wikidata.org/wiki/Q21198","display_name":"Computer
-          science","level":0,"score":0.6407423},{"id":"https://openalex.org/C177264268","wikidata":"https://www.wikidata.org/wiki/Q1514741","display_name":"Set
-          (abstract data type)","level":2,"score":0.44978535},{"id":"https://openalex.org/C74187038","wikidata":"https://www.wikidata.org/wiki/Q1418791","display_name":"Drug
-          discovery","level":2,"score":0.41493544},{"id":"https://openalex.org/C171250308","wikidata":"https://www.wikidata.org/wiki/Q11468","display_name":"Nanotechnology","level":1,"score":0.34248286},{"id":"https://openalex.org/C2522767166","wikidata":"https://www.wikidata.org/wiki/Q2374463","display_name":"Data
-          science","level":1,"score":0.3251446},{"id":"https://openalex.org/C185592680","wikidata":"https://www.wikidata.org/wiki/Q2329","display_name":"Chemistry","level":0,"score":0.3200932},{"id":"https://openalex.org/C127413603","wikidata":"https://www.wikidata.org/wiki/Q11023","display_name":"Engineering","level":0,"score":0.16270861},{"id":"https://openalex.org/C199360897","wikidata":"https://www.wikidata.org/wiki/Q9143","display_name":"Programming
-          language","level":1,"score":0.108196944},{"id":"https://openalex.org/C78519656","wikidata":"https://www.wikidata.org/wiki/Q101333","display_name":"Mechanical
-          engineering","level":1,"score":0.0},{"id":"https://openalex.org/C31258907","wikidata":"https://www.wikidata.org/wiki/Q1301371","display_name":"Computer
-          network","level":1,"score":0.0},{"id":"https://openalex.org/C55493867","wikidata":"https://www.wikidata.org/wiki/Q7094","display_name":"Biochemistry","level":1,"score":0.0},{"id":"https://openalex.org/C192562407","wikidata":"https://www.wikidata.org/wiki/Q228736","display_name":"Materials
-          science","level":0,"score":0.0}],"mesh":[],"locations_count":3,"locations":[{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
-          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
-          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
-          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},{"is_oa":true,"landing_page_url":"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11116106","pdf_url":null,"source":{"id":"https://openalex.org/S2764455111","display_name":"PubMed
-          Central","issn_l":null,"issn":null,"is_oa":true,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I1299303238","host_organization_name":"National
-          Institutes of Health","host_organization_lineage":["https://openalex.org/I1299303238"],"host_organization_lineage_names":["National
-          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":"publishedVersion","is_accepted":true,"is_published":true},{"is_oa":false,"landing_page_url":"https://pubmed.ncbi.nlm.nih.gov/38799228","pdf_url":null,"source":{"id":"https://openalex.org/S4306525036","display_name":"PubMed","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I1299303238","host_organization_name":"National
-          Institutes of Health","host_organization_lineage":["https://openalex.org/I1299303238"],"host_organization_lineage_names":["National
-          Institutes of Health"],"type":"repository"},"license":null,"license_id":null,"version":null,"is_accepted":false,"is_published":false}],"best_oa_location":{"is_oa":true,"landing_page_url":"https://doi.org/10.1038/s42256-024-00832-8","pdf_url":"https://www.nature.com/articles/s42256-024-00832-8.pdf","source":{"id":"https://openalex.org/S2912241403","display_name":"Nature
-          Machine Intelligence","issn_l":"2522-5839","issn":["2522-5839"],"is_oa":false,"is_in_doaj":false,"is_core":true,"host_organization":"https://openalex.org/P4310319908","host_organization_name":"Nature
-          Portfolio","host_organization_lineage":["https://openalex.org/P4310319908","https://openalex.org/P4310319965"],"host_organization_lineage_names":["Nature
-          Portfolio","Springer Nature"],"type":"journal"},"license":"cc-by","license_id":"https://openalex.org/licenses/cc-by","version":"publishedVersion","is_accepted":true,"is_published":true},"sustainable_development_goals":[{"display_name":"Quality
-          education","id":"https://metadata.un.org/sdg/4","score":0.49}],"grants":[{"funder":"https://openalex.org/F4320306076","funder_display_name":"National
-          Science Foundation","award_id":"1751471"},{"funder":"https://openalex.org/F4320320924","funder_display_name":"Schweizerischer
-          Nationalfonds zur F\u00f6rderung der Wissenschaftlichen Forschung","award_id":"180544"}],"datasets":[],"versions":[],"referenced_works_count":57,"referenced_works":["https://openalex.org/W1964666522","https://openalex.org/W1972905466","https://openalex.org/W1988037271","https://openalex.org/W1995396482","https://openalex.org/W2034354062","https://openalex.org/W2037825667","https://openalex.org/W2119396661","https://openalex.org/W2126363023","https://openalex.org/W2189911347","https://openalex.org/W2324964582","https://openalex.org/W2478294658","https://openalex.org/W2529996553","https://openalex.org/W2594183968","https://openalex.org/W2606363443","https://openalex.org/W2747592475","https://openalex.org/W2903262661","https://openalex.org/W2966357564","https://openalex.org/W2968071222","https://openalex.org/W2970764640","https://openalex.org/W2987091515","https://openalex.org/W2998702515","https://openalex.org/W3010145447","https://openalex.org/W3014089210","https://openalex.org/W3023658436","https://openalex.org/W3088999551","https://openalex.org/W3094640617","https://openalex.org/W3094686696","https://openalex.org/W3097758405","https://openalex.org/W3098269892","https://openalex.org/W3101155908","https://openalex.org/W3103092523","https://openalex.org/W3121024033","https://openalex.org/W3123901912","https://openalex.org/W3128474010","https://openalex.org/W3129039627","https://openalex.org/W3157679602","https://openalex.org/W3179394107","https://openalex.org/W3198449425","https://openalex.org/W4220681836","https://openalex.org/W4220715560","https://openalex.org/W4220747243","https://openalex.org/W4225876201","https://openalex.org/W4226159083","https://openalex.org/W4281669078","https://openalex.org/W4283034548","https://openalex.org/W4285093994","https://openalex.org/W4306845856","https://openalex.org/W4310603653","https://openalex.org/W4319996831","https://openalex.org/W4327564965","https://openalex.org/W4365794116","https://openalex.org/W4385571219","https://openalex.org/W4387567938","https://openalex.org/W4389519254","https://openalex.org/W4389520103","https://openalex.org/W4389991792","https://openalex.org/W4391561379"],"related_works":["https://openalex.org/W4388870064","https://openalex.org/W4248308508","https://openalex.org/W4235186151","https://openalex.org/W2667588871","https://openalex.org/W2272354214","https://openalex.org/W2210139803","https://openalex.org/W2084768720","https://openalex.org/W2056057048","https://openalex.org/W2054685365","https://openalex.org/W2043010663"],"abstract_inverted_index":{"Abstract":[0],"Large":[1],"language":[2],"models":[3,19],"(LLMs)":[4],"have":[5],"shown":[6],"strong":[7],"performance":[8,67],"in":[9,30,68,108],"tasks":[10,43],"across":[11,44],"domains":[12],"but":[13,128],"struggle":[14],"with":[15],"chemistry-related":[16],"problems.":[17],"These":[18],"also":[20,129],"lack":[21],"access":[22],"to":[23,41],"external":[24],"knowledge":[25],"sources,":[26],"limiting":[27],"their":[28],"usefulness":[29],"scientific":[31,131],"applications.":[32],"We":[33],"introduce":[34],"ChemCrow,":[35],"an":[36,83],"LLM":[37,66,101],"chemistry":[38],"agent":[39,75],"designed":[40],"accomplish":[42],"organic":[45],"synthesis,":[46],"drug":[47],"discovery":[48,92],"and":[49,57,70,78,86,89,102,123,139],"materials":[50],"design.":[51],"By":[52],"integrating":[53],"18":[54],"expert-designed":[55],"tools":[56],"using":[58],"GPT-4":[59],"as":[60],"the":[61,65,80,91,135],"LLM,":[62],"ChemCrow":[63],"augments":[64],"chemistry,":[69],"new":[71],"capabilities":[72],"emerge.":[73],"Our":[74,97,116],"autonomously":[76],"planned":[77],"executed":[79],"syntheses":[81],"of":[82,93,113],"insect":[84],"repellent":[85],"three":[87],"organocatalysts":[88],"guided":[90],"a":[94,110],"novel":[95],"chromophore.":[96],"evaluation,":[98],"including":[99],"both":[100],"expert":[103,121],"assessments,":[104],"demonstrates":[105],"ChemCrow\u2019s":[106],"effectiveness":[107],"automating":[109],"diverse":[111],"set":[112],"chemical":[114],"tasks.":[115],"work":[117],"not":[118],"only":[119],"aids":[120],"chemists":[122],"lowers":[124],"barriers":[125],"for":[126],"non-experts":[127],"fosters":[130],"advancement":[132],"by":[133],"bridging":[134],"gap":[136],"between":[137],"experimental":[138],"computational":[140],"chemistry.":[141]},"cited_by_api_url":"https://api.openalex.org/works?filter=cites:W4396723768","counts_by_year":[{"year":2024,"cited_by_count":46},{"year":2023,"cited_by_count":3}],"updated_date":"2024-11-08T06:24:39.275006","created_date":"2024-05-09"}],"group_by":[]}
-
-          '
-      headers:
-        Access-Control-Allow-Credentials:
-          - "true"
-        Access-Control-Allow-Headers:
-          - Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Authorization,
-            Cache-Control
-        Access-Control-Allow-Methods:
-          - POST, GET, OPTIONS, PUT, DELETE, PATCH
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Expose-Headers:
-          - Authorization, Cache-Control
-        Connection:
-          - keep-alive
-        Content-Encoding:
-          - gzip
-        Content-Length:
-          - "5993"
-        Content-Security-Policy:
-          - default-src 'self'; object-src 'none'
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
-        Nel:
-          - '{"report_to":"heroku-nel","max_age":3600,"success_fraction":0.005,"failure_fraction":0.05,"response_headers":["Via"]}'
-        Referrer-Policy:
-          - strict-origin-when-cross-origin
-        Report-To:
-          - '{"group":"heroku-nel","max_age":3600,"endpoints":[{"url":"https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D"}]}'
-        Reporting-Endpoints:
-          - heroku-nel=https://nel.heroku.com/reports?ts=1731107837&sid=1b10b0ff-8a76-4548-befa-353fc6c6c045&s=ZIRBb24HewjZVtKGsZ7ujli7BbeExRdtzRmMlnaDchg%3D
-        Server:
-          - gunicorn
-        Strict-Transport-Security:
-          - max-age=31556926; includeSubDomains
-        Vary:
-          - Accept-Encoding
-        Via:
-          - 1.1 vegur
-        X-Api-Pool:
-          - common
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        X-Xss-Protection:
-          - 1; mode=block
       status:
         code: 200
         message: OK
@@ -2159,7 +2222,7 @@ interactions:
         Connection:
           - close
         Date:
-          - Fri, 08 Nov 2024 23:17:18 GMT
+          - Mon, 02 Dec 2024 19:36:33 GMT
         Server:
           - Jetty(9.4.40.v20210413)
         Transfer-Encoding:
@@ -2176,69 +2239,6 @@ interactions:
           - 1s
         x-ratelimit-limit:
           - "150"
-      status:
-        code: 200
-        message: OK
-  - request:
-      body: null
-      headers: {}
-      method: GET
-      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=Augmenting+large+language+models+with+chemistry+tools&fields=authors,citationCount,citationStyles,externalIds,influentialCitationCount,isOpenAccess,journal,openAccessPdf,publicationDate,publicationTypes,title,url,venue,year
-    response:
-      body:
-        string:
-          '{"data": [{"paperId": "354dcdebf3f8b5feeed5c62090e0bc1f0c28db06", "externalIds":
-          {"DBLP": "journals/natmi/BranCSBWS24", "ArXiv": "2304.05376", "PubMedCentral":
-          "11116106", "DOI": "10.1038/s42256-024-00832-8", "CorpusId": 258059792, "PubMed":
-          "38799228"}, "url": "https://www.semanticscholar.org/paper/354dcdebf3f8b5feeed5c62090e0bc1f0c28db06",
-          "title": "Augmenting large language models with chemistry tools", "venue":
-          "Nat. Mac. Intell.", "year": 2023, "citationCount": 225, "influentialCitationCount":
-          11, "isOpenAccess": true, "openAccessPdf": {"url": "https://www.nature.com/articles/s42256-024-00832-8.pdf",
-          "status": "HYBRID"}, "publicationTypes": ["JournalArticle"], "publicationDate":
-          "2023-04-11", "journal": {"name": "Nature Machine Intelligence", "pages":
-          "525 - 535", "volume": "6"}, "citationStyles": {"bibtex": "@Article{Bran2023AugmentingLL,\n
-          author = {Andr\u00e9s M Bran and Sam Cox and Oliver Schilter and Carlo Baldassari
-          and Andrew D. White and P. Schwaller},\n booktitle = {Nat. Mac. Intell.},\n
-          journal = {Nature Machine Intelligence},\n pages = {525 - 535},\n title =
-          {Augmenting large language models with chemistry tools},\n volume = {6},\n
-          year = {2023}\n}\n"}, "authors": [{"authorId": "2216007369", "name": "Andr\u00e9s
-          M Bran"}, {"authorId": "2161337138", "name": "Sam Cox"}, {"authorId": "1820929773",
-          "name": "Oliver Schilter"}, {"authorId": "2251414370", "name": "Carlo Baldassari"},
-          {"authorId": "2150199535", "name": "Andrew D. White"}, {"authorId": "1379965853",
-          "name": "P. Schwaller"}], "matchScore": 176.78436}]}
-
-          '
-      headers:
-        Access-Control-Allow-Origin:
-          - "*"
-        Connection:
-          - keep-alive
-        Content-Length:
-          - "1551"
-        Content-Type:
-          - application/json
-        Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        Via:
-          - 1.1 0ac5a786563da4ae2e2a28a1fe210e04.cloudfront.net (CloudFront)
-        X-Amz-Cf-Id:
-          - OEVv26roLSfPvUOOIiUDGl-BP8eKkJWPGmQmz7D01DNWnCiSmq3FmQ==
-        X-Amz-Cf-Pop:
-          - SFO53-P7
-        X-Cache:
-          - Miss from cloudfront
-        x-amz-apigw-id:
-          - A81PoFzpvHcElTA=
-        x-amzn-Remapped-Connection:
-          - keep-alive
-        x-amzn-Remapped-Content-Length:
-          - "1551"
-        x-amzn-Remapped-Date:
-          - Fri, 08 Nov 2024 23:17:19 GMT
-        x-amzn-Remapped-Server:
-          - gunicorn
-        x-amzn-RequestId:
-          - 7a2b0ea7-f659-4258-a727-621819fed167
       status:
         code: 200
         message: OK

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -116,7 +116,8 @@ async def test_title_search(paper_attributes: dict[str, str]) -> None:
             ),
         )
         details = await client.query(title=paper_attributes["title"])
-        assert set(details.other["client_source"]) == set(  # type: ignore[union-attr]
+        assert details, "Assertions require successful query"
+        assert set(details.other["client_source"]) == set(
             paper_attributes["source"]
         ), "Should have the correct source"
         for key, value in paper_attributes.items():
@@ -124,7 +125,7 @@ async def test_title_search(paper_attributes: dict[str, str]) -> None:
                 assert getattr(details, key) == value, f"Should have the correct {key}"
             elif key == "is_oa":
                 assert (
-                    details.other.get("is_oa") == value  # type: ignore[union-attr]
+                    details.other.get("is_oa") == value
                 ), "Open access data should match"
 
 
@@ -223,7 +224,8 @@ async def test_doi_search(paper_attributes: dict[str, str | list[str]]) -> None:
             ),
         )
         details = await client.query(doi=paper_attributes["doi"])
-        assert set(details.other["client_source"]) == set(  # type: ignore[union-attr]
+        assert details, "Assertions require successful query"
+        assert set(details.other["client_source"]) == set(
             paper_attributes["source"]
         ), "Should have the correct source"
         for key, value in paper_attributes.items():
@@ -238,7 +240,7 @@ async def test_doi_search(paper_attributes: dict[str, str | list[str]]) -> None:
                     ), f"Should have the correct {key}"
             elif key == "is_oa":
                 assert (
-                    details.other.get("is_oa") == value  # type: ignore[union-attr]
+                    details.other.get("is_oa") == value
                 ), "Open access data should match"
 
 
@@ -414,8 +416,10 @@ async def test_crossref_journalquality_fields_filtering() -> None:
             ),
             fields=["title", "doi", "authors", "journal"],
         )
-
-        assert nejm_crossref_details.source_quality == 3, "Should have source quality data"  # type: ignore[union-attr]
+        assert nejm_crossref_details, "Assertions require successful query"
+        assert (
+            nejm_crossref_details.source_quality == 3
+        ), "Should have source quality data"
 
 
 @pytest.mark.vcr
@@ -458,9 +462,8 @@ async def test_odd_client_requests() -> None:
             authors=["Andres M. Bran", "Sam Cox"],
             fields=["title", "doi"],
         )
-        assert (
-            details.authors  # type: ignore[union-attr]
-        ), "Should return correct author results"
+        assert details, "Assertions require successful query"
+        assert details.authors, "Should return correct author results"
 
     # try querying using a title, asking for no DOI back
     async with aiohttp.ClientSession() as session:
@@ -469,9 +472,8 @@ async def test_odd_client_requests() -> None:
             title="Augmenting large language models with chemistry tools",
             fields=["title"],
         )
-        assert (
-            details.doi  # type: ignore[union-attr]
-        ), "Should return a doi even though we don't ask for it"
+        assert details, "Assertions require successful query"
+        assert details.doi, "Should return a doi even though we don't ask for it"
 
     # try querying using a title, asking for no title back
     async with aiohttp.ClientSession() as session:
@@ -480,9 +482,8 @@ async def test_odd_client_requests() -> None:
             title="Augmenting large language models with chemistry tools",
             fields=["doi"],
         )
-        assert (
-            details.title  # type: ignore[union-attr]
-        ), "Should return a title even though we don't ask for it"
+        assert details, "Assertions require successful query"
+        assert details.title, "Should return a title even though we don't ask for it"
 
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(session)
@@ -490,8 +491,9 @@ async def test_odd_client_requests() -> None:
             doi="10.1007/s40278-023-41815-2",
             fields=["doi", "title", "gibberish-field", "no-field"],
         )
+        assert details, "Assertions require successful query"
         assert (
-            details.title  # type: ignore[union-attr]
+            details.title
         ), "Should return title even though we asked for some bad fields"
 
 


### PR DESCRIPTION
For the last week, we have been seeing 502's from OpenAI in CI. It turns out this was due to our cassette caching, which this PR redoes.

Refreshing the cassettes shows `test_search` now has outdated citation counts, which I generalize our assertions for here. Also, I fixed some `type: ignore[union-attr]`s due to a missing `bool(DocDetails)` assertion