### PR TITLE
Moved Renovate config validation to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: hynek/build-and-inspect-python-package@v2
       - run: uv sync --python-preference=only-managed
       - run: uv run pylint paperqa
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.1
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,11 +67,6 @@ repos:
     rev: 0.6.10
     hooks:
       - id: uv-lock
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.213.4
-    hooks:
-      - id: renovate-config-validator
-        args: [--strict]
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
     hooks:


### PR DESCRIPTION
Seen in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/14201198722/job/39788349395?pr=930):

```none
[INFO] Installing environment for https://github.com/renovatebot/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/runner/.cache/pre-commit/repokcq29hi0/node_env-system/bin/node', '/usr/local/bin/npm', 'install', '-g', '/home/runner/.cache/pre-commit/repokcq29hi0/dummy_package-0.0.0.tgz', 'renovate@39.213.4')
return code: 1
stdout: (none)
stderr:
    npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
    npm warn deprecated rimraf@2.4.5: Rimraf versions prior to v4 are no longer supported
    npm warn deprecated glob@6.0.4: Glob versions prior to v9 are no longer supported
    npm warn deprecated boolean@3.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
    npm error code E403
    npm error 403 403 Forbidden - GET https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz
    npm error 403 In most cases, you or one of your dependencies are requesting
    npm error 403 a package version that is forbidden by your security policy, or
    npm error 403 on a server you do not have access to.
    npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-04-01T16_40_57_624Z-debug-0.log
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```

We don't need Renovate config validation in `pre-commit`, let's just move to lint CI