### PR TITLE
Move context str generation into configurable function

### DIFF
--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -768,8 +768,8 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
         context_str = answer_config.context_str_fn(
             settings=query_settings,
             contexts=contexts,
-            pre_str=pre_str,
             question=session.question,
+            pre_str=pre_str,
         )
 
         if len(context_str.strip()) < 10:  # noqa: PLR2004
@@ -847,13 +847,11 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
 
 
 def default_context_str_fn(
-    settings: Settings, contexts: list[Context], **kwargs
+    settings: Settings, contexts: list[Context], question: str, pre_str: str | None
 ) -> str:
     """Default context string function for generating a context string."""
     answer_config = settings.answer
     prompt_config = settings.prompts
-    question = kwargs.get("question", "No question provided.")
-    pre_str = kwargs.get("pre_str", "")
 
     # sort by first score, then name
     filtered_contexts = sorted(

--- a/src/paperqa/settings.py
+++ b/src/paperqa/settings.py
@@ -78,7 +78,11 @@ class ContextStrFn(Protocol):
     """Protocol for generating a context string from settings and context."""
 
     def __call__(
-        self, settings: "Settings", contexts: list[Context], **kwargs
+        self,
+        settings: "Settings",
+        contexts: list[Context],
+        question: str,
+        pre_str: str | None,
     ) -> str: ...
 
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -570,7 +570,10 @@ async def test_query(docs_fixture) -> None:
 async def test_custom_context_str_fn(docs_fixture) -> None:
 
     def custom_context_str_fn(
-        settings: Settings, contexts: list[Context], **kwargs  # noqa: ARG001
+        settings: Settings,  # noqa: ARG001
+        contexts: list[Context],  # noqa: ARG001
+        question: str,  # noqa: ARG001
+        pre_str: str | None = None,  # noqa: ARG001
     ) -> str:
         return "TEST OVERRIDE"
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -567,6 +567,27 @@ async def test_query(docs_fixture) -> None:
 
 
 @pytest.mark.asyncio
+async def test_custom_context_str_fn(docs_fixture) -> None:
+
+    def custom_context_str_fn(
+        settings: Settings, contexts: list[Context], **kwargs  # noqa: ARG001
+    ) -> str:
+        return "TEST OVERRIDE"
+
+    settings = Settings(
+        prompts={"answer_iteration_prompt": None},
+        answer={"context_str_fn": custom_context_str_fn},
+    )
+
+    session = await docs_fixture.aquery(
+        "Is XAI usable in chemistry?", settings=settings
+    )
+    assert (
+        session.context == "TEST OVERRIDE"
+    ), "Expected custom context string to be returned."
+
+
+@pytest.mark.asyncio
 async def test_aquery_groups_contexts_by_question(docs_fixture) -> None:
 
     session = PQASession(question="What is the relationship between chemistry and AI?")


### PR DESCRIPTION
Users may want custom control over how contexts are generated and munged before inserting into the final answer. This was previously locked into the `aquery` code, but this exposes it as a configurable function. 

We may not be the best, but by god, we'll be the most configurable. 