### PR TITLE
Allowing more general types in `Settings`

### DIFF
--- a/paperqa/core.py
+++ b/paperqa/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from paperqa.llms import PromptRunner
@@ -41,7 +41,7 @@ async def map_fxn_summary(
     prompt_runner: PromptRunner | None,
     extra_prompt_data: dict[str, str] | None = None,
     parser: Callable[[str], dict[str, Any]] | None = None,
-    callbacks: list[Callable[[str], None]] | None = None,
+    callbacks: Sequence[Callable[[str], None]] | None = None,
 ) -> tuple[Context, LLMResult]:
     """Parses the given text and returns a context object with the parser and prompt runner.
 

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -6,7 +6,7 @@ import os
 import re
 import tempfile
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import datetime
 from functools import partial
 from io import BytesIO
@@ -549,7 +549,7 @@ class Docs(BaseModel):
         query: PQASession | str,
         exclude_text_filter: set[str] | None = None,
         settings: MaybeSettings = None,
-        callbacks: list[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         embedding_model: EmbeddingModel | None = None,
         summary_llm_model: LLMModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
@@ -571,7 +571,7 @@ class Docs(BaseModel):
         query: PQASession | str,
         exclude_text_filter: set[str] | None = None,
         settings: MaybeSettings = None,
-        callbacks: list[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         embedding_model: EmbeddingModel | None = None,
         summary_llm_model: LLMModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
@@ -668,7 +668,7 @@ class Docs(BaseModel):
         self,
         query: PQASession | str,
         settings: MaybeSettings = None,
-        callbacks: list[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         llm_model: LLMModel | None = None,
         summary_llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
@@ -690,12 +690,16 @@ class Docs(BaseModel):
         self,
         query: PQASession | str,
         settings: MaybeSettings = None,
-        callbacks: list[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         llm_model: LLMModel | None = None,
         summary_llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
     ) -> PQASession:
+        # TODO: remove list cast after release of https://github.com/Future-House/llm-client/pull/36
+        callbacks = cast(
+            list[Callable] | None, list(callbacks) if callbacks else callbacks
+        )
 
         query_settings = get_settings(settings)
         answer_config = query_settings.answer

--- a/paperqa/llms.py
+++ b/paperqa/llms.py
@@ -47,7 +47,7 @@ except ImportError:
     qdrant_installed = False
 
 PromptRunner = Callable[
-    [dict, list[Callable[[str], None]] | None, str | None],
+    [dict, Sequence[Callable[[str], None]] | None, str | None],
     Awaitable[LLMResult],
 ]
 

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -3,7 +3,7 @@ import importlib.resources
 import os
 import pathlib
 import warnings
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from enum import StrEnum
 from pydoc import locate
 from typing import Any, ClassVar, Self, TypeAlias, assert_never, cast
@@ -521,7 +521,7 @@ class AgentSettings(BaseModel):
     )
     index: IndexSettings = Field(default_factory=IndexSettings)
 
-    callbacks: Mapping[str, list[Callable[[_EnvironmentState], Any]]] = Field(
+    callbacks: Mapping[str, Sequence[Callable[[_EnvironmentState], Any]]] = Field(
         default_factory=dict,
         description="""
             A mapping that associates callback names with lists of corresponding callable functions.

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -194,7 +194,7 @@ class ParsingSettings(BaseModel):
         ),
     )
     chunking_algorithm: ChunkingOptions = ChunkingOptions.SIMPLE_OVERLAP
-    doc_filters: list[dict] | None = Field(
+    doc_filters: Sequence[Mapping[str, Any]] | None = Field(
         default=None,
         description=(
             "Optional filters to only allow documents that match this filter. This is a"
@@ -498,7 +498,7 @@ class AgentSettings(BaseModel):
         description="If set to true, run the search tool before invoking agent.",
     )
 
-    tool_names: set[str] | None = Field(
+    tool_names: set[str] | Sequence[str] | None = Field(
         default=None,
         description=(
             "Optional override on the tools to provide the agent. Leaving as the"

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -66,7 +66,7 @@ class Doc(Embeddable):
     def formatted_citation(self) -> str:
         return self.citation
 
-    def matches_filter_criteria(self, filter_criteria: dict) -> bool:
+    def matches_filter_criteria(self, filter_criteria: Mapping[str, Any]) -> bool:
         """Returns True if the doc matches the filter criteria, False otherwise."""
         data_dict = self.model_dump()
         for key, value in filter_criteria.items():

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -492,7 +492,7 @@ async def test_agent_sharing_state(
             "gather_evidence_completed": [gather_evidence_completed_callback],
         }
 
-    agent_test_settings.agent.callbacks = callbacks  # type: ignore[assignment]
+    agent_test_settings.agent.callbacks = callbacks
 
     session = PQASession(question="What is is a self-explanatory model?")
     env_state = EnvironmentState(docs=Docs(), session=session)


### PR DESCRIPTION
- Allowing `Sequence` for `callbacks`
- Allowing `Mapping` for `doc_filter`
- Allowing `set[str] | Sequence[str]` for `tool_names`
    - https://github.com/Future-House/paper-qa/pull/289 had moved it from `Collection[str]` to `set[str]`