### PR TITLE
Removing dead `print_callback` and `empty_callback`

### DIFF
--- a/paperqa/__init__.py
+++ b/paperqa/__init__.py
@@ -14,7 +14,7 @@ from lmi import (
 
 from paperqa.agents import ask
 from paperqa.agents.main import agent_query
-from paperqa.docs import Docs, PQASession, print_callback
+from paperqa.docs import Docs, PQASession
 from paperqa.llms import (
     NumpyVectorStore,
     QdrantVectorStore,
@@ -55,5 +55,4 @@ __all__ = [
     "ask",
     "embedding_model_factory",
     "get_settings",
-    "print_callback",
 ]

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -15,12 +15,7 @@ from typing import Any, BinaryIO, cast
 from uuid import UUID, uuid4
 
 from aviary.core import Message
-from lmi import (
-    Embeddable,
-    EmbeddingModel,
-    LLMModel,
-    LLMResult,
-)
+from lmi import Embeddable, EmbeddingModel, LLMModel
 from lmi.types import set_llm_session_ids
 from lmi.utils import gather_with_concurrency
 from pydantic import (
@@ -53,15 +48,6 @@ from paperqa.utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# this is just to reduce None checks/type checks
-async def empty_callback(result: LLMResult) -> None:
-    pass
-
-
-async def print_callback(result: str | LLMResult) -> None:
-    pass
 
 
 class Docs(BaseModel):

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -41,7 +41,6 @@ from paperqa import (
     Settings,
     Text,
     VectorStore,
-    print_callback,
 )
 from paperqa.clients import CrossrefProvider
 from paperqa.clients.journal_quality import JournalQualityPostProcessor
@@ -859,10 +858,13 @@ async def test_custom_llm(stub_data_dir: Path) -> None:
     ).contexts
     assert "Echo" in evidence[0].context
 
+    async def test_callback(result: LLMResult | str) -> None:
+        """Empty callback for testing purposes."""
+
     evidence = (
         await docs.aget_evidence(
             "Echo",
-            callbacks=[print_callback],
+            callbacks=[test_callback],
             summary_llm_model=StubLLMModel(),
             settings=no_json_settings,
         )


### PR DESCRIPTION
These seem unused in the codebase