### PR TITLE
Add clinical trials search tool

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -151,6 +151,13 @@ def make_clinical_trial_status(
     )
 
 
+# SEE: https://regex101.com/r/L0L5MH/1
+CLINICAL_STATUS_SEARCH_REGEX_PATTERN: str = (
+    r"Status: Paper Count=(\d+) \| Relevant Papers=(\d+)(?:\s\|\sClinical Trial Count=(\d+)\s"
+    r"\|\sRelevant Clinical Trials=(\d+))?\s\|\sCurrent Evidence=(\d+)"
+)
+
+
 def clinical_trial_status(state: "EnvironmentState") -> str:
     return make_clinical_trial_status(
         total_paper_count=len(

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from copy import deepcopy
 from typing import Any, ClassVar, Self, cast
 
@@ -26,6 +25,7 @@ from paperqa.utils import get_year
 from .models import QueryRequest
 from .tools import (
     AVAILABLE_TOOL_NAME_TO_CLASS,
+    DEFAULT_TOOL_NAMES,
     ClinicalTrialsSearch,
     Complete,
     EnvironmentState,
@@ -38,18 +38,6 @@ from .tools import (
 logger = logging.getLogger(__name__)
 
 POPULATE_FROM_SETTINGS = None
-
-DEFAULT_TOOL_NAMES: list[str] = [
-    name.strip()
-    for name in os.environ.get("PAPERQA_DEFAULT_TOOL_NAMES", "").split(",")
-    if name.strip()
-] or [
-    PaperSearch.TOOL_FN_NAME,
-    GatherEvidence.TOOL_FN_NAME,
-    GenerateAnswer.TOOL_FN_NAME,
-    Reset.TOOL_FN_NAME,
-    Complete.TOOL_FN_NAME,
-]
 
 
 def settings_to_tools(  # noqa: PLR0912

--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -52,7 +52,7 @@ DEFAULT_TOOL_NAMES: list[str] = [
 ]
 
 
-def settings_to_tools(
+def settings_to_tools(  # noqa: PLR0912
     settings: Settings,
     llm_model: LiteLLMModel | None = POPULATE_FROM_SETTINGS,
     summary_llm_model: LiteLLMModel | None = POPULATE_FROM_SETTINGS,

--- a/paperqa/agents/helpers.py
+++ b/paperqa/agents/helpers.py
@@ -9,6 +9,7 @@ from llmclient import LiteLLMModel, LLMModel
 from rich.table import Table
 
 from paperqa.docs import Docs
+from paperqa.types import DocDetails
 
 from .models import AnswerResponse
 
@@ -92,10 +93,10 @@ def table_formatter(
         table.add_column("File", style="magenta")
         for obj, filename in objects:
             try:
-                display_name = cast(Docs, obj).texts[0].doc.title
+                display_name = cast(DocDetails, cast(Docs, obj).texts[0].doc).title
             except AttributeError:
                 display_name = cast(Docs, obj).texts[0].doc.formatted_citation
-            table.add_row(display_name[:max_chars_per_column], filename)
+            table.add_row(cast(str, display_name)[:max_chars_per_column], filename)
         return table
     raise NotImplementedError(
         f"Object type {type(example_object)} can not be converted to table."

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -412,8 +412,7 @@ class ClinicalTrialsSearch(NamedTool):
 
     # Gather evidence tool must be modified to understand the new evidence
     GATHER_EVIDENCE_TOOL_PROMPT_OVERRIDE: ClassVar[str] = (
-        """
-        Gather evidence from previous papers and clinical trials given a specific question.
+        """Gather evidence from previous papers and clinical trials given a specific question.
 
         Will increase evidence, relevant paper counts, and relevant clinical trial counts.
         A valuable time to invoke this tool is right after another tool increases paper or clinical trials count.
@@ -429,9 +428,8 @@ class ClinicalTrialsSearch(NamedTool):
         """
     )
 
-    async def clinical_trials_search(self, query: str, state: EnvironmentState):
-        r"""
-        Search for clinical trials, with support for repeated calls and concurrent execution.
+    async def clinical_trials_search(self, query: str, state: EnvironmentState) -> str:
+        r"""Search for clinical trials, with support for repeated calls and concurrent execution.
 
         Will add new clinical trials to the state, and return metadata about the number of trials found.
 

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from paperqa.docs import Docs
 from paperqa.settings import Settings
+from paperqa.sources.clinical_trials import add_clinical_trials_to_docs
 from paperqa.types import DocDetails, PQASession
 
 from .search import get_directory_index
@@ -397,6 +398,253 @@ class Complete(NamedTool):
         )
         # Return answer and status to simplify postprocessing of tool response
         return f"{'Success' if has_successful_answer else 'Unsure'} | {state.status}"
+
+
+class ClinicalTrialsSearch(NamedTool):
+    TOOL_FN_NAME = "clinical_trials_search"
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    search_count: int = 8
+    previous_searches: dict[str, int] = Field(default_factory=dict)
+    settings: Settings = Field(default_factory=Settings)
+
+    # Gather evidence tool must be modified to understand the new evidence
+    GATHER_EVIDENCE_TOOL_PROMPT_OVERRIDE: ClassVar[str] = (
+        """
+        Gather evidence from previous papers and clinical trials given a specific question.
+
+        Will increase evidence, relevant paper counts, and relevant clinical trial counts.
+        A valuable time to invoke this tool is right after another tool increases paper or clinical trials count.
+        Feel free to invoke this tool in parallel with other tools, but do not call this tool in parallel with itself.
+        Only invoke this tool when the paper count or clinical trial count is above zero, or this tool will be useless.
+
+        Args:
+            question: Specific question to gather evidence for.
+            state: Current state.
+
+        Returns:
+            String describing gathered evidence and the current status.
+        """
+    )
+
+    async def clinical_trials_search(self, query: str, state: EnvironmentState):
+        r"""
+        Search for clinical trials, with support for repeated calls and concurrent execution.
+
+        Will add new clinical trials to the state, and return metadata about the number of trials found.
+
+        Args:
+            query: The search query string. Supports complex boolean expressions, field-specific
+                searches, and query modifiers through operators. All configuration is done through
+                operators in the query string.
+                Query Syntax:
+                    Basic Search:
+                        Simple text automatically uses default EXPANSION[Relaxation] and COVERAGE[Contains]
+                        >>> "heart attack"
+
+                    Modified Search:
+                        Use operators to modify search behavior:
+                        >>> 'EXPANSION[None]COVERAGE[FullMatch]"exact phrase"'
+                        >>> 'EXPANSION[Concept]heart attack'
+
+                    Field Search:
+                        Specify fields using AREA operator:
+                        >>> 'AREA[InterventionName]aspirin'
+                        >>> 'AREA[Phase]PHASE3'
+
+                    Location Search:
+                        Use SEARCH operator for compound location queries:
+                        >>> 'cancer AND SEARCH[Location](AREA[LocationCity]Boston AND AREA[LocationState]Massachusetts)'
+
+                    Complex Boolean:
+                        Combine terms with AND, OR, NOT and parentheses:
+                        >>> '(cancer OR tumor) AND NOT (EXPANSION[None]pediatric OR AREA[StdAge]CHILD)'
+
+                    Date Ranges:
+                        Use RANGE to specify date ranges with formats like "yyyy-MM" or "yyyy-MM-dd".
+                        Note that MIN and MAX can be used for open-ended ranges:
+                        >>> AREA[ResultsFirstPostDate]RANGE[2015-01-01, MAX]
+
+                Operators:
+                    EXPANSION[type]: Controls term expansion
+                        - None: Exact match only, case and accent sensitive
+                        - Term: Includes lexical variants (plurals, spellings)
+                        - Concept: Includes UMLS synonyms
+                        - Relaxation: Relaxes adjacency requirements (default)
+                        - Lossy: Allows missing partial terms
+
+                    COVERAGE[type]: Controls text matching
+                        - FullMatch: Must match entire field
+                        - StartsWith: Must match beginning of field
+                        - EndsWith: Must match end of field
+                        - Contains: Must match part of field (default)
+
+                    AREA[field]: Specifies field to search
+                        - See Field Reference for available fields
+
+                    SEARCH[type]: Groups field searches
+                        - Location: Groups location-related fields
+                        - Study: Groups study-related fields
+
+                Usage Notes:
+                    - All search expressions are implicitly OR expressions
+                    - Operator precedence (highest to lowest): terms/source operators, NOT/context operators, AND, OR
+                    - Use quotes for exact phrase matching: "heart attack"
+                    - Use parentheses for grouping: (heart OR cardiac) AND attack
+                    - Use backslash to escape operators: \AND
+                    - Default expansion is EXPANSION[Relaxation]
+                    - Default coverage is COVERAGE[Contains]
+
+                Field Reference:
+                    High Priority Fields (weight >= 0.8):
+                        - NCTId (1.0): Trial identifier
+                        - Acronym (1.0): Study acronym
+                        - BriefTitle (0.89): Short title
+                        - OfficialTitle (0.85): Full official title
+                        - Condition (0.81): Medical condition
+                        - InterventionName (0.8): Primary intervention name
+                        - OverallStatus: Trial status
+
+                    Medium Priority Fields (0.5-0.79):
+                        - InterventionOtherName (0.75): Alternative intervention names
+                        - Phase (0.65): Trial phase
+                        - StdAge (0.65): Standard age groups
+                        - Keyword (0.6): Study keywords
+                        - BriefSummary (0.6): Short description
+                        - SecondaryOutcomeMeasure (0.5): Secondary outcomes
+
+                    Low Priority Fields (< 0.5):
+                        - DesignPrimaryPurpose (0.3): Primary purpose of study
+                        - StudyType (0.3)
+                        - Various descriptive, location, and administrative fields
+
+                Supported Enums:
+                    Phase:
+                        - EARLY_PHASE1: Early Phase 1
+                        - PHASE1: Phase 1
+                        - PHASE2: Phase 2
+                        - PHASE3: Phase 3
+                        - PHASE4: Phase 4
+                        - NA: Not Applicable
+
+                    StandardAge:
+                        - CHILD: Child
+                        - ADULT: Adult
+                        - OLDER_ADULT: Older Adult
+
+                    Status:
+                        - RECRUITING: Currently recruiting participants
+                        - ACTIVE_NOT_RECRUITING: Active but not recruiting
+                        - COMPLETED: Study completed
+                        - ENROLLING_BY_INVITATION: Enrolling by invitation only
+                        - NOT_YET_RECRUITING: Not yet recruiting
+                        - SUSPENDED: Study suspended
+                        - TERMINATED: Study terminated
+                        - WITHDRAWN: Study withdrawn
+                        - AVAILABLE: Available
+                        - NO_LONGER_AVAILABLE: No longer available
+                        - TEMPORARILY_NOT_AVAILABLE: Temporarily not available
+                        - APPROVED_FOR_MARKETING: Approved for marketing
+                        - WITHHELD: Withheld
+                        - UNKNOWN: Unknown status
+
+                    StudyType:
+                        - INTERVENTIONAL: Interventional studies
+                        - OBSERVATIONAL: Observational studies
+                        - EXPANDED_ACCESS: Expanded access studies
+
+                    PrimaryPurpose:
+                        - TREATMENT: Treatment
+                        - PREVENTION: Prevention
+                        - DIAGNOSTIC: Diagnostic
+                        - ECT: Educational/Counseling/Training
+                        - SUPPORTIVE_CARE: Supportive Care
+                        - SCREENING: Screening
+                        - HEALTH_SERVICES_RESEARCH: Health Services Research
+                        - BASIC_SCIENCE: Basic Science
+                        - DEVICE_FEASIBILITY: Device Feasibility
+                        - OTHER: Other
+
+                    InterventionType:
+                        - BEHAVIORAL: Behavioral interventions
+                        - BIOLOGICAL: Biological interventions
+                        - COMBINATION_PRODUCT: Combination product interventions
+                        - DEVICE: Device interventions
+                        - DIAGNOSTIC_TEST: Diagnostic test interventions
+                        - DIETARY_SUPPLEMENT: Dietary supplement interventions
+                        - DRUG: Drug interventions
+                        - GENETIC: Genetic interventions
+                        - PROCEDURE: Procedure interventions
+                        - RADIATION: Radiation interventions
+                        - OTHER: Other interventions
+
+                    DesignAllocation:
+                        - RANDOMIZED: Randomized allocation
+                        - NON_RANDOMIZED: Non-randomized allocation
+                        - NA: Not applicable
+
+                    InterventionalAssignment:
+                        - SINGLE_GROUP: Single group assignment
+                        - PARALLEL: Parallel assignment
+                        - CROSSOVER: Crossover assignment
+                        - FACTORIAL: Factorial assignment
+                        - SEQUENTIAL: Sequential assignment
+
+                    ObservationalModel:
+                        - COHORT: Cohort
+                        - CASE_CONTROL: Case-Control
+                        - CASE_ONLY: Case-Only
+                        - CASE_CROSSOVER: Case-Crossover
+                        - ECOLOGIC_OR_COMMUNITY: Ecologic or Community
+                        - FAMILY_BASED: Family-Based
+                        - DEFINED_POPULATION: Defined Population
+                        - NATURAL_HISTORY: Natural History
+                        - OTHER: Other
+
+                    DesignMasking:
+                        - NONE: None (Open Label)
+                        - SINGLE: Single
+                        - DOUBLE: Double
+                        - TRIPLE: Triple
+                        - QUADRUPLE: Quadruple
+
+                    WhoMasked:
+                        - PARTICIPANT: Participant
+                        - CARE_PROVIDER: Care Provider
+                        - INVESTIGATOR: Investigator
+                        - OUTCOMES_ASSESSOR: Outcomes Assessor
+
+            state: Current state
+
+        Returns:
+            String describing current status
+        """
+        # get offset if we've done this search before (continuation of search)
+        # or mark this search as new (so offset 0)
+        try:
+            offset = self.previous_searches[query]
+        except KeyError:
+            offset = self.previous_searches[query] = 0
+
+        total_result_count, new_result_count, error_message = (
+            await add_clinical_trials_to_docs(
+                query,
+                state.docs,
+                self.settings,
+                limit=self.search_count,
+                offset=offset,
+            )
+        )
+        # mark how far we've searched so that continuation will start at the right place
+        self.previous_searches[query] += self.search_count
+        if error_message is None:
+            return (
+                f"Found clinical trial search results from search {offset} to {offset + new_result_count}"
+                f" among {total_result_count} total results."
+                f" {state.status}"
+            )
+        return f"Error in clinical trial query syntax: {error_message}"
 
 
 AVAILABLE_TOOL_NAME_TO_CLASS: dict[str, type[NamedTool]] = {

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -3,6 +3,7 @@
 import asyncio
 import inspect
 import logging
+import os
 import re
 import sys
 from collections.abc import Callable
@@ -403,7 +404,7 @@ class Complete(NamedTool):
 class ClinicalTrialsSearch(NamedTool):
     TOOL_FN_NAME = "clinical_trials_search"
 
-    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    model_config = ConfigDict(extra="forbid")
 
     search_count: int = 8
     previous_searches: dict[str, int] = Field(default_factory=dict)
@@ -656,3 +657,16 @@ AVAILABLE_TOOL_NAME_TO_CLASS: dict[str, type[NamedTool]] = {
         and v is not NamedTool,
     )
 }
+
+
+DEFAULT_TOOL_NAMES: list[str] = [
+    name.strip()
+    for name in os.environ.get("PAPERQA_DEFAULT_TOOL_NAMES", "").split(",")
+    if name.strip()
+] or [
+    PaperSearch.TOOL_FN_NAME,
+    GatherEvidence.TOOL_FN_NAME,
+    GenerateAnswer.TOOL_FN_NAME,
+    Reset.TOOL_FN_NAME,
+    Complete.TOOL_FN_NAME,
+]

--- a/paperqa/clients/__init__.py
+++ b/paperqa/clients/__init__.py
@@ -164,16 +164,13 @@ class DocMetadataClient:
                     sum(
                         await gather_with_concurrency(
                             len(task.processors),
-                            task.processor_queries(
-                                cast(DocDetails, doc_details), session
-                            ),
+                            task.processor_queries(doc_details, session),
                         )
                     )
                     or None
                 )
 
             if doc_details:
-                doc_details = cast(DocDetails, doc_details)
                 # abuse int handling in __add__ for empty all_doc_details, None types won't work
                 all_doc_details = doc_details + (all_doc_details or 0)
 

--- a/paperqa/clients/crossref.py
+++ b/paperqa/clients/crossref.py
@@ -197,7 +197,7 @@ async def parse_crossref_to_doc_details(
         elif len(date_parts) == 1:
             publication_date = datetime(date_parts[0], 1, 1)
 
-    doc_details = DocDetails(
+    doc_details = DocDetails(  # type: ignore[call-arg]
         key=None if not bibtex else bibtex.split("{")[1].split(",")[0],
         bibtex_type=CROSSREF_CONTENT_TYPE_TO_BIBTEX_MAPPING.get(
             message.get("type", "other"), "misc"

--- a/paperqa/clients/journal_quality.py
+++ b/paperqa/clients/journal_quality.py
@@ -44,7 +44,7 @@ class JournalQualityPostProcessor(MetadataPostProcessor[JournalQuery]):
         # docname can be blank since the validation will add it
         # remember, if both have docnames (i.e. key) they are
         # wiped and re-generated with resultant data
-        return doc_details + DocDetails(
+        return doc_details + DocDetails(  # type: ignore[call-arg]
             source_quality=max(
                 [
                     self.data.get(query.journal.casefold(), DocDetails.UNDEFINED_JOURNAL_QUALITY),  # type: ignore[union-attr]

--- a/paperqa/clients/openalex.py
+++ b/paperqa/clients/openalex.py
@@ -178,7 +178,7 @@ async def parse_openalex_to_doc_details(message: dict[str, Any]) -> DocDetails:
 
     bibtex_type = BIBTEX_MAPPING.get(message.get("type") or "other", "misc")
 
-    return DocDetails(
+    return DocDetails(  # type: ignore[call-arg]
         key=None,
         bibtex_type=bibtex_type,
         bibtex=None,

--- a/paperqa/clients/retractions.py
+++ b/paperqa/clients/retractions.py
@@ -71,7 +71,7 @@ class RetractionDataPostProcessor(MetadataPostProcessor[DOIQuery]):
         if not self.doi_set:
             await self.load_data()
 
-        return doc_details + DocDetails(is_retracted=query.doi in self.doi_set)
+        return doc_details + DocDetails(is_retracted=query.doi in self.doi_set)  # type: ignore[call-arg]
 
     def query_creator(self, doc_details: DocDetails, **kwargs) -> DOIQuery | None:
         try:

--- a/paperqa/clients/semantic_scholar.py
+++ b/paperqa/clients/semantic_scholar.py
@@ -182,7 +182,7 @@ async def parse_s2_to_doc_details(
 
     journal_data = paper_data.get("journal") or {}
 
-    doc_details = DocDetails(
+    doc_details = DocDetails(  # type: ignore[call-arg]
         key=None if not bibtex else bibtex.split("{")[1].split(",")[0],
         bibtex_type="article",  # s2 should be basically all articles
         bibtex=bibtex,

--- a/paperqa/clients/unpaywall.py
+++ b/paperqa/clients/unpaywall.py
@@ -166,7 +166,7 @@ class UnpaywallProvider(DOIOrTitleBasedProvider):
         if data.best_oa_location:
             pdf_url = data.best_oa_location.url_for_pdf
             license = data.best_oa_location.license  # noqa: A001
-        return DocDetails(
+        return DocDetails(  # type: ignore[call-arg]
             authors=[
                 f"{author.given} {author.family}" for author in (data.z_authors or [])
             ],

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -9,8 +9,9 @@ from collections.abc import (
     Callable,
     Iterable,
     Sequence,
+    Sized,
 )
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 from llmclient import (
@@ -335,7 +336,8 @@ class QdrantVectorStore(VectorStore):
 
         if texts_list and not self.client.collection_exists(self.collection_name):
             params = models.VectorParams(
-                size=len(texts_list[0].embedding), distance=models.Distance.COSINE
+                size=len(cast(Sized, texts_list[0].embedding)),
+                distance=models.Distance.COSINE,
             )
             self.client.create_collection(
                 self.collection_name,

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -200,6 +200,10 @@ class ParsingSettings(BaseModel):
             " 'bad title' and a year of 2022 or no year at all."
         ),
     )
+    use_human_readable_clinical_trials: bool = Field(
+        default=False,
+        description="Parse clinical trial JSONs into human readable text",
+    )
 
     def chunk_type(self, chunking_selection: ChunkingOptions | None = None) -> str:
         """Future chunking implementations (i.e. by section) will get an elif clause here."""

--- a/paperqa/sources/clinical_trials.py
+++ b/paperqa/sources/clinical_trials.py
@@ -1,0 +1,321 @@
+import json
+import logging
+import os
+from contextlib import suppress
+from datetime import datetime
+from typing import Any, cast
+
+import aiohttp
+from aiohttp import ClientResponseError, ClientSession
+from aiohttp.web import HTTPBadRequest
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_incrementing,
+)
+
+from paperqa import DocDetails, Docs
+from paperqa.settings import Settings
+from paperqa.types import Embeddable, Text
+from paperqa.utils import gather_with_concurrency
+
+logger = logging.getLogger(__name__)
+
+
+CLINICAL_TRIALS_BASE = "clinicaltrials.gov"
+CLINICAL_TRIALS_URL = f"https://{CLINICAL_TRIALS_BASE}"
+STUDIES_API_URL = CLINICAL_TRIALS_URL + "/api/v2/studies"
+SEARCH_API_FIELDS = "NCTId,OfficialTitle"
+SEARCH_PAGE_SIZE = 1000
+TRIAL_API_FIELDS = "protocolSection,derivedSection"
+DOWNLOAD_CONCURRENCY = 20
+TRIAL_CHAR_TRUNCATION_SIZE = 30_000  # larger will prevent embeddings from working
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_incrementing(0.1, 0.1),
+    retry=retry_if_exception_type(ClientResponseError),
+)
+async def api_search_clinical_trials(query: str, session: ClientSession) -> dict:
+    async with session.get(
+        STUDIES_API_URL,
+        params={
+            "query.term": query,
+            "fields": SEARCH_API_FIELDS,
+            "pageSize": SEARCH_PAGE_SIZE,
+            "countTotal": "true",
+            "sort": "@relevance",
+        },
+    ) as response:
+        if response.status == 400:
+            # the 400s from clinicaltrials.gov are not JSON
+            raise HTTPBadRequest(reason=await response.text())
+        response.raise_for_status()
+        return await response.json()
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_incrementing(0.1, 0.1),
+)
+async def api_get_clinical_trial(nct_id: str, session: ClientSession) -> dict | None:
+    with suppress(ClientResponseError):
+        async with session.get(
+            f"{STUDIES_API_URL}/{nct_id}", params={"fields": TRIAL_API_FIELDS}
+        ) as response:
+            response.raise_for_status()
+            return await response.json()
+    return None
+
+
+async def search_retrieve_clinical_trials(
+    query: str,
+    session: ClientSession,
+    limit: int = 10,
+    offset: int = 0,
+) -> tuple[list[dict], int]:
+
+    search_results = await api_search_clinical_trials(query, session=session)
+    return (
+        [
+            trial
+            for trial in await gather_with_concurrency(
+                DOWNLOAD_CONCURRENCY,
+                [
+                    api_get_clinical_trial(
+                        result["protocolSection"]["identificationModule"]["nctId"],
+                        session,
+                    )
+                    for result in search_results.get("studies", [])[
+                        offset : offset + limit
+                    ]
+                ],
+            )
+            if trial
+        ],
+        search_results.get("totalCount", 0),
+    )
+
+
+def format_to_doc_details(trial_data: dict) -> DocDetails:
+    """
+    Format clinical trial data into ICMJE citation style.
+
+    Args:
+        trial_data (dict): Clinical trial data in ClinicalTrials.gov JSON format
+    """
+    protocol = trial_data.get("protocolSection", {})
+
+    investigator = (
+        protocol.get("sponsorCollaboratorsModule", {})
+        .get("responsibleParty", {})
+        .get("investigatorFullName", "")
+    )
+    title = protocol.get("identificationModule", {}).get("briefTitle", "")
+    organization = (
+        protocol.get("sponsorCollaboratorsModule", {})
+        .get("leadSponsor", {})
+        .get("name", "")
+    )
+    start_date = (
+        protocol.get("statusModule", {}).get("startDateStruct", {}).get("date", "")
+    )
+    nct_id = protocol.get("identificationModule", {}).get("nctId", "")
+
+    # Extract year from date (assuming YYYY-MM format)
+    year = start_date.split("-")[0] if start_date else ""
+
+    citation_parts = []
+
+    if investigator:
+        citation_parts.append(f"{investigator}.")
+
+    if title:
+        citation_parts.append(f" {title}.")
+
+    if organization:
+        citation_parts.append(f" {organization}.")
+
+    if year:
+        citation_parts.append(f" {year}.")
+
+    if nct_id:
+        citation_parts.append(f" ClinicalTrials.gov Identifier: {nct_id}")
+
+    citation = "".join(citation_parts)
+
+    return DocDetails(
+        title=title,
+        docname=nct_id,
+        dockey=nct_id,
+        authors=[investigator],
+        year=year or None,
+        citation=citation,
+        other={"client_source": [CLINICAL_TRIALS_BASE]},
+        overwrite_fields_from_metadata=False,
+    )
+
+
+def parse_clinical_trial(json_data: dict[str, Any]) -> str:
+    """Convert clinical trial JSON data into human readable format."""
+    protocol = json_data.get("protocolSection", {})
+    # Get different sections
+    identification = protocol.get("identificationModule", {})
+    status = protocol.get("statusModule", {})
+    description = protocol.get("descriptionModule", {})
+    eligibility = protocol.get("eligibilityModule", {})
+    design = protocol.get("designModule", {})
+
+    # Build all sections at once
+    sections = [
+        # Title and Basic Information
+        "CLINICAL TRIAL INFORMATION",
+        "=" * 25,
+        f"NCT Number: {identification.get('nctId', 'Not provided')}",
+        f"Title: {identification.get('briefTitle', 'Not provided')}",
+        f"Organization: {identification.get('organization', {}).get('fullName', 'Not provided')}",
+        # Status Information
+        "\nSTUDY STATUS",
+        "=" * 13,
+        f"Overall Status: {status.get('overallStatus', 'Not provided')}",
+        f"Start Date: {status.get('startDateStruct', {}).get('date', 'Not provided')}",
+        f"Completion Date: {status.get('completionDateStruct', {}).get('date', 'Not provided')}",
+        # Study Description
+        "\nSTUDY DESCRIPTION",
+        "=" * 17,
+        description.get("briefSummary", "Not provided"),
+        # Study Design
+        "\nSTUDY DESIGN",
+        "=" * 13,
+        f"Study Type: {design.get('studyType', 'Not provided')}",
+        f"Phase: {', '.join(design.get('phases', ['Not provided']))}",
+        f"Enrollment: {design.get('enrollmentInfo', {}).get('count', 'Not provided')} participants",
+        # Eligibility
+        "\nELIGIBILITY CRITERIA",
+        "=" * 19,
+        eligibility.get("eligibilityCriteria", "Not provided"),
+    ]
+
+    # Add detailed description if available
+    if description.get("detailedDescription"):
+        detailed_section = [
+            "\nDETAILED DESCRIPTION",
+            "=" * 20,
+            description.get("detailedDescription", "Not provided"),
+        ]
+        # Insert detailed description after brief summary
+        sections[13:13] = detailed_section
+
+    # Format the final text
+    return "\n".join(sections)
+
+
+async def add_clinical_trials_to_docs(
+    query: str,
+    docs: Docs,
+    settings: Settings,
+    limit: int = 10,
+    offset: int = 0,
+    session: ClientSession | None = None,
+) -> tuple[int, int, str | None]:
+    """Add clinical trials to the docs state.
+
+    Args:
+        query: Query to search for.
+        docs: Docs state to add the trials to.
+        settings: Query settings.
+        limit: Number of trials to add.
+        offset: Offset for the search results.
+        session: AIOHTTP session.
+
+    Returns:
+        tuple[int, int, str | None]:
+            Total number of trials found, number of trials added, and error message if any.
+
+    """
+    session = aiohttp.ClientSession() if session is None else session
+
+    logger.info(f"Querying clinical trials for: {query}.")
+
+    try:
+        trials, total_result_count = await search_retrieve_clinical_trials(
+            query, session, limit, offset
+        )
+    except Exception as e:
+        logger.warning(f"Failed to retrieve clinical trials for query: {query}.")
+        return (0, 0, str(e))
+
+    logger.info(f"Successfully found {len(trials)} trials.")
+
+    inital_docs_size = len(docs.texts)
+
+    for trial in trials:
+        trial_text = (
+            parse_clinical_trial(trial)
+            if settings.parsing.use_human_readable_clinical_trials
+            else json.dumps(trial)
+        )
+        doc_details = format_to_doc_details(trial)
+        # always uses full object, no chunking for clinical trials
+        # for embedding model context windows, we truncate at TRIAL_CHAR_TRUNCATION_SIZE
+        await docs.aadd_texts(
+            texts=[
+                Text(
+                    text=trial_text[:TRIAL_CHAR_TRUNCATION_SIZE],
+                    name=doc_details.docname,
+                    doc=doc_details,
+                )
+            ],
+            doc=doc_details,
+            settings=settings,
+        )
+    logger.info(f"Added {len(docs.texts) - inital_docs_size} trials to docs state.")
+
+    # we add a final context stub representing the metadata surrounding this search
+    # it can be used to answer questions about the search results
+    meta_details = DocDetails(
+        title="Clinical Trials Search Result",
+        docname=f"Clinical Trial Search: {query}",
+        dockey=f"Clinical Trial Search: {query}",
+        authors=["PaperQA"],
+        year=datetime.now().year,
+        citation=f"Clinical Trials Search via ClinicalTrials.gov: {query}",
+        other={"client_source": [CLINICAL_TRIALS_BASE]},
+        overwrite_fields_from_metadata=False,
+    )
+
+    await docs.aadd_texts(
+        texts=[
+            Text(
+                text=(
+                    f"After querying the ClinicalTrials.gov API for '{query}',"
+                    f" {total_result_count} trials were found."
+                ),
+                name=meta_details.docname,
+                doc=meta_details,
+            )
+        ],
+        doc=meta_details,
+        settings=settings,
+    )
+
+    return (total_result_count, len(docs.texts) - inital_docs_size, None)
+
+
+def partition_clinical_trials_by_source(text: Embeddable) -> int:
+    if (
+        hasattr(text, "doc")
+        and isinstance(text.doc, DocDetails)
+        and CLINICAL_TRIALS_BASE in text.doc.other.get("client_source", [])
+    ):
+        return 1
+    return 0
+
+
+# SEE: https://regex101.com/r/L0L5MH/1
+CLINICAL_STATUS_SEARCH_REGEX_PATTERN: str = (
+    r"Status: Paper Count=(\d+) \| Relevant Papers=(\d+)(?:\s\|\sClinical Trial Count=(\d+)\s"
+    r"\|\sRelevant Clinical Trials=(\d+))?\s\|\sCurrent Evidence=(\d+)"
+)

--- a/paperqa/sources/clinical_trials.py
+++ b/paperqa/sources/clinical_trials.py
@@ -14,9 +14,9 @@ from tenacity import (
     wait_incrementing,
 )
 
-from paperqa import DocDetails, Docs
+from paperqa.docs import Docs
 from paperqa.settings import Settings
-from paperqa.types import Embeddable, Text
+from paperqa.types import DocDetails, Embeddable, Text
 from paperqa.utils import gather_with_concurrency
 
 logger = logging.getLogger(__name__)

--- a/paperqa/sources/clinical_trials.py
+++ b/paperqa/sources/clinical_trials.py
@@ -233,7 +233,6 @@ async def add_clinical_trials_to_docs(
     Returns:
         tuple[int, int, str | None]:
             Total number of trials found, number of trials added, and error message if any.
-
     """
     session = aiohttp.ClientSession() if session is None else session
 
@@ -312,10 +311,3 @@ def partition_clinical_trials_by_source(text: Embeddable) -> int:
     ):
         return 1
     return 0
-
-
-# SEE: https://regex101.com/r/L0L5MH/1
-CLINICAL_STATUS_SEARCH_REGEX_PATTERN: str = (
-    r"Status: Paper Count=(\d+) \| Relevant Papers=(\d+)(?:\s\|\sClinical Trial Count=(\d+)\s"
-    r"\|\sRelevant Clinical Trials=(\d+))?\s\|\sCurrent Evidence=(\d+)"
-)

--- a/paperqa/sources/clinical_trials.py
+++ b/paperqa/sources/clinical_trials.py
@@ -1,9 +1,8 @@
 import json
 import logging
-import os
 from contextlib import suppress
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 
 import aiohttp
 from aiohttp import ClientResponseError, ClientSession
@@ -31,6 +30,7 @@ SEARCH_PAGE_SIZE = 1000
 TRIAL_API_FIELDS = "protocolSection,derivedSection"
 DOWNLOAD_CONCURRENCY = 20
 TRIAL_CHAR_TRUNCATION_SIZE = 30_000  # larger will prevent embeddings from working
+MALFORMATTED_QUERY_STATUS: int = 400
 
 
 @retry(
@@ -49,7 +49,7 @@ async def api_search_clinical_trials(query: str, session: ClientSession) -> dict
             "sort": "@relevance",
         },
     ) as response:
-        if response.status == 400:
+        if response.status == MALFORMATTED_QUERY_STATUS:
             # the 400s from clinicaltrials.gov are not JSON
             raise HTTPBadRequest(reason=await response.text())
         response.raise_for_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ preview = true
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-ignore-words-list = "aadd,astroid,ser"
+ignore-words-list = "aadd,astroid,ser,ECT"
 skip = "docs/2024-10-16_litqa2-splits.json5"
 
 [tool.mypy]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -27,8 +27,8 @@ from pytest_subtests import SubTests
 from tantivy import Index
 
 from paperqa.agents import SearchIndex, agent_query
-from paperqa.agents.env import settings_to_tools
-from paperqa.agents.main import FAKE_AGENT_TYPE
+from paperqa.agents.env import settings_to_tools, clinical_trial_status
+from paperqa.agents.main import FAKE_AGENT_TYPE, run_agent
 from paperqa.agents.models import AgentStatus, AnswerResponse, QueryRequest
 from paperqa.agents.search import (
     FAILED_DOCUMENT_ADD_ID,
@@ -43,11 +43,13 @@ from paperqa.agents.tools import (
     GenerateAnswer,
     PaperSearch,
     Reset,
+    ClinicalTrialsSearch,
     make_status,
 )
 from paperqa.docs import Docs
 from paperqa.prompts import CANNOT_ANSWER_PHRASE, CONTEXT_INNER_PROMPT_NOT_DETAILED
 from paperqa.settings import AgentSettings, IndexSettings, Settings
+from paperqa.sources.clinical_trials import CLINICAL_STATUS_SEARCH_REGEX_PATTERN
 from paperqa.types import Context, Doc, PQASession, Text
 from paperqa.utils import extract_thought, get_year, md5sum
 
@@ -981,3 +983,68 @@ class TestGradablePaperQAEnvironment:
             )
 
             assert time.time() - tic > 2 * SLEEP_TIME  # since they are sequential
+
+@pytest.mark.asyncio
+async def test_clinical_tool_usage() -> None:
+    docs = Docs()
+    query = QueryRequest(
+        query=(
+            "What are the NCTIDs of clinical trials for depression that focus on health "
+            "services research, are in phase 2, have no status type, and started in or after 2017?"
+        ),
+        settings={
+            "llm": "gpt-4o",
+            "summary_llm": "gpt-4o",
+            "answer": {"answer_max_sources": 3, "evidence_k": 10},
+            "parsing": {"use_human_readable_clinical_trials": False},
+            "agent": {
+                "papers_from_evidence_citations_config": {
+                    "limit_total_papers": 4  # Keep low for speed
+                },
+                "tool_names": {
+                    "clinical_trials_search",
+                    "gather_evidence",
+                    "gen_answer",
+                    "complete",
+                },
+            },
+        },
+    )
+    response = await run_agent(docs, query)
+    # make sure the tool was used at least once
+    assert any(
+        ClinicalTrialsSearch.TOOL_FN_NAME in step
+        for step in response.session.tool_history
+    ), "ClinicalTrialsSearch was not used"
+    # make sure some clinical trials are pulled in as contexts
+    assert any(
+        "ClinicalTrials.gov" in c.text.doc.citation for c in response.session.contexts
+    ), "No clinical trials were put into contexts"
+
+
+class TestClinicalTrialSearchTool:
+    @pytest.mark.asyncio
+    async def test_continuation(self) -> None:
+        # TODO: get session... 
+        docs = Docs()
+        state = EnvironmentState(
+            docs=docs, session=session, status_fn=clinical_trial_status
+        )
+        tool = ClinicalTrialsSearch(
+            search_count=4,  # Keep low for speed
+            settings=Settings(),
+        )
+        result = await tool.clinical_trials_search("Covid-19 vaccines", state)
+        # 4 trials + the metadata context = 5
+        assert len(state.docs.docs) == 5, "Search did not return enough trials"
+        assert re.search(
+            pattern=CLINICAL_STATUS_SEARCH_REGEX_PATTERN, string=result
+        )
+        match = re.search(r"Clinical Trial Count=(\d+)", result)
+        assert match
+        trial_count = int(match.group(1))
+        assert trial_count == len(state.docs.docs)
+
+        # Check continuation of the search
+        result = await tool.clinical_trials_search("Covid-19 vaccines", state)
+        assert len(state.docs.docs) > trial_count, "Search was unable to continue"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,7 +18,6 @@ from uuid import uuid4
 
 import ldp.agent
 import pytest
-from aiohttp import ClientSession
 from aviary.core import Tool, ToolCall, ToolRequestMessage, ToolsAdapter, ToolSelector
 from ldp.agent import MemoryAgent, SimpleAgent
 from ldp.graph.memory import Memory, UIndexMemoryModel
@@ -1024,10 +1023,9 @@ async def test_clinical_tool_usage() -> None:
 class TestClinicalTrialSearchTool:
     @pytest.mark.asyncio
     async def test_continuation(self) -> None:
-        # TODO: get session...
         docs = Docs()
         state = EnvironmentState(
-            docs=docs, session=ClientSession(), status_fn=clinical_trial_status
+            docs=docs, session=PQASession(question=""), status_fn=clinical_trial_status
         )
         tool = ClinicalTrialsSearch(
             search_count=4,  # Keep low for speed

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -27,7 +27,11 @@ from pytest_subtests import SubTests
 from tantivy import Index
 
 from paperqa.agents import SearchIndex, agent_query
-from paperqa.agents.env import clinical_trial_status, settings_to_tools
+from paperqa.agents.env import (
+    CLINICAL_STATUS_SEARCH_REGEX_PATTERN,
+    clinical_trial_status,
+    settings_to_tools,
+)
 from paperqa.agents.main import FAKE_AGENT_TYPE, run_agent
 from paperqa.agents.models import AgentStatus, AnswerResponse, QueryRequest
 from paperqa.agents.search import (
@@ -49,7 +53,6 @@ from paperqa.agents.tools import (
 from paperqa.docs import Docs
 from paperqa.prompts import CANNOT_ANSWER_PHRASE, CONTEXT_INNER_PROMPT_NOT_DETAILED
 from paperqa.settings import AgentSettings, IndexSettings, Settings
-from paperqa.sources.clinical_trials import CLINICAL_STATUS_SEARCH_REGEX_PATTERN
 from paperqa.types import Context, Doc, PQASession, Text
 from paperqa.utils import extract_thought, get_year, md5sum
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -989,27 +989,22 @@ class TestGradablePaperQAEnvironment:
 
 
 @pytest.mark.asyncio
-async def test_clinical_tool_usage() -> None:
+async def test_clinical_tool_usage(agent_test_settings) -> None:
+    agent_test_settings.llm = "gpt-4o"
+    agent_test_settings.summary_llm = "gpt-4o"
+    agent_test_settings.agent.tool_names = {
+        "clinical_trials_search",
+        "gather_evidence",
+        "gen_answer",
+        "complete",
+    }
     docs = Docs()
     query = QueryRequest(
         query=(
             "What are the NCTIDs of clinical trials for depression that focus on health "
             "services research, are in phase 2, have no status type, and started in or after 2017?"
         ),
-        settings={
-            "llm": "gpt-4o",
-            "summary_llm": "gpt-4o",
-            "answer": {"answer_max_sources": 3, "evidence_k": 10},
-            "parsing": {"use_human_readable_clinical_trials": False},
-            "agent": {
-                "tool_names": {
-                    "clinical_trials_search",
-                    "gather_evidence",
-                    "gen_answer",
-                    "complete",
-                },
-            },
-        },
+        settings=agent_test_settings,
     )
     response = await run_agent(docs, query)
     # make sure the tool was used at least once

--- a/tests/test_clinical_trials.py
+++ b/tests/test_clinical_trials.py
@@ -1,0 +1,206 @@
+# pylint: disable=redefined-outer-name
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from aiohttp import ClientResponseError, ClientSession
+
+from paperqa import Docs, Settings
+from paperqa.sources.clinical_trials import (
+    add_clinical_trials_to_docs,
+    api_get_clinical_trial,
+    api_search_clinical_trials,
+    format_to_doc_details,
+    parse_clinical_trial,
+)
+
+SAMPLE_TRIAL_DATA = {
+    "protocolSection": {
+        "identificationModule": {
+            "nctId": "NCT12345678",
+            "briefTitle": "Test Clinical Trial",
+        },
+        "sponsorCollaboratorsModule": {
+            "responsibleParty": {"investigatorFullName": "Dr. John Doe"},
+            "leadSponsor": {"name": "Test Organization"},
+        },
+        "statusModule": {"startDateStruct": {"date": "2023-01"}},
+    }
+}
+
+
+@pytest.fixture
+def mock_bucket_client():
+    with patch("app.clinical_trials.GCS_BUCKET_CLINICAL_TRIALS_CLIENT") as mock_client:
+        yield mock_client
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock(spec=ClientSession)
+
+
+@pytest.mark.asyncio
+async def test_api_search_clinical_trials_success(mock_session):
+    mock_response = AsyncMock(status=200)
+    mock_response.raise_for_status.return_value = None
+    mock_response.text.return_value = json.dumps({"studies": [SAMPLE_TRIAL_DATA]})
+    mock_response.json.return_value = {"studies": [SAMPLE_TRIAL_DATA]}
+    mock_session.get.return_value.__aenter__.return_value = mock_response
+
+    result = await api_search_clinical_trials("test query", mock_session)
+
+    assert result == {"studies": [SAMPLE_TRIAL_DATA]}
+    mock_session.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_api_get_clinical_trial_success(mock_session):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = SAMPLE_TRIAL_DATA
+    mock_session.get.return_value.__aenter__.return_value = mock_response
+
+    result = await api_get_clinical_trial("NCT12345678", mock_session)
+
+    assert result == SAMPLE_TRIAL_DATA
+
+
+@pytest.mark.asyncio
+async def test_api_get_clinical_trial_not_found(mock_session):
+    mock_session.get.side_effect = ClientResponseError(
+        request_info=Mock(), history=Mock(), status=404
+    )
+
+    result = await api_get_clinical_trial("NCT12345678", mock_session)
+
+    assert result is None, "Should be robust to missing trials"
+
+
+def test_format_to_doc_details():
+    result = format_to_doc_details(SAMPLE_TRIAL_DATA)
+
+    assert result.title == "Test Clinical Trial"
+    assert result.authors == ["Dr. John Doe"]
+    assert result.year == 2023
+    assert "Dr. John Doe" in result.citation
+    assert "Test Clinical Trial" in result.citation
+    assert "Test Organization" in result.citation
+    assert "2023" in result.citation
+    assert "NCT12345678" in result.citation
+
+
+@pytest.mark.asyncio
+async def test_add_clinical_trials_to_docs():
+    mock_session = AsyncMock(spec=ClientSession)
+    mock_docs = Mock(spec=Docs)
+    mock_docs.aadd_texts = AsyncMock()
+    mock_docs.texts = []
+
+    mock_response = AsyncMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "studies": [
+            {"protocolSection": {"identificationModule": {"nctId": "NCT12345678"}}}
+        ]
+    }
+    mock_session.get.return_value.__aenter__.return_value = mock_response
+
+    with patch(
+        "paperqa.sources.clinical_trials.search_retrieve_clinical_trials",
+        return_value=([SAMPLE_TRIAL_DATA], 1),
+    ):
+        await add_clinical_trials_to_docs(
+            "test query", mock_docs, Settings(), session=mock_session
+        )
+
+        assert (
+            mock_docs.aadd_texts.call_count == 2
+        ), "One for the metadata and one for the trial"
+        call_args = mock_docs.aadd_texts.call_args[1]
+        assert "doc" in call_args
+        assert isinstance(call_args["doc"].citation, str)
+
+
+def test_parse_clinical_trial():
+    # Test data with all fields including detailed description
+    complete_trial_data = {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": "NCT12345678",
+                "briefTitle": "Sample Trial",
+                "organization": {"fullName": "Test Hospital"},
+            },
+            "statusModule": {
+                "overallStatus": "Recruiting",
+                "startDateStruct": {"date": "2023-01"},
+                "completionDateStruct": {"date": "2024-12"},
+            },
+            "descriptionModule": {
+                "briefSummary": "This is a brief summary",
+                "detailedDescription": "This is a detailed description",
+            },
+            "designModule": {
+                "studyType": "Interventional",
+                "phases": ["Phase 1", "Phase 2"],
+                "enrollmentInfo": {"count": 100},
+            },
+            "eligibilityModule": {"eligibilityCriteria": "Must be 18 or older"},
+        }
+    }
+
+    # Test data without detailed description
+    minimal_trial_data = {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": "NCT87654321",
+                "briefTitle": "Basic Trial",
+            },
+            "statusModule": {},
+            "descriptionModule": {"briefSummary": "Brief summary only"},
+            "designModule": {"phases": []},
+            "eligibilityModule": {},
+        }
+    }
+
+    # Test complete data
+    result_complete = parse_clinical_trial(complete_trial_data)
+
+    # Verify all sections are present
+    assert "CLINICAL TRIAL INFORMATION" in result_complete
+    assert "NCT Number: NCT12345678" in result_complete
+    assert "Organization: Test Hospital" in result_complete
+    assert "Overall Status: Recruiting" in result_complete
+    assert "Start Date: 2023-01" in result_complete
+    assert "Completion Date: 2024-12" in result_complete
+    assert "This is a brief summary" in result_complete
+    assert "This is a detailed description" in result_complete
+    assert "Study Type: Interventional" in result_complete
+    assert "Phase: Phase 1, Phase 2" in result_complete
+    assert "Enrollment: 100 participants" in result_complete
+    assert "Must be 18 or older" in result_complete
+
+    # Verify section order (detailed description should come after brief summary)
+    brief_pos = result_complete.find("This is a brief summary")
+    detailed_pos = result_complete.find("This is a detailed description")
+    assert (
+        brief_pos < detailed_pos
+    ), "Detailed description should come after brief summary"
+
+    # Test minimal data
+    result_minimal = parse_clinical_trial(minimal_trial_data)
+
+    # Verify default values for missing fields
+    assert "NCT Number: NCT87654321" in result_minimal
+    assert "Organization: Not provided" in result_minimal
+    assert "Start Date: Not provided" in result_minimal
+    assert "Phase: " in result_minimal  # Empty phases list results in empty string
+    assert (
+        "DETAILED DESCRIPTION" not in result_minimal
+    ), "Detailed description section should not be present"
+
+    # Verify newlines and formatting
+    assert result_complete.count("\n") > result_minimal.count(
+        "\n"
+    ), "Complete result should have more lines due to detailed description"
+    assert "=" * 25 in result_complete, "Section separators should be present"

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -683,7 +683,7 @@ def test_sparse_embedding(stub_data_dir: Path, vector_store: type[VectorStore]) 
         citation="WikiMedia Foundation, 2023, Accessed now",
         embedding_model=SparseEmbeddingModel(),
     )
-    assert any(docs.texts[0].embedding)
+    assert any(cast(list[float], docs.texts[0].embedding))
     assert all(
         len(np.array(x.embedding).shape) == 1 for x in docs.texts
     ), "Embeddings should be 1D"
@@ -705,7 +705,7 @@ def test_hybrid_embedding(stub_data_dir: Path, vector_store: type[VectorStore]) 
         citation="WikiMedia Foundation, 2023, Accessed now",
         embedding_model=emb_model,
     )
-    assert any(docs.texts[0].embedding)
+    assert any(cast(list[float], docs.texts[0].embedding))
 
     # check the embeddings are the same size
     assert docs.texts[0].embedding is not None
@@ -1211,7 +1211,7 @@ def test_answer_rename(recwarn) -> None:
     ],
 )
 def test_dois_resolve_to_correct_journals(doi_journals):
-    details = DocDetails(doi=doi_journals["doi"])
+    details = DocDetails(doi=doi_journals["doi"])  # type: ignore[call-arg]
     assert details.journal == doi_journals["journal"]
 
 


### PR DESCRIPTION
This upstreams FutureHouse's clinical trials search tool to make it open source. The tool is not turned on by default, but I'm going to make more docs on how to use the tool as well. 

I also found many typing regressions -- I've added those back in where necessary.