### PR TITLE
Fixed `README` typo from `answer.k` to `answer.evidence_k`

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ from paperqa import Settings
 
 settings = Settings()
 settings.answer.answer_max_sources = 3
-settings.answer.k = 5
+settings.answer.evidence_k = 5
 
 await docs.aquery(
     "What is PaperQA2?",


### PR DESCRIPTION
Looks like https://github.com/Future-House/paper-qa/pull/344 had a typo.

Closes https://github.com/Future-House/paper-qa/issues/958