### PR TITLE
Simplifying `pre-commit` local and CI set up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,9 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - run: echo "UV_PROJECT_ENVIRONMENT=$(python -c "import sysconfig; print(sysconfig.get_config_var('prefix'))")" >> $GITHUB_ENV
-      - run: uv python pin ${{ matrix.python-version }} # uv requires .python-version to match OS Python: https://github.com/astral-sh/uv/issues/11389
       - run: uv sync --python-preference only-system
-      - run: git checkout .python-version # For clean git diff given `pre-commit run --show-diff-on-failure`
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,9 @@ jobs:
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - run: echo "UV_PROJECT_ENVIRONMENT=$(python -c "import sysconfig; print(sysconfig.get_config_var('prefix'))")" >> $GITHUB_ENV
-      - run: uv sync --python-preference only-system
+          activate-environment: true # Activate for simple `uv sync` below
+      - run: uv sync
+      - run: uv pip install pip # Prepare for pre-commit's usage of pip
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.1.0
         if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,6 +91,6 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: uv run --frozen mypy # Use --frozen to avoid mutating local venv
         language: system
         types_or: [python, pyi]

--- a/src/paperqa/core.py
+++ b/src/paperqa/core.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, TypeVar
 
 import litellm
 from aviary.core import Message
@@ -14,6 +14,9 @@ from paperqa.types import Context, Text
 from paperqa.utils import extract_score, strip_citations
 
 logger = logging.getLogger(__name__)
+
+TTest = TypeVar("TTest", default=float)
+type Alias = int
 
 
 def llm_parse_json(text: str) -> dict[str, JsonValue]:

--- a/src/paperqa/core.py
+++ b/src/paperqa/core.py
@@ -16,9 +16,7 @@ from paperqa.utils import extract_score, strip_citations
 logger = logging.getLogger(__name__)
 
 
-def llm_parse_json(
-    text: str
-) -> dict[str, JsonValue]:
+def llm_parse_json(text: str) -> dict[str, JsonValue]:
     """Read LLM output and extract JSON data from it."""
     # Removing <think> tags for reasoning models
     ptext = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()

--- a/src/paperqa/core.py
+++ b/src/paperqa/core.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from collections.abc import Callable, Sequence
-from typing import Any, TypeVar
+from typing import Any
 
 import litellm
 from aviary.core import Message
@@ -15,11 +15,10 @@ from paperqa.utils import extract_score, strip_citations
 
 logger = logging.getLogger(__name__)
 
-TTest = TypeVar("TTest", default=float)
-type Alias = int
 
-
-def llm_parse_json(text: str) -> dict[str, JsonValue]:
+def llm_parse_json(
+    text: str
+) -> dict[str, JsonValue]:
     """Read LLM output and extract JSON data from it."""
     # Removing <think> tags for reasoning models
     ptext = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()


### PR DESCRIPTION
- Modernizes our `setup-uv` parameters
    - `UV_PROJECT_ENVIRONMENT` --> `activate-environment` parameter
    - `uv python pin` --> `python-version` parameter
- Enforces `pre-commit` config to use `uv`-managed venv