### PR TITLE
Renovate `lockFileMaintenance` respecting `schedule`, 2-week stability period, no `openai` pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,10 @@
   prHourlyLimit: 4,
   timezone: "America/Los_Angeles",
   rangeStrategy: "widen",
-  lockFileMaintenance: { enabled: true },
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["* 2 1-7 * 1"], // Work around https://github.com/renovatebot/renovate/discussions/33152
+  },
   "pre-commit": { enabled: true },
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,7 @@
     enabled: true,
     schedule: ["* 2 1-7 * 1"], // Work around https://github.com/renovatebot/renovate/discussions/33152
   },
+  minimumReleaseAge: "2 weeks",
   "pre-commit": { enabled: true },
   packageRules: [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,11 +13,6 @@
   "pre-commit": { enabled: true },
   packageRules: [
     {
-      // Allow 'widen' range strategy while matching aviary_internal pyproject.toml
-      matchPackageNames: ["openai"],
-      allowedVersions: "<1.47",
-    },
-    {
       // TODO: remove after fhaviary supports Python 3.13
       matchPackageNames: ["python"],
       allowedVersions: "<=3.12",


### PR DESCRIPTION
- Accounts for https://github.com/renovatebot/renovate/discussions/33152 in `lockFileMaintenance`
- Added a two-week stability period to deps so Renovate avoids hotfixes
- https://github.com/Future-House/paper-qa/pull/670 missed removing `openai` downpinning from Renovate