### PR TITLE
Made it possible to get answers from litqa evaluations

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -109,6 +109,7 @@ class PaperQAEnvironment(Environment[EnvironmentState]):
         embedding_model: EmbeddingModel | None = POPULATE_FROM_SETTINGS,
         **env_kwargs,
     ):
+        print(env_kwargs)
         super().__init__(**env_kwargs)
         # Hold onto QueryRequest to create fresh tools and answer during each reset
         self._query = query

--- a/paperqa/litqa.py
+++ b/paperqa/litqa.py
@@ -104,13 +104,19 @@ class LitQAEvaluation(StrEnum):
 
     @property
     def answer(self) -> str | None:
-        """Get the stored answer associated with this evaluation."""
         return getattr(self, "_answer", None)
 
     @answer.setter
     def answer(self, value: str | None) -> None:
-        """Set the answer associated with this evaluation."""
         self._answer = value
+
+    @property
+    def ideal(self) -> str | None:
+        return getattr(self, "_ideal", None)
+
+    @ideal.setter
+    def ideal(self, value: str) -> None:
+        self._ideal = value
 
     def make_discounted_returns(
         self,
@@ -155,6 +161,7 @@ class LitQAEvaluation(StrEnum):
         ):
             # The result extracted was not in the options
             evaluation = cls.INCORRECT
+            evaluation.answer = result
         # From here, if we don't match either the ideal or the unsure multiple choice
         # options then we declare the answer as incorrect.
         elif unsure_mc_answer and result[0].lower() == unsure_mc_answer[0].lower():
@@ -166,6 +173,7 @@ class LitQAEvaluation(StrEnum):
         else:
             evaluation = cls.INCORRECT
             evaluation.answer = result
+        evaluation.ideal = ideal_mc_answer
         return evaluation
 
     @classmethod
@@ -235,8 +243,9 @@ class LitQAEvaluation(StrEnum):
                 unsure_mc_answer=unsure_answer,
                 total_options=len(distractor_answers) + (2 if use_unsure else 1),
             )
-            # convert MC answer back to distractor option so that it
+            # convert MC answers back to full text option so that it
             # is meaningful
+            evaluation.ideal = ideal
             if evaluation == cls.CORRECT:
                 evaluation.answer = ideal
             elif evaluation == cls.UNSURE:

--- a/tests/test_litqa.py
+++ b/tests/test_litqa.py
@@ -148,6 +148,7 @@ class TestLitQAEvaluation:
         if evaluation == LitQAEvaluation.CORRECT:
             assert evaluation.answer == ideal
         assert evaluation.answer == extracted_answer
+        assert evaluation.ideal == ideal
         assert evaluation.make_discounted_returns(3, discount=0.5) == expected_dreturns
 
     def test_consistent_mc_options(self) -> None:

--- a/tests/test_litqa.py
+++ b/tests/test_litqa.py
@@ -47,6 +47,7 @@ class TestLitQAEvaluation:
             "answer",
             "expected_eval",
             "expected_dreturns",
+            "extracted_answer",
         ),
         [
             pytest.param(
@@ -54,6 +55,7 @@ class TestLitQAEvaluation:
                 "the answer is 94107",
                 LitQAEvaluation.CORRECT,
                 [0.25, 0.5, 1.0],
+                "94107",
                 id="matched-correct-option",
             ),
             pytest.param(
@@ -61,6 +63,7 @@ class TestLitQAEvaluation:
                 "the answer is 14004",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="didnt-match-and-no-llm-innate-knowledge",
             ),
             pytest.param(
@@ -68,6 +71,7 @@ class TestLitQAEvaluation:
                 "the answer is 94106",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                "94106",
                 id="matched-incorrect-option",
             ),
             pytest.param(
@@ -75,6 +79,7 @@ class TestLitQAEvaluation:
                 "Insufficient information",
                 LitQAEvaluation.UNSURE,
                 [0.025, 0.05, 0.1],
+                "unsure",
                 id="matched-unsure-option",
             ),
             pytest.param(
@@ -82,6 +87,7 @@ class TestLitQAEvaluation:
                 "the answer is 94106 or 94107",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="matched-several-options",
             ),
             pytest.param(
@@ -89,6 +95,7 @@ class TestLitQAEvaluation:
                 "",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="empty-answer1",
             ),
             pytest.param(
@@ -96,6 +103,7 @@ class TestLitQAEvaluation:
                 "14",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="didnt-match-and-llm-has-innate-knowledge",
             ),
             pytest.param(
@@ -103,6 +111,7 @@ class TestLitQAEvaluation:
                 "",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="empty-answer2",
             ),
             pytest.param(
@@ -110,6 +119,7 @@ class TestLitQAEvaluation:
                 "",
                 LitQAEvaluation.INCORRECT,
                 [-0.25, -0.5, -1.0],
+                None,
                 id="empty-answer3",
             ),
         ],
@@ -122,6 +132,7 @@ class TestLitQAEvaluation:
         answer: str,
         expected_eval: LitQAEvaluation,
         expected_dreturns: list[float],
+        extracted_answer: str,
     ) -> None:
         """Tests that we can create a LitQA question and evaluate answers."""
         qa_prompt, eval_fn = LitQAEvaluation.from_question(
@@ -134,6 +145,9 @@ class TestLitQAEvaluation:
 
         evaluation = await eval_fn(answer)
         assert evaluation == expected_eval
+        if evaluation == LitQAEvaluation.CORRECT:
+            assert evaluation.answer == ideal
+        assert evaluation.answer == extracted_answer
         assert evaluation.make_discounted_returns(3, discount=0.5) == expected_dreturns
 
     def test_consistent_mc_options(self) -> None:


### PR DESCRIPTION
I'm not super happy with the pattern, but I modified `LitQAEvaluation` so that it stuffs the extracted answer into the `StrEnum` value. This makes it so we can recover the actual answers at the end, to help with consensus sampling. 