### PR TITLE
Lowering OpenAI base client log verbosity during CI

### DIFF
--- a/paperqa/utils.py
+++ b/paperqa/utils.py
@@ -457,6 +457,15 @@ def pqa_directory(name: str) -> Path:
 def setup_default_logs() -> None:
     """Configure logs to reasonable defaults."""
     configure_llm_logs()
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "loggers": {
+                "openai._base_client": {"level": "WARNING"}  # For OpenAI POSTs
+            },
+        }
+    )
 
 
 def extract_thought(content: str | None) -> str:


### PR DESCRIPTION
My logs were getting blown up by OpenAI, so I lowered this

Also see https://github.com/Future-House/ldp/pull/315