### PR TITLE
Resolved a few deprecation warnings

### DIFF
--- a/paperqa/clients/crossref.py
+++ b/paperqa/clients/crossref.py
@@ -227,7 +227,7 @@ async def parse_crossref_to_doc_details(
     for key, value in (
         message | {"client_source": ["crossref"], "bibtex_source": [bibtex_source]}
     ).items():
-        if key not in doc_details.model_fields:
+        if key not in type(doc_details).model_fields:
             if key in doc_details.other:
                 doc_details.other[key] = [doc_details.other[key], value]
             else:

--- a/paperqa/clients/semantic_scholar.py
+++ b/paperqa/clients/semantic_scholar.py
@@ -204,7 +204,7 @@ async def parse_s2_to_doc_details(
         paper_data
         | {"client_source": ["semantic_scholar"], "bibtex_source": [bibtex_source]}
     ).items():
-        if key not in doc_details.model_fields:
+        if key not in type(doc_details).model_fields:
             doc_details.other[key] = value
 
     return doc_details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,6 +281,7 @@ filterwarnings = [
     "ignore:The `dict` method is deprecated; use `model_dump` instead",  # SEE: https://github.com/BerriAI/litellm/issues/5987
     "ignore:Use 'content=<...>' to upload raw bytes/text content:DeprecationWarning",  # SEE: https://github.com/BerriAI/litellm/issues/5986
     "ignore:builtin type (SwigPyPacked|SwigPyObject|swigvarlink) has no __module__:DeprecationWarning:importlib._bootstrap",  # SEE: https://github.com/pymupdf/PyMuPDF/issues/3931 --> https://github.com/swig/swig/issues/2881#issuecomment-2332652634
+    'ignore:There is no current event loop:DeprecationWarning:litellm.caching.llm_caching_handler',  # SEE: https://github.com/BerriAI/litellm/issues/9641
     'ignore:open_text is deprecated. Use files\(\) instead:DeprecationWarning',  # SEE: https://github.com/BerriAI/litellm/issues/5647
     'ignore:pkg_resources is deprecated as an API.:DeprecationWarning:pybtex',  # SEE: https://bitbucket.org/pybtex-devs/pybtex/issues/169/replace-pkg_resources-with
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 # Per-module configuration options
 module = [
-    "openreview",
+    "openreview",  # SEE: https://github.com/openreview/openreview-py/issues/2551
     "pybtex.*",  # SEE: https://bitbucket.org/pybtex-devs/pybtex/issues/141/type-annotations
     "pymupdf",  # SEE: https://github.com/pymupdf/PyMuPDF/issues/2883
     "pyzotero",  # SEE: https://github.com/urschrei/pyzotero/issues/110


### PR DESCRIPTION
Seen in `pytest` logs after https://github.com/Future-House/paper-qa/pull/920:

```none
tests/test_clients.py: 422 warnings
tests/test_agents.py: 281 warnings
  /path/to/paper-qa/paperqa/clients/semantic_scholar.py:207: PydanticDeprecatedSince211: Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    if key not in doc_details.model_fields:

tests/test_clients.py: 691 warnings
tests/test_agents.py: 367 warnings
tests/test_paperqa.py: 7 warnings
  /path/to/paper-qa/paperqa/clients/crossref.py:230: PydanticDeprecatedSince211: Accessing this attribute on the instance is deprecated, and will be removed in Pydantic V3. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    if key not in doc_details.model_fields:
```

Also this one from `litellm`:

```none
.venv/lib/python3.12/site-packages/litellm/caching/llm_caching_handler.py:18: 12 warnings
  /Users/jamesbraza/code/paper-qa/.venv/lib/python3.12/site-packages/litellm/caching/llm_caching_handler.py:18: DeprecationWarning: There is no current event loop
    event_loop = asyncio.get_event_loop()
```

This PR also documents a `py.typed` issue for `openreview-py`