### PR TITLE
Fixed `chunk_code_text`'s `UnboundLocalError` crash on empty code file

### DIFF
--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -222,7 +222,7 @@ def chunk_code_text(
     """Parse a document into chunks, based on line numbers (for code)."""
     text_buffer = ""
     texts: list[Text] = []
-    last_line_i = 0
+    line_i = last_line_i = 0
 
     if not isinstance(parsed_text.content, str | list):
         raise NotImplementedError(

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -245,7 +245,10 @@ def chunk_code_text(
             )
             text_buffer = text_buffer[chunk_chars - overlap :]
             last_line_i = line_i
-    if len(text_buffer) > overlap or not texts:
+    if (
+        len(text_buffer) > overlap  # Save meaningful amount of content as a final text
+        or not texts  # Contents were smaller than one chunk, save it anyways
+    ):
         texts.append(
             Text(
                 text=text_buffer[:chunk_chars],

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -220,36 +220,36 @@ def chunk_code_text(
     parsed_text: ParsedText, doc: Doc, chunk_chars: int, overlap: int
 ) -> list[Text]:
     """Parse a document into chunks, based on line numbers (for code)."""
-    split = ""
+    text_buffer = ""
     texts: list[Text] = []
-    last_line = 0
+    last_line_i = 0
 
     if not isinstance(parsed_text.content, str | list):
         raise NotImplementedError(
             f"Didn't yet handle ParsedText.content of type {type(parsed_text.content)}."
         )
 
-    for i, line in enumerate(
+    for line_i, line in enumerate(
         [parsed_text.content]
         if isinstance(parsed_text.content, str)
         else parsed_text.content
     ):
-        split += line
-        while len(split) > chunk_chars:
+        text_buffer += line
+        while len(text_buffer) > chunk_chars:
             texts.append(
                 Text(
-                    text=split[:chunk_chars],
-                    name=f"{doc.docname} lines {last_line}-{i}",
+                    text=text_buffer[:chunk_chars],
+                    name=f"{doc.docname} lines {last_line_i}-{line_i}",
                     doc=doc,
                 )
             )
-            split = split[chunk_chars - overlap :]
-            last_line = i
-    if len(split) > overlap or not texts:
+            text_buffer = text_buffer[chunk_chars - overlap :]
+            last_line_i = line_i
+    if len(text_buffer) > overlap or not texts:
         texts.append(
             Text(
-                text=split[:chunk_chars],
-                name=f"{doc.docname} lines {last_line}-{i}",
+                text=text_buffer[:chunk_chars],
+                name=f"{doc.docname} lines {last_line_i}-{line_i}",
                 doc=doc,
             )
         )

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1163,6 +1163,7 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
     for code_input in (
         Path(__file__),  # Python gets parsed into `list[str]` content
         stub_data_dir / ".DS_Store",  # .DS_Store gets parsed into `str` content
+        stub_data_dir / "py.typed",  # Marker file gets parsed into empty `list` content
     ):
         chunk_text, metadata = await read_doc(
             path=code_input,


### PR DESCRIPTION
If a code file is empty (e.g. a `py.typed` file), the `Text`-creation loop inside `chunk_code_text` will not be entered, so we hit an `UnboundLocalError`:

```none
UnboundLocalError: cannot access local variable 'i' where it is not associated with a value
```

This PR:

- Fixes that crash, with test coverage
- Improves variable names and documents the purpose of conditional logic