### PR TITLE
S2 metadata retrieval: fallback to exact title match if authors do not match

### DIFF
--- a/src/paperqa/clients/semantic_scholar.py
+++ b/src/paperqa/clients/semantic_scholar.py
@@ -156,9 +156,10 @@ def s2_authors_match(authors: list[str], data: dict) -> bool:
 
 
 def _sanitize_title(title: str) -> str:
-    """Sanitize the title to remove extra whitespace, punctuation,.
+    """Sanitize the title.
 
-    emphasis, and capitalization.
+    Removes XML tags, punctuation, and capitalization.
+    Also replaces multiple spaces with a single space.
     """
     title = re.sub(r"<[^>]*>", "", title)
     title = re.sub(r"[^\w\s]", "", title)


### PR DESCRIPTION
Sometimes the author check can have false negatives, so this implements a fallback to exact title match. To avoid introducing false positives, it's only applied if the titles are at least 10 words long. 