### PR TITLE
Pin fh-llm-client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
           - aiohttp>=3.10.6 # Match pyproject.toml
           - PyMuPDF>=1.24.12
           - anyio
-          - fh-llm-client[deepseek]>=0.0.11 # Match pyproject.toml
+          - fh-llm-client[deepseek]<0.1.0 # Match pyproject.toml
           - fhaviary[llm]>=0.14 # Match pyproject.toml
           - ldp>=0.20 # Match pyproject.toml
           - html2text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "PyMuPDF>=1.24.12",  # For pymupdf.set_messages addition
     "aiohttp>=3.10.6",  # TODO: remove in favor of httpx, pin for aiohttp.ClientConnectionResetError
     "anyio",
-    "fh-llm-client>=0.0.11",  # Pin for LLMModel.run_prompt allowing Iterable
+    "fh-llm-client<0.1.0",  # Pin to avoid breaking changes until lfrqa is migrated
     "fhaviary[llm]>=0.14",  # For MultipleChoiceQuestion
     "html2text",  # TODO: evaluate moving to an opt-in dependency
     "httpx",

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.6" },
     { name = "anyio" },
     { name = "datasets", marker = "extra == 'datasets'" },
-    { name = "fh-llm-client", specifier = ">=0.0.11" },
+    { name = "fh-llm-client", specifier = "<0.1.0" },
     { name = "fh-llm-client", extras = ["deepseek"], marker = "extra == 'dev'", specifier = ">=0.0.11" },
     { name = "fhaviary", extras = ["llm"], specifier = ">=0.14" },
     { name = "html2text" },


### PR DESCRIPTION
We are pinning fh-llm-client to 0.1.0 so that its next release won't be imported. This is to avoid breaking changes for now