### PR TITLE
Fixing `gather_evidence` and `complete` response messages

### DIFF
--- a/paperqa/agents/env.py
+++ b/paperqa/agents/env.py
@@ -160,6 +160,7 @@ CLINICAL_STATUS_SEARCH_REGEX_PATTERN: str = (
 
 
 def clinical_trial_status(state: "EnvironmentState") -> str:
+    relevant_contexts = state.get_relevant_contexts()
     return make_clinical_trial_status(
         total_paper_count=len(
             {
@@ -172,9 +173,8 @@ def clinical_trial_status(state: "EnvironmentState") -> str:
         relevant_paper_count=len(
             {
                 c.text.doc.dockey
-                for c in state.session.contexts
-                if c.score > state.RELEVANT_SCORE_CUTOFF
-                and CLINICAL_TRIALS_BASE
+                for c in relevant_contexts
+                if CLINICAL_TRIALS_BASE
                 not in getattr(c.text.doc, "other", {}).get("client_source", [])
             }
         ),
@@ -189,15 +189,12 @@ def clinical_trial_status(state: "EnvironmentState") -> str:
         relevant_clinical_trials=len(
             {
                 c.text.doc.dockey
-                for c in state.session.contexts
-                if c.score > state.RELEVANT_SCORE_CUTOFF
-                and CLINICAL_TRIALS_BASE
+                for c in relevant_contexts
+                if CLINICAL_TRIALS_BASE
                 in getattr(c.text.doc, "other", {}).get("client_source", [])
             }
         ),
-        evidence_count=len(
-            [c for c in state.session.contexts if c.score > state.RELEVANT_SCORE_CUTOFF]
-        ),
+        evidence_count=len(relevant_contexts),
         cost=state.session.cost,
     )
 

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -225,7 +225,8 @@ class GatherEvidence(NamedTool):
 
         logger.info(f"{self.TOOL_FN_NAME} starting for question {question!r}.")
         original_question = state.session.question
-        l1_all = l1_relevant = l0 = len(state.session.contexts)
+        l1 = l0 = len(state.session.contexts)
+        l1_relevant = l0_relevant = len(state.get_relevant_contexts())
 
         try:
             # Swap out the question with the more specific question
@@ -243,7 +244,7 @@ class GatherEvidence(NamedTool):
                     f"{self.TOOL_FN_NAME}_aget_evidence"
                 ),
             )
-            l1_all = len(state.session.contexts)
+            l1 = len(state.session.contexts)
             l1_relevant = len(state.get_relevant_contexts())
         finally:
             state.session.question = original_question
@@ -276,7 +277,7 @@ class GatherEvidence(NamedTool):
             )
 
         return (
-            f"Added {l1_all - l0} pieces of evidence, {l1_relevant - l0} of which were"
+            f"Added {l1 - l0} pieces of evidence, {l1_relevant - l0_relevant} of which were"
             f" relevant.{best_evidence}\n\n" + status
         )
 

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -412,10 +412,10 @@ class Complete(NamedTool):
 
         logger.info(
             f"Completing '{state.session.question}' as"
-            f" '{'a success' if has_successful_answer else 'unsure'}'."
+            f" '{'sure' if has_successful_answer else 'unsure'}'."
         )
         # Return answer and status to simplify postprocessing of tool response
-        return f"{'Success' if has_successful_answer else 'Unsure'} | {state.status}"
+        return f"{'Sure' if has_successful_answer else 'Unsure'} | {state.status}"
 
 
 class ClinicalTrialsSearch(NamedTool):

--- a/paperqa/agents/tools.py
+++ b/paperqa/agents/tools.py
@@ -405,10 +405,10 @@ class Complete(NamedTool):
 
         logger.info(
             f"Completing '{state.session.question}' as"
-            f" '{'sure' if has_successful_answer else 'unsure'}'."
+            f" '{'certain' if has_successful_answer else 'unsure'}'."
         )
         # Return answer and status to simplify postprocessing of tool response
-        return f"{'Sure' if has_successful_answer else 'Unsure'} | {state.status}"
+        return f"{'Certain' if has_successful_answer else 'Unsure'} | {state.status}"
 
 
 class ClinicalTrialsSearch(NamedTool):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -580,6 +580,17 @@ async def test_agent_sharing_state(
             gather_evidence_initialized_callback.assert_awaited_once_with(env_state)
             gather_evidence_completed_callback.assert_awaited_once_with(env_state)
 
+        split = re.split(
+            r"(\d+) pieces of evidence, (\d+) of which were relevant",
+            response,
+            maxsplit=1,
+        )
+        assert len(split) == 4, "Unexpected response shape"
+        total_added_1, relevant_added_1 = int(split[1]), int(split[2])
+        assert all(
+            x >= 0 for x in (total_added_1, relevant_added_1)
+        ), "Expected non-negative counts"
+        assert len(env_state.get_relevant_contexts()) == relevant_added_1
         # ensure 1 piece of top evidence is returned
         assert "\n1." in response, "gather_evidence did not return any results"
         assert (
@@ -590,6 +601,21 @@ async def test_agent_sharing_state(
         gather_evidence_tool.settings.agent.agent_evidence_n = 2
         response = await gather_evidence_tool.gather_evidence(
             session.question, state=env_state
+        )
+
+        split = re.split(
+            r"(\d+) pieces of evidence, (\d+) of which were relevant",
+            response,
+            maxsplit=1,
+        )
+        assert len(split) == 4, "Unexpected response shape"
+        total_added_2, relevant_added_2 = int(split[1]), int(split[2])
+        assert all(
+            x >= 0 for x in (total_added_2, relevant_added_2)
+        ), "Expected non-negative counts"
+        assert (
+            len(env_state.get_relevant_contexts())
+            == relevant_added_1 + relevant_added_2
         )
         # ensure both evidences are returned
         assert "\n1." in response, "gather_evidence did not return any results"


### PR DESCRIPTION
This PR fixes two misconceptions:
- https://github.com/Future-House/paper-qa/pull/809 incorrectly based the relevant docs added count to `l0`, but it should have only been relevant ones
- If `complete` tool gets passed `has_successful_answer` its response starts with "Success". However, if it turns out the answer is wrong, this response may not make sense. Now the response starts with ~"Sure"~ "Certain" to be clear