### PR TITLE
Assertions that chunked `Text.name` have correct page ranges

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1152,8 +1152,13 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
     assert metadata.chunk_metadata.chunk_type == "overlap_pdf_by_page"
     assert metadata.chunk_metadata.overlap == 100
     assert metadata.chunk_metadata.chunk_chars == 3000
-    assert all(len(chunk.text) <= 3000 for chunk in chunk_text)
-    assert metadata.total_parsed_text_length // 3000 <= len(chunk_text)
+    assert all(
+        len(chunk.text) <= metadata.chunk_metadata.chunk_chars for chunk in chunk_text
+    )
+    assert (
+        metadata.total_parsed_text_length // metadata.chunk_metadata.chunk_chars
+        <= len(chunk_text)
+    )
     assert all(
         chunk_text[i].text[-100:] == chunk_text[i + 1].text[:100]
         for i in range(len(chunk_text) - 1)
@@ -1171,8 +1176,14 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
     assert metadata.chunk_metadata.chunk_type == "overlap"
     assert metadata.chunk_metadata.overlap == 100
     assert metadata.chunk_metadata.chunk_chars == 3000
-    assert all(len(chunk.text) <= 3000 * 1.25 for chunk in chunk_text)
-    assert metadata.total_parsed_text_length // 3000 <= len(chunk_text)
+    assert all(
+        len(chunk.text) <= metadata.chunk_metadata.chunk_chars * 1.25
+        for chunk in chunk_text
+    )
+    assert (
+        metadata.total_parsed_text_length // metadata.chunk_metadata.chunk_chars
+        <= len(chunk_text)
+    )
 
     for code_input in (
         Path(__file__),  # Python gets parsed into `list[str]` content
@@ -1189,8 +1200,14 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
         assert metadata.chunk_metadata.chunk_type == "overlap_code_by_line"
         assert metadata.chunk_metadata.overlap == 100
         assert metadata.chunk_metadata.chunk_chars == 3000
-        assert all(len(chunk.text) <= 3000 * 1.25 for chunk in chunk_text)
-        assert metadata.total_parsed_text_length // 3000 <= len(chunk_text)
+        assert all(
+            len(chunk.text) <= metadata.chunk_metadata.chunk_chars * 1.25
+            for chunk in chunk_text
+        )
+        assert (
+            metadata.total_parsed_text_length // metadata.chunk_metadata.chunk_chars
+            <= len(chunk_text)
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Just DRYing up `test_chunk_metadata_reader` and confirming `read_doc` behaviors are as expected