### PR TITLE
Fixing tool failures crashing runners in failover answer

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -166,10 +166,11 @@ async def _run_with_timeout_failure(
         generate_answer_tool = next(
             filter(lambda x: x.info.name == GenerateAnswer.TOOL_FN_NAME, env.tools)
         )
-        await generate_answer_tool._tool_fn(state=env.state)
-        env.state.record_action(
-            ToolRequestMessage(tool_calls=[ToolCall.from_tool(generate_answer_tool)])
+        action = ToolRequestMessage(
+            tool_calls=[ToolCall.from_tool(generate_answer_tool)]
         )
+        await env.exec_tool_calls(message=action, state=env.state, handle_tool_exc=True)
+        env.state.record_action(action)
     return env.state.session, status
 
 


### PR DESCRIPTION
During normal `PaperQAEnvironment.step`, we call tools using `exec_tool_calls(..., handle_tool_exc=True)`. This means we don't crash on tool failures.

During the rollout's truncation's failover `gen_answer` invocation, we didn't have the same `handle_tool_exc=True` protection in place, so we could crash. This PR just moves the failover `gen_answer` invocation to use `exec_tool_calls` for the same safety.