### PR TITLE
Support for answer iterations in the gen_answer flow

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -782,11 +782,18 @@ class Docs(BaseModel):
                     Message(role="system", content=prompt_config.system),
                     Message(
                         role="user",
-                        content=prompt_config.qa.format(
+                        content=prompt_config.configured_qa_prompt.format(
                             context=context_str,
                             answer_length=answer_config.answer_length,
                             question=session.question,
                             example_citation=prompt_config.EXAMPLE_CITATION,
+                            answer_iteration_context=(
+                                prompt_config.iteration_prompt.format(
+                                    prior_answer=session.answer
+                                )
+                                if session.answer
+                                else ""
+                            ),
                         ),
                     ),
                 ]

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -778,9 +778,9 @@ class Docs(BaseModel):
             answer_reasoning = None
         else:
             with set_llm_session_ids(session.id):
-                iteration_context = ""
+                prior_answer_prompt = ""
                 if prompt_config.iteration_prompt and session.answer:
-                    iteration_context = prompt_config.iteration_prompt.format(
+                    prior_answer_prompt = prompt_config.iteration_prompt.format(
                         prior_answer=session.answer
                     )
                 messages = [
@@ -792,7 +792,7 @@ class Docs(BaseModel):
                             answer_length=answer_config.answer_length,
                             question=session.question,
                             example_citation=prompt_config.EXAMPLE_CITATION,
-                            answer_iteration_context=iteration_context,
+                            prior_answer_prompt=prior_answer_prompt,
                         ),
                     ),
                 ]

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -779,8 +779,8 @@ class Docs(BaseModel):
         else:
             with set_llm_session_ids(session.id):
                 prior_answer_prompt = ""
-                if prompt_config.iteration_prompt and session.answer:
-                    prior_answer_prompt = prompt_config.iteration_prompt.format(
+                if prompt_config.answer_iteration_prompt and session.answer:
+                    prior_answer_prompt = prompt_config.answer_iteration_prompt.format(
                         prior_answer=session.answer
                     )
                 messages = [

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -778,22 +778,21 @@ class Docs(BaseModel):
             answer_reasoning = None
         else:
             with set_llm_session_ids(session.id):
+                iteration_context = ""
+                if prompt_config.iteration_prompt and session.answer:
+                    iteration_context = prompt_config.iteration_prompt.format(
+                        prior_answer=session.answer
+                    )
                 messages = [
                     Message(role="system", content=prompt_config.system),
                     Message(
                         role="user",
-                        content=prompt_config.configured_qa_prompt.format(
+                        content=prompt_config.qa.format(
                             context=context_str,
                             answer_length=answer_config.answer_length,
                             question=session.question,
                             example_citation=prompt_config.EXAMPLE_CITATION,
-                            answer_iteration_context=(
-                                prompt_config.iteration_prompt.format(
-                                    prior_answer=session.answer
-                                )
-                                if session.answer
-                                else ""
-                            ),
+                            answer_iteration_context=iteration_context,
                         ),
                     ),
                 ]

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -21,7 +21,7 @@ summary_json_prompt = (
 # 1. Lead to complete tool being called with has_successful_answer=False
 # 2. Can be used for unit testing
 CANNOT_ANSWER_PHRASE = "I cannot answer"
-qa_prompt = (
+qa_without_iteration_prompt = (
     "Answer the question below with the context.\n\n"
     "Context (with relevance scores):\n\n{context}\n\n----\n\n"
     "Question: {question}\n\n"
@@ -48,7 +48,7 @@ answer_iteration_prompt = (
     "also included in the above context.\n\n"
 )
 
-qa_with_iteration_prompt = (
+qa_prompt = (
     "Answer the question below with the context.\n\n"
     "Context (with relevance scores):\n\n{context}\n\n----\n\n"
     "Question: {question}\n\n"

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -21,24 +21,6 @@ summary_json_prompt = (
 # 1. Lead to complete tool being called with has_successful_answer=False
 # 2. Can be used for unit testing
 CANNOT_ANSWER_PHRASE = "I cannot answer"
-qa_without_iteration_prompt = (
-    "Answer the question below with the context.\n\n"
-    "Context (with relevance scores):\n\n{context}\n\n----\n\n"
-    "Question: {question}\n\n"
-    "Write an answer based on the context. "
-    "If the context provides insufficient information reply "
-    f'"{CANNOT_ANSWER_PHRASE}." '
-    "For each part of your answer, indicate which sources most support "
-    "it via citation keys at the end of sentences, "
-    "like {example_citation}. Only cite from the context "
-    "below and only use the valid keys. Write in the style of a "
-    "Wikipedia article, with concise sentences and coherent paragraphs. "
-    "The context comes from a variety of sources and is only a summary, "
-    "so there may inaccuracies or ambiguities. If quotes are present and "
-    "relevant, use them in the answer. This answer will go directly onto "
-    "Wikipedia, so do not add any extraneous information.\n\n"
-    "Answer ({answer_length}):"
-)
 
 answer_iteration_prompt = (
     "You are iterating on a prior answer, with a potentially different context:\n\n"

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -40,6 +40,34 @@ qa_prompt = (
     "Answer ({answer_length}):"
 )
 
+answer_iteration_prompt = (
+    "You are iterating on a prior answer, with a potentially different context:\n\n"
+    "{prior_answer}\n\n"
+    "Create a new answer only using keys and data from the included context, do not "
+    "you can not use context keys from the prior answer which are not "
+    "also included in the above context.\n\n"
+)
+
+qa_with_iteration_prompt = (
+    "Answer the question below with the context.\n\n"
+    "Context (with relevance scores):\n\n{context}\n\n----\n\n"
+    "Question: {question}\n\n"
+    "Write an answer based on the context. "
+    "If the context provides insufficient information reply "
+    f'"{CANNOT_ANSWER_PHRASE}." '
+    "For each part of your answer, indicate which sources most support "
+    "it via citation keys at the end of sentences, "
+    "like {example_citation}. Only cite from the context "
+    "below and only use the valid keys. Write in the style of a "
+    "Wikipedia article, with concise sentences and coherent paragraphs. "
+    "The context comes from a variety of sources and is only a summary, "
+    "so there may inaccuracies or ambiguities. If quotes are present and "
+    "relevant, use them in the answer. This answer will go directly onto "
+    "Wikipedia, so do not add any extraneous information.\n\n"
+    "{answer_iteration_context}"
+    "Answer ({answer_length}):"
+)
+
 select_paper_prompt = (
     "Select papers that may help answer the question below. "
     "Papers are listed as $KEY: $PAPER_INFO. "

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -22,7 +22,7 @@ summary_json_prompt = (
 # 2. Can be used for unit testing
 CANNOT_ANSWER_PHRASE = "I cannot answer"
 
-answer_iteration_prompt = (
+answer_iteration_prompt_template = (
     "You are iterating on a prior answer, with a potentially different context:\n\n"
     "{prior_answer}\n\n"
     "Create a new answer only using keys and data from the included context."
@@ -46,7 +46,7 @@ qa_prompt = (
     "so there may inaccuracies or ambiguities. If quotes are present and "
     "relevant, use them in the answer. This answer will go directly onto "
     "Wikipedia, so do not add any extraneous information.\n\n"
-    "{answer_iteration_context}"
+    "{prior_answer_prompt}"
     "Answer ({answer_length}):"
 )
 

--- a/paperqa/prompts.py
+++ b/paperqa/prompts.py
@@ -25,8 +25,8 @@ CANNOT_ANSWER_PHRASE = "I cannot answer"
 answer_iteration_prompt = (
     "You are iterating on a prior answer, with a potentially different context:\n\n"
     "{prior_answer}\n\n"
-    "Create a new answer only using keys and data from the included context, do not "
-    "you can not use context keys from the prior answer which are not "
+    "Create a new answer only using keys and data from the included context."
+    " You can not use context keys from the prior answer which are not "
     "also included in the above context.\n\n"
 )
 

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -42,7 +42,7 @@ from paperqa._ldp_shims import (
 from paperqa.prompts import (
     CONTEXT_INNER_PROMPT,
     CONTEXT_OUTER_PROMPT,
-    answer_iteration_prompt,
+    answer_iteration_prompt_template,
     citation_prompt,
     default_system_prompt,
     env_reset_prompt,
@@ -267,7 +267,7 @@ class PromptSettings(BaseModel):
     summary: str = summary_prompt
     qa: str = qa_prompt
     iteration_prompt: str | None = Field(
-        default=answer_iteration_prompt,
+        default=answer_iteration_prompt_template,
         description=(
             "Prompt to inject existing prior answers into the qa prompt to allow the model to iterate. "
             "If None, then no prior answers will be injected."

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -48,7 +48,7 @@ from paperqa.prompts import (
     env_reset_prompt,
     env_system_prompt,
     qa_prompt,
-    qa_with_iteration_prompt,
+    qa_without_iteration_prompt,
     select_paper_prompt,
     structured_citation_prompt,
     summary_json_prompt,
@@ -267,7 +267,7 @@ class PromptSettings(BaseModel):
 
     summary: str = summary_prompt
     qa: str = qa_prompt
-    qa_with_iteration: str = qa_with_iteration_prompt
+    qa_without_iteration: str = qa_without_iteration_prompt
     iteration_prompt: str = answer_iteration_prompt
     use_qa_iterations: bool = True
     select: str = select_paper_prompt
@@ -323,15 +323,15 @@ class PromptSettings(BaseModel):
             )
         return v
 
-    @field_validator("qa_with_iteration")
+    @field_validator("qa_without_iteration")
     @classmethod
     def check_qa_with_iteration(cls, v: str) -> str:
         if not get_formatted_variables(v).issubset(
-            get_formatted_variables(qa_with_iteration_prompt)
+            get_formatted_variables(qa_without_iteration_prompt)
         ):
             raise ValueError(
                 "QA prompt can only have variables:"
-                f" {get_formatted_variables(qa_with_iteration_prompt)}"
+                f" {get_formatted_variables(qa_without_iteration_prompt)}"
             )
         return v
 
@@ -382,8 +382,8 @@ class PromptSettings(BaseModel):
     @property
     def configured_qa_prompt(self) -> str:
         if self.use_qa_iterations:
-            return self.qa_with_iteration
-        return self.qa
+            return self.qa
+        return self.qa_without_iteration
 
 
 class IndexSettings(BaseModel):

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -266,7 +266,7 @@ class PromptSettings(BaseModel):
 
     summary: str = summary_prompt
     qa: str = qa_prompt
-    iteration_prompt: str | None = Field(
+    answer_iteration_prompt: str | None = Field(
         default=answer_iteration_prompt_template,
         description=(
             "Prompt to inject existing prior answers into the qa prompt to allow the model to iterate. "

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -539,7 +539,29 @@ def test_location_awareness(docs_fixture) -> None:
 
 
 def test_query(docs_fixture) -> None:
-    docs_fixture.query("Is XAI usable in chemistry?")
+    settings = Settings(prompts={"use_qa_iterations": False})
+    docs_fixture.query("Is XAI usable in chemistry?", settings=settings)
+
+
+def test_query_with_iteration(docs_fixture) -> None:
+    # we store these results to check that the prompts are OK
+    my_results: list[LLMResult] = []
+    # explicitly set the prompt to use QA iterations
+    settings = Settings(prompts={"use_qa_iterations": True})
+    llm = settings.get_llm()
+    llm.llm_result_callback = my_results.append
+    prior_answer = "No, it isn't usable in chemistry."
+    question = "Is XAI usable in chemistry?"
+    prior_session = PQASession(question=question, answer=prior_answer)
+    docs_fixture.query(prior_session, llm_model=llm, settings=settings)
+    assert prior_answer in cast(
+        "str", my_results[-1].prompt[1].content  # type: ignore[union-attr, index]
+    ), "prior answer not in prompt"
+    # run without a prior session to check that the flow works correctly
+    docs_fixture.query(question, llm_model=llm, settings=settings)
+    assert settings.prompts.iteration_prompt[:10] not in cast(
+        "str", my_results[-1].prompt[1].content  # type: ignore[union-attr, index]
+    ), "prior answer prompt should not be inserted"
 
 
 def test_llmresult_callback(docs_fixture: Docs) -> None:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -539,7 +539,7 @@ def test_location_awareness(docs_fixture) -> None:
 
 
 def test_query(docs_fixture) -> None:
-    settings = Settings(prompts={"use_qa_iterations": False})
+    settings = Settings(prompts={"iteration_prompt": None})
     docs_fixture.query("Is XAI usable in chemistry?", settings=settings)
 
 
@@ -547,7 +547,7 @@ def test_query_with_iteration(docs_fixture) -> None:
     # we store these results to check that the prompts are OK
     my_results: list[LLMResult] = []
     # explicitly set the prompt to use QA iterations
-    settings = Settings(prompts={"use_qa_iterations": True})
+    settings = Settings()
     llm = settings.get_llm()
     llm.llm_result_callback = my_results.append
     prior_answer = "No, it isn't usable in chemistry."
@@ -559,7 +559,7 @@ def test_query_with_iteration(docs_fixture) -> None:
     ), "prior answer not in prompt"
     # run without a prior session to check that the flow works correctly
     docs_fixture.query(question, llm_model=llm, settings=settings)
-    assert settings.prompts.iteration_prompt[:10] not in cast(
+    assert settings.prompts.iteration_prompt[:10] not in cast(  # type: ignore[index]
         "str", my_results[-1].prompt[1].content  # type: ignore[union-attr, index]
     ), "prior answer prompt should not be inserted"
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -539,7 +539,7 @@ def test_location_awareness(docs_fixture) -> None:
 
 
 def test_query(docs_fixture) -> None:
-    settings = Settings(prompts={"iteration_prompt": None})
+    settings = Settings(prompts={"answer_iteration_prompt": None})
     docs_fixture.query("Is XAI usable in chemistry?", settings=settings)
 
 
@@ -559,7 +559,7 @@ def test_query_with_iteration(docs_fixture) -> None:
     ), "prior answer not in prompt"
     # run without a prior session to check that the flow works correctly
     docs_fixture.query(question, llm_model=llm, settings=settings)
-    assert settings.prompts.iteration_prompt[:10] not in cast(  # type: ignore[index]
+    assert settings.prompts.answer_iteration_prompt[:10] not in cast(  # type: ignore[index]
         "str", my_results[-1].prompt[1].content  # type: ignore[union-attr, index]
     ), "prior answer prompt should not be inserted"
 


### PR DESCRIPTION
If we are answering after a prior answer already exists in the session, we currently don't expose that to the `gen_answer` tool  / `aquery`. To support continuations, where a user follows up to a query, exposing the prior answer if very helpful (because the agent can't pass it directly), so this implements that feature. 