### PR TITLE
Missing `None` failovers in LDP shims

### DIFF
--- a/paperqa/_ldp_shims.py
+++ b/paperqa/_ldp_shims.py
@@ -46,5 +46,15 @@ except ImportError:
     class Callback:  # type: ignore[no-redef]
         """Placeholder parent class for when ldp isn't installed."""
 
+    Agent = None  # type: ignore[assignment,misc]
+    HTTPAgentClient = None  # type: ignore[assignment,misc]
+    _Memories = None  # type: ignore[assignment]
+    Memory = None  # type: ignore[assignment,misc]
+    MemoryAgent = None  # type: ignore[assignment,misc]
+    ReActAgent = None  # type: ignore[assignment,misc]
     RolloutManager = None  # type: ignore[assignment,misc]
+    SimpleAgent = None  # type: ignore[assignment,misc]
+    SimpleAgentState = None  # type: ignore[assignment,misc]
+    UIndexMemoryModel = None  # type: ignore[assignment,misc]
     discounted_returns = None  # type: ignore[assignment]
+    set_training_mode = None  # type: ignore[assignment]


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/772 created an LDP shim module, but missed that due to `__all__` we need `None` failovers for all entries in `__all__`.