### PR TITLE
Removed dead `Docs.index_path` and generalized `aadd` types

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -303,7 +303,7 @@ class ParsedImage(BaseModel):
 
     index: int = Field(description="Index of the image in a given page.")
     data: bytes = Field(
-        description="Raw image, ideally directly savable to an image file."
+        description="Raw image, ideally directly savable to a PNG image."
     )
     info: dict[str, JsonValue | tuple[float, ...] | bytes] = Field(
         default_factory=dict,

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -107,6 +107,9 @@ class Text(Embeddable):
             " (e.g., 'Wiki2023 chunk 1', 'sentence1')."
         )
     )
+    images: list[ParsedImage] = Field(
+        default_factory=list, description="Optional list of associated images."
+    )
     doc: Doc | DocDetails = Field(
         union_mode="left_to_right",
         description="Source document this text chunk originates from.",

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1202,6 +1202,9 @@ async def test_chunk_metadata_reader(stub_data_dir: Path) -> None:
         int(last_page) - int(stlast_page) <= 2
     ), "Incorrect page range if last chunk is a partial chunk"
     assert metadata.count_parsed_images > 1, "Expected images to be parsed"
+    assert (
+        sum(len(t.images) for t in chunk_text) == metadata.count_parsed_images
+    ), "Expected chunks' images to match parsed images"
 
     chunk_text, metadata = await read_doc(
         stub_data_dir / "flag_day.html",

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1006,7 +1006,9 @@ def test_parse_pdf_to_pages(stub_data_dir: Path) -> None:
     p2_text, p2_images = parsed_text.content["2"]
     assert "Figure 1" in p2_text, "Expected Figure 1 title"
     assert "Crawler" in p2_text, "Expected Figure 1 contents"
-    assert len(p2_images) > 10, "Figure 1 contains many images"
+    assert (
+        1 <= len(p2_images) <= 3
+    ), "Expected Figure 1 to be present within a reasonable number of images"
     for i, image in enumerate(p2_images):
         assert image.index == i
         assert isinstance(image.data, bytes)

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1135,8 +1135,9 @@ async def test_parser_only_reader(stub_data_dir: Path):
     )
     assert parsed_text.metadata.parse_type == "pdf"
     assert parsed_text.metadata.chunk_metadata is None
+    assert isinstance(parsed_text.content, dict)
     assert parsed_text.metadata.total_parsed_text_length == sum(
-        len(t) for t in parsed_text.content.values()  # type: ignore[misc,union-attr]
+        len(t) for t in parsed_text.content.values()
     )
 
 


### PR DESCRIPTION
- `Docs.index_path` appears to be dead code since we created to `Settings.index_directory` in https://github.com/Future-House/paper-qa/pull/289
- Generalizes a few type hints from `Path` to `os.PathLike`