### PR TITLE
Refactor to remove `QueryRequest` entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,13 +321,11 @@ answer_response = ask(
 `ask` is just a convenience wrapper around the real entrypoint, which can be accessed if you'd like to run concurrent asynchronous workloads:
 
 ```python
-from paperqa import Settings, agent_query, QueryRequest
+from paperqa import Settings, agent_query
 
 answer_response = await agent_query(
-    QueryRequest(
-        query="What manufacturing challenges are unique to bispecific antibodies?",
-        settings=Settings(temperature=0.5, paper_directory="my_papers"),
-    )
+    query="What manufacturing challenges are unique to bispecific antibodies?",
+    settings=Settings(temperature=0.5, paper_directory="my_papers"),
 )
 ```
 
@@ -682,7 +680,6 @@ import os
 
 from paperqa import Settings
 from paperqa.agents.main import agent_query
-from paperqa.agents.models import QueryRequest
 from paperqa.agents.search import get_directory_index
 
 
@@ -696,15 +693,12 @@ async def amain(folder_of_papers: str | os.PathLike) -> None:
 
     # 2. Use the settings as many times as you want with ask
     answer_response_1 = await agent_query(
-        query=QueryRequest(
-            query="What is the best way to make a vaccine?", settings=settings
-        )
+        query="What is the best way to make a vaccine?",
+        settings=settings,
     )
     answer_response_2 = await agent_query(
-        query=QueryRequest(
-            query="What manufacturing challenges are unique to bispecific antibodies?",
-            settings=settings,
-        )
+        query="What manufacturing challenges are unique to bispecific antibodies?",
+        settings=settings,
     )
 ```
 
@@ -726,15 +720,13 @@ from ldp.agent import SimpleAgent
 from ldp.alg.callbacks import MeanMetricsCallback
 from ldp.alg.runners import Evaluator, EvaluatorConfig
 
-from paperqa import QueryRequest, Settings
+from paperqa import Settings
 from paperqa.agents.task import TASK_DATASET_NAME
 
 
 async def evaluate(folder_of_litqa_v2_papers: str | os.PathLike) -> None:
-    base_query = QueryRequest(
-        settings=Settings(paper_directory=folder_of_litqa_v2_papers)
-    )
-    dataset = TaskDataset.from_name(TASK_DATASET_NAME, base_query=base_query)
+    settings = Settings(paper_directory=folder_of_litqa_v2_papers)
+    dataset = TaskDataset.from_name(TASK_DATASET_NAME, settings=settings)
     metrics_callback = MeanMetricsCallback(eval_dataset=dataset)
 
     evaluator = Evaluator(

--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -14,7 +14,6 @@ from llmclient import (
 
 from paperqa.agents import ask
 from paperqa.agents.main import agent_query
-from paperqa.agents.models import QueryRequest
 from paperqa.docs import Docs, PQASession, print_callback
 from paperqa.llms import (
     NumpyVectorStore,
@@ -46,7 +45,6 @@ __all__ = [
     "NumpyVectorStore",
     "PQASession",
     "QdrantVectorStore",
-    "QueryRequest",
     "SentenceTransformerEmbeddingModel",
     "Settings",
     "SparseEmbeddingModel",

--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -15,7 +15,7 @@ from paperqa.utils import get_loop, pqa_directory, setup_default_logs
 from paperqa.version import __version__
 
 from .main import agent_query, index_search
-from .models import AnswerResponse, QueryRequest
+from .models import AnswerResponse
 from .search import SearchIndex, get_directory_index
 
 logger = logging.getLogger(__name__)
@@ -102,10 +102,7 @@ def ask(query: str | MultipleChoiceQuestion, settings: Settings) -> AnswerRespon
     """Query PaperQA via an agent."""
     configure_cli_logging(settings)
     return get_loop().run_until_complete(
-        agent_query(
-            QueryRequest(query=query, settings=settings),
-            agent_type=settings.agent.agent_type,
-        )
+        agent_query(query, settings, agent_type=settings.agent.agent_type)
     )
 
 

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -23,12 +23,12 @@ from tenacity import (
 
 from paperqa._ldp_shims import Callback, RolloutManager
 from paperqa.docs import Docs
-from paperqa.settings import AgentSettings
+from paperqa.settings import AgentSettings, Settings
 from paperqa.types import PQASession
 
 from .env import PaperQAEnvironment
 from .helpers import litellm_get_search_query, table_formatter
-from .models import AgentStatus, AnswerResponse, QueryRequest, SimpleProfiler
+from .models import AgentStatus, AnswerResponse, SimpleProfiler
 from .search import SearchDocumentStorage, SearchIndex, get_directory_index
 from .tools import (
     Complete,
@@ -50,24 +50,23 @@ DEFAULT_AGENT_TYPE = AgentSettings.model_fields["agent_type"].default
 
 
 async def agent_query(
-    query: str | MultipleChoiceQuestion | QueryRequest,
+    query: str | MultipleChoiceQuestion,
+    settings: Settings,
     docs: Docs | None = None,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
     **runner_kwargs,
 ) -> AnswerResponse:
-    if isinstance(query, str | MultipleChoiceQuestion):
-        query = QueryRequest(query=query)
     if docs is None:
         docs = Docs()
 
     answers_index = SearchIndex(
         fields=[*SearchIndex.REQUIRED_FIELDS, "question"],
         index_name="answers",
-        index_directory=query.settings.agent.index.index_directory,
+        index_directory=settings.agent.index.index_directory,
         storage=SearchDocumentStorage.JSON_MODEL_DUMP,
     )
 
-    response = await run_agent(docs, query, agent_type, **runner_kwargs)
+    response = await run_agent(docs, query, settings, agent_type, **runner_kwargs)
     agent_logger.debug(f"agent_response: {response}")
 
     agent_logger.info(f"[bold blue]Answer: {response.session.answer}[/bold blue]")
@@ -89,7 +88,8 @@ FAKE_AGENT_TYPE = "fake"  # No agent, just invoke tools in deterministic order
 
 async def run_agent(
     docs: Docs,
-    query: QueryRequest,
+    query: str | MultipleChoiceQuestion,
+    settings: Settings,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
     **runner_kwargs,
 ) -> AnswerResponse:
@@ -99,6 +99,7 @@ async def run_agent(
     Args:
         docs: Docs to run upon.
         query: Query to answer.
+        settings: Settings to use.
         agent_type: Agent type (or fully qualified name to the type) to pass to
             AgentType.get_agent, or "fake" to TODOC.
         runner_kwargs: Keyword arguments to pass to the runner.
@@ -107,25 +108,27 @@ async def run_agent(
         Tuple of resultant answer, token counts, and agent status.
     """
     profiler = SimpleProfiler()
-    outer_profile_name = f"agent-{agent_type}-{query.settings.agent.agent_llm}"
+    outer_profile_name = f"agent-{agent_type}-{settings.agent.agent_llm}"
     profiler.start(outer_profile_name)
-
+    question = query if isinstance(query, str) else query.question_prompt
     logger.info(
-        f"Beginning agent {agent_type!r} run with question {query.query!r} and full"
-        f" query {query.model_dump()}."
+        f"Beginning agent {agent_type!r} run with question {question!r} and full"
+        f" settings {settings.model_dump()}."
     )
 
     # Build the index once here, and then all tools won't need to rebuild it
-    await get_directory_index(settings=query.settings)
+    await get_directory_index(settings=settings)
     if isinstance(agent_type, str) and agent_type.lower() == FAKE_AGENT_TYPE:
-        session, agent_status = await run_fake_agent(query, docs, **runner_kwargs)
-    elif tool_selector_or_none := query.settings.make_aviary_tool_selector(agent_type):
-        session, agent_status = await run_aviary_agent(
-            query, docs, tool_selector_or_none, **runner_kwargs
+        session, agent_status = await run_fake_agent(
+            query, settings, docs, **runner_kwargs
         )
-    elif ldp_agent_or_none := await query.settings.make_ldp_agent(agent_type):
+    elif tool_selector_or_none := settings.make_aviary_tool_selector(agent_type):
+        session, agent_status = await run_aviary_agent(
+            query, settings, docs, tool_selector_or_none, **runner_kwargs
+        )
+    elif ldp_agent_or_none := await settings.make_ldp_agent(agent_type):
         session, agent_status = await run_ldp_agent(
-            query, docs, ldp_agent_or_none, **runner_kwargs
+            query, settings, docs, ldp_agent_or_none, **runner_kwargs
         )
     else:
         raise NotImplementedError(f"Didn't yet handle agent type {agent_type}.")
@@ -134,7 +137,7 @@ async def run_agent(
         agent_status = AgentStatus.UNSURE
     # stop after, so overall isn't reported as long-running step.
     logger.info(
-        f"Finished agent {agent_type!r} run with question {query.query!r} and status"
+        f"Finished agent {agent_type!r} run with question {question!r} and status"
         f" {agent_status}."
     )
     return AnswerResponse(session=session, status=agent_status)
@@ -142,15 +145,15 @@ async def run_agent(
 
 async def _run_with_timeout_failure(
     rollout: Callable[[], Awaitable[AgentStatus]],
-    query: QueryRequest,
+    settings: Settings,
     env: PaperQAEnvironment,
 ) -> tuple[PQASession, AgentStatus]:
     try:
-        async with asyncio.timeout(query.settings.agent.timeout):
+        async with asyncio.timeout(settings.agent.timeout):
             status = await rollout()
     except TimeoutError:
         logger.warning(
-            f"Agent timeout after {query.settings.agent.timeout}-sec, just answering."
+            f"Agent timeout after {settings.agent.timeout}-sec, just answering."
         )
         status = AgentStatus.TRUNCATED
     except Exception:
@@ -171,7 +174,8 @@ async def _run_with_timeout_failure(
 
 
 async def run_fake_agent(
-    query: QueryRequest,
+    query: str | MultipleChoiceQuestion,
+    settings: Settings,
     docs: Docs,
     env_class: type[PaperQAEnvironment] = PaperQAEnvironment,
     on_env_reset_callback: Callable[[EnvironmentState], Awaitable] | None = None,
@@ -183,12 +187,12 @@ async def run_fake_agent(
     ) = None,
     **env_kwargs,
 ) -> tuple[PQASession, AgentStatus]:
-    if query.settings.agent.max_timesteps is not None:
+    if settings.agent.max_timesteps is not None:
         logger.warning(
-            f"Max timesteps (configured {query.settings.agent.max_timesteps}) is not"
+            f"Max timesteps (configured {settings.agent.max_timesteps}) is not"
             " applicable with the fake agent, ignoring it."
         )
-    env = env_class(query, docs, **env_kwargs)
+    env = env_class(query, settings, docs, **env_kwargs)
     obs, tools = await env.reset()
     if on_env_reset_callback:
         await on_env_reset_callback(env.state)
@@ -219,7 +223,7 @@ async def run_fake_agent(
             await on_env_step_callback(obs, reward, done, truncated)
 
     async def rollout() -> AgentStatus:
-        llm_model = query.settings.get_llm()
+        llm_model = settings.get_llm()
 
         # Seed docs with a few LLM-proposed search calls
         # TODO: make properly support year ranges
@@ -243,11 +247,12 @@ async def run_fake_agent(
             else AgentStatus.UNSURE
         )
 
-    return await _run_with_timeout_failure(rollout, query, env)
+    return await _run_with_timeout_failure(rollout, settings, env)
 
 
 async def run_aviary_agent(
-    query: QueryRequest,
+    query: str | MultipleChoiceQuestion,
+    settings: Settings,
     docs: Docs,
     agent: ToolSelector,
     env_class: type[PaperQAEnvironment] = PaperQAEnvironment,
@@ -260,7 +265,7 @@ async def run_aviary_agent(
     ) = None,
     **env_kwargs,
 ) -> tuple[PQASession, AgentStatus]:
-    env = env_class(query, docs, **env_kwargs)
+    env = env_class(query, settings, docs, **env_kwargs)
 
     async def rollout() -> AgentStatus:
         obs, tools = await env.reset()
@@ -272,16 +277,16 @@ async def run_aviary_agent(
                 [
                     Message(
                         role="system",
-                        content=query.settings.agent.agent_system_prompt,
+                        content=settings.agent.agent_system_prompt,
                     )
                 ]
-                if query.settings.agent.agent_system_prompt
+                if settings.agent.agent_system_prompt
                 else []
             ),
             tools=tools,
         )
 
-        timestep, max_timesteps = 0, query.settings.agent.max_timesteps
+        timestep, max_timesteps = 0, settings.agent.max_timesteps
         done = False
         while not done:
             if max_timesteps is not None and timestep >= max_timesteps:
@@ -309,7 +314,7 @@ async def run_aviary_agent(
             timestep += 1
         return AgentStatus.SUCCESS
 
-    return await _run_with_timeout_failure(rollout, query, env)
+    return await _run_with_timeout_failure(rollout, settings, env)
 
 
 class LDPRolloutCallback(Callback):
@@ -343,7 +348,8 @@ class LDPRolloutCallback(Callback):
 
 
 async def run_ldp_agent(
-    query: QueryRequest,
+    query: str | MultipleChoiceQuestion,
+    settings: Settings,
     docs: Docs,
     agent: "Agent[SimpleAgentState]",
     env_class: type[PaperQAEnvironment] = PaperQAEnvironment,
@@ -355,7 +361,7 @@ async def run_ldp_agent(
     ldp_callback_type: type[LDPRolloutCallback] = LDPRolloutCallback,
     **env_kwargs,
 ) -> tuple[PQASession, AgentStatus]:
-    env = env_class(query, docs, **env_kwargs)
+    env = env_class(query, settings, docs, **env_kwargs)
     # NOTE: don't worry about ldp import checks, because we know Settings.make_ldp_agent
     # has already taken place, which checks that ldp is installed
 
@@ -372,14 +378,14 @@ async def run_ldp_agent(
             ],
         )
         trajs = await rollout_manager.sample_trajectories(
-            environments=[env], max_steps=query.settings.agent.max_timesteps
+            environments=[env], max_steps=settings.agent.max_timesteps
         )
         traj = trajs[0]
         if traj.steps[-1].truncated:
             return AgentStatus.TRUNCATED
         return AgentStatus.SUCCESS
 
-    return await _run_with_timeout_failure(rollout, query, env)
+    return await _run_with_timeout_failure(rollout, settings, env)
 
 
 async def index_search(


### PR DESCRIPTION
The `QueryRequest` entity here served a few purposes oriented around a PaperQA web service infrastructure:

- Group query, settings, and session ID
- Provides a way to link `Docs` with a given run

`QueryRequest` also comes with a few tradeoffs:

- One more entity in the stack --> one more level to recurse down
- Complicates `deepcopy` since `QueryRequest` is stateful
- Most of the time we just need `(query, settings)`, a session ID is irrelevant

Since this repo is really more about CLI usage and the core algorithm, we don't need this entity here, so this PR removes it.