### PR TITLE
Fixed `test_agent_types` after Gemini 1.5 deprecation

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -328,7 +328,7 @@ async def test_get_directory_index_w_no_citations(
 
 @pytest.mark.flaky(reruns=2, only_rerun=["AssertionError", "httpx.RemoteProtocolError"])
 @pytest.mark.parametrize("agent_type", [FAKE_AGENT_TYPE, ToolSelector, SimpleAgent])
-@pytest.mark.parametrize("llm_name", ["gpt-4o", "gemini/gemini-1.5-flash"])
+@pytest.mark.parametrize("llm_name", ["gpt-4o", "gemini/gemini-2.0-flash-lite"])
 @pytest.mark.asyncio
 async def test_agent_types(
     agent_test_settings: Settings,


### PR DESCRIPTION
From https://ai.google.dev/gemini-api/docs/models, Gemini 1.5 Flash is deprecated:

<img width="1000" height="80" alt="screenshot of Gemini 1.5 models overview" src="https://github.com/user-attachments/assets/364e0f2d-8cf7-4e75-9bea-17e703cd9073" />

This PR just updates the model to `gemini-2.0-flash-lite` (I used `lite` to keep CI low-cost and fast)