### PR TITLE
Fixed `Record` import from Qdrant not being in `TYPE_CHECKING` block

### DIFF
--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -447,7 +447,7 @@ class QdrantVectorStore(VectorStore):
     @classmethod
     async def load_docs(
         cls,
-        client: AsyncQdrantClient,
+        client: "AsyncQdrantClient",
         collection_name: str,
         vector_name: str | None = None,
         batch_size: int = 100,

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import asyncio
 import itertools
 import logging
@@ -452,7 +450,7 @@ class QdrantVectorStore(VectorStore):
         vector_name: str | None = None,
         batch_size: int = 100,
         max_concurrent_requests: int = 5,
-    ) -> Docs:
+    ) -> "Docs":
         from paperqa.docs import Docs  # Avoid circular imports
 
         vectorstore = cls(

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -30,13 +30,15 @@ from pydantic import (
     Field,
     model_validator,
 )
-from qdrant_client.http.models import Record
 from typing_extensions import override
 
 from paperqa.types import Doc, Text
 
 if TYPE_CHECKING:
+    from qdrant_client.http.models import Record
+
     from paperqa.docs import Docs
+
 try:
     from qdrant_client import AsyncQdrantClient, models
 


### PR DESCRIPTION
When not using Qdrant, installers as of v5.9.0 will get this error:

```none
.venv/lib/python3.12/site-packages/paperqa/llms.py:35: in <module>
    from qdrant_client.http.models import Record
E   ModuleNotFoundError: No module named 'qdrant_client'
```

This PR:
- Fixes the non-lazily imported type hint
- Removed an unnecessary `from __future__ import annotations`