### PR TITLE
Supporting `bytes` in stored documents

### DIFF
--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -77,7 +77,7 @@ class SearchDocumentStorage(StrEnum):
     def write_to_string(self, data: BaseModel | SupportsPickle) -> bytes:
         if self == SearchDocumentStorage.JSON_MODEL_DUMP:
             if isinstance(data, BaseModel):
-                return json.dumps(data.model_dump(mode="json")).encode("utf-8")
+                return data.model_dump_json().encode("utf-8")
             raise ValueError("JSON_MODEL_DUMP requires a BaseModel object.")
         if self == SearchDocumentStorage.PICKLE_COMPRESSED:
             return zlib.compress(pickle.dumps(data))


### PR DESCRIPTION
The DIY `RobustEncoder` doesn't support common datatypes such as `bytes`. This PR adds support for them by offloading serialization behaviors to the Pydantic-native JSON dump mode.