### PR TITLE
Allow extras to be kept in user output

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -242,9 +242,9 @@ class PQASession(BaseModel):
         """Filter out extra items (inplace) that do not need to be returned to the user."""
         self.contexts = [
             Context(
-                context=c.context,
-                question=c.question,
-                score=c.score,
+                # Dump all fields from the original context (including extras),
+                # but exclude 'text' so we can replace it below.
+                **c.model_dump(exclude={"text"}),
                 text=Text(
                     text="",
                     **c.text.model_dump(exclude={"text", "embedding", "doc"}),

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -960,6 +960,7 @@ def test_answers_are_striped() -> None:
                     ),
                 ),
                 score=3,
+                extra_field="extra_value",
             )
         ],
     )
@@ -969,6 +970,7 @@ def test_answers_are_striped() -> None:
     assert not response.session.contexts[0].text.text
     assert response.session.contexts[0].text.doc is not None
     assert response.session.contexts[0].text.doc.embedding is None
+    assert response.session.contexts[0].extra_field is not None  # type: ignore[attr-defined]
     # make sure it serializes
     response.model_dump_json()
 


### PR DESCRIPTION
We previously filtered these out when the embeddings, etc. were removed. 