### PR TITLE
Exposing `IndexSettings.files_filter` for programmatic user

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,7 @@ will return much faster than the first query and we'll be certain the authors ma
 | `agent.index.recurse_subdirectories`         | `True`                                 | Whether to recurse into subdirectories when indexing.                                                   |
 | `agent.index.concurrency`                    | `5`                                    | Number of concurrent filesystem reads.                                                                  |
 | `agent.index.sync_with_paper_directory`      | `True`                                 | Whether to sync index with paper directory on load.                                                     |
+| `agent.index.files_filter`                   | `lambda f: f.suffix in {...}`          | Filter function to mark files in the paper directory to index.                                          |
 
 ## Where do I get papers?
 

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -691,7 +691,7 @@ async def get_directory_index(  # noqa: PLR0912
             if index_settings.recurse_subdirectories
             else paper_directory.iterdir()
         )
-        if file.suffix in {".txt", ".pdf", ".html", ".md"}
+        if index_settings.files_filter(file)
     ]
     if len(valid_papers_rel_file_paths) > WARN_IF_INDEXING_MORE_THAN:
         logger.warning(

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -430,6 +430,14 @@ class IndexSettings(BaseModel):
             " directory."
         ),
     )
+    files_filter: Callable[[anyio.Path], bool] = Field(
+        default=lambda f: f.suffix in {".txt", ".pdf", ".html", ".md"},
+        exclude=True,
+        description=(
+            "Filter function to apply to files in the paper directory."
+            " When the function returns True, the file will be indexed."
+        ),
+    )
 
     def get_named_index_directory(self) -> anyio.Path:
         """Get the directory where the index, when named, will be located.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -138,11 +138,20 @@ async def test_get_directory_index(
         # Now we actually remove (but not add!) a file from the paper directory,
         # and we still don't reprocess files
         (paper_dir / "obama.txt").unlink()
-        with patch.object(
-            Docs, "aadd", autospec=True, side_effect=Docs.aadd
-        ) as mock_aadd:
+        with (
+            patch.object(
+                Docs, "aadd", autospec=True, side_effect=Docs.aadd
+            ) as mock_aadd,
+            patch.object(
+                agent_test_settings.agent.index,
+                "files_filter",
+                lambda f: f.suffix in {".txt", ".pdf", ".md"},  # Also, exclude HTML
+            ),
+        ):
             index = await get_directory_index(settings=agent_test_settings)
-        assert len(await index.index_files) == len(path_to_id) - 1
+        # Subtract 1 for the removed obama.txt file,
+        # and another 1 for the filtered out flag_day.html
+        assert len(await index.index_files) == len(path_to_id) - 2
         mock_aadd.assert_not_awaited(), "Expected we didn't re-add files"
 
         # Note let's delete files.zip, and confirm we can't load the index


### PR DESCRIPTION
This allows for us to add unofficially supported extensions (e.g. `.py`) to indexes