### PR TITLE
Expose more contexts as output from gather_evidence tool

### DIFF
--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -253,11 +253,17 @@ class GatherEvidence(NamedTool):
         sorted_contexts = sorted(
             state.session.contexts, key=lambda x: x.score, reverse=True
         )
-        best_evidence = (
-            f" Best evidence:\n\n{sorted_contexts[0].context}"
-            if sorted_contexts
-            else ""
+
+        top_contexts = "\n".join(
+            [
+                f"{n + 1}. {sc.context}\n"
+                for n, sc in enumerate(
+                    sorted_contexts[: self.settings.agent.agent_evidence_n]
+                )
+            ]
         )
+
+        best_evidence = f" Best evidence(s):\n\n{top_contexts}" if top_contexts else ""
 
         if f"{self.TOOL_FN_NAME}_completed" in self.settings.agent.callbacks:
             await asyncio.gather(

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -467,6 +467,11 @@ class AgentSettings(BaseModel):
     )
     search_count: int = 8
     wipe_context_on_answer_failure: bool = True
+    agent_evidence_n: int = Field(
+        default=1,
+        description="Top n ranked evidences shown to the "
+        "agent after the GatherEvidence tool.",
+    )
     timeout: float = Field(
         default=500.0,
         description=(

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -469,6 +469,7 @@ class AgentSettings(BaseModel):
     wipe_context_on_answer_failure: bool = True
     agent_evidence_n: int = Field(
         default=1,
+        ge=1,
         description="Top n ranked evidences shown to the "
         "agent after the GatherEvidence tool.",
     )


### PR DESCRIPTION
When we approach more complex trajectories, the agent models need more info for decision making. We only return by default 1 top-ranked context, this allows us to expose more to the agent model.