### PR TITLE
Removed `reset_log_levels` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 from collections.abc import Iterator
@@ -136,22 +135,3 @@ def stub_data_dir_w_near_dupes(stub_data_dir: Path, tmp_path: Path) -> Iterator[
 
     if tmp_path.exists():
         shutil.rmtree(tmp_path, ignore_errors=True)
-
-
-@pytest.fixture(name="reset_log_levels")
-def fixture_reset_log_levels(caplog) -> Iterator[None]:
-    logging.getLogger().setLevel(logging.DEBUG)
-
-    for name in logging.root.manager.loggerDict:
-        logger = logging.getLogger(name)
-        logger.setLevel(logging.DEBUG)
-        logger.propagate = True
-
-    caplog.set_level(logging.DEBUG)
-
-    yield
-
-    for name in logging.root.manager.loggerDict:
-        logger = logging.getLogger(name)
-        logger.setLevel(logging.NOTSET)
-        logger.propagate = True

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -531,7 +531,6 @@ def test_bad_init() -> None:
 
 
 @pytest.mark.vcr
-@pytest.mark.usefixtures("reset_log_levels")
 @pytest.mark.asyncio
 async def test_ensure_sequential_run(caplog) -> None:
     caplog.set_level(logging.DEBUG)
@@ -574,7 +573,6 @@ async def test_ensure_sequential_run(caplog) -> None:
 
 
 @pytest.mark.vcr
-@pytest.mark.usefixtures("reset_log_levels")
 @pytest.mark.asyncio
 async def test_ensure_sequential_run_early_stop(caplog) -> None:
     caplog.set_level(logging.DEBUG)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -533,7 +533,7 @@ def test_bad_init() -> None:
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_ensure_sequential_run(caplog) -> None:
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger=paperqa.clients.__name__)
     # were using a DOI that is NOT in crossref, but running the crossref client first
     # we will ensure that both are run sequentially
 
@@ -551,14 +551,18 @@ async def test_ensure_sequential_run(caplog) -> None:
             fields=["doi", "title"],
         )
         assert details, "Should find the right DOI in the second client"
-        record_indices = {"crossref": -1, "semantic_scholar": -1}
+        record_indices: dict[str, list[int]] = {"crossref": [], "semantic_scholar": []}
         for n, record in enumerate(caplog.records):
+            if not record.name.startswith(paperqa.__name__):  # Skip non-PQA logs
+                continue
             if "CrossrefProvider" in record.msg:
-                record_indices["crossref"] = n
+                record_indices["crossref"].append(n)
             if "SemanticScholarProvider" in record.msg:
-                record_indices["semantic_scholar"] = n
+                record_indices["semantic_scholar"].append(n)
+        assert record_indices["crossref"], "Crossref should run"
+        assert record_indices["semantic_scholar"], "Semantic Scholar should run"
         assert (
-            record_indices["crossref"] < record_indices["semantic_scholar"]
+            record_indices["crossref"][-1] < record_indices["semantic_scholar"][-1]
         ), "Crossref should run first"
 
         non_clobbered_details = await client.query(
@@ -575,7 +579,7 @@ async def test_ensure_sequential_run(caplog) -> None:
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_ensure_sequential_run_early_stop(caplog) -> None:
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger=paperqa.clients.__name__)
     # now we should stop after hitting s2
     async with aiohttp.ClientSession() as session:
         client = DocMetadataClient(
@@ -591,21 +595,23 @@ async def test_ensure_sequential_run_early_stop(caplog) -> None:
             fields=["doi", "title"],
         )
         assert details, "Should find the right DOI in the second client"
-        record_indices = {"crossref": -1, "semantic_scholar": -1, "early_stop": -1}
+        record_indices: dict[str, list[int]] = {
+            "crossref": [],
+            "semantic_scholar": [],
+            "early_stop": [],
+        }
         for n, record in enumerate(caplog.records):
+            if not record.name.startswith(paperqa.__name__):  # Skip non-PQA logs
+                continue
             if "CrossrefProvider" in record.msg:
-                record_indices["crossref"] = n
+                record_indices["crossref"].append(n)
             if "SemanticScholarProvider" in record.msg:
-                record_indices["semantic_scholar"] = n
+                record_indices["semantic_scholar"].append(n)
             if "stopping early." in record.msg:
-                record_indices["early_stop"] = n
-        assert (
-            record_indices["crossref"] == -1
-        ), "Crossref should be index -1 i.e. not found"
-        assert (
-            record_indices["semantic_scholar"] != -1
-        ), "Semantic Scholar should be found"
-        assert record_indices["early_stop"] != -1, "We should stop early."
+                record_indices["early_stop"].append(n)
+        assert not record_indices["crossref"], "Crossref should not have run"
+        assert record_indices["semantic_scholar"], "Semantic Scholar should have run"
+        assert record_indices["early_stop"], "We should stop early"
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/311 added some log parsing as a way of checking call ordering, and used a complicated fixture `reset_log_levels` to do so.

This code was confusing me a bit, so I just went ahead and cleaned it up to better use `pytest`'s built-in `caplog`, with tighter assertions.