### PR TITLE
Updated repo badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # PaperQA2
 
 [![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/Future-House/paper-qa)
-[![tests](https://github.com/Future-House/paper-qa/actions/workflows/tests.yml/badge.svg)](https://github.com/Future-House/paper-qa)
 [![PyPI version](https://badge.fury.io/py/paper-qa.svg)](https://badge.fury.io/py/paper-qa)
+[![tests](https://github.com/Future-House/paper-qa/actions/workflows/tests.yml/badge.svg)](https://github.com/Future-House/paper-qa)
+![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)
+![PyPI Python Versions](https://img.shields.io/pypi/pyversions/paper-qa)
 
 PaperQA2 is a package for doing high-accuracy retrieval augmented generation (RAG) on PDFs or text files,
 with a focus on the scientific literature.


### PR DESCRIPTION
Our public repos follow different badge patterns. It became more evident with the cookbook. 
Now that we are linking the platform documentation to the platform and plan to release it, the cookbook will see more traffic. This PR (together with similar ones on other repos) fixes it.