### PR TITLE
Add error handling for index file loading in SearchIndex

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -266,6 +266,7 @@ class SearchIndex:
                         logger.exception(
                             f"Failed to load index file {file_index_path}."
                         )
+                        raise
         return self._index_files
 
     @staticmethod

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -258,9 +258,12 @@ class SearchIndex:
             if await file_index_path.exists():
                 async with await anyio.open_file(file_index_path, "rb") as f:
                     content = await f.read()
-                    self._index_files = pickle.loads(  # noqa: S301
-                        zlib.decompress(content)
-                    )
+                    try:
+                        self._index_files = pickle.loads(  # noqa: S301
+                            zlib.decompress(content)
+                        )
+                    except Exception:
+                        logger.exception(f"Failed to load index file {file_index_path}")
         return self._index_files
 
     @staticmethod

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -263,7 +263,9 @@ class SearchIndex:
                             zlib.decompress(content)
                         )
                     except Exception:
-                        logger.exception(f"Failed to load index file {file_index_path}.")
+                        logger.exception(
+                            f"Failed to load index file {file_index_path}."
+                        )
         return self._index_files
 
     @staticmethod

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -263,7 +263,7 @@ class SearchIndex:
                             zlib.decompress(content)
                         )
                     except Exception:
-                        logger.exception(f"Failed to load index file {file_index_path}")
+                        logger.exception(f"Failed to load index file {file_index_path}.")
         return self._index_files
 
     @staticmethod


### PR DESCRIPTION
I got the following error while playing with paper-qa:

```
File D:\Programming\paper-qa\paperqa\agents\search.py:262, in SearchIndex.index_files(self)
    259         async with await anyio.open_file(file_index_path, "rb") as f:
    260             content = await f.read()
    261             self._index_files = pickle.loads(  # noqa: S301
--> 262                 zlib.decompress(content)
    263             )
    264 return self._index_files

error: Error -5 while decompressing data: incomplete or truncated stream
```
Since it was a bit hard to locate the offending file, I added logging so that one can see where the error is.

(Not sure why the error occurred in the first place, it disappeared after deleting the index files.)
