### PR TITLE
Context id updates

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -388,9 +388,7 @@ class PQASession(BaseModel):
                 for key in get_citation_ids(parenthetical)
                 if id_to_name_map.get(key)
             )
-            # replace the parenthetical with the deduped names
             if deduped_names:
-
                 formatted_without_references = formatted_without_references.replace(
                     parenthetical,
                     f"({', '.join(deduped_names)})",

--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -41,7 +41,7 @@ from paperqa.utils import (
     encode_id,
     format_bibtex,
     get_citation_ids,
-    get_parentheses_substrings,
+    get_parenthetical_substrings,
     maybe_get_date,
     string_to_bytes,
 )
@@ -287,8 +287,6 @@ class PQASession(BaseModel):
         ),
     )
 
-    MAX_CITATION_NESTING_DEPTH: ClassVar[int] = 3
-
     def __str__(self) -> str:
         """Return the answer as a string."""
         return self.formatted_answer
@@ -380,9 +378,9 @@ class PQASession(BaseModel):
         }
         name_bib = {}
 
-        for parenthetical in get_parentheses_substrings(formatted_without_references):
+        for parenthetical in get_parenthetical_substrings(formatted_without_references):
             # now we replace eligible parentheticals with the deduped names
-            # preserve order and deduplicate
+            # while we preserve order and deduplicate
             deduped_names: dict[str, None] = dict.fromkeys(
                 id_to_name_map.get(key)  # type: ignore[misc]
                 for key in get_citation_ids(parenthetical)

--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -382,7 +382,7 @@ class PQASession(BaseModel):
             # now we replace eligible parentheticals with the deduped names
             # while we preserve order and deduplicate
             deduped_names: dict[str, None] = dict.fromkeys(
-                id_to_name_map.get(key)  # type: ignore[misc]
+                id_to_name_map[key]
                 for key in get_citation_ids(parenthetical)
                 if id_to_name_map.get(key)
             )

--- a/src/paperqa/utils.py
+++ b/src/paperqa/utils.py
@@ -154,7 +154,7 @@ def extract_score(text: str) -> int:
     raise ValueError(f"Failed to extract score from text {text!r}.")
 
 
-def get_parentheses_substrings(text: str) -> list[str]:
+def get_parenthetical_substrings(text: str) -> list[str]:
     """
     Finds the all nested parenthetical substrings.
 

--- a/src/paperqa/utils.py
+++ b/src/paperqa/utils.py
@@ -154,8 +154,31 @@ def extract_score(text: str) -> int:
     raise ValueError(f"Failed to extract score from text {text!r}.")
 
 
-def get_citation_ids(text: str) -> set[str]:
-    return set(re.findall(r"\bpqac-[a-zA-Z0-9]{8}\b", text))
+def get_parentheses_substrings(text: str) -> list[str]:
+    """
+    Finds the all nested parenthetical substrings.
+
+    Args:
+        text: The input string to analyze.
+
+    Returns:
+        A list of parenthetical substrings.
+    """
+    substrings = []
+    open_paren_indices = []
+    for i, char in enumerate(text):
+        if char == "(":
+            open_paren_indices.append(i)
+        elif char == ")" and open_paren_indices:
+            start_index = open_paren_indices.pop()
+            substrings.append(text[start_index : i + 1])
+    return substrings
+
+
+def get_citation_ids(text: str) -> list[str]:
+    matches = re.findall(r"\bpqac-[a-zA-Z0-9]{8}\b", text)
+    # remove duplicates while preserving order
+    return list(dict.fromkeys(matches))
 
 
 def extract_doi(reference: str) -> str:


### PR DESCRIPTION
We had some scenarios where our formatted answer could miss context-ids. This implements a more universal matching solution along with tests. 