### PR TITLE
Re-raising original exception in `clinical_trials` tools

### DIFF
--- a/src/paperqa/sources/clinical_trials.py
+++ b/src/paperqa/sources/clinical_trials.py
@@ -48,6 +48,7 @@ class CookieWarningFilter(logging.Filter):
     stop=stop_after_attempt(3),
     wait=wait_incrementing(0.1, 0.1),
     retry=retry_if_exception_type(ClientResponseError),
+    reraise=True,
 )
 async def api_search_clinical_trials(query: str, session: ClientSession) -> dict:
 
@@ -74,6 +75,7 @@ async def api_search_clinical_trials(query: str, session: ClientSession) -> dict
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_incrementing(0.1, 0.1),
+    reraise=True,
 )
 async def api_get_clinical_trial(nct_id: str, session: ClientSession) -> dict | None:
     with logging_filters(loggers={"aiohttp.client"}, filters={CookieWarningFilter}):


### PR DESCRIPTION
Tools should always have `reraise=True` so the agent can see the original error, not some `tenacity.RetryError`-obfuscated exception that looks like so:

```none
RetryError: RetryError[<Future at 0x107af0650 state=finished raised ValueError>]
```