### PR TITLE
Removed extra test `test_can_read_normal_pdf_reader`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,23 +64,25 @@ def fixture_vcr_config() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
-def tmp_path_cleanup(tmp_path: Path) -> Iterator[Path]:
+@pytest.fixture(name="tmp_path_cleanup")
+def fixture_tmp_path_cleanup(tmp_path: Path) -> Iterator[Path]:
     yield tmp_path
     # Cleanup after the test
     if tmp_path.exists():
         shutil.rmtree(tmp_path, ignore_errors=True)
 
 
-@pytest.fixture
-def agent_home_dir(tmp_path_cleanup: str | os.PathLike) -> Iterator[str | os.PathLike]:
+@pytest.fixture(name="agent_home_dir")
+def fixture_agent_home_dir(
+    tmp_path_cleanup: str | os.PathLike,
+) -> Iterator[str | os.PathLike]:
     """Set up a unique temporary folder for the agent module."""
     with patch.dict("os.environ", {"PQA_HOME": str(tmp_path_cleanup)}):
         yield tmp_path_cleanup
 
 
-@pytest.fixture
-def agent_index_dir(agent_home_dir: Path) -> Path:
+@pytest.fixture(name="agent_index_dir")
+def fixture_agent_index_dir(agent_home_dir: Path) -> Path:
     return agent_home_dir / ".pqa" / "indexes"
 
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -66,8 +66,8 @@ from paperqa.utils import (
 THIS_MODULE = pathlib.Path(__file__)
 
 
-@pytest_asyncio.fixture
-async def docs_fixture(stub_data_dir: Path) -> Docs:
+@pytest_asyncio.fixture(name="docs_fixture")
+async def fixture_docs_fixture(stub_data_dir: Path) -> Docs:
     docs = Docs()
     with (stub_data_dir / "paper.pdf").open("rb") as f:
         await docs.aadd_file(f, "Wellawatte et al, XAI Review, 2023")

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -930,12 +930,6 @@ async def test_repeat_keys(stub_data_dir) -> None:
 
 
 @pytest.mark.asyncio
-async def test_can_read_normal_pdf_reader(docs_fixture) -> None:
-    answer = await docs_fixture.aquery("Are counterfactuals actionable? [yes/no]")
-    assert "yes" in answer.answer or "Yes" in answer.answer
-
-
-@pytest.mark.asyncio
 async def test_pdf_reader_w_no_match_doc_details(stub_data_dir: Path) -> None:
     docs = Docs()
     await docs.aadd(

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1082,8 +1082,8 @@ async def test_pdf_reader_match_doc_details(stub_data_dir: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_fileio_reader_pdf(stub_data_dir: Path) -> None:
+    docs = Docs()
     with (stub_data_dir / "paper.pdf").open("rb") as f:
-        docs = Docs()
         await docs.aadd_file(f, "Wellawatte et al, XAI Review, 2023")
     num_retries = 3
     for _ in range(num_retries):


### PR DESCRIPTION
- `test_can_read_normal_pdf_reader` was a subset of `test_fileio_reader_pdf`
- Named some `pytest` fixtures so `pylint` can not report name collisions