### PR TITLE
Allow `agent_query` to Use an Existing Search Index Without Rebuilding

### DIFF
--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -55,6 +55,7 @@ async def agent_query(
     settings: Settings,
     docs: Docs | None = None,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
+    rebuild_index: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     if docs is None:
@@ -67,7 +68,9 @@ async def agent_query(
         storage=SearchDocumentStorage.JSON_MODEL_DUMP,
     )
 
-    response = await run_agent(docs, query, settings, agent_type, **runner_kwargs)
+    response = await run_agent(
+        docs, query, settings, agent_type, rebuild_index, **runner_kwargs
+    )
     agent_logger.debug(f"agent_response: {response}")
 
     agent_logger.info(f"[bold blue]Answer: {response.session.answer}[/bold blue]")
@@ -92,6 +95,7 @@ async def run_agent(
     query: str | MultipleChoiceQuestion,
     settings: Settings,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
+    rebuild_index: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     """
@@ -103,6 +107,7 @@ async def run_agent(
         settings: Settings to use.
         agent_type: Agent type (or fully qualified name to the type) to pass to
             AgentType.get_agent, or "fake" to TODOC.
+        rebuild_index: If True, we force the index to be rebuild.
         runner_kwargs: Keyword arguments to pass to the runner.
 
     Returns:
@@ -120,7 +125,7 @@ async def run_agent(
     # Build the index once here, and then all tools won't need to rebuild it
     # only build if the a search tool is requested
     if PaperSearch.TOOL_FN_NAME in (settings.agent.tool_names or DEFAULT_TOOL_NAMES):
-        await get_directory_index(settings=settings)
+        await get_directory_index(settings=settings, build=rebuild_index)
 
     if isinstance(agent_type, str) and agent_type.lower() == FAKE_AGENT_TYPE:
         session, agent_status = await run_fake_agent(

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -67,9 +67,7 @@ async def agent_query(
         storage=SearchDocumentStorage.JSON_MODEL_DUMP,
     )
 
-    response = await run_agent(
-        docs, query, settings, agent_type, **runner_kwargs
-    )
+    response = await run_agent(docs, query, settings, agent_type, **runner_kwargs)
     agent_logger.debug(f"agent_response: {response}")
 
     agent_logger.info(f"[bold blue]Answer: {response.session.answer}[/bold blue]")

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -55,7 +55,6 @@ async def agent_query(
     settings: Settings,
     docs: Docs | None = None,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
-    force_index_rebuild: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     if docs is None:
@@ -69,7 +68,7 @@ async def agent_query(
     )
 
     response = await run_agent(
-        docs, query, settings, agent_type, force_index_rebuild, **runner_kwargs
+        docs, query, settings, agent_type, **runner_kwargs
     )
     agent_logger.debug(f"agent_response: {response}")
 
@@ -95,7 +94,6 @@ async def run_agent(
     query: str | MultipleChoiceQuestion,
     settings: Settings,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
-    force_index_rebuild: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     """
@@ -107,7 +105,6 @@ async def run_agent(
         settings: Settings to use.
         agent_type: Agent type (or fully qualified name to the type) to pass to
             AgentType.get_agent, or "fake" to TODOC.
-        force_index_rebuild: If True, we force the index to be rebuild.
         runner_kwargs: Keyword arguments to pass to the runner.
 
     Returns:
@@ -125,7 +122,7 @@ async def run_agent(
     # Build the index once here, and then all tools won't need to rebuild it
     # only build if the a search tool is requested
     if PaperSearch.TOOL_FN_NAME in (settings.agent.tool_names or DEFAULT_TOOL_NAMES):
-        await get_directory_index(settings=settings, build=force_index_rebuild)
+        await get_directory_index(settings=settings, build=settings.agent.rebuild_index)
 
     if isinstance(agent_type, str) and agent_type.lower() == FAKE_AGENT_TYPE:
         session, agent_status = await run_fake_agent(

--- a/paperqa/agents/main.py
+++ b/paperqa/agents/main.py
@@ -55,7 +55,7 @@ async def agent_query(
     settings: Settings,
     docs: Docs | None = None,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
-    rebuild_index: bool = True,
+    force_index_rebuild: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     if docs is None:
@@ -69,7 +69,7 @@ async def agent_query(
     )
 
     response = await run_agent(
-        docs, query, settings, agent_type, rebuild_index, **runner_kwargs
+        docs, query, settings, agent_type, force_index_rebuild, **runner_kwargs
     )
     agent_logger.debug(f"agent_response: {response}")
 
@@ -95,7 +95,7 @@ async def run_agent(
     query: str | MultipleChoiceQuestion,
     settings: Settings,
     agent_type: str | type = DEFAULT_AGENT_TYPE,
-    rebuild_index: bool = True,
+    force_index_rebuild: bool = True,
     **runner_kwargs,
 ) -> AnswerResponse:
     """
@@ -107,7 +107,7 @@ async def run_agent(
         settings: Settings to use.
         agent_type: Agent type (or fully qualified name to the type) to pass to
             AgentType.get_agent, or "fake" to TODOC.
-        rebuild_index: If True, we force the index to be rebuild.
+        force_index_rebuild: If True, we force the index to be rebuild.
         runner_kwargs: Keyword arguments to pass to the runner.
 
     Returns:
@@ -125,7 +125,7 @@ async def run_agent(
     # Build the index once here, and then all tools won't need to rebuild it
     # only build if the a search tool is requested
     if PaperSearch.TOOL_FN_NAME in (settings.agent.tool_names or DEFAULT_TOOL_NAMES):
-        await get_directory_index(settings=settings, build=rebuild_index)
+        await get_directory_index(settings=settings, build=force_index_rebuild)
 
     if isinstance(agent_type, str) and agent_type.lower() == FAKE_AGENT_TYPE:
         session, agent_status = await run_fake_agent(

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -523,6 +523,11 @@ class AgentSettings(BaseModel):
     )
     index: IndexSettings = Field(default_factory=IndexSettings)
 
+    rebuild_index: bool = Field(
+        default=True,
+        description="If True, we force the index to be rebuild.",
+    )
+
     callbacks: Mapping[str, Sequence[Callable[[_EnvironmentState], Any]]] = Field(
         default_factory=dict,
         description="""

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -525,7 +525,10 @@ class AgentSettings(BaseModel):
 
     rebuild_index: bool = Field(
         default=True,
-        description="If True, we force the index to be rebuild.",
+        description=(
+            "Flag to rebuild the index at the start of agent runners, default is True"
+            " for CLI users to ensure all source PDFs are pulled in."
+        ),
     )
 
     callbacks: Mapping[str, Sequence[Callable[[_EnvironmentState], Any]]] = Field(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1089,7 +1089,7 @@ async def test_agent_empty_index(agent_test_settings: Settings):
             query="Are COVID-19 vaccines effective?",
             settings=agent_test_settings,
             agent_type=FAKE_AGENT_TYPE,
-            rebuild_index=False,
+            force_index_rebuild=False,
         )
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1083,9 +1083,9 @@ async def test_search_pagination(agent_test_settings: Settings) -> None:
 @pytest.mark.asyncio
 async def test_empty_index_without_index_rebuild(agent_test_settings: Settings):
     """Test that empty index and `rebuild_index=False` lead to a RuntimeError."""
-    agent_test_settings.agent = AgentSettings(index=IndexSettings()) # empty index
+    agent_test_settings.agent = AgentSettings(index=IndexSettings())  # empty index
     agent_test_settings.agent.rebuild_index = False
-    with pytest.raises(RuntimeError, match=f"Index .* was empty, please rebuild it."):
+    with pytest.raises(RuntimeError, match=r"Index .* was empty, please rebuild it."):
         await agent_query(
             query="Are COVID-19 vaccines effective?",
             settings=agent_test_settings,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1081,10 +1081,11 @@ async def test_search_pagination(agent_test_settings: Settings) -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_empty_index(agent_test_settings: Settings):
+async def test_empty_index_without_index_rebuild(agent_test_settings: Settings):
     """Test that empty index and `rebuild_index=False` lead to a RuntimeError."""
     agent_test_settings.agent = AgentSettings(index=IndexSettings()) # empty index
-    with pytest.raises(RuntimeError):
+    agent_test_settings.agent.rebuild_index = False
+    with pytest.raises(RuntimeError, match=f"Index .* was empty, please rebuild it."):
         await agent_query(
             query="Are COVID-19 vaccines effective?",
             settings=agent_test_settings,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1080,6 +1080,19 @@ async def test_search_pagination(agent_test_settings: Settings) -> None:
     ), "Second page should match second slice of all results"
 
 
+@pytest.mark.asyncio
+async def test_agent_empty_index(agent_test_settings: Settings):
+    """Test that empty index and `rebuild_index=False` lead to a RuntimeError."""
+    agent_test_settings.agent = AgentSettings(index=IndexSettings()) # empty index
+    with pytest.raises(RuntimeError):
+        await agent_query(
+            query="Are COVID-19 vaccines effective?",
+            settings=agent_test_settings,
+            agent_type=FAKE_AGENT_TYPE,
+            rebuild_index=False,
+        )
+
+
 class TestClinicalTrialSearchTool:
     @pytest.mark.asyncio
     async def test_continuation(self) -> None:


### PR DESCRIPTION
##### My Use Case:
- I have a collection of several hundred papers that I want to index once (i.e. chunking PDFs and embedding them in a vector database)
- I use a Jupyter notebook to configure all PaperQA settings (see [tutorial](https://github.com/psl-schaefer/expert_system/blob/main/tutorial.ipynb)), allowing me to query these documents without rebuilding the index. To achieve this, I always use the same `IndexSettings` with a fixed `name` attribute.
- To build the index, I want to use a custom function ([build_search_index.py](https://github.com/psl-schaefer/expert_system/blob/main/src/build_search_index.py)) that does not rely on external APIs such as Semantic Scholar and Crossref. SemanticScholar API "key issuance is currently on pause due to high demand", and I do not require metadata from these sources since I already have all PDFs stored in Zotero.

##### My Solution:
- The only modification needed in the PaperQA codebase is adding a boolean argument `rebuild_index` to `agent_query` which is passed down to `run_agent`. In `run_agent` this argument is passed down to `get_directory_index` as the `build` parameter.
    - If `rebuild_index=True` (the default), the index is fully rebuilt.
    - If `rebuild_index=False`, we use the search index as previously build
- This change allows me to build the index once using my custom function ([build_search_index.py](https://github.com/psl-schaefer/expert_system/blob/main/src/build_search_index.py)).
- Before running any queries with `agent_query`, I first create the search index using this custom function.
- For a detailed overview of the workflow, see the [tutorial](https://github.com/psl-schaefer/expert_system/blob/main/tutorial.ipynb).

##### Also
- What do you think about adding such a `build_search_index` (see [build_search_index.py](https://github.com/psl-schaefer/expert_system/blob/main/src/build_search_index.py)) function that does not rely on external APIs to the PaperQA code base?