### PR TITLE
Lower bibtex logging to debug

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -915,7 +915,7 @@ class DocDetails(Doc):
                 ):
                     data["citation"] = None
             except Exception:
-                logger.warning(
+                logger.debug(
                     "Failed to generate bibtex for"
                     f" {data.get('docname') or data.get('citation')}"
                 )


### PR DESCRIPTION
This log is quite common, and not important enough to be a warning. 