### PR TITLE
Avoiding citation prompt hallucinating doi.org URLs

### DIFF
--- a/src/paperqa/prompts.py
+++ b/src/paperqa/prompts.py
@@ -77,6 +77,8 @@ select_paper_prompt = (
 citation_prompt = (
     "Provide the citation for the following text in MLA Format. "
     "Do not write an introductory sentence. "
+    "Do not fabricate a DOI such as '10.xxxx' if one cannot be found,"
+    " just leave it out of the citation. "
     f"If reporting date accessed, the current year is {datetime.now().year}\n\n"
     "{text}\n\n"
     "Citation:"


### PR DESCRIPTION
When given the first page of [A Perspective on Explanations of Molecular Prediction Models](https://pubs.acs.org/doi/10.1021/acs.jctc.2c01235), our `citation_prompt` would infer:

```none
Wellawatte, Geemi P., et al. "A Perspective on Explanations of Molecular Prediction Models." *Department of Chemistry, University of Rochester*, 2025, https://doi.org/10.xxxx. Accessed 25 Oct. 2025.
```

Note there are two LLM hallucinations:

1. A doi.org URL: `https://doi.org/10.xxxx`
2. Accessed date: `Accessed 25 Oct. 2025`

We don't extract the accessed date, so that's fine, but we should correct the DOI hallucination via prompting.