### PR TITLE
Remove threaded pdf parsing

### DIFF
--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -356,8 +356,8 @@ async def read_doc(
 
     # start with parsing -- users may want to store this separately
     if str_path.endswith(".pdf"):
-        # TODO: Make parse_pdf_to_pages async
-        parsed_text = await asyncio.to_thread(parse_pdf_to_pages, path, **parser_kwargs)
+        # pymupdf is not thread-safe per docs here: https://pymupdf.readthedocs.io/en/latest/recipes-multiprocessing.html
+        parsed_text = parse_pdf_to_pages(path, **parser_kwargs)
     elif str_path.endswith(".txt"):
         # TODO: Make parse_text async
         parser_kwargs.pop("use_block_parsing", None)  # Not a parse_text kwarg


### PR DESCRIPTION
Removing multi-threading from the pdf parsing, as pymypdf is not threadsafe per the documentation. When parsing many *large* files simultaneously, i.e. patents, pqa was throwing segmentation faults otherwise. 