### PR TITLE
Enforcing `DocDetails.tzinfo` to be UTC

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -10,7 +10,7 @@ import re
 import warnings
 from collections.abc import Collection, Iterable, Mapping, Sequence
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from random import Random
@@ -706,6 +706,15 @@ class DocDetails(Doc):
     def clean_key(cls, value: str) -> str:
         # Replace HTML tags with empty string
         return re.sub(pattern=r"<\/?\w{1,10}>", repl="", string=value)
+
+    @field_validator("publication_date")
+    @classmethod
+    def add_tzinfo(cls, value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            return value.replace(tzinfo=UTC)  # Assume UTC if unspecified
+        return value.astimezone(UTC)  # Convert to UTC
 
     @classmethod
     def lowercase_doi_and_populate_doc_id(cls, data: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Collection, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -225,7 +225,7 @@ async def test_title_search(paper_attributes: dict[str, str]) -> None:
         },
         {
             "bibtex_type": "article",
-            "publication_date": datetime(2015, 6, 29),
+            "publication_date": datetime(2015, 6, 29, tzinfo=UTC),
             "year": 2015,
             "volume": "87",
             "pages": (
@@ -244,7 +244,7 @@ async def test_title_search(paper_attributes: dict[str, str]) -> None:
             "doi_url": "https://doi.org/10.1016/j.addr.2015.01.008",
         },
         {
-            "publication_date": datetime(2014, 10, 27),
+            "publication_date": datetime(2014, 10, 27, tzinfo=UTC),
             "year": 2014,
             "volume": "111",
             "pages": "E4832-E4841",


### PR DESCRIPTION
Seen in client code:

```none
Traceback (most recent call last):
  ...
    result = sum(doc_details_to_combine)
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/paperqa/types.py", line 1058, in __add__
    PREFER_OTHER = self.publication_date <= other.publication_date
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

This PR resolves this issue by ensuring all `publication_date` are in UTC