### PR TITLE
Fix paperqa/configs link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ pqa --settings <setting name> \
 
 ### Bundled Settings
 
-Inside [`paperqa/configs`](paperqa/configs) we bundle known useful settings:
+Inside [`src/paperqa/configs`](src/paperqa/configs) we bundle known useful settings:
 
 | Setting Name | Description                                                                                                                  |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The link didn't work. It does now, tested at https://github.com/chrisranderson/paper-qa/tree/patch-1?tab=readme-ov-file#bundled-settings.