### PR TITLE
Support grouping contexts by question in the final context

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@ will return much faster than the first query and we'll be certain the authors ma
 | `answer.max_concurrent_requests`             | `4`                                    | Max concurrent requests to LLMs.                                                                        |
 | `answer.answer_filter_extra_background`      | `False`                                | Whether to cite background info from model.                                                             |
 | `answer.get_evidence_if_no_contexts`         | `True`                                 | Allow lazy evidence gathering.                                                                          |
+| `answer.group_contexts_by_question`          | `False`                                | Groups the final contexts by the underlying `gather_evidence` question in the final context prompt.     |
 | `parsing.chunk_size`                         | `5000`                                 | Characters per chunk (0 for no chunking).                                                               |
 | `parsing.page_size_limit`                    | `1,280,000`                            | Character limit per page.                                                                               |
 | `parsing.pdfs_use_block_parsing`             | `False`                                | Opt-in flag for block-based PDF parsing over text-based PDF parsing.                                    |

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -781,26 +781,53 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             # Only keep "\nFrom {citation}" if we are showing detailed citations
             context_inner_prompt = context_inner_prompt.replace("\nFrom {citation}", "")
 
-        inner_context_strs = [
-            context_inner_prompt.format(
-                name=c.id,
-                text=c.context,
-                citation=c.text.doc.formatted_citation,
-                **(c.model_extra or {}),
-            )
-            for c in filtered_contexts
-        ]
+        context_str_body = ""
+        if answer_config.group_contexts_by_question:
+            contexts_by_question: dict[str, list] = {}
+            for c in filtered_contexts:
+                # Fallback to the main session question if not available.
+                question = getattr(c, "question", session.question)
+                if question not in contexts_by_question:
+                    contexts_by_question[question] = []
+                contexts_by_question[question].append(c)
+
+            context_sections = []
+            for question, contexts_in_group in contexts_by_question.items():
+                inner_strs = [
+                    context_inner_prompt.format(
+                        name=c.id,
+                        text=c.context,
+                        citation=c.text.doc.formatted_citation,
+                        **(c.model_extra or {}),
+                    )
+                    for c in contexts_in_group
+                ]
+                # Create a section with a question heading
+                section_header = f'Contexts related to the question: "{question}"'
+                section = f"{section_header}\n\n" + "\n\n".join(inner_strs)
+                context_sections.append(section)
+            context_str_body = "\n\n---\n\n".join(context_sections)
+        else:
+            inner_context_strs = [
+                context_inner_prompt.format(
+                    name=c.id,
+                    text=c.context,
+                    citation=c.text.doc.formatted_citation,
+                    **(c.model_extra or {}),
+                )
+                for c in filtered_contexts
+            ]
+            context_str_body = "\n\n".join(inner_context_strs)
+
         if pre_str:
-            inner_context_strs += (
-                [f"Extra background information: {pre_str}"] if pre_str else []
-            )
+            context_str_body += f"\n\nExtra background information: {pre_str}"
 
         context_str = prompt_config.context_outer.format(
-            context_str="\n\n".join(inner_context_strs),
+            context_str=context_str_body,
             valid_keys=", ".join([c.id for c in filtered_contexts]),
         )
 
-        if len(context_str) < 10:  # noqa: PLR2004
+        if len(context_str_body.strip()) < 10:  # noqa: PLR2004
             answer_text = (
                 f"{CANNOT_ANSWER_PHRASE} this question due to insufficient information."
             )

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -7,6 +7,7 @@ import re
 import tempfile
 import urllib.request
 import warnings
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from datetime import datetime
 from io import BytesIO
@@ -29,7 +30,7 @@ from paperqa.llms import (
 from paperqa.prompts import CANNOT_ANSWER_PHRASE
 from paperqa.readers import read_doc
 from paperqa.settings import MaybeSettings, get_settings
-from paperqa.types import Doc, DocDetails, DocKey, PQASession, Text
+from paperqa.types import Context, Doc, DocDetails, DocKey, PQASession, Text
 from paperqa.utils import (
     citation_to_docname,
     get_loop,
@@ -783,12 +784,12 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
 
         context_str_body = ""
         if answer_config.group_contexts_by_question:
-            contexts_by_question: dict[str, list] = {}
+            contexts_by_question: dict[str, list[Context]] = defaultdict(list)
             for c in filtered_contexts:
                 # Fallback to the main session question if not available.
+                # question attribute is optional, so if a user
+                # sets contexts externally, it may not have a question.
                 question = getattr(c, "question", session.question)
-                if question not in contexts_by_question:
-                    contexts_by_question[question] = []
                 contexts_by_question[question].append(c)
 
             context_sections = []

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -807,7 +807,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 section_header = f'Contexts related to the question: "{question}"'
                 section = f"{section_header}\n\n" + "\n\n".join(inner_strs)
                 context_sections.append(section)
-            context_str_body = "\n\n---\n\n".join(context_sections)
+            context_str_body = "\n\n----\n\n".join(context_sections)
         else:
             inner_context_strs = [
                 context_inner_prompt.format(

--- a/src/paperqa/settings.py
+++ b/src/paperqa/settings.py
@@ -111,6 +111,10 @@ class AnswerSettings(BaseModel):
             " called before evidence was gathered."
         ),
     )
+    group_contexts_by_question: bool = Field(
+        default=False,
+        description=("Whether to group contexts by question when generating answers."),
+    )
 
     @model_validator(mode="after")
     def _deprecated_field(self) -> Self:

--- a/src/paperqa/settings.py
+++ b/src/paperqa/settings.py
@@ -113,7 +113,7 @@ class AnswerSettings(BaseModel):
     )
     group_contexts_by_question: bool = Field(
         default=False,
-        description=("Whether to group contexts by question when generating answers."),
+        description="Whether to group contexts by question when generating answers.",
     )
 
     @model_validator(mode="after")

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -620,7 +620,7 @@ async def test_aquery_groups_contexts_by_question(docs_fixture) -> None:
     assert "Details on how drug discovery leverages AI." in final_context_str
     assert "General facts about organic chemistry." in final_context_str
 
-    assert "\n\n---\n\n" in final_context_str
+    assert "\n\n----\n\n" in final_context_str
     q1_header_pos = final_context_str.find(
         'Contexts related to the question: "Is XAI usable in chemistry?"'
     )
@@ -630,7 +630,9 @@ async def test_aquery_groups_contexts_by_question(docs_fixture) -> None:
     context1_pos = final_context_str.find("Explanation about XAI and molecules.")
     context3_pos = final_context_str.find("General facts about organic chemistry.")
 
-    assert 0 == q1_header_pos < context1_pos
+    assert (
+        0 == q1_header_pos < context1_pos
+    ), "Expected q1 header to be first, and the context to follow."
     assert q1_header_pos < q2_header_pos
     assert q2_header_pos < context3_pos
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -52,7 +52,7 @@ from paperqa.core import llm_parse_json
 from paperqa.prompts import CANNOT_ANSWER_PHRASE
 from paperqa.prompts import qa_prompt as default_qa_prompt
 from paperqa.readers import PDFParserFn, read_doc
-from paperqa.types import ChunkMetadata
+from paperqa.types import ChunkMetadata, Context
 from paperqa.utils import (
     clean_possessives,
     encode_id,
@@ -564,6 +564,75 @@ async def test_location_awareness(docs_fixture) -> None:
 async def test_query(docs_fixture) -> None:
     settings = Settings(prompts={"answer_iteration_prompt": None})
     await docs_fixture.aquery("Is XAI usable in chemistry?", settings=settings)
+
+
+@pytest.mark.asyncio
+async def test_aquery_groups_contexts_by_question(docs_fixture) -> None:
+
+    session = PQASession(question="What is the relationship between chemistry and AI?")
+
+    doc = Doc(docname="test_doc", citation="Test Doc, 2025", dockey="key1")
+    text1 = Text(text="XAI is useful for molecules.", name="t1", doc=doc)
+    text2 = Text(text="Drug discovery uses AI.", name="t2", doc=doc)
+    text3 = Text(text="Organic chemistry is a field.", name="t3", doc=doc)
+
+    session.contexts = [
+        Context(
+            text=text1,
+            context="Explanation about XAI and molecules.",
+            score=6,
+            question="Is XAI usable in chemistry?",
+        ),
+        Context(
+            text=text2,
+            context="Details on how drug discovery leverages AI.",
+            score=5,
+            question="Is XAI usable in chemistry?",
+        ),
+        Context(
+            text=text3,
+            context="General facts about organic chemistry.",
+            score=5,
+            question="What is organic chemistry?",
+        ),
+    ]
+
+    settings = Settings(
+        prompts={"answer_iteration_prompt": None},
+        answer={"group_contexts_by_question": True},
+    )
+
+    result = await docs_fixture.aquery(session, settings=settings)
+
+    final_context_str = result.context
+
+    assert (
+        'Contexts related to the question: "Is XAI usable in chemistry?"'
+        in final_context_str
+    )
+
+    assert (
+        'Contexts related to the question: "What is organic chemistry?"'
+        in final_context_str
+    )
+
+    assert "Explanation about XAI and molecules." in final_context_str
+    assert "Details on how drug discovery leverages AI." in final_context_str
+    assert "General facts about organic chemistry." in final_context_str
+
+    assert "\n\n---\n\n" in final_context_str
+    q1_header_pos = final_context_str.find(
+        'Contexts related to the question: "Is XAI usable in chemistry?"'
+    )
+    q2_header_pos = final_context_str.find(
+        'Contexts related to the question: "What is organic chemistry?"'
+    )
+    context1_pos = final_context_str.find("Explanation about XAI and molecules.")
+    context3_pos = final_context_str.find("General facts about organic chemistry.")
+
+    assert 0 == q1_header_pos < context1_pos
+    assert q1_header_pos < q2_header_pos
+    assert q2_header_pos < context3_pos
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Often gather evidence is run multiple times to answer sub-questions of your data, this supports including those sub-questions in the final context and grouping the contexts under each heading. 