### PR TITLE
Fixed `aiohttp.ClientOSError` crashing us

### DIFF
--- a/paperqa/clients/client_models.py
+++ b/paperqa/clients/client_models.py
@@ -118,9 +118,9 @@ class DOIOrTitleBasedProvider(MetadataProvider[DOIQuery | TitleAuthorQuery]):
                 f" {self.__class__.__name__}."
             )
         # we're suppressing this error to not fail on 403 or 500 errors from providers
-        except aiohttp.ClientResponseError:
+        except aiohttp.ClientError:
             logger.warning(
-                "Client response error for"
+                "Client error for"
                 f" {client_query.doi if isinstance(client_query, DOIQuery) else client_query.title} in"
                 f" {self.__class__.__name__}."
             )

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -337,6 +337,18 @@ async def test_bad_titles() -> None:
         assert details, "Should find a similar title"
 
 
+@pytest.mark.asyncio
+async def test_client_os_error() -> None:
+    """Confirm an OSError variant does not crash us."""
+    async with aiohttp.ClientSession() as session:
+        client = DocMetadataClient(session, clients=[SemanticScholarProvider])
+        with patch.object(
+            session, "get", side_effect=aiohttp.ClientOSError("Bad file descriptor")
+        ) as mock_get:
+            assert not await client.query(doi="placeholder")
+        assert mock_get.call_count == 1, "Expected the exception to have been thrown"
+
+
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_bad_dois() -> None:


### PR DESCRIPTION
Seen in some logs:

```none
Traceback (most recent call last):
...
    doc_details = await client.query(**kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/clients/__init__.py", line 153, in query
    await gather_with_concurrency(
  File "/srv/.venv/lib/python3.12/site-packages/lmi/utils.py", line 100, in gather_with_concurrency
    return await asyncio.gather(*(sem_coro(c) for c in coros))
  File "/srv/.venv/lib/python3.12/site-packages/lmi/utils.py", line 87, in sem_coro
    return await coro
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/clients/client_models.py", line 110, in query
    return await self._query(client_query)
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 347, in _query
    return await get_s2_doc_details_from_doi(
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    result = await action(retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    return call(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 297, in get_s2_doc_details_from_doi
    paper_data=await _s2_get_with_retrying(
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    result = await action(retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    return call(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/clients/semantic_scholar.py", line 119, in _s2_get_with_retrying
    return await _get_with_retrying(
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    result = await action(retry_state)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner
    return call(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/__init__.py", line 398, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
  File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/srv/.venv/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/paperqa/utils.py", line 434, in _get_with_retrying
    async with session.get(url, **get_kwargs) as response:
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 1425, in __aenter__
    self._resp: _RetType = await self._coro
  File "/srv/paperscraper/utils.py", line 252, in _request
    response = await self.request_or_proxy(proxy_port, *args, **kwargs)
  File "/srv/paperscraper/utils.py", line 229, in request_or_proxy
    return await super()._request(*args, **(kwargs | {"proxy": proxy_uri}))
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp_client_cache/session.py", line 117, in _request
    new_response = await super()._request(method, str_or_url, **kwargs)
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/client.py", line 703, in _request
    conn = await self._connector.connect(
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 548, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1054, in _create_connection
    _, proto = await self._create_proxy_connection(req, traces, timeout)
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/connector.py", line 1467, in _create_proxy_connection
    resp = await proxy_resp.start(conn)
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1059, in start
    message, payload = await protocol.read()  # type: ignore[union-attr]
  File "/srv/.venv/lib/python3.12/site-packages/aiohttp/streams.py", line 671, in read
    await self._waiter
aiohttp.client_exceptions.ClientOSError: [Errno 9] Bad file descriptor
```

This PR fixes that crash from crashing us