### PR TITLE
skip bibtex call to crossref

### DIFF
--- a/src/paperqa/clients/crossref.py
+++ b/src/paperqa/clients/crossref.py
@@ -166,7 +166,7 @@ async def doi_to_bibtex(
 async def parse_crossref_to_doc_details(
     message: dict[str, Any],
     session: aiohttp.ClientSession,
-    query_bibtex: bool = True,
+    query_bibtex: bool = False,
 ) -> DocDetails:
 
     bibtex_source = BibTeXSource.SELF_GENERATED.value


### PR DESCRIPTION
we were double hitting and it's not necessary