### PR TITLE
Supporting `.md` in indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ It just removes the automation associated with an agent picking the documents to
 ```python
 from paperqa import Docs, Settings
 
-# valid extensions include .pdf, .txt, and .html
+# valid extensions include .pdf, .txt, .md, and .html
 doc_paths = ("myfile.pdf", "myotherfile.pdf")
 
 # Prepare the Docs object by adding a bunch of documents
@@ -390,7 +390,7 @@ from paperqa import Docs
 
 async def main() -> None:
     docs = Docs()
-    # valid extensions include .pdf, .txt, and .html
+    # valid extensions include .pdf, .txt, .md, and .html
     for doc in ("myfile.pdf", "myotherfile.pdf"):
         await docs.aadd(doc)
 

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -684,7 +684,7 @@ async def get_directory_index(  # noqa: PLR0912
             if index_settings.recurse_subdirectories
             else paper_directory.iterdir()
         )
-        if file.suffix in {".txt", ".pdf", ".html"}
+        if file.suffix in {".txt", ".pdf", ".html", ".md"}
     ]
     if len(valid_papers_rel_file_paths) > WARN_IF_INDEXING_MORE_THAN:
         logger.warning(

--- a/tests/stub_data/gravity_hill.md
+++ b/tests/stub_data/gravity_hill.md
@@ -31,7 +31,8 @@ The illusion is similar to the [Ames room](https://en.wikipedia.org/wiki/Ames_ro
 in which objects can also appear to roll against gravity.
 
 The opposite phenomenon—an uphill road that appears flat—is known in
-[bicycle racing](https://en.wikipedia.org/wiki/Cycle_sport) as a ["false flat"](https://en.wikipedia.org/wiki/Glossary_of_cycling#F).
+[bicycle racing](https://en.wikipedia.org/wiki/Cycle_sport)
+as a ["false flat"](https://en.wikipedia.org/wiki/Glossary_of_cycling#F).
 
 ## See also
 

--- a/tests/stub_data/gravity_hill.md
+++ b/tests/stub_data/gravity_hill.md
@@ -1,0 +1,44 @@
+# Gravity hill
+
+> "Magnetic hill" and "Mystery hill" redirect here. For other uses,
+> see [Magnetic Hill (disambiguation)](<https://en.wikipedia.org/wiki/Magnetic_Hill_(disambiguation)>)
+> and [Mystery Hill (disambiguation)](https://en.wikipedia.org/wiki/Mystery_Hill).
+
+A **gravity hill**, also known as a
+**magnetic hill**, **mystery hill**, **mystery spot**, **gravity road**, or **anti-gravity hill**,
+is a place where the layout of the surrounding land produces an [illusion](https://en.wikipedia.org/wiki/Illusion),
+making a slight downhill slope appear to be an uphill slope.
+Thus, a car left out of gear will appear to be rolling uphill against [gravity](https://en.wikipedia.org/wiki/Gravity).
+
+Although the slope of gravity hills is an illusion,
+sites are often accompanied by claims that magnetic or supernatural forces are at work.
+The most important factor contributing to the illusion is a completely
+or mostly obstructed horizon.
+Without a horizon,
+it becomes difficult for a person to judge the slope of a surface,
+as a reliable reference point is missing,
+and misleading visual cues can adversely affect the sense of balance.
+Objects which one would normally assume to be more or less perpendicular to the ground,
+such as trees, may be leaning, offsetting the visual reference.
+
+A 2003 study looked into how the absence of a horizon can skew the perspective on gravity hills,
+by recreating a number of antigravity places in the lab to see how volunteers would react.
+In conclusion, researchers from the Universities of Padua and Pavia in Italy
+found that without a true horizon in sight,
+the human brain could be tricked by common landmarks such as trees and signs.
+
+The illusion is similar to the [Ames room](https://en.wikipedia.org/wiki/Ames_room),
+in which objects can also appear to roll against gravity.
+
+The opposite phenomenon—an uphill road that appears flat—is known in
+[bicycle racing](https://en.wikipedia.org/wiki/Cycle_sport) as a ["false flat"](https://en.wikipedia.org/wiki/Glossary_of_cycling#F).
+
+## See also
+
+- [List of gravity hills](https://en.wikipedia.org/wiki/List_of_gravity_hills)
+- [The Crooked House](https://en.wikipedia.org/wiki/The_Crooked_House) –
+  a pub (now demolished) with an internal gravity hill illusion.
+
+## References
+
+## External links


### PR DESCRIPTION
This PR adds support for `.md` to index folders
- Adds https://en.wikipedia.org/wiki/Gravity_hill to our stub data
- Adds test cases for it