### PR TITLE
Fixed flaky test `test_chain_completion` via resolving `Cannot add callback`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
           - aiohttp>=3.10.6 # Match pyproject.toml
           - PyMuPDF>=1.24.12
           - anyio
-          - fhlmi>=0.25.4 # Match pyproject.toml
+          - fhlmi>=0.28 # Match pyproject.toml
           - fhaviary[llm]>=0.19 # Match pyproject.toml
           - ldp>=0.25.0 # Match pyproject.toml
           - html2text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [
-    "fhlmi>=0.27",  # For LLMResult reflecting actual model
+    "fhlmi>=0.28",  # For update_litellm_max_callbacks convenience
     "ipykernel>=6.29",  # For running Jupter notebooks, and pin to keep recent
     "ipython>=8",  # Pin to keep recent
     "litellm>=1.68",  # Pin for PydanticDeprecatedSince20 fixes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from lmi.utils import (
     CROSSREF_KEY_HEADER,
     OPENAI_API_KEY_HEADER,
     SEMANTIC_SCHOLAR_KEY_HEADER,
+    update_litellm_max_callbacks,
 )
 
 if TYPE_CHECKING:
@@ -39,6 +40,11 @@ def _setup_default_logs() -> None:
     from paperqa.utils import setup_default_logs
 
     setup_default_logs()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _defeat_litellm_callbacks() -> None:
+    update_litellm_max_callbacks()
 
 
 @pytest.fixture(scope="session", name="vcr_config")

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ llm = [
 
 [[package]]
 name = "fhlmi"
-version = "0.27.0"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coredis" },
@@ -603,9 +603,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/1a/d2f07e3588240b419259cfa451afe1bd4506b0cec22818145fe36d01e4ad/fhlmi-0.27.0.tar.gz", hash = "sha256:ec5a1b5e7d09ab600670886cc45d3801969d917a1bfde480e7127a01dd35a314", size = 153292, upload-time = "2025-04-21T16:17:32.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/5a/a4f9cef3eafb83952b75d80ccf4641168036ab2cc3adf3a8e59002ea767b/fhlmi-0.28.0.tar.gz", hash = "sha256:9a196ca3f95532b111d776a5d6cf61b4a7cd24bb304ed3d942d7caa760d426bf", size = 137019, upload-time = "2025-06-16T21:15:34.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/47/d6e07653d5792522a7ab529cbc94b528d9d1bba662c45746b7b1ae643c43/fhlmi-0.27.0-py3-none-any.whl", hash = "sha256:1e9097a6891ba2d501f58d078222ec8423bae552fc9a5d5e95be079f66432d69", size = 38842, upload-time = "2025-04-21T16:17:30.383Z" },
+    { url = "https://files.pythonhosted.org/packages/17/8b/189d03e8bb3d40a8df315b12410652932829cddcf93ed6e92a235ff8dddb/fhlmi-0.28.0-py3-none-any.whl", hash = "sha256:c42634b3597f41d8e800eb77e05b681303275cbcb83d8c5b93cddb67bb70028f", size = 39268, upload-time = "2025-06-16T21:15:33.316Z" },
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ requires-dist = [
     { name = "anyio" },
     { name = "fhaviary", extras = ["llm"], specifier = ">=0.20" },
     { name = "fhlmi", specifier = ">=0.25.4" },
-    { name = "fhlmi", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "fhlmi", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "html2text" },
     { name = "httpx" },
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.29" },


### PR DESCRIPTION
Seen in `test_paperqa.py::test_chain_completion` in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/15655138522/job/44105167098#step:6:554):

```none
>       assert not caplog.records
E       assert not [<LogRecord: LiteLLM, 30, /home/runner/work/paper-qa/paper-qa/.venv/lib/python3.13/site-packages/litellm/litellm_core_...gging_callback_manager.py, 124, "Cannot add callback - would exceed MAX_CALLBACKS limit of 30. Current callbacks: 30">]
E        +  where [<LogRecord: LiteLLM, 30, /home/runner/work/paper-qa/paper-qa/.venv/lib/python3.13/site-packages/litellm/litellm_core_...gging_callback_manager.py, 124, "Cannot add callback - would exceed MAX_CALLBACKS limit of 30. Current callbacks: 30">] = <_pytest.logging.LogCaptureFixture object at 0x7f6cb08b4910>.records
```

This PR resolves that flaky test by using `update_litellm_max_callbacks` from LMI