### PR TITLE
Fixing flaky `test_ensure_robust_to_timeouts` by lowering timeout by 10X

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -509,9 +509,9 @@ async def test_odd_client_requests() -> None:
 
 
 @pytest.mark.asyncio
-@patch.object(paperqa.clients.crossref, "CROSSREF_API_REQUEST_TIMEOUT", 0.05)
+@patch.object(paperqa.clients.crossref, "CROSSREF_API_REQUEST_TIMEOUT", 0.001)
 @patch.object(
-    paperqa.clients.semantic_scholar, "SEMANTIC_SCHOLAR_API_REQUEST_TIMEOUT", 0.05
+    paperqa.clients.semantic_scholar, "SEMANTIC_SCHOLAR_API_REQUEST_TIMEOUT", 0.001
 )
 async def test_ensure_robust_to_timeouts() -> None:
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
It looks like from [this CI run](https://github.com/Future-House/paper-qa/actions/runs/15577336831/job/43864664393?pr=962):

```none
>       assert details is None, "Should return None for timeout"
E       AssertionError: Should return None for timeout
E       assert DocDetails(docname='unknownauthors2023convalescentantisarscov2plasmaimmuneglobulin', dockey='c2a60b772778732c', citati...s40278-023-41815-2, doi:10.1007/s40278-023-41815-2. This article has 0 citations and is from a peer-reviewed journal.') is None
```

That S2 can answer within 50-ms now. This PR just lowers the timeout by over 10X from 50-ms to 1-ms to ensure a timeout takes place.