### PR TITLE
Fixing flaky test `test_cli_can_build_and_search_index` by retrying

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import os
 import sys
+import zlib
 from pathlib import Path
 
 import pytest
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt
 
 from paperqa import Docs
 from paperqa.settings import Settings
@@ -76,7 +78,13 @@ def test_cli_can_build_and_search_index(
     settings.agent.index.paper_directory = rel_path_home_to_stub_data
     settings.agent.index.index_directory = agent_index_dir
     index_name = "test"
-    build_index(index_name, stub_data_dir, settings)
+    for attempt in Retrying(
+        stop=stop_after_attempt(3),
+        # zlib.error: Error -5 while decompressing data: incomplete or truncated stream
+        retry=retry_if_exception_type(zlib.error),
+    ):
+        with attempt:
+            build_index(index_name, stub_data_dir, settings)
     result = search_query("XAI", index_name, settings)
     assert len(result) == 1
     assert isinstance(result[0][0], Docs)


### PR DESCRIPTION
We can see from [this CI run](https://github.com/Future-House/paper-qa/actions/runs/12819627890/job/35747663034) that `test_cli_can_build_and_search_index` flaked in `build_index` with a `zlib.error`:

```python
  |   File "/home/runner/work/paper-qa/paper-qa/tests/test_cli.py", line 79, in test_cli_can_build_and_search_index
  |     build_index(index_name, stub_data_dir, settings)
  |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/__init__.py", line 141, in build_index
  |     return get_loop().run_until_complete(get_directory_index(settings=settings))
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/asyncio/base_events.py", line 686, in run_until_complete
  |     return future.result()
  |            ^^^^^^^^^^^^^^^
  |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 674, in get_directory_index
  |     async with anyio.create_task_group() as tg:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/runner/work/paper-qa/paper-qa/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 767, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 476, in process_file
    |     if not await search_index.filecheck(filename=file_location):
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 263, in filecheck
    |     index_files = await self.index_files
    |                   ^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py", line 252, in index_files
    |     zlib.decompress(content)
    | zlib.error: Error -5 while decompressing data: incomplete or truncated stream
    +------------------------------------
```

I am not entirely sure why this `zlib.error` happened, but this change is a first step in figuring it out. If the `zlib.error` happens across 3 retries, then we know there's deeper more going on.