### PR TITLE
Added tutorial showing how to configure paperqa `Settings`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/mwouts/jupytext
+    rev: v1.16.7
+    hooks:
+      - id: jupytext
+        args: [--sync, --pipe, black]
+        additional_dependencies: [black]
+        files: ^docs/.*\.ipynb$
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:
@@ -35,13 +42,6 @@ repos:
     rev: v3.4.2
     hooks:
       - id: prettier
-  - repo: https://github.com/mwouts/jupytext
-    rev: v1.16.7
-    hooks:
-      - id: jupytext
-        args: [--sync, --pipe, black]
-        additional_dependencies: [black]
-        files: ^docs/.*\.ipynb$
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:
@@ -78,7 +78,7 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        exclude: \.md$ # markdown files are being blackened by jupytext
+        exclude: \.md$ # The generated markdown files are being blackened by jupytext
   - repo: https://github.com/srstevenson/nb-clean
     rev: 4.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
     rev: v3.4.2
     hooks:
       - id: prettier
+        exclude: ^docs/.*\.md$
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,13 @@ repos:
     rev: v3.4.2
     hooks:
       - id: prettier
+  - repo: https://github.com/mwouts/jupytext
+    rev: v1.16.7
+    hooks:
+      - id: jupytext
+        args: [--sync, --pipe, black]
+        additional_dependencies: [black]
+        files: ^docs/.*\.ipynb$
   - repo: https://github.com/pappasam/toml-sort
     rev: v0.24.2
     hooks:
@@ -71,6 +78,12 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
+        exclude: \.md$ # markdown files are being blackened by jupytext
+  - repo: https://github.com/srstevenson/nb-clean
+    rev: 4.0.1
+    hooks:
+      - id: nb-clean
+        args: [--preserve-cell-outputs, --remove-empty-cells]
   - repo: https://github.com/jsh9/markdown-toc-creator
     rev: 0.0.10
     hooks:

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -22,10 +22,7 @@
     "!echo \"OPENAI_API_KEY=<your-openai-api-key>\" > .env\n",
     "!echo \"ANTHROPIC_API_KEY=<your-anthropic-api-key>\" >> .env\n",
     "\n",
-    "!uv pip install -q nest-asyncio\n",
-    "!uv pip install -q python-dotenv\n",
-    "!uv pip install -q fhlmi\n",
-    "!uv pip install -q \"paper-qa[local]\""
+    "!uv pip install -q nest-asyncio python-dotenv aiohttp fhlmi \"paper-qa[local]\""
    ]
   },
   {
@@ -36,8 +33,8 @@
    "source": [
     "import os\n",
     "\n",
+    "import aiohttp\n",
     "import nest_asyncio\n",
-    "import requests\n",
     "from dotenv import load_dotenv\n",
     "\n",
     "nest_asyncio.apply()\n",
@@ -64,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,9 +75,10 @@
     "\n",
     "# Download the paper from arXiv and save it to the `papers` directory\n",
     "url = \"https://arxiv.org/pdf/2407.01603\"\n",
-    "response = requests.get(url, timeout=60)\n",
-    "with open(\"papers/2407.01603.pdf\", \"wb\") as f:\n",
-    "    f.write(response.content)\n"
+    "async with aiohttp.ClientSession() as session, session.get(url, timeout=60) as response:\n",
+    "    content = await response.read()\n",
+    "    with open(\"papers/2407.01603.pdf\", \"wb\") as f:\n",
+    "        f.write(content)\n"
    ]
   },
   {
@@ -112,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -6,10 +6,12 @@
    "source": [
     "# Setup\n",
     "\n",
+    "> This tutorial is available as a Jupyter notebook [here](https://github.com/Future-House/paper-qa/blob/main/docs/tutorials/settings_tutorial.ipynb).\n",
+    "\n",
     "This tutorial aims to show how to use the `Settings` class to configure `PaperQA`.\n",
     "Firstly, we will be using `OpenAI` and `Anthropic` models, so we need to set the `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` environment variables.\n",
     "We will use both models to make it clear when `paperqa` agent is using either one or the other.\n",
-    "We use `python-dotenv` to load the environment variables from a `.env` file. \n",
+    "We use `python-dotenv` to load the environment variables from a `.env` file.\n",
     "Hence, our first step is to create a `.env` file and install the required packages."
    ]
   },
@@ -19,12 +21,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# fmt: off\n",
     "# Create .env file with OpenAI API key\n",
     "# Replace <your-openai-api-key> and <your-anthropic-api-key> with your actual API keys\n",
     "!echo \"OPENAI_API_KEY=<your-openai-api-key>\" > .env # fmt: skip\n",
     "!echo \"ANTHROPIC_API_KEY=<your-anthropic-api-key>\" >> .env # fmt: skip\n",
     "\n",
-    "!uv pip install -q nest-asyncio python-dotenv aiohttp fhlmi \"paper-qa[local]\""
+    "!uv pip install -q nest-asyncio python-dotenv aiohttp fhlmi \"paper-qa[local]\"\n",
+    "# fmt: on"
    ]
   },
   {
@@ -80,14 +84,14 @@
     "async with aiohttp.ClientSession() as session, session.get(url, timeout=60) as response:\n",
     "    content = await response.read()\n",
     "    with open(\"papers/2407.01603.pdf\", \"wb\") as f:\n",
-    "        f.write(content)\n"
+    "        f.write(content)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Settings` class is used to configure the PaperQA settings. \n",
+    "The `Settings` class is used to configure the PaperQA settings.\n",
     "Official documentation can be found [here](https://github.com/Future-House/paper-qa?tab=readme-ov-file#settings-cheatsheet) and the open source code can be found [here](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py).\n",
     "\n",
     "Here is a basic example of how to use the `Settings` class. We will be unnecessarily verbose for the sake of clarity. Please notice that most of the settings are optional and the defaults are good for most cases. Refer to the [descriptions of each setting](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py) for more information.\n",
@@ -97,16 +101,12 @@
     "A common source of confusion is that multiple `llms` are used in paperqa. We have `llm`, `summary_llm`, `agent_llm`, and `embedding`. Hence, if `llm` is set to an `Anthropic` model, `summary_llm` and `agent_llm` will still require a `OPENAI_API_KEY`, since `OpenAI` models are the default.\n",
     "\n",
     "Among the objects that use `llms` in `paperqa`, we have `llm`, `summary_llm`, `agent_llm`, and `embedding`:\n",
+    "\n",
     "- `llm`: Main LLM used by the agent to reason about the question, extract metadata from documents, etc.\n",
     "- `summary_llm`: LLM used to summarize the papers.\n",
     "- `agent_llm`: LLM used to answer questions and select tools.\n",
-    "- `embedding`: Embedding model used to embed the papers.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "- `embedding`: Embedding model used to embed the papers.\n",
+    "\n",
     "Let's see some examples around this concept. First, we define the settings with `llm` set to an `OpenAI` model. Please notice this is not an complete list of settings. But take your time to read through this `Settings` class and all customization that can be done."
    ]
   },
@@ -132,7 +132,14 @@
     "    summary_json_system_prompt,\n",
     "    summary_prompt,\n",
     ")\n",
-    "from paperqa.settings import AgentSettings, AnswerSettings, IndexSettings, ParsingSettings, PromptSettings, Settings\n",
+    "from paperqa.settings import (\n",
+    "    AgentSettings,\n",
+    "    AnswerSettings,\n",
+    "    IndexSettings,\n",
+    "    ParsingSettings,\n",
+    "    PromptSettings,\n",
+    "    Settings,\n",
+    ")\n",
     "\n",
     "settings = Settings(\n",
     "    llm=llm_openai,\n",
@@ -143,8 +150,8 @@
     "                \"litellm_params\": {\n",
     "                    \"model\": llm_openai,\n",
     "                    \"temperature\": 0.1,\n",
-    "                    \"max_tokens\": 512,\n",
-    "                }\n",
+    "                    \"max_tokens\": 4096,\n",
+    "                },\n",
     "            }\n",
     "        ],\n",
     "        \"rate_limit\": {\n",
@@ -203,7 +210,7 @@
     "                    \"model_name\": llm_openai,\n",
     "                    \"litellm_params\": {\n",
     "                        \"model\": llm_openai,\n",
-    "                    }\n",
+    "                    },\n",
     "                }\n",
     "            ],\n",
     "            \"rate_limit\": {\n",
@@ -216,7 +223,7 @@
     "        index=IndexSettings(\n",
     "            paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
     "            index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
-    "        )\n",
+    "        ),\n",
     "    ),\n",
     ")"
    ]
@@ -238,7 +245,9 @@
    "source": [
     "from paperqa import ask\n",
     "\n",
-    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+    "response = ask(\n",
+    "    \"What are the most relevant language models used for chemistry?\", settings=settings\n",
+    ")"
    ]
   },
   {
@@ -266,7 +275,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+    "response = ask(\n",
+    "    \"What are the most relevant language models used for chemistry?\", settings=settings\n",
+    ")"
    ]
   },
   {
@@ -291,7 +302,7 @@
     "                \"model\": llm_anthropic,\n",
     "                \"temperature\": 0.1,\n",
     "                \"max_tokens\": 512,\n",
-    "            }\n",
+    "            },\n",
     "        }\n",
     "    ],\n",
     "    \"rate_limit\": {\n",
@@ -312,13 +323,15 @@
     "        },\n",
     "    },\n",
     "    index=IndexSettings(\n",
-    "            paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
-    "            index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
-    "        )\n",
+    "        paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
+    "        index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
+    "    ),\n",
     ")\n",
     "# settings.embedding = \"st-multi-qa-MiniLM-L6-cos-v1\"\n",
     "settings.embedding = \"hybrid-st-multi-qa-MiniLM-L6-cos-v1\"\n",
-    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+    "response = ask(\n",
+    "    \"What are the most relevant language models used for chemistry?\", settings=settings\n",
+    ")"
    ]
   },
   {
@@ -327,13 +340,8 @@
    "source": [
     "Now the agent is able to use `Anthropic` models only and although we don't have a valid `OPENAI_API_KEY`, the question is answered because the agent will not use `OpenAI` models. See that we also changed the `embedding` because it was using `text-embedding-3-small` by default, which is a `OpenAI` model. `Paperqa` implements a few embedding models. Please refer to the [documentation](https://github.com/Future-House/paper-qa?tab=readme-ov-file#embedding-model) for more information.\n",
     "\n",
-    "Notice that we redefined `settings.agent.paper_directory` and `settings.agent.index` settings. `Paperqa` actually uses the setting from `settings.agent`. However, for convenience, we implemented an alias in `settings.paper_directory` and `settings.index_directory`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "Notice that we redefined `settings.agent.paper_directory` and `settings.agent.index` settings. `Paperqa` actually uses the setting from `settings.agent`. However, for convenience, we implemented an alias in `settings.paper_directory` and `settings.index_directory`.\n",
+    "\n",
     "# The output\n",
     "\n",
     "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions. We recommend printing the `PQASession` object (`print(response.session)`) to understand the information it contains. Let's check the `PQASession` object:"
@@ -388,7 +396,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lastly, `PQASession.session.contexts` contains the contexts used to generate the answer. Each context has a score, which is the similarity between the question and the context. \n",
+    "Lastly, `PQASession.session.contexts` contains the contexts used to generate the answer. Each context has a score, which is the similarity between the question and the context.\n",
     "`Paperqa` uses this score to choose what contexts is more relevant to answer the question."
    ]
   },
@@ -399,7 +407,9 @@
    "outputs": [],
    "source": [
     "print(\"4. Contexts used to generate the answer:\")\n",
-    "print(\"These are the relevant text passages that were retrieved and used to formulate the answer:\")\n",
+    "print(\n",
+    "    \"These are the relevant text passages that were retrieved and used to formulate the answer:\"\n",
+    ")\n",
     "for i, ctx in enumerate(response.session.contexts, 1):\n",
     "    print(f\"\\nContext {i}:\")\n",
     "    print(f\"Source: {ctx.text.name}\")\n",
@@ -409,6 +419,9 @@
   }
  ],
  "metadata": {
+  "jupytext": {
+   "formats": "ipynb,md"
+  },
   "kernelspec": {
    "display_name": "test",
    "language": "python",

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -19,8 +19,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!echo \"OPENAI_API_KEY=<your-openai-api-key>\" > .env\n",
-    "!echo \"ANTHROPIC_API_KEY=<your-anthropic-api-key>\" >> .env\n",
+    "# Create .env file with OpenAI API key\n",
+    "# Replace <your-openai-api-key> and <your-anthropic-api-key> with your actual API keys\n",
+    "!echo \"OPENAI_API_KEY=<your-openai-api-key>\" > .env # fmt: skip\n",
+    "!echo \"ANTHROPIC_API_KEY=<your-anthropic-api-key>\" >> .env # fmt: skip\n",
     "\n",
     "!uv pip install -q nest-asyncio python-dotenv aiohttp fhlmi \"paper-qa[local]\""
    ]
@@ -61,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +90,7 @@
     "The `Settings` class is used to configure the PaperQA settings. \n",
     "Official documentation can be found [here](https://github.com/Future-House/paper-qa?tab=readme-ov-file#settings-cheatsheet) and the open source code can be found [here](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py).\n",
     "\n",
-    "Here is a basic example of how to use the `Settings` class. We will be unnecessarily verbose for the sake of clarity. Please notice that most of the settings are optional and the defaults are good for most cases. Refer to the [descriptions of each setting]((https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py)) for more information.\n",
+    "Here is a basic example of how to use the `Settings` class. We will be unnecessarily verbose for the sake of clarity. Please notice that most of the settings are optional and the defaults are good for most cases. Refer to the [descriptions of each setting](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py) for more information.\n",
     "\n",
     "Within this `Settings` object, I'd like to discuss specifically how the llms are configured and how `paperqa` looks for papers.\n",
     "\n",
@@ -110,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +336,7 @@
    "source": [
     "# The output\n",
     "\n",
-    "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions."
+    "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions. We recommend printing the `PQASession` object (`print(response)`) to understand the information it contains."
    ]
   },
   {
@@ -343,7 +345,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response.__dict__"
+    "print(response.session)"
    ]
   },
   {
@@ -404,13 +406,6 @@
     "    print(f\"Content: {ctx.context}\")\n",
     "    print(f\"Score: {ctx.score}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -428,8 +423,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -336,7 +336,7 @@
    "source": [
     "# The output\n",
     "\n",
-    "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions. We recommend printing the `PQASession` object (`print(response)`) to understand the information it contains."
+    "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions. We recommend printing the `PQASession` object (`print(response.session)`) to understand the information it contains. Let's check the `PQASession` object:"
    ]
   },
   {

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -1,0 +1,436 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup\n",
+    "\n",
+    "This tutorial aims to show how to use the `Settings` class to configure `PaperQA`.\n",
+    "Firstly, we will be using `OpenAI` and `Anthropic` models, so we need to set the `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` environment variables.\n",
+    "We will use both models to make it clear when `paperqa` agent is using either one or the other.\n",
+    "We use `python-dotenv` to load the environment variables from a `.env` file. \n",
+    "Hence, our first step is to create a `.env` file and install the required packages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo \"OPENAI_API_KEY=<your-openai-api-key>\" > .env\n",
+    "!echo \"ANTHROPIC_API_KEY=<your-anthropic-api-key>\" >> .env\n",
+    "\n",
+    "!uv pip install -q nest-asyncio\n",
+    "!uv pip install -q python-dotenv\n",
+    "!uv pip install -q fhlmi\n",
+    "!uv pip install -q \"paper-qa[local]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import os\n",
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv(\".env\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"You have set the following environment variables:\")\n",
+    "print(f\"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}\")\n",
+    "print(f\"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use the `lmi` package to get the model names and the `.papers` directory to save documents we will use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lmi import CommonLLMNames\n",
+    "\n",
+    "llm_openai = CommonLLMNames.OPENAI_TEST.value\n",
+    "llm_anthropic = CommonLLMNames.ANTHROPIC_TEST.value\n",
+    "\n",
+    "# Create the `papers` directory if it doesn't exist\n",
+    "os.makedirs(\"papers\", exist_ok=True)\n",
+    "\n",
+    "# Download the paper from arXiv and save it to the `papers` directory\n",
+    "url = \"https://arxiv.org/pdf/2407.01603\"\n",
+    "response = requests.get(url)\n",
+    "with open(\"papers/2407.01603.pdf\", \"wb\") as f:\n",
+    "    f.write(response.content)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Settings` class is used to configure the PaperQA settings. \n",
+    "Official documentation can be found [here](https://github.com/Future-House/paper-qa?tab=readme-ov-file#settings-cheatsheet) and the open source code can be found [here](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py).\n",
+    "\n",
+    "Here is a basic example of how to use the `Settings` class. We will be unnecessarily verbose for the sake of clarity. Please notice that most of the settings are optional and the defaults are good for most cases. Refer to the [descriptions of each setting]((https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py)) for more information.\n",
+    "\n",
+    "Within this `Settings` object, I'd like to discuss specifically how the llms are configured and how `paperqa` looks for papers.\n",
+    "\n",
+    "A common source of confusion is that multiple `llms` are used in paperqa. We have `llm`, `summary_llm`, `agent_llm`, and `embedding`. Hence, if `llm` is set to an `Anthropic` model, `summary_llm` and `agent_llm` will still require a `OPENAI_API_KEY`, since `OpenAI` models are the default.\n",
+    "\n",
+    "Among the objects that use `llms` in `paperqa`, we have `llm`, `summary_llm`, `agent_llm`, and `embedding`:\n",
+    "- `llm`: Main LLM used by the agent to reason about the question, extract metadata from documents, etc.\n",
+    "- `summary_llm`: LLM used to summarize the papers.\n",
+    "- `agent_llm`: LLM used to answer questions and select tools.\n",
+    "- `embedding`: Embedding model used to embed the papers.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see some examples around this concept. First, we define the settings with `llm` set to an `OpenAI` model. Please notice this is not an complete list of settings. But take your time to read through this `Settings` class and all customization that can be done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "from paperqa.settings import Settings, AnswerSettings, ParsingSettings, PromptSettings, AgentSettings, IndexSettings\n",
+    "from paperqa.prompts import (\n",
+    "    CONTEXT_INNER_PROMPT,\n",
+    "    CONTEXT_OUTER_PROMPT,\n",
+    "    citation_prompt,\n",
+    "    default_system_prompt,\n",
+    "    env_reset_prompt,\n",
+    "    env_system_prompt,\n",
+    "    qa_prompt,\n",
+    "    select_paper_prompt,\n",
+    "    structured_citation_prompt,\n",
+    "    summary_json_prompt,\n",
+    "    summary_json_system_prompt,\n",
+    "    summary_prompt,\n",
+    ")\n",
+    "\n",
+    "settings = Settings(\n",
+    "    llm=llm_openai,\n",
+    "    llm_config={\n",
+    "        \"model_list\": [\n",
+    "            {\n",
+    "                \"model_name\": llm_openai,\n",
+    "                \"litellm_params\": {\n",
+    "                    \"model\": llm_openai,\n",
+    "                    \"temperature\": 0.1,\n",
+    "                    \"max_tokens\": 512,\n",
+    "                }\n",
+    "            }\n",
+    "        ],\n",
+    "        \"rate_limit\": {\n",
+    "            llm_openai: \"30000 per 1 minute\",\n",
+    "        },\n",
+    "    },\n",
+    "    summary_llm=llm_openai,\n",
+    "    summary_llm_config={\n",
+    "        \"rate_limit\": {\n",
+    "            llm_openai: \"30000 per 1 minute\",\n",
+    "        },\n",
+    "    },\n",
+    "    embedding=\"text-embedding-3-small\",\n",
+    "    embedding_config={},\n",
+    "    temperature=0.1,\n",
+    "    batch_size=1,\n",
+    "    verbosity=1,\n",
+    "    manifest_file=None,\n",
+    "    paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
+    "    index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
+    "    answer=AnswerSettings(\n",
+    "        evidence_k=10,\n",
+    "        evidence_detailed_citations=True,\n",
+    "        evidence_retrieval=True,\n",
+    "        evidence_summary_length=\"about 100 words\",\n",
+    "        evidence_skip_summary=False,\n",
+    "        answer_max_sources=5,\n",
+    "        max_answer_attempts=None,\n",
+    "        answer_length=\"about 200 words, but can be longer\",\n",
+    "        max_concurrent_requests=10,\n",
+    "    ),\n",
+    "    parsing=ParsingSettings(\n",
+    "        chunk_size=5000,\n",
+    "        overlap=250,\n",
+    "        citation_prompt=citation_prompt,\n",
+    "        structured_citation_prompt=structured_citation_prompt,\n",
+    "    ),\n",
+    "    prompts=PromptSettings(\n",
+    "        summary=summary_prompt,\n",
+    "        qa=qa_prompt,\n",
+    "        select=select_paper_prompt,\n",
+    "        pre=None,\n",
+    "        post=None,\n",
+    "        system=default_system_prompt,\n",
+    "        use_json=True,\n",
+    "        summary_json=summary_json_prompt,\n",
+    "        summary_json_system=summary_json_system_prompt,\n",
+    "        context_outer=CONTEXT_OUTER_PROMPT,\n",
+    "        context_inner=CONTEXT_INNER_PROMPT,\n",
+    "    ),\n",
+    "    agent=AgentSettings(\n",
+    "        agent_llm=llm_openai,\n",
+    "        agent_llm_config={\n",
+    "            \"model_list\": [\n",
+    "                {\n",
+    "                    \"model_name\": llm_openai,\n",
+    "                    \"litellm_params\": {\n",
+    "                        \"model\": llm_openai,\n",
+    "                    }\n",
+    "                }\n",
+    "            ],\n",
+    "            \"rate_limit\": {\n",
+    "                llm_openai: \"30000 per 1 minute\",\n",
+    "            },\n",
+    "        },\n",
+    "        agent_prompt=env_reset_prompt,\n",
+    "        agent_system_prompt=env_system_prompt,\n",
+    "        search_count=8,\n",
+    "        index=IndexSettings(\n",
+    "            paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
+    "            index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
+    "        )\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As it is evident, `Paperqa` is absolutely customizable. And here we reinterate that despite this possible fine customization, the defaults are good for most cases. Although, the user is welcome to explore the settings and customize the `paperqa` to their needs.\n",
+    "\n",
+    "We also set settings.verbosity to 1, which will print the agent configuration. Feel free to set it to 0 to silence the logging after your first run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from paperqa import ask\n",
+    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which probably worked fine. Let's now try to remove `OPENAI_API_KEY` and run again the same question with the same settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['OPENAI_API_KEY'] = \"sk-invalid-key\"\n",
+    "print(f\"Curent environment variables:\")\n",
+    "print(f\"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}\")\n",
+    "print(f\"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It would obviously fail. We don't have a valid `OPENAI_API_KEY`, so the agent will not be able to use `OpenAI` models. Let's change it to an `Anthropic` model and see if it works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.llm = llm_anthropic\n",
+    "settings.llm_config = {\n",
+    "    \"model_list\": [\n",
+    "        {\n",
+    "            \"model_name\": llm_anthropic,\n",
+    "            \"litellm_params\": {\n",
+    "                \"model\": llm_anthropic,\n",
+    "                \"temperature\": 0.1,\n",
+    "                \"max_tokens\": 512,\n",
+    "            }\n",
+    "        }\n",
+    "    ],\n",
+    "    \"rate_limit\": {\n",
+    "        llm_anthropic: \"30000 per 1 minute\",\n",
+    "    },\n",
+    "}\n",
+    "settings.summary_llm = llm_anthropic\n",
+    "settings.summary_llm_config = {\n",
+    "    \"rate_limit\": {\n",
+    "        llm_anthropic: \"30000 per 1 minute\",\n",
+    "    },\n",
+    "}\n",
+    "settings.agent = AgentSettings(\n",
+    "    agent_llm=llm_anthropic,\n",
+    "    agent_llm_config={\n",
+    "        \"rate_limit\": {\n",
+    "            llm_anthropic: \"30000 per 1 minute\",\n",
+    "        },\n",
+    "    },\n",
+    "    index=IndexSettings(\n",
+    "            paper_directory=pathlib.Path.cwd().joinpath(\"papers\"),\n",
+    "            index_directory=pathlib.Path.cwd().joinpath(\"papers/index\"),\n",
+    "        )\n",
+    ")\n",
+    "# settings.embedding = \"st-multi-qa-MiniLM-L6-cos-v1\"\n",
+    "settings.embedding = \"hybrid-st-multi-qa-MiniLM-L6-cos-v1\"\n",
+    "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now the agent is able to use `Anthropic` models only and although we don't have a valid `OPENAI_API_KEY`, the question is answered because the agent will not use `OpenAI` models. See that we also changed the `embedding` because it was using `text-embedding-3-small` by default, which is a `OpenAI` model. `Paperqa` implements a few embedding models. Please refer to the [documentation](https://github.com/Future-House/paper-qa?tab=readme-ov-file#embedding-model) for more information.\n",
+    "\n",
+    "Notice that we redefined `settings.agent.paper_directory` and `settings.agent.index` settings. `Paperqa` actually uses the setting from `settings.agent`. However, for convenience, we implemented an alias in `settings.paper_directory` and `settings.index_directory`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The output\n",
+    "\n",
+    "`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response.__dict__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Let's examine the PQASession object returned by paperqa:\\n\")\n",
+    "\n",
+    "print(f\"Status: {response.status.value}\")\n",
+    "\n",
+    "print(\"1. Question asked:\")\n",
+    "print(f\"{response.session.question}\\n\")\n",
+    "\n",
+    "print(\"2. Answer provided:\")\n",
+    "print(f\"{response.session.answer}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the answer, the `PQASession` object contains all the references and contexts used to generate the answer.\n",
+    "\n",
+    "Because `paperqa` splits the documents into chunks, each chunk is a valid reference. You can see that it also references the page where the context was found."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"3. References cited:\")\n",
+    "print(f\"{response.session.references}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, `PQASession.session.contexts` contains the contexts used to generate the answer. Each context has a score, which is the similarity between the question and the context. \n",
+    "`Paperqa` uses this score to choose what contexts is more relevant to answer the question."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"4. Contexts used to generate the answer:\")\n",
+    "print(\"These are the relevant text passages that were retrieved and used to formulate the answer:\")\n",
+    "for i, ctx in enumerate(response.session.contexts, 1):\n",
+    "    print(f\"\\nContext {i}:\")\n",
+    "    print(f\"Source: {ctx.text.name}\")\n",
+    "    print(f\"Content: {ctx.context}\")\n",
+    "    print(f\"Score: {ctx.score}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/tutorials/settings_tutorial.ipynb
+++ b/docs/tutorials/settings_tutorial.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,12 +34,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import requests\n",
     "import os\n",
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()\n",
     "\n",
+    "import nest_asyncio\n",
+    "import requests\n",
     "from dotenv import load_dotenv\n",
+    "\n",
+    "nest_asyncio.apply()\n",
     "load_dotenv(\".env\")"
    ]
   },
@@ -49,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"You have set the following environment variables:\")\n",
+    "print(\"You have set the following environment variables:\")\n",
     "print(f\"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}\")\n",
     "print(f\"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}\")"
    ]
@@ -63,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +78,7 @@
     "\n",
     "# Download the paper from arXiv and save it to the `papers` directory\n",
     "url = \"https://arxiv.org/pdf/2407.01603\"\n",
-    "response = requests.get(url)\n",
+    "response = requests.get(url, timeout=60)\n",
     "with open(\"papers/2407.01603.pdf\", \"wb\") as f:\n",
     "    f.write(response.content)\n"
    ]
@@ -111,12 +112,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pathlib\n",
-    "from paperqa.settings import Settings, AnswerSettings, ParsingSettings, PromptSettings, AgentSettings, IndexSettings\n",
+    "\n",
     "from paperqa.prompts import (\n",
     "    CONTEXT_INNER_PROMPT,\n",
     "    CONTEXT_OUTER_PROMPT,\n",
@@ -131,6 +132,7 @@
     "    summary_json_system_prompt,\n",
     "    summary_prompt,\n",
     ")\n",
+    "from paperqa.settings import AgentSettings, AnswerSettings, IndexSettings, ParsingSettings, PromptSettings, Settings\n",
     "\n",
     "settings = Settings(\n",
     "    llm=llm_openai,\n",
@@ -235,6 +237,7 @@
    "outputs": [],
    "source": [
     "from paperqa import ask\n",
+    "\n",
     "response = ask(\"What are the most relevant language models used for chemistry?\", settings=settings)"
    ]
   },
@@ -251,8 +254,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ['OPENAI_API_KEY'] = \"sk-invalid-key\"\n",
-    "print(f\"Curent environment variables:\")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"sk-invalid-key\"\n",
+    "print(\"Current environment variables:\")\n",
     "print(f\"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}\")\n",
     "print(f\"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}\")"
    ]

--- a/docs/tutorials/settings_tutorial.md
+++ b/docs/tutorials/settings_tutorial.md
@@ -1,0 +1,285 @@
+# Setup
+
+> 🚨 An executable jupyter notebook version of this tutorial can be found [here](https://github.com/Future-House/paper-qa/blob/main/docs/tutorials/settings_tutorial.ipynb).
+
+This tutorial aims to show how to use the `Settings` class to configure `PaperQA`.
+Firstly, we will be using `OpenAI` and `Anthropic` models, so we need to set the `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` environment variables.
+We will use both models to make it clear when `paperqa` agent is using either one or the other.
+We use `python-dotenv` to load the environment variables from a `.env` file. 
+Hence, our first step is to create a `.env` file and install the required packages.
+
+```bash
+echo "OPENAI_API_KEY=<your-openai-api-key>" > .env
+echo "ANTHROPIC_API_KEY=<your-anthropic-api-key>" >> .env
+
+uv pip install -q nest-asyncio
+uv pip install -q python-dotenv
+uv pip install -q fhlmi
+uv pip install -q "paper-qa[local]"
+```
+
+```python
+import os
+import nest_asyncio
+import requests
+from dotenv import load_dotenv
+
+nest_asyncio.apply()
+load_dotenv(".env")
+```
+
+```python
+print(f"You have set the following environment variables:")
+print(f"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}")
+print(f"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}")
+```
+
+We will use the `lmi` package to get the model names and the `.papers` directory to save documents we will use.
+
+```python
+from lmi import CommonLLMNames
+
+llm_openai = CommonLLMNames.OPENAI_TEST.value
+llm_anthropic = CommonLLMNames.ANTHROPIC_TEST.value
+
+# Create the `papers` directory if it doesn't exist
+os.makedirs("papers", exist_ok=True)
+
+# Download the paper from arXiv and save it to the `papers` directory
+url = "https://arxiv.org/pdf/2407.01603"
+response = requests.get(url, timeout=60)
+with open("papers/2407.01603.pdf", "wb") as f:
+    f.write(response.content)
+```
+
+The `Settings` class is used to configure the PaperQA settings. 
+Official documentation can be found [here](https://github.com/Future-House/paper-qa?tab=readme-ov-file#settings-cheatsheet) and the open source code can be found [here](https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py).
+
+Here is a basic example of how to use the `Settings` class. We will be unnecessarily verbose for the sake of clarity. Please notice that most of the settings are optional and the defaults are good for most cases. Refer to the [descriptions of each setting]((https://github.com/Future-House/paper-qa/blob/main/paperqa/settings.py)) for more information.
+
+Within this `Settings` object, I'd like to discuss specifically how the llms are configured and how `paperqa` looks for papers.
+
+A common source of confusion is that multiple `llms` are used in paperqa. We have `llm`, `summary_llm`, `agent_llm`, and `embedding`. Hence, if `llm` is set to an `Anthropic` model, `summary_llm` and `agent_llm` will still require a `OPENAI_API_KEY`, since `OpenAI` models are the default.
+
+Among the objects that use `llms` in `paperqa`, we have `llm`, `summary_llm`, `agent_llm`, and `embedding`:
+- `llm`: Main LLM used by the agent to reason about the question, extract metadata from documents, etc.
+- `summary_llm`: LLM used to summarize the papers.
+- `agent_llm`: LLM used to answer questions and select tools.
+- `embedding`: Embedding model used to embed the papers.
+
+Let's see some examples around this concept. First, we define the settings with `llm` set to an `OpenAI` model. Please notice this is not an complete list of settings. But take your time to read through this `Settings` class and all customization that can be done.
+
+```python
+import pathlib
+from paperqa.settings import Settings, AnswerSettings, ParsingSettings, PromptSettings, AgentSettings, IndexSettings
+from paperqa.prompts import (
+    CONTEXT_INNER_PROMPT,
+    CONTEXT_OUTER_PROMPT,
+    citation_prompt,
+    default_system_prompt,
+    env_reset_prompt,
+    env_system_prompt,
+    qa_prompt,
+    select_paper_prompt,
+    structured_citation_prompt,
+    summary_json_prompt,
+    summary_json_system_prompt,
+    summary_prompt,
+)
+
+settings = Settings(
+    llm=llm_openai,
+    llm_config={
+        "model_list": [
+            {
+                "model_name": llm_openai,
+                "litellm_params": {
+                    "model": llm_openai,
+                    "temperature": 0.1,
+                    "max_tokens": 512,
+                }
+            }
+        ],
+        "rate_limit": {
+            llm_openai: "30000 per 1 minute",
+        },
+    },
+    summary_llm=llm_openai,
+    summary_llm_config={
+        "rate_limit": {
+            llm_openai: "30000 per 1 minute",
+        },
+    },
+    embedding="text-embedding-3-small",
+    embedding_config={},
+    temperature=0.1,
+    batch_size=1,
+    verbosity=1,
+    manifest_file=None,
+    paper_directory=pathlib.Path.cwd().joinpath("papers"),
+    index_directory=pathlib.Path.cwd().joinpath("papers/index"),
+    answer=AnswerSettings(
+        evidence_k=10,
+        evidence_detailed_citations=True,
+        evidence_retrieval=True,
+        evidence_summary_length="about 100 words",
+        evidence_skip_summary=False,
+        answer_max_sources=5,
+        max_answer_attempts=None,
+        answer_length="about 200 words, but can be longer",
+        max_concurrent_requests=10,
+    ),
+    parsing=ParsingSettings(
+        chunk_size=5000,
+        overlap=250,
+        citation_prompt=citation_prompt,
+        structured_citation_prompt=structured_citation_prompt,
+    ),
+    prompts=PromptSettings(
+        summary=summary_prompt,
+        qa=qa_prompt,
+        select=select_paper_prompt,
+        pre=None,
+        post=None,
+        system=default_system_prompt,
+        use_json=True,
+        summary_json=summary_json_prompt,
+        summary_json_system=summary_json_system_prompt,
+        context_outer=CONTEXT_OUTER_PROMPT,
+        context_inner=CONTEXT_INNER_PROMPT,
+    ),
+    agent=AgentSettings(
+        agent_llm=llm_openai,
+        agent_llm_config={
+            "model_list": [
+                {
+                    "model_name": llm_openai,
+                    "litellm_params": {
+                        "model": llm_openai,
+                    }
+                }
+            ],
+            "rate_limit": {
+                llm_openai: "30000 per 1 minute",
+            },
+        },
+        agent_prompt=env_reset_prompt,
+        agent_system_prompt=env_system_prompt,
+        search_count=8,
+        index=IndexSettings(
+            paper_directory=pathlib.Path.cwd().joinpath("papers"),
+            index_directory=pathlib.Path.cwd().joinpath("papers/index"),
+        )
+    ),
+)
+```
+
+As it is evident, `Paperqa` is absolutely customizable. And here we reinterate that despite this possible fine customization, the defaults are good for most cases. Although, the user is welcome to explore the settings and customize the `paperqa` to their needs.
+
+We also set settings.verbosity to 1, which will print the agent configuration. Feel free to set it to 0 to silence the logging after your first run.
+
+```python
+from paperqa import ask
+response = ask("What are the most relevant language models used for chemistry?", settings=settings)
+```
+
+Which probably worked fine. Let's now try to remove `OPENAI_API_KEY` and run again the same question with the same settings.
+
+```python
+os.environ['OPENAI_API_KEY'] = "sk-invalid-key"
+print(f"Current environment variables:")
+print(f"OPENAI_API_KEY: {os.environ['OPENAI_API_KEY']}")
+print(f"ANTHROPIC_API_KEY: {os.environ['ANTHROPIC_API_KEY']}")
+```
+
+```python
+response = ask("What are the most relevant language models used for chemistry?", settings=settings)
+```
+
+It would obviously fail. We don't have a valid `OPENAI_API_KEY`, so the agent will not be able to use `OpenAI` models. Let's change it to an `Anthropic` model and see if it works.
+
+```python
+settings.llm = llm_anthropic
+settings.llm_config = {
+    "model_list": [
+        {
+            "model_name": llm_anthropic,
+            "litellm_params": {
+                "model": llm_anthropic,
+                "temperature": 0.1,
+                "max_tokens": 512,
+            }
+        }
+    ],
+    "rate_limit": {
+        llm_anthropic: "30000 per 1 minute",
+    },
+}
+settings.summary_llm = llm_anthropic
+settings.summary_llm_config = {
+    "rate_limit": {
+        llm_anthropic: "30000 per 1 minute",
+    },
+}
+settings.agent = AgentSettings(
+    agent_llm=llm_anthropic,
+    agent_llm_config={
+        "rate_limit": {
+            llm_anthropic: "30000 per 1 minute",
+        },
+    },
+    index=IndexSettings(
+            paper_directory=pathlib.Path.cwd().joinpath("papers"),
+            index_directory=pathlib.Path.cwd().joinpath("papers/index"),
+        )
+)
+# settings.embedding = "st-multi-qa-MiniLM-L6-cos-v1"
+settings.embedding = "hybrid-st-multi-qa-MiniLM-L6-cos-v1"
+response = ask("What are the most relevant language models used for chemistry?", settings=settings)
+```
+
+Now the agent is able to use `Anthropic` models only and although we don't have a valid `OPENAI_API_KEY`, the question is answered because the agent will not use `OpenAI` models. See that we also changed the `embedding` because it was using `text-embedding-3-small` by default, which is a `OpenAI` model. `Paperqa` implements a few embedding models. Please refer to the [documentation](https://github.com/Future-House/paper-qa?tab=readme-ov-file#embedding-model) for more information.
+
+Notice that we redefined `settings.agent.paper_directory` and `settings.agent.index` settings. `Paperqa` actually uses the setting from `settings.agent`. However, for convenience, we implemented an alias in `settings.paper_directory` and `settings.index_directory`.
+
+# The output
+
+`Paperqa` returns a `PQASession` object, which contains not only the answer but also all the information gatheres to answer the questions.
+
+```python
+response.__dict__
+```
+
+```python
+print("Let's examine the PQASession object returned by paperqa:\n")
+
+print(f"Status: {response.status.value}")
+
+print("1. Question asked:")
+print(f"{response.session.question}\n")
+
+print("2. Answer provided:")
+print(f"{response.session.answer}\n")
+```
+
+In addition to the answer, the `PQASession` object contains all the references and contexts used to generate the answer.
+
+Because `paperqa` splits the documents into chunks, each chunk is a valid reference. You can see that it also references the page where the context was found.
+
+```python
+print("3. References cited:")
+print(f"{response.session.references}\n")
+```
+
+Lastly, `PQASession.session.contexts` contains the contexts used to generate the answer. Each context has a score, which is the similarity between the question and the context. 
+`Paperqa` uses this score to choose what contexts is more relevant to answer the question.
+
+```python
+print("4. Contexts used to generate the answer:")
+print("These are the relevant text passages that were retrieved and used to formulate the answer:")
+for i, ctx in enumerate(response.session.contexts, 1):
+    print(f"\nContext {i}:")
+    print(f"Source: {ctx.text.name}")
+    print(f"Content: {ctx.context}")
+    print(f"Score: {ctx.score}")
+```


### PR DESCRIPTION
The main motivation for that is the number of open issues with user asking why paperqa still requires an `OPENAI_API_KEY` even though they set `Settings.llm` to some other provider. This is a quick tutorial showing why paperqa keeps asking OpenAI key in such cases.

TODO:
- [x] Check if gitbook is able to render a jupyter notebook