### PR TITLE
Documenting why we drop embeddings

### DIFF
--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -72,7 +72,7 @@ class AnswerResponse(BaseModel):
     ) -> PQASession:
         # This modifies in place, this is fine
         # because when a response is being constructed,
-        # we should be done with the Answer object
+        # we should be done with the PQASession object
         v.filter_content_for_user()
         return v
 

--- a/paperqa/core.py
+++ b/paperqa/core.py
@@ -209,9 +209,12 @@ async def map_fxn_summary(
             context=context,
             question=question,
             text=Text(
-                text=text.text,
-                name=text.name,
+                # Embeddings enable the retrieval of Texts to make Contexts.
+                # Once we already have Contexts, we filter them by score
+                # (and not the underlying Text's embeddings),
+                # so embeddings can be safely dropped from the deepcopy
                 doc=text.doc.model_dump(exclude={"embedding"}),
+                **text.model_dump(exclude={"embedding", "doc"}),
             ),
             score=score,  # pylint: disable=possibly-used-before-assignment
             **extras,

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -289,7 +289,11 @@ class PQASession(BaseModel):
         }
 
     def filter_content_for_user(self) -> None:
-        """Filter out extra items (inplace) that do not need to be returned to the user."""
+        """
+        In-place filter/drop items that are irrelevant to the user.
+
+        This is mainly done to keep HTTP requests reasonably sized.
+        """
         self.contexts = [
             Context(
                 # Dump all fields from the original context (including extras),
@@ -297,8 +301,11 @@ class PQASession(BaseModel):
                 **c.model_dump(exclude={"text"}),
                 text=Text(
                     text="",
-                    **c.text.model_dump(exclude={"text", "embedding", "doc"}),
+                    # Similar to the explanation in `map_fxn_summary`'s internal's
+                    # on why we drop embeddings, drop embeddings here too because
+                    # embeddings aren't displayed to front end users
                     doc=c.text.doc.model_dump(exclude={"embedding"}),
+                    **c.text.model_dump(exclude={"text", "embedding", "doc"}),
                 ),
             )
             for c in self.contexts


### PR DESCRIPTION
I got hung up on this for a bit, so I am adding some docs on the rationale