### PR TITLE
Pinning min version of `fh-llm-client`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,10 +84,10 @@ repos:
           - aiohttp>=3.10.6 # Match pyproject.toml
           - PyMuPDF>=1.24.12
           - anyio
+          - fh-llm-client>=0.0.3 # Match pyproject.toml
           - fhaviary[llm]>=0.14 # Match pyproject.toml
           - ldp>=0.17 # Match pyproject.toml
           - html2text
-          - fh-llm-client
           - httpx
           - pybtex
           - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "PyMuPDF>=1.24.12",  # For pymupdf.set_messages addition
     "aiohttp>=3.10.6",  # TODO: remove in favor of httpx, pin for aiohttp.ClientConnectionResetError
     "anyio",
-    "fh-llm-client",
+    "fh-llm-client>=0.0.3",  # Pin for EmbeddingModel
     "fhaviary[llm]>=0.14",  # For MultipleChoiceQuestion
     "html2text",  # TODO: evaluate moving to an opt-in dependency
     "httpx",

--- a/uv.lock
+++ b/uv.lock
@@ -1643,7 +1643,7 @@ wheels = [
 
 [[package]]
 name = "paper-qa"
-version = "5.8.1.dev15+gf68b03e.d20250102"
+version = "5.9.1.dev0+gf4c299a.d20250106"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -1747,7 +1747,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.6" },
     { name = "anyio" },
     { name = "datasets", marker = "extra == 'datasets'" },
-    { name = "fh-llm-client" },
+    { name = "fh-llm-client", specifier = ">=0.0.3" },
     { name = "fhaviary", extras = ["llm"], specifier = ">=0.14" },
     { name = "html2text" },
     { name = "httpx" },


### PR DESCRIPTION
The `fh-llm-client` added in https://github.com/Future-House/paper-qa/pull/757 had an unpinned min version, which it turns out caused some problems downstream CI:

```none
Installed 137 packages in 61ms
...
 + fh-llm-client==0.0.1
...

    from paperqa.agents.task import GradablePaperQAEnvironment, LitQAv2TaskDataset
.venv/lib/python3.11/site-packages/paperqa/__init__.py:3: in <module>
    from llmclient import (
E   ImportError: cannot import name 'EmbeddingModel' from 'llmclient' 
```
