### PR TITLE
Specifying `default=` in `AnswerSettings.answer_length`

### DIFF
--- a/paperqa/settings.py
+++ b/paperqa/settings.py
@@ -98,7 +98,8 @@ class AnswerSettings(BaseModel):
         ),
     )
     answer_length: str = Field(
-        "about 200 words, but can be longer", description="Length of final answer."
+        default="about 200 words, but can be longer",
+        description="Length of final answer.",
     )
     max_concurrent_requests: int = Field(
         default=4, description="Max concurrent requests to LLMs."


### PR DESCRIPTION
Without this, PyCharm was giving me an IDE warning:

> Parameter 'answer_length' unfilled 

<img width="660" alt="answer length tooltip" src="https://github.com/user-attachments/assets/dd326d99-5695-4fc5-a1c3-f4f8de4f921b" />
