### PR TITLE
Denying empty text going to `citation_prompt`

### DIFF
--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -283,7 +283,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 use_block_parsing=parse_config.pdfs_use_block_parsing,
                 parse_pdf=parse_config.parse_pdf,
             )
-            if not texts:
+            if not texts or not texts[0].text:
                 raise ValueError(f"Could not read document {path}. Is it empty?")
             result = await llm_model.call_single(
                 messages=[

--- a/paperqa/docs.py
+++ b/paperqa/docs.py
@@ -283,7 +283,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 use_block_parsing=parse_config.pdfs_use_block_parsing,
                 parse_pdf=parse_config.parse_pdf,
             )
-            if not texts or not texts[0].text:
+            if not texts or not texts[0].text.strip():
                 raise ValueError(f"Could not read document {path}. Is it empty?")
             result = await llm_model.call_single(
                 messages=[


### PR DESCRIPTION
An empty `Text.text` was not being denied, which can lead to `citation` such as:

```none
I'm sorry, but I need the text or source details you'd like me to cite in MLA format. Could you please provide that information?
```