### PR TITLE
Refactor to expose PDF parsing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,8 @@ will return much faster than the first query and we'll be certain the authors ma
 | `parsing.use_doc_details`                    | `True`                                 | Whether to get metadata details for docs.                                                               |
 | `parsing.overlap`                            | `250`                                  | Characters to overlap chunks.                                                                           |
 | `parsing.defer_embedding`                    | `False`                                | Whether to defer embedding until summarization.                                                         |
+| `parsing.parse_pdf`                          | `parse_pdf_to_pages`                   | Function to parse PDF files.                                                                            |
+| `parsing.configure_pdf_parser`               | `setup_pymupdf_python_logging`         | Callable to configure the PDF parser within `parse_pdf`, useful for behaviors such as enabling logging. |
 | `parsing.chunking_algorithm`                 | `ChunkingOptions.SIMPLE_OVERLAP`       | Algorithm for chunking.                                                                                 |
 | `parsing.doc_filters`                        | `None`                                 | Optional filters for allowed documents.                                                                 |
 | `parsing.use_human_readable_clinical_trials` | `False`                                | Parse clinical trial JSONs into readable text.                                                          |

--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -11,8 +11,7 @@ from aviary.utils import MultipleChoiceQuestion
 from pydantic_settings import CliSettingsSource
 from rich.logging import RichHandler
 
-from paperqa.readers import setup_pymupdf_python_logging
-from paperqa.settings import Settings, get_settings
+from paperqa.settings import ParsingSettings, Settings, get_settings
 from paperqa.utils import pqa_directory, run_or_ensure, setup_default_logs
 from paperqa.version import __version__
 
@@ -92,10 +91,12 @@ def configure_log_verbosity(verbosity: int = 0) -> None:
 def configure_cli_logging(verbosity: int | Settings = 0) -> None:
     """Suppress loquacious loggers according to the settings' verbosity level."""
     setup_default_logs()
-    setup_pymupdf_python_logging()
     set_up_rich_handler()
     if isinstance(verbosity, Settings):
+        verbosity.parsing.configure_pdf_parser()
         verbosity = verbosity.verbosity
+    else:
+        ParsingSettings.model_fields["configure_pdf_parser"].default()
     configure_log_verbosity(verbosity)
     if verbosity > 0:
         print(f"PaperQA version: {__version__}")

--- a/paperqa/agents/__init__.py
+++ b/paperqa/agents/__init__.py
@@ -11,6 +11,7 @@ from aviary.utils import MultipleChoiceQuestion
 from pydantic_settings import CliSettingsSource
 from rich.logging import RichHandler
 
+from paperqa.readers import setup_pymupdf_python_logging
 from paperqa.settings import Settings, get_settings
 from paperqa.utils import pqa_directory, run_or_ensure, setup_default_logs
 from paperqa.version import __version__
@@ -91,6 +92,7 @@ def configure_log_verbosity(verbosity: int = 0) -> None:
 def configure_cli_logging(verbosity: int | Settings = 0) -> None:
     """Suppress loquacious loggers according to the settings' verbosity level."""
     setup_default_logs()
+    setup_pymupdf_python_logging()
     set_up_rich_handler()
     if isinstance(verbosity, Settings):
         verbosity = verbosity.verbosity

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -15,7 +15,7 @@ except ImportError as e:
         " `pip install paper-qa[zotero]`."
     ) from e
 from paperqa.paths import PAPERQA_DIR
-from paperqa.readers import parse_pdf_to_pages
+from paperqa.readers import PDFParserFn, parse_pdf_to_pages
 
 
 class ZoteroPaper(BaseModel):
@@ -72,6 +72,7 @@ class ZoteroDB(zotero.Zotero):
         library_id: str | None = None,
         api_key: str | None = None,
         storage: str | os.PathLike | None = None,
+        parse_pdf: PDFParserFn = parse_pdf_to_pages,
         **kwargs,
     ):
         self.logger = logging.getLogger("ZoteroDB")
@@ -105,6 +106,7 @@ class ZoteroDB(zotero.Zotero):
 
         self.logger.info(f"Using cache location: {storage}")
         self.storage = Path(storage)
+        self._parse_pdf = parse_pdf
 
         super().__init__(
             library_type=library_type, library_id=library_id, api_key=api_key, **kwargs
@@ -252,11 +254,13 @@ class ZoteroDB(zotero.Zotero):
                 pdf = cast("Path", pdf)
                 title = item["data"].get("title", "")
                 if len(items) >= start:
-                    parsed_text = parse_pdf_to_pages(pdf)
-                    assert isinstance(parsed_text.content, dict), (  # noqa: S101
-                        f"The content type coming from {parse_pdf_to_pages.__name__}"
-                        f" should be a dict, not {type(parsed_text.content)}."
-                    )
+                    parsed_text = self._parse_pdf(pdf)
+                    if not isinstance(parsed_text.content, dict):
+                        raise ValueError(
+                            "The content type coming from the PDF parser"
+                            f" should be a dict, not {type(parsed_text.content)},"
+                            " did you misspecify the PDF parsing function?"
+                        )
                     yield ZoteroPaper(
                         key=_get_citation_key(item),
                         title=title,

--- a/paperqa/contrib/zotero.py
+++ b/paperqa/contrib/zotero.py
@@ -15,7 +15,7 @@ except ImportError as e:
         " `pip install paper-qa[zotero]`."
     ) from e
 from paperqa.paths import PAPERQA_DIR
-from paperqa.utils import count_pdf_pages
+from paperqa.readers import parse_pdf_to_pages
 
 
 class ZoteroPaper(BaseModel):
@@ -252,11 +252,16 @@ class ZoteroDB(zotero.Zotero):
                 pdf = cast("Path", pdf)
                 title = item["data"].get("title", "")
                 if len(items) >= start:
+                    parsed_text = parse_pdf_to_pages(pdf)
+                    assert isinstance(parsed_text.content, dict), (  # noqa: S101
+                        f"The content type coming from {parse_pdf_to_pages.__name__}"
+                        f" should be a dict, not {type(parsed_text.content)}."
+                    )
                     yield ZoteroPaper(
                         key=_get_citation_key(item),
                         title=title,
                         pdf=pdf,
-                        num_pages=count_pdf_pages(pdf),
+                        num_pages=len(parsed_text.content),
                         details=item,
                         zotero_key=item["key"],
                     )

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -299,6 +299,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 overlap=parse_config.overlap,
                 page_size_limit=parse_config.page_size_limit,
                 use_block_parsing=parse_config.pdfs_use_block_parsing,
+                parse_pdf=parse_config.parse_pdf,
             )
             if not texts:
                 raise ValueError(f"Could not read document {path}. Is it empty?")
@@ -392,6 +393,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             overlap=parse_config.overlap,
             page_size_limit=parse_config.page_size_limit,
             use_block_parsing=parse_config.pdfs_use_block_parsing,
+            parse_pdf=parse_config.parse_pdf,
         )
         # loose check to see if document was loaded
         if (

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -357,7 +357,7 @@ async def read_doc(
     # start with parsing -- users may want to store this separately
     if str_path.endswith(".pdf"):
         # pymupdf is not thread-safe per docs here: https://pymupdf.readthedocs.io/en/latest/recipes-multiprocessing.html
-        parsed_text = parse_pdf_to_pages(path, **parser_kwargs)
+        parsed_text: ParsedText = parse_pdf_to_pages(path, **parser_kwargs)
     elif str_path.endswith(".txt"):
         # TODO: Make parse_text async
         parser_kwargs.pop("use_block_parsing", None)  # Not a parse_text kwarg

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -21,6 +21,16 @@ from paperqa.types import (
 from paperqa.utils import ImpossibleParsingError
 from paperqa.version import __version__ as pqa_version
 
+
+def setup_pymupdf_python_logging() -> None:
+    """
+    Configure PyMuPDF to use Python logging.
+
+    SEE: https://pymupdf.readthedocs.io/en/latest/app3.html#diagnostics
+    """
+    pymupdf.set_messages(pylogging=True)
+
+
 BLOCK_TEXT_INDEX = 4
 
 

--- a/paperqa/readers.py
+++ b/paperqa/readers.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 from math import ceil
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import Literal, Protocol, cast, overload, runtime_checkable
 
 import pymupdf
 import tiktoken
@@ -29,6 +29,18 @@ def setup_pymupdf_python_logging() -> None:
     SEE: https://pymupdf.readthedocs.io/en/latest/app3.html#diagnostics
     """
     pymupdf.set_messages(pylogging=True)
+
+
+@runtime_checkable
+class PDFParserFn(Protocol):
+    """Protocol for parsing a PDF."""
+
+    def __call__(
+        self,
+        path: str | os.PathLike,
+        page_size_limit: int | None = None,
+        use_block_parsing: bool = False,
+    ) -> ParsedText: ...
 
 
 BLOCK_TEXT_INDEX = 4
@@ -299,6 +311,7 @@ async def read_doc(
     include_metadata: Literal[True],
     chunk_chars: int = ...,
     overlap: int = ...,
+    parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,
 ) -> ParsedText: ...
 @overload
@@ -309,6 +322,7 @@ async def read_doc(
     include_metadata: Literal[False] = ...,
     chunk_chars: int = ...,
     overlap: int = ...,
+    parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,
 ) -> ParsedText: ...
 @overload
@@ -319,6 +333,7 @@ async def read_doc(
     include_metadata: Literal[True],
     chunk_chars: int = ...,
     overlap: int = ...,
+    parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,
 ) -> tuple[list[Text], ParsedMetadata]: ...
 @overload
@@ -329,6 +344,7 @@ async def read_doc(
     include_metadata: Literal[False] = ...,
     chunk_chars: int = ...,
     overlap: int = ...,
+    parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,
 ) -> list[Text]: ...
 @overload
@@ -339,6 +355,7 @@ async def read_doc(
     include_metadata: Literal[True],
     chunk_chars: int = ...,
     overlap: int = ...,
+    parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,
 ) -> tuple[list[Text], ParsedMetadata]: ...
 async def read_doc(
@@ -348,6 +365,7 @@ async def read_doc(
     include_metadata: bool = False,
     chunk_chars: int = 3000,
     overlap: int = 100,
+    parse_pdf: PDFParserFn | None = None,
     **parser_kwargs,
 ) -> list[Text] | ParsedText | tuple[list[Text], ParsedMetadata]:
     """Parse a document and split into chunks.
@@ -360,14 +378,18 @@ async def read_doc(
         include_metadata: return a tuple
         chunk_chars: size of chunks
         overlap: size of overlap between chunks
+        parse_pdf: Optional function to parse PDF files (if you're parsing a PDF).
         parser_kwargs: Keyword arguments to pass to the used parsing function.
     """
     str_path = str(path)
 
     # start with parsing -- users may want to store this separately
     if str_path.endswith(".pdf"):
-        # pymupdf is not thread-safe per docs here: https://pymupdf.readthedocs.io/en/latest/recipes-multiprocessing.html
-        parsed_text: ParsedText = parse_pdf_to_pages(path, **parser_kwargs)
+        if parse_pdf is None:
+            raise ValueError("When parsing a PDF, a parsing function must be provided.")
+        # Some PDF parsers are not thread-safe,
+        # so can't use multithreading via `asyncio.to_thread` here
+        parsed_text: ParsedText = parse_pdf(path, **parser_kwargs)
     elif str_path.endswith(".txt"):
         # TODO: Make parse_text async
         parser_kwargs.pop("use_block_parsing", None)  # Not a parse_text kwarg

--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -54,6 +54,11 @@ from paperqa.prompts import (
     summary_json_system_prompt,
     summary_prompt,
 )
+from paperqa.readers import (
+    PDFParserFn,
+    parse_pdf_to_pages,
+    setup_pymupdf_python_logging,
+)
 from paperqa.utils import hexdigest, pqa_directory
 from paperqa.version import __version__
 
@@ -151,7 +156,7 @@ class ChunkingOptions(StrEnum):
 class ParsingSettings(BaseModel):
     """Settings relevant for parsing and chunking documents."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
 
     chunk_size: int = Field(
         default=5000,
@@ -201,6 +206,17 @@ class ParsingSettings(BaseModel):
             "Whether to embed documents immediately as they are added, or defer until"
             " summarization."
         ),
+    )
+    parse_pdf: PDFParserFn = Field(
+        default=parse_pdf_to_pages, description="Function to parse PDF.", exclude=True
+    )
+    configure_pdf_parser: Callable[[], Any] = Field(
+        default=setup_pymupdf_python_logging,
+        description=(
+            "Callable to configure the PDF parser within parse_pdf,"
+            " useful for behaviors such as enabling logging."
+        ),
+        exclude=True,
     )
     chunking_algorithm: ChunkingOptions = ChunkingOptions.SIMPLE_OVERLAP
     doc_filters: Sequence[Mapping[str, Any]] | None = Field(

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -96,9 +96,19 @@ class Doc(Embeddable):
 
 
 class Text(Embeddable):
-    text: str
-    name: str
-    doc: Doc | DocDetails = Field(union_mode="left_to_right")
+    """A text chunk ready for use in retrieval with a linked document."""
+
+    text: str = Field(description="Processed text content of the chunk.")
+    name: str = Field(
+        description=(
+            "Human-readable identifier for the chunk"
+            " (e.g., 'Wiki2023 chunk 1', 'sentence1')."
+        )
+    )
+    doc: Doc | DocDetails = Field(
+        union_mode="left_to_right",
+        description="Source document this text chunk originates from.",
+    )
 
     def __hash__(self) -> int:
         return hash(self.text)
@@ -286,10 +296,22 @@ class ParsedMetadata(BaseModel):
 
 
 class ParsedText(BaseModel):
-    """Parsed text (pre-chunking)."""
+    """All text from a document read, before any processing such as chunking."""
 
-    content: dict | str | list[str]
-    metadata: ParsedMetadata
+    content: dict[str, str] | str | list[str] = Field(
+        description=(
+            "All parsed but not further processed (e.g. not chunked) contents from a"
+            " document. It may be structured, depending on the parser's implementation."
+            " Thus it can take various shapes depending on the document type"
+            " (e.g. PDF, HTML) and parser:"
+            "\n- `dict[str, str]` (e.g. page number -> page text) for PDFs."
+            "\n- `str` for text files."
+            "\n- `list[str]` for line-by-line parsings."
+        )
+    )
+    metadata: ParsedMetadata = Field(
+        description="Metadata on the parsing process used."
+    )
 
     def encode_content(self):
         # we tokenize using tiktoken so cuts are in reasonable places

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -296,7 +296,7 @@ class ParsedMetadata(BaseModel):
 
 
 class ParsedText(BaseModel):
-    """All text from a document read, before any processing such as chunking."""
+    """All text from a document read, before chunking."""
 
     content: dict[str, str] | str | list[str] = Field(
         description=(

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -96,11 +96,6 @@ def strings_similarity(s1: str, s2: str, case_insensitive: bool = True) -> float
     return len(ss1.intersection(ss2)) / len(ss1.union(ss2))
 
 
-def count_pdf_pages(file_path: str | os.PathLike) -> int:
-    with pymupdf.open(file_path) as doc:
-        return len(doc)
-
-
 def hexdigest(data: str | bytes) -> str:
     if isinstance(data, str):
         return hashlib.md5(data.encode("utf-8")).hexdigest()  # noqa: S324

--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -20,7 +20,6 @@ from uuid import UUID
 
 import aiohttp
 import httpx
-import pymupdf
 from lmi import configure_llm_logs
 from pybtex.database import Person, parse_string
 from pybtex.database.input.bibtex import Parser
@@ -473,9 +472,6 @@ def pqa_directory(name: str) -> Path:
 
 def setup_default_logs() -> None:
     """Configure logs to reasonable defaults."""
-    # Trigger PyMuPDF to use Python logging
-    # SEE: https://pymupdf.readthedocs.io/en/latest/app3.html#diagnostics
-    pymupdf.set_messages(pylogging=True)
     configure_llm_logs()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def _load_env() -> None:
     load_dotenv()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="session")
 def _setup_default_logs() -> None:
     # Lazily import from paperqa so typeguard doesn't throw:
     # > /path/to/.venv/lib/python3.12/site-packages/typeguard/_pytest_plugin.py:93:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,11 @@ def _setup_default_logs() -> None:
     # > /path/to/.venv/lib/python3.12/site-packages/typeguard/_pytest_plugin.py:93:
     # > InstrumentationWarning: typeguard cannot check these packages because they
     # > are already imported: paperqa
-    from paperqa.readers import setup_pymupdf_python_logging
+    from paperqa.settings import ParsingSettings
     from paperqa.utils import setup_default_logs
 
     setup_default_logs()
-    setup_pymupdf_python_logging()
+    ParsingSettings.model_fields["configure_pdf_parser"].default()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,9 +37,11 @@ def _setup_default_logs() -> None:
     # > /path/to/.venv/lib/python3.12/site-packages/typeguard/_pytest_plugin.py:93:
     # > InstrumentationWarning: typeguard cannot check these packages because they
     # > are already imported: paperqa
+    from paperqa.readers import setup_pymupdf_python_logging
     from paperqa.utils import setup_default_logs
 
     setup_default_logs()
+    setup_pymupdf_python_logging()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -65,10 +65,13 @@ HOME_DIR = str(pathlib.Path.home())
 
 def test_settings_default_instantiation(tmpdir, subtests: SubTests) -> None:
     default_settings = Settings()
-    assert "gpt-" in default_settings.llm
-    assert default_settings.answer.evidence_k == 10
-    assert HOME_DIR in str(default_settings.agent.index.index_directory)
-    assert ".pqa" in str(default_settings.agent.index.index_directory)
+    # Also let's check our default settings work fine with round-trip JSON serialization
+    serde_default_settings = Settings(**default_settings.model_dump(mode="json"))
+    for setting in (default_settings, serde_default_settings):
+        assert "gpt-" in setting.llm
+        assert setting.answer.evidence_k == 10
+        assert HOME_DIR in str(setting.agent.index.index_directory)
+        assert ".pqa" in str(setting.agent.index.index_directory)
 
     with subtests.test(msg="alternate-pqa-home"):
         assert HOME_DIR not in str(tmpdir), "Later assertion requires this to pass"

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1131,6 +1131,7 @@ async def test_parser_only_reader(stub_data_dir: Path):
         Path(doc_path),
         Doc(docname="foo", citation="Foo et al, 2002", dockey="1"),
         parsed_text_only=True,
+        parse_pdf=parse_pdf_to_pages,
     )
     assert parsed_text.metadata.parse_type == "pdf"
     assert parsed_text.metadata.chunk_metadata is None
@@ -1146,6 +1147,7 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
         Doc(docname="foo", citation="Foo et al, 2002", dockey="1"),
         parsed_text_only=False,  # noqa: FURB120
         include_metadata=True,
+        parse_pdf=parse_pdf_to_pages,
     )
     assert metadata.parse_type == "pdf"
     assert isinstance(metadata.chunk_metadata, ChunkMetadata)


### PR DESCRIPTION
This PR enables users to bring their own PDF parser if desired.

It also documents `ParsedText` and `Text` a bit, since they're related.