### PR TITLE
Began deprecation of non-`async` methods in `Docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ doc_paths = ("myfile.pdf", "myotherfile.pdf")
 # Prepare the Docs object by adding a bunch of documents
 docs = Docs()
 for doc_path in doc_paths:
-    docs.add(doc_path)
+    await docs.aadd(doc_path)
 
 # Set up how we want to query the Docs object
 settings = Settings()
@@ -561,7 +561,7 @@ from paperqa import Docs, Settings
 
 docs = Docs()
 for doc in ("myfile.pdf", "myotherfile.pdf"):
-    docs.add(doc, settings=Settings(embedding="text-embedding-large-3"))
+    await docs.aadd(doc, settings=Settings(embedding="text-embedding-large-3"))
 ```
 
 Note that PaperQA2 uses Numpy as a dense vector store.
@@ -585,7 +585,7 @@ model = HybridEmbeddingModel(
 )
 docs = Docs()
 for doc in ("myfile.pdf", "myotherfile.pdf"):
-    docs.add(doc, embedding_model=model)
+    await docs.aadd(doc, embedding_model=model)
 ```
 
 The sparse embedding (keyword) models default to having 256 dimensions, but this can be specified via the `ndim` argument.
@@ -651,7 +651,7 @@ source_files = glob.glob("**/*.js")
 docs = Docs()
 for f in source_files:
     # this assumes the file names are unique in code
-    docs.add(f, citation="File " + os.path.basename(f), docname=os.path.basename(f))
+    await docs.aadd(f, citation="File " + os.path.basename(f), docname=os.path.basename(f))
 session = docs.query("Where is the search bar in the header defined?")
 print(session)
 ```

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ settings.llm = "claude-3-5-sonnet-20240620"
 settings.answer.answer_max_sources = 3
 
 # Query the Docs object to get an answer
-session = docs.query(
+session = await docs.aquery(
     "What manufacturing challenges are unique to bispecific antibodies?",
     settings=settings,
 )
@@ -631,7 +631,7 @@ settings = Settings()
 settings.answer.answer_max_sources = 3
 settings.answer.k = 5
 
-docs.query(
+await docs.aquery(
     "What manufacturing challenges are unique to bispecific antibodies?",
     settings=settings,
 )
@@ -652,7 +652,7 @@ docs = Docs()
 for f in source_files:
     # this assumes the file names are unique in code
     await docs.aadd(f, citation="File " + os.path.basename(f), docname=os.path.basename(f))
-session = docs.query("Where is the search bar in the header defined?")
+session = await docs.aquery("Where is the search bar in the header defined?")
 print(session)
 ```
 
@@ -861,7 +861,7 @@ docs = Docs()
 
 # add some docs...
 
-docs.query(
+await docs.aquery(
     "What manufacturing challenges are unique to bispecific antibodies?",
     callbacks=[typewriter],
 )
@@ -890,7 +890,7 @@ my_qa_prompt = (
 docs = Docs()
 settings = Settings()
 settings.prompts.qa = my_qa_prompt
-docs.query("Are covid-19 vaccines effective?", settings=settings)
+await docs.aquery("Are covid-19 vaccines effective?", settings=settings)
 ```
 
 ### Pre and Post Prompts

--- a/docs/tutorials/where_do_I_get_papers.md
+++ b/docs/tutorials/where_do_I_get_papers.md
@@ -76,7 +76,7 @@ zotero = ZoteroDB(library_type="user")  # "group" if group library
 for item in zotero.iterate(limit=20):
     if item.num_pages > 30:
         continue  # skip long papers
-    docs.add(item.pdf, docname=item.key)
+    await docs.aadd(item.pdf, docname=item.key)
 ```
 
 which will download the first 20 papers in your Zotero database and add
@@ -93,7 +93,7 @@ for item in zotero.iterate(
     limit=100,
 ):
     print("Adding", item.title)
-    docs.add(item.pdf, docname=item.key)
+    await docs.aadd(item.pdf, docname=item.key)
 ```
 
 You can read more about the search syntax by typing `zotero.iterate?` in IPython.
@@ -111,7 +111,7 @@ papers = paperscraper.search_papers(keyword_search)
 docs = Docs()
 for path, data in papers.items():
     try:
-        docs.add(path)
+        await docs.aadd(path)
     except ValueError as e:
         # sometimes this happens if PDFs aren't downloaded or readable
         print("Could not read", path, e)

--- a/docs/tutorials/where_do_I_get_papers.md
+++ b/docs/tutorials/where_do_I_get_papers.md
@@ -32,7 +32,7 @@ submissions = helper.fetch_relevant_papers(question)
 docs = await helper.aadd_docs(submissions)
 
 # Now you can continue asking like in the [main tutorial](../../README.md)
-session = docs.query(question, settings=settings)
+session = await docs.aquery(question, settings=settings)
 print(session.answer)
 ```
 
@@ -115,7 +115,7 @@ for path, data in papers.items():
     except ValueError as e:
         # sometimes this happens if PDFs aren't downloaded or readable
         print("Could not read", path, e)
-session = docs.query(
+session = await docs.aquery(
     "What manufacturing challenges are unique to bispecific antibodies?"
 )
 print(session)

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -259,6 +259,13 @@ class Docs(BaseModel):
         embedding_model: EmbeddingModel | None = None,
         **kwargs,
     ) -> str | None:
+        warnings.warn(
+            "The synchronous `add` method is being deprecated in favor of the"
+            " asynchronous `aadd` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aadd(
                 path,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -202,6 +202,13 @@ class Docs(BaseModel):
         llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
     ) -> str | None:
+        warnings.warn(
+            "The synchronous `add_url` method is being deprecated in favor of the"
+            " asynchronous `aadd_url` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aadd_url(
                 url,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -701,6 +701,13 @@ class Docs(BaseModel):
         embedding_model: EmbeddingModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
     ) -> PQASession:
+        warnings.warn(
+            "The synchronous `query` method is being deprecated in favor of the"
+            " asynchronous `aquery` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aquery(
                 query,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -6,6 +6,7 @@ import os
 import re
 import tempfile
 import urllib.request
+import warnings
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from io import BytesIO
@@ -133,6 +134,13 @@ class Docs(BaseModel):
         llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
     ) -> str | None:
+        warnings.warn(
+            "The synchronous `add_file` method is being deprecated in favor of the"
+            " asynchronous `aadd_file` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aadd_file(
                 file,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -575,6 +575,13 @@ class Docs(BaseModel):
         summary_llm_model: LLMModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
     ) -> PQASession:
+        warnings.warn(
+            "The synchronous `get_evidence` method is being deprecated in favor of the"
+            " asynchronous `aget_evidence` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aget_evidence(
                 query=query,

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -424,6 +424,13 @@ class Docs(BaseModel):
         settings: MaybeSettings = None,
         embedding_model: EmbeddingModel | None = None,
     ) -> bool:
+        warnings.warn(
+            "The synchronous `add_texts` method is being deprecated in favor of the"
+            " asynchronous `aadd_texts` method, this deprecation will conclude in"
+            " version 6.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return get_loop().run_until_complete(
             self.aadd_texts(
                 texts, doc, settings=settings, embedding_model=embedding_model

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -13,6 +13,7 @@ from typing import cast
 import httpx
 import numpy as np
 import pytest
+import pytest_asyncio
 from aviary.core import Message
 from lmi import (
     CommonLLMNames,
@@ -61,11 +62,11 @@ from paperqa.utils import (
 THIS_MODULE = pathlib.Path(__file__)
 
 
-@pytest.fixture
-def docs_fixture(stub_data_dir: Path) -> Docs:
+@pytest_asyncio.fixture
+async def docs_fixture(stub_data_dir: Path) -> Docs:
     docs = Docs()
     with (stub_data_dir / "paper.pdf").open("rb") as f:
-        docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
+        await docs.aadd_file(f, "Wellawatte et al, XAI Review, 2023")
     return docs
 
 
@@ -1024,10 +1025,11 @@ def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
     raise AssertionError(f"Query was incorrect across {num_retries} retries.")
 
 
-def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
     with (stub_data_dir / "paper.pdf").open("rb") as f:
         docs = Docs()
-        docs.add_file(f, "Wellawatte et al, XAI Review, 2023")
+        await docs.aadd_file(f, "Wellawatte et al, XAI Review, 2023")
     num_retries = 3
     for _ in range(num_retries):
         answer = docs.query("Are counterfactuals actionable? [yes/no]")
@@ -1036,13 +1038,14 @@ def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
     raise AssertionError(f"Query was incorrect across {num_retries} retries.")
 
 
-def test_fileio_reader_txt(stub_data_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_fileio_reader_txt(stub_data_dir: Path) -> None:
     # can't use curie, because it has trouble with parsed HTML
     docs = Docs()
     with (stub_data_dir / "bates.txt").open("rb") as file:
         file_content = file.read()
 
-    docs.add_file(
+    await docs.aadd_file(
         BytesIO(file_content),
         "WikiMedia Foundation, 2023, Accessed now",
     )


### PR DESCRIPTION
Our `async` wrappers using `run_until_complete` commonly cause issues for users: https://github.com/Future-House/paper-qa/issues/584, https://github.com/Future-House/paper-qa/issues/915

This PR addresses them by starting a deprecation cycle for these `run_until_complete` wrappers, we should just let callers handle this themselves.

After this deprecation there will be less code and users will be more performant