### PR TITLE
Using API key and VCR constants defined in `lmi`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from dotenv import load_dotenv
+from lmi.utils import ANTHROPIC_API_KEY_HEADER, OPENAI_API_KEY_HEADER
 
 from paperqa.clients.crossref import CROSSREF_HEADER_KEY
 from paperqa.clients.semantic_scholar import SEMANTIC_SCHOLAR_HEADER_KEY
@@ -29,12 +30,6 @@ def _load_env() -> None:
 @pytest.fixture(autouse=True)
 def _setup_default_logs() -> None:
     setup_default_logs()
-
-
-OPENAI_API_KEY_HEADER = "authorization"
-ANTHROPIC_API_KEY_HEADER = "x-api-key"
-# SEE: https://github.com/kevin1024/vcrpy/blob/v6.0.1/vcr/config.py#L43
-VCR_DEFAULT_MATCH_ON = "method", "scheme", "host", "port", "path", "query"
 
 
 @pytest.fixture(scope="session", name="vcr_config")

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -25,6 +25,7 @@ from lmi import (
     SparseEmbeddingModel,
 )
 from lmi.llms import rate_limited
+from lmi.utils import VCR_DEFAULT_MATCH_ON
 from pytest_subtests import SubTests
 
 from paperqa import (
@@ -55,7 +56,6 @@ from paperqa.utils import (
     strings_similarity,
     strip_citations,
 )
-from tests.conftest import VCR_DEFAULT_MATCH_ON
 
 THIS_MODULE = pathlib.Path(__file__)
 


### PR DESCRIPTION
See PR title