### PR TITLE
Removed `JSONType` for Pydantic's equivalent `JsonValue`

### DIFF
--- a/paperqa/agents/models.py
+++ b/paperqa/agents/models.py
@@ -5,27 +5,17 @@ import logging
 import time
 from contextlib import asynccontextmanager
 from enum import StrEnum
-from typing import Any, ClassVar, Protocol, TypeAlias, cast
+from typing import Any, ClassVar, Protocol, cast
 from uuid import UUID, uuid4
 
 from aviary.core import Message
 from lmi import LiteLLMModel, LLMModel
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    ValidationInfo,
-    field_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from paperqa.types import PQASession
 from paperqa.version import __version__
 
 logger = logging.getLogger(__name__)
-
-JSONType: TypeAlias = (
-    dict[str, "JSONType"] | list["JSONType"] | str | int | float | bool | None
-)
 
 
 class SupportsPickle(Protocol):

--- a/paperqa/agents/search.py
+++ b/paperqa/agents/search.py
@@ -17,7 +17,7 @@ from enum import StrEnum, auto
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import anyio
-from pydantic import BaseModel
+from pydantic import BaseModel, JsonValue
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -47,7 +47,7 @@ from paperqa.settings import IndexSettings, get_settings
 from paperqa.types import VAR_MATCH_LOOKUP, DocDetails
 from paperqa.utils import ImpossibleParsingError, clean_possessives, hexdigest
 
-from .models import JSONType, SupportsPickle
+from .models import SupportsPickle
 
 if TYPE_CHECKING:
     from tantivy import IndexWriter
@@ -86,7 +86,7 @@ class SearchDocumentStorage(StrEnum):
 
     def read_from_string(
         self, data: str | bytes
-    ) -> BaseModel | SupportsPickle | JSONType:
+    ) -> BaseModel | SupportsPickle | JsonValue:
         if self == SearchDocumentStorage.JSON_MODEL_DUMP:
             return json.loads(data)
         if self == SearchDocumentStorage.PICKLE_COMPRESSED:


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/962 added in a JSON type alias, but as seen in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/16453474103/job/46504464218):

```none
tests/test_cli.py::test_cli_ask
  /home/runner/work/paper-qa/paper-qa/paperqa/agents/search.py:91: TypeHintWarning: Skipping type check against 'JSONType'; this looks like a string-form forward reference imported from another module
    return json.loads(data)
```

We appear to have issues with it. Let's just use Pydantic's built-in one, so there's less code here