### PR TITLE
Allow for non-mutated user specified doc-ids

### DIFF
--- a/paperqa/clients/journal_quality.py
+++ b/paperqa/clients/journal_quality.py
@@ -45,12 +45,14 @@ class JournalQualityPostProcessor(MetadataPostProcessor[JournalQuery]):
         # remember, if both have docnames (i.e. key) they are
         # wiped and re-generated with resultant data
         return doc_details + DocDetails(
+            doc_id=doc_details.doc_id,  # ensure doc_id is preserved
+            dockey=doc_details.dockey,  # ensure dockey is preserved
             source_quality=max(
                 [
                     self.data.get(query.journal.casefold(), DocDetails.UNDEFINED_JOURNAL_QUALITY),  # type: ignore[union-attr]
                     self.data.get("the " + query.journal.casefold(), DocDetails.UNDEFINED_JOURNAL_QUALITY),  # type: ignore[union-attr]
                 ]
-            )
+            ),
         )
 
     def query_creator(self, doc_details: DocDetails, **kwargs) -> JournalQuery | None:

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -431,14 +431,15 @@ class DocDetails(Doc):
                 if doi.startswith(url_prefix_to_remove):
                     doi = doi.replace(url_prefix_to_remove, "")
             data["doi"] = doi.lower()
-            data["doc_id"] = encode_id(doi.lower())
-        else:
+            if "doc_id" not in data or not data["doc_id"]:  # keep user defined doc_ids
+                data["doc_id"] = encode_id(doi.lower())
+        elif "doc_id" not in data or not data["doc_id"]:  # keep user defined doc_ids
             data["doc_id"] = encode_id(uuid4())
 
         if "dockey" in data.get(
             "fields_to_overwrite_from_metadata",
             DEFAULT_FIELDS_TO_OVERWRITE_FROM_METADATA,
-        ):
+        ) and ("dockey" not in data or not data["dockey"]):
             data["dockey"] = data["doc_id"]
 
         return data

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1578,8 +1578,8 @@ def test_docdetails_doc_id_roundtrip() -> None:
         doc_details_no_doi_with_doc_id.doi is None
     ), "DocDetails without doi should be None"
     assert (
-        doc_details_no_doi_with_doc_id.dockey == doc_details_with_doi_no_doc_id.doc_id
-    )
+        doc_details_no_doi_with_doc_id.dockey == doc_details_no_doi_with_doc_id.doc_id
+    ), "DocDetails dockey should match doc_id for the same object"
 
     # round-trip serializaiton should keep the same doc_id
     new_no_doi_with_doc_id = DocDetails(

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -50,6 +50,7 @@ from paperqa.prompts import qa_prompt as default_qa_prompt
 from paperqa.readers import parse_pdf_to_pages, read_doc
 from paperqa.types import ChunkMetadata
 from paperqa.utils import (
+    encode_id,
     extract_score,
     get_citenames,
     maybe_get_date,
@@ -1486,6 +1487,150 @@ def test_docdetails_deserialization() -> None:
     assert (
         deserialize_to_doc == deepcopy_deserialize_to_doc
     ), "Deserialization should not mutate input"
+
+
+def test_docdetails_doc_id_roundtrip() -> None:
+    """Test that DocDetails can be initialized with doc_id or doi inputs."""
+    test_doi = "10.1234/test.doi"
+    test_doi_doc_id = encode_id(test_doi.lower())
+    test_specified_doc_id = "abc123"
+    # first we test without a doc_id or doi, ensure it's still valid
+    doc_details_no_doi_no_doc_id = DocDetails(
+        docname="test_doc",
+        citation="Test Citation",
+        dockey="test_dockey",
+        embedding=None,
+        formatted_citation="Formatted Test Citation",
+    )
+
+    assert (
+        doc_details_no_doi_no_doc_id.doc_id != test_doi_doc_id
+    ), "DocDetails without doc_id should not match test_doi_doc_id"
+    assert (
+        doc_details_no_doi_no_doc_id.doi is None
+    ), "DocDetails without doi should have None doi"
+    assert doc_details_no_doi_no_doc_id.dockey == doc_details_no_doi_no_doc_id.doc_id
+
+    # now round-trip serializaiton should keep the same doc_id
+    new_no_doi_no_doc_id = DocDetails(
+        **doc_details_no_doi_no_doc_id.model_dump(exclude_none=True)
+    )
+    assert (
+        new_no_doi_no_doc_id.doc_id == doc_details_no_doi_no_doc_id.doc_id
+    ), "DocDetails without doc_id should keep the same doc_id after serialization"
+
+    # since validation runs on assignment, make sure we can assign correctly
+    doc_details_no_doi_no_doc_id.doc_id = test_specified_doc_id
+    assert (
+        doc_details_no_doi_no_doc_id.doc_id == test_specified_doc_id
+    ), "DocDetails with doc_id should match test_specified_doc_id"
+    assert doc_details_no_doi_no_doc_id.dockey == doc_details_no_doi_no_doc_id.doc_id
+
+    # now let's do this with a doi
+    doc_details_with_doi_no_doc_id = DocDetails(
+        doi=test_doi,
+        docname="test_doc",
+        citation="Test Citation",
+        dockey="test_dockey",
+        embedding=None,
+        formatted_citation="Formatted Test Citation",
+    )
+    assert (
+        doc_details_with_doi_no_doc_id.doc_id == test_doi_doc_id
+    ), "DocDetails with doc_id should not match test_doi_doc_id"
+    assert (
+        doc_details_with_doi_no_doc_id.doi == test_doi
+    ), "DocDetails with doi should match test_doi"
+    assert (
+        doc_details_with_doi_no_doc_id.dockey == doc_details_with_doi_no_doc_id.doc_id
+    )
+
+    # round-trip serializaiton should keep the same doc_id
+    new_with_doi_no_doc_id = DocDetails(
+        **doc_details_with_doi_no_doc_id.model_dump(exclude_none=True)
+    )
+    assert (
+        new_with_doi_no_doc_id.doc_id == doc_details_with_doi_no_doc_id.doc_id
+    ), "DocDetails with doc_id should keep the same doc_id after serialization"
+
+    # since validation runs on assignment, make sure we can assign correctly
+    doc_details_with_doi_no_doc_id.doc_id = test_specified_doc_id
+    assert (
+        doc_details_with_doi_no_doc_id.doc_id == test_specified_doc_id
+    ), "DocDetails with doc_id should match test_specified_doc_id"
+    assert (
+        doc_details_with_doi_no_doc_id.dockey == doc_details_with_doi_no_doc_id.doc_id
+    )
+
+    # let's specify the doc_id directly
+    doc_details_no_doi_with_doc_id = DocDetails(
+        doc_id=test_specified_doc_id,
+        docname="test_doc",
+        citation="Test Citation",
+        dockey="test_dockey",
+        embedding=None,
+        formatted_citation="Formatted Test Citation",
+    )
+    assert (
+        doc_details_no_doi_with_doc_id.doc_id == test_specified_doc_id
+    ), "DocDetails with doc_id should not match test_specified_doc_id"
+    assert (
+        doc_details_no_doi_with_doc_id.doi is None
+    ), "DocDetails without doi should be None"
+    assert (
+        doc_details_no_doi_with_doc_id.dockey == doc_details_with_doi_no_doc_id.doc_id
+    )
+
+    # round-trip serializaiton should keep the same doc_id
+    new_no_doi_with_doc_id = DocDetails(
+        **doc_details_no_doi_with_doc_id.model_dump(exclude_none=True)
+    )
+    assert (
+        new_no_doi_with_doc_id.doc_id == doc_details_with_doi_no_doc_id.doc_id
+    ), "DocDetails with doc_id should keep the same doc_id after serialization"
+
+    # since validation runs on assignment, make sure we can assign correctly
+    new_no_doi_with_doc_id.doc_id = test_doi_doc_id
+    assert (
+        new_no_doi_with_doc_id.doc_id == test_doi_doc_id
+    ), "DocDetails with doc_id should match test_specified_doc_id"
+    assert new_no_doi_with_doc_id.dockey == new_no_doi_with_doc_id.doc_id
+
+    # now we specify both doi and doc_id, ensuring doc_id takes precedence
+    doc_details_with_doi_with_doc_id = DocDetails(
+        doc_id=test_specified_doc_id,
+        doi=test_doi,
+        docname="test_doc",
+        citation="Test Citation",
+        dockey="test_dockey",
+        embedding=None,
+        formatted_citation="Formatted Test Citation",
+    )
+    assert (
+        doc_details_with_doi_with_doc_id.doc_id == test_specified_doc_id
+    ), "DocDetails with doc_id should not match test_specified_doc_id"
+    assert (
+        doc_details_with_doi_with_doc_id.doi == test_doi
+    ), "DocDetails without doi should match test_doi"
+    assert (
+        doc_details_with_doi_with_doc_id.dockey
+        == doc_details_with_doi_with_doc_id.doc_id
+    )
+
+    # round-trip serializaiton should keep the same doc_id
+    new_with_doi_with_doc_id = DocDetails(
+        **doc_details_with_doi_with_doc_id.model_dump(exclude_none=True)
+    )
+    assert (
+        new_with_doi_with_doc_id.doc_id == doc_details_with_doi_with_doc_id.doc_id
+    ), "DocDetails with doc_id should keep the same doc_id after serialization"
+
+    # since validation runs on assignment, make sure we can assign correctly
+    new_with_doi_with_doc_id.doc_id = test_doi_doc_id
+    assert (
+        new_with_doi_with_doc_id.doc_id == test_doi_doc_id
+    ), "DocDetails with doc_id should match test_specified_doc_id"
+    assert new_with_doi_with_doc_id.dockey == new_with_doi_with_doc_id.doc_id
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
This was a deep bug. On round-trip serialization of a `DocDetails` object, if a user doesn't have a `doi` field to create a deterministic `doc_id`, then when serializing/deserializing (during validation), the `doc_id` was mutating. This prevented users from ever setting their own `doc_id` value. 

This round trip serialization happens during the `gather_evidence` step, when the existing `doc_id` for each `DocDetails` object in `Docs` would then diverge from the `doc_id` for the associated `Context` objects generated. So for each call to `gather_evidence`, if a `DocDetails` did not have a DOI, a random `doc_id` was created for each `Text.doc` object within each `Context`. This PR fixes this behavior.

As an aside, my tests were failing because the `RetractionDataPostProcessor` test file (`tests/stub_data/test_retractions.csv`) was more than 30 days since the creation date. So this triggered a cache break which tried to rebuild the file. This then triggered a network call which broke the VCR cassette cache. I turned this behavior off by default, as I don't think this is needed under normal circumstances. 