### PR TITLE
Adding variable timeouts for clients

### DIFF
--- a/paperqa/clients/crossref.py
+++ b/paperqa/clients/crossref.py
@@ -38,7 +38,9 @@ logger = logging.getLogger(__name__)
 
 CROSSREF_HOST = "api.crossref.org"
 CROSSREF_BASE_URL = f"https://{CROSSREF_HOST}"
-CROSSREF_API_REQUEST_TIMEOUT = 5.0
+CROSSREF_API_REQUEST_TIMEOUT = float(
+    os.environ.get("CROSSREF_API_REQUEST_TIMEOUT", "10.0")
+)  # seconds
 CROSSREF_API_MAPPING: dict[str, Collection[str]] = {
     "title": {"title"},
     "doi": {"DOI"},

--- a/paperqa/clients/openalex.py
+++ b/paperqa/clients/openalex.py
@@ -17,7 +17,9 @@ from .client_models import DOIOrTitleBasedProvider, DOIQuery, TitleAuthorQuery
 from .exceptions import DOINotFoundError
 
 OPENALEX_BASE_URL = "https://api.openalex.org"
-OPENALEX_API_REQUEST_TIMEOUT = 5.0
+OPENALEX_API_REQUEST_TIMEOUT = float(
+    os.environ.get("OPENALEX_API_REQUEST_TIMEOUT", "10.0")
+)  # seconds
 
 logger = logging.getLogger(__name__)
 

--- a/paperqa/clients/semantic_scholar.py
+++ b/paperqa/clients/semantic_scholar.py
@@ -45,7 +45,9 @@ SEMANTIC_SCHOLAR_API_MAPPING: dict[str, Collection[str]] = {
     "citation_count": {"citationCount"},
     "source_quality": {"journal"},
 }
-SEMANTIC_SCHOLAR_API_REQUEST_TIMEOUT = 10.0
+SEMANTIC_SCHOLAR_API_REQUEST_TIMEOUT = float(
+    os.environ.get("SEMANTIC_SCHOLAR_API_REQUEST_TIMEOUT", "10.0")
+)  # seconds
 SEMANTIC_SCHOLAR_API_FIELDS: str = ",".join(
     union_collections_to_ordered_list(SEMANTIC_SCHOLAR_API_MAPPING.values())
 )


### PR DESCRIPTION
Our default timeouts were not long enough for Crossref. This ups the default and makes it a configurable variable. 