### PR TITLE
Fixing `gen_answer` failover leaving `raw_answer` blank

### DIFF
--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -309,9 +309,6 @@ class GenerateAnswer(NamedTool):
         Args:
             state: Current state.
         """
-        if not state.docs.docs:
-            raise EmptyDocsError("Not generating an answer due to having no papers.")
-
         logger.info(f"Generating answer for '{state.session.question}'.")
 
         if f"{self.TOOL_FN_NAME}_initialized" in self.settings.agent.callbacks:

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -742,7 +742,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
         contexts = session.contexts
         if answer_config.get_evidence_if_no_contexts and not contexts:
             session = await self.aget_evidence(
-                query=session,
+                session,
                 callbacks=callbacks,
                 settings=settings,
                 embedding_model=embedding_model,

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -26,7 +26,7 @@ from paperqa.llms import (
     NumpyVectorStore,
     VectorStore,
 )
-from paperqa.prompts import CANNOT_ANSWER_PHRASE
+from paperqa.prompts import CANNOT_ANSWER_PHRASE, EMPTY_CONTEXTS
 from paperqa.readers import read_doc
 from paperqa.settings import MaybeSettings, get_settings
 from paperqa.types import Doc, DocDetails, DocKey, PQASession, Text
@@ -774,9 +774,10 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             pre_str=pre_str,
         )
 
-        if len(context_str.strip()) < 10:  # noqa: PLR2004
+        if len(context_str.strip()) <= EMPTY_CONTEXTS:
             answer_text = (
-                f"{CANNOT_ANSWER_PHRASE} this question due to insufficient information."
+                f"{CANNOT_ANSWER_PHRASE} this question due to"
+                f" {'having no papers' if not self.docs else 'insufficient information.'}."
             )
             answer_reasoning = None
         else:

--- a/src/paperqa/prompts.py
+++ b/src/paperqa/prompts.py
@@ -146,5 +146,6 @@ EVAL_PROMPT_TEMPLATE = (
 )
 
 CONTEXT_OUTER_PROMPT = "{context_str}\n\nValid Keys: {valid_keys}"
+EMPTY_CONTEXTS = len(CONTEXT_OUTER_PROMPT.format(context_str="", valid_keys="").strip())
 CONTEXT_INNER_PROMPT_NOT_DETAILED = "{name}: {text}"
 CONTEXT_INNER_PROMPT = f"{CONTEXT_INNER_PROMPT_NOT_DETAILED}\nFrom {{citation}}"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -467,7 +467,7 @@ async def test_successful_memory_agent(agent_test_settings: Settings) -> None:
 @pytest.mark.asyncio
 async def test_timeout(agent_test_settings: Settings, agent_type: str | type) -> None:
     agent_test_settings.prompts.pre = None
-    agent_test_settings.agent.timeout = 0.001
+    agent_test_settings.agent.timeout = 0.05  # Give time for Environment.reset()
     agent_test_settings.llm = "gpt-4o-mini"
     agent_test_settings.agent.tool_names = {"gen_answer", "complete"}
     response = await agent_query(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -12,7 +12,7 @@ import zlib
 from functools import wraps
 from pathlib import Path
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import ldp.agent
@@ -467,27 +467,15 @@ async def test_successful_memory_agent(agent_test_settings: Settings) -> None:
 @pytest.mark.asyncio
 async def test_timeout(agent_test_settings: Settings, agent_type: str | type) -> None:
     agent_test_settings.prompts.pre = None
-    agent_test_settings.agent.timeout = 0.05  # Give time for Environment.reset()
+    agent_test_settings.agent.timeout = 0.001
     agent_test_settings.llm = "gpt-4o-mini"
     agent_test_settings.agent.tool_names = {"gen_answer", "complete"}
-    docs = Docs()
-
-    async def custom_aget_evidence(*_, **kwargs) -> PQASession:  # noqa: RUF029
-        return kwargs["query"]
-
-    with (
-        patch.object(docs, "docs", {"stub_key": MagicMock(spec_set=Doc)}),
-        patch.multiple(
-            Docs, clear_docs=MagicMock(), aget_evidence=custom_aget_evidence
-        ),
-    ):
-        response = await agent_query(
-            query="Are COVID-19 vaccines effective?",
-            settings=agent_test_settings,
-            docs=docs,
-            agent_type=agent_type,
-        )
-    # Ensure that GenerateAnswerTool was called in truncation's failover
+    response = await agent_query(
+        query="Are COVID-19 vaccines effective?",
+        settings=agent_test_settings,
+        agent_type=agent_type,
+    )
+    # ensure that GenerateAnswerTool was called
     assert response.status == AgentStatus.TRUNCATED, "Agent did not timeout"
     assert CANNOT_ANSWER_PHRASE in response.session.answer
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -475,7 +475,7 @@ async def test_timeout(agent_test_settings: Settings, agent_type: str | type) ->
         settings=agent_test_settings,
         agent_type=agent_type,
     )
-    # ensure that GenerateAnswerTool was called
+    # Ensure that GenerateAnswerTool was called in truncation's failover
     assert response.status == AgentStatus.TRUNCATED, "Agent did not timeout"
     assert CANNOT_ANSWER_PHRASE in response.session.answer
 


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/1073 was suboptimal in that if the `EmptyDocsError` route was taken, the `PQASession`'s `raw_answer`/`answer_reasoning` would be left unpopulated without `patch`ing in-place. This PR:
- Keeps the specialization in the returned tool response message
- While allowing the code to populate `raw_answer`/`answer_reasoning` in a normal flow