### PR TITLE
Fixed `Context` not always requiring a `call-arg` type ignore

### DIFF
--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -127,13 +127,14 @@ class Text(Embeddable):
         return hash((self.name, self.text))
 
 
+# Sentinel to autopopulate a field within model_validator
+AUTOPOPULATE_VALUE = ""  # NOTE: this is falsy by design
+
+
 class Context(BaseModel):
     """A class to hold the context of a question."""
 
     model_config = ConfigDict(extra="allow")
-
-    # Sentinel to auto-populate a field within model_validator
-    AUTOPOPULATE_VALUE: ClassVar[str] = ""
 
     id: str = Field(
         default=AUTOPOPULATE_VALUE,
@@ -163,7 +164,7 @@ class Context(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def populate_id(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if not data.get("id"):
+        if not data.get("id"):  # NOTE: this includes missing or empty strings
             content = (
                 data.get("question", "")
                 + data.get("context", "")[: cls.CONTEXT_ENCODING_LENGTH]
@@ -489,9 +490,6 @@ JOURNAL_EXPECTED_DOI_LENGTHS = {
 
 class DocDetails(Doc):
     model_config = ConfigDict(validate_assignment=True, extra="ignore")
-
-    # Sentinel to auto-populate a field within model_validator
-    AUTOPOPULATE_VALUE: ClassVar[str] = ""
 
     docname: str = AUTOPOPULATE_VALUE
     dockey: DocKey = AUTOPOPULATE_VALUE

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -132,9 +132,12 @@ class Context(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    # Sentinel to auto-populate a field within model_validator
+    AUTOPOPULATE_VALUE: ClassVar[str] = ""
+
     id: str = Field(
+        default=AUTOPOPULATE_VALUE,
         description="Unique identifier for the context. Auto-generated if not provided.",
-        init=False,
     )
 
     context: str = Field(description="Summary of the text with respect to a question.")

--- a/paperqa/types.py
+++ b/paperqa/types.py
@@ -162,15 +162,17 @@ class Context(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def populate_id(cls, data: Any) -> Any:
+    def populate_id(cls, data: dict[str, Any]) -> dict[str, Any]:
         if not data.get("id"):
             content = (
                 data.get("question", "")
                 + data.get("context", "")[: cls.CONTEXT_ENCODING_LENGTH]
             )
-            data["id"] = cls.REFERENCE_TEMPLATE.format(
-                id=encode_id(content or str(uuid4()), maxsize=cls.ID_HASH_LENGTH)
-            )
+            return data | {  # Avoid mutating input data
+                "id": cls.REFERENCE_TEMPLATE.format(
+                    id=encode_id(content or str(uuid4()), maxsize=cls.ID_HASH_LENGTH)
+                )
+            }
         return data
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -953,7 +953,7 @@ def test_answers_are_striped() -> None:
     session = PQASession(
         question="What is the meaning of life?",
         contexts=[
-            Context(  # type: ignore[call-arg]
+            Context(
                 context="bla",
                 question="foo",
                 text=Text(


### PR DESCRIPTION
After https://github.com/Future-House/paper-qa/pull/990 all clients constructing a `Context` had to eat a `type: ignore[call-arg]` comment:

```none
error: Missing named argument "id" for "Context"
 [call-arg]
                Context(
                ^
```

Also, there was a risk of mutating the input data.

This PR fixes both of those issues.