### PR TITLE
Fixed flaky `test_answer_rename` via `flaky` decoration

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1170,6 +1170,10 @@ def test_case_insensitive_matching():
     assert strings_similarity("A B c d e", "a b c f") == 0.5
 
 
+@pytest.mark.flaky(
+    reruns=3,  # pytest-xdist can lead to >1 DeprecationWarning
+    only_rerun=["AssertionError"],
+)
 def test_answer_rename(recwarn) -> None:
     # TODO: delete this test in v6
     answer = Answer(question="")


### PR DESCRIPTION
I noticed in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/13440101933/job/37552101786):

```none
______________________________ test_answer_rename ______________________________
[gw1] linux -- Python 3.12.9 /home/runner/work/paper-qa/paper-qa/.venv/bin/python

recwarn = WarningsRecorder(record=True)

    def test_answer_rename(recwarn) -> None:
        # TODO: delete this test in v6
        answer = Answer(question="")
        assert isinstance(answer, PQASession)
>       assert len(recwarn) == 1
E       assert 6 == 1
E        +  where 6 = len(WarningsRecorder(record=True))

tests/test_paperqa.py:1177: AssertionError
```

It seems `pytest-xdist` lead to multiple warnings being captured here, so I fixed this test using `pytest.mark.flaky`