### PR TITLE
Dropping `refurb` in favor of its `ruff` port

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
       - run: uv python pin ${{ matrix.python-version }}
       - uses: hynek/build-and-inspect-python-package@v2
       - run: uv sync --python-preference=only-managed
-      - run: uv run refurb paperqa tests
       - run: uv run pylint paperqa
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.2
+    rev: v0.8.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -63,7 +63,7 @@ repos:
     hooks:
       - id: uv-lock
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.58.1
+    rev: 39.75.1
     hooks:
       - id: renovate-config-validator
         args: [--strict]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,9 +285,9 @@ testpaths = ["tests"]
 [tool.refurb]
 enable_all = true
 ignore = [
-    "FURB101",  # FURB101, FURB103, FURB141, FURB144, FURB146, FURB147, FURB150, FURB155: no need for pathlib
-    "FURB103",
-    "FURB141",
+    "FURB101",  # Rely on ruff FURB101 for this
+    "FURB103",  # Rely on ruff FURB103 for this
+    "FURB141",  # FURB141, FURB144, FURB146, FURB147, FURB150, FURB155: don't care to enforce pathlib
     "FURB144",
     "FURB146",
     "FURB147",
@@ -379,6 +379,7 @@ extend-select = [
     "FURB166",
     "FURB171",
     "FURB180",
+    "FURB181",
     "FURB188",
     "FURB189",
     "FURB192",
@@ -440,6 +441,8 @@ ignore = [
     "FBT002",
     "FIX",  # Don't care to prevent TODO, FIXME, etc.
     "FLY002",  # Can be less readable
+    "FURB101",  # FURB101, FURB103: don't care to enforce pathlib
+    "FURB103",
     "G004",  # f-strings are convenient
     "INP001",  # Can use namespace packages
     "ISC001",  # For ruff format compatibility


### PR DESCRIPTION
This PR:
- Drops `refurb` from CI since the `ruff` port has reached "critical mass"
- Updates the `refurb` config for the ongoing `ruff` port