### PR TITLE
Fixing flaky test `test_cli_can_build_and_search_index` by retrying

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -782,13 +782,15 @@ class Docs(BaseModel):
             )
         else:
             with set_llm_session_ids(session.id):
+                example_citation, style = prompt_config.EXAMPLE_CITATION_AND_STYLE
                 answer_result = await llm_model.run_prompt(
                     prompt=prompt_config.qa,
                     data={
                         "context": context_str,
                         "answer_length": answer_config.answer_length,
                         "question": session.question,
-                        "example_citation": prompt_config.EXAMPLE_CITATION,
+                        "example_citation": example_citation,
+                        "citation_style": style,
                     },
                     callbacks=callbacks,
                     name="answer",
@@ -797,8 +799,8 @@ class Docs(BaseModel):
             answer_text = answer_result.text
             session.add_tokens(answer_result)
         # it still happens
-        if prompt_config.EXAMPLE_CITATION in answer_text:
-            answer_text = answer_text.replace(prompt_config.EXAMPLE_CITATION, "")
+        if (ex_citation := prompt_config.EXAMPLE_CITATION_AND_STYLE[0]) in answer_text:
+            answer_text = answer_text.replace(ex_citation, "")
         for c in filtered_contexts:
             name = c.text.name
             citation = c.text.doc.formatted_citation

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -26,9 +26,10 @@ qa_prompt = (
     f'"{CANNOT_ANSWER_PHRASE}." '
     "For each part of your answer, indicate which sources most support "
     "it via citation keys at the end of sentences, "
-    "like {example_citation}. Only cite from the context "
-    "below and only use the valid keys. Write in the style of a "
-    "Wikipedia article, with concise sentences and coherent paragraphs. "
+    "like {example_citation}, which uses the {citation_style} citation style. "
+    "Only cite from the context below and only use the valid keys. "
+    "Write in the style of a Wikipedia article, "
+    "with concise sentences and coherent paragraphs. "
     "The context comes from a variety of sources and is only a summary, "
     "so there may inaccuracies or ambiguities. If quotes are present and "
     "relevant, use them in the answer. This answer will go directly onto "

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -259,7 +259,10 @@ def get_formatted_variables(s: str) -> set[str]:
 class PromptSettings(BaseModel):
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
-    EXAMPLE_CITATION: ClassVar[str] = "(Example2012Example pages 3-4)"
+    EXAMPLE_CITATION_AND_STYLE: ClassVar[tuple[str, str]] = (
+        "(Example2012Example pages 3-4)",
+        "MLA parenthetical in-text citation",  # SEE: https://nwtc.libguides.com/citations/MLA#s-lg-box-707489
+    )
 
     summary: str = summary_prompt
     qa: str = qa_prompt


### PR DESCRIPTION
We can see from [this CI run](https://github.com/Future-House/paper-qa/actions/runs/12819627890/job/35747663034) that `test_cli_can_build_and_search_index` flaked in `build_index` with a `zlib.error`:

```python
  |   File "/home/runner/work/paper-qa/paper-qa/tests/test_cli.py", line 79, in test_cli_can_build_and_search_index
  |     build_index(index_name, stub_data_dir, settings)
  |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/__init__.py", line 141, in build_index
  |     return get_loop().run_until_complete(get_directory_index(settings=settings))
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/base_events.py", line 686, in run_until_complete
  |     return future.result()
  |            ^^^^^^^^^^^^^^^
  |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 674, in get_directory_index
  |     async with anyio.create_task_group() as tg:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/work/paper-qa/paper-qa/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 767, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 476, in process_file
    |     if not await search_index.filecheck(filename=file_location):
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 263, in filecheck
    |     index_files = await self.index_files
    |                   ^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 252, in index_files
    |     zlib.decompress(content)
    | zlib.error: Error -5 while decompressing data: incomplete or truncated stream
    +------------------------------------
```

I am not entirely sure why this `zlib.error` happened, but this change is a first step in figuring it out. If the `zlib.error` happens across 3 retries, then we know there's deeper more going on.