### PR TITLE
`gather_evidence` tool response filtering empty `Context`

### DIFF
--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -252,11 +252,12 @@ class GatherEvidence(NamedTool):
         status = state.status
         logger.info(status)
         # only show top n contexts for this particular question to the agent
-        sorted_contexts = sorted(
+        # only show non-empty context so tool response doesn't include empty contexts
+        sorted_nonempty_contexts = sorted(
             [
                 c
                 for c in state.session.contexts
-                if (c.question is None or c.question == question)
+                if ((c.question is None or c.question == question) and c.context)
             ],
             key=lambda x: x.score,
             reverse=True,
@@ -266,7 +267,7 @@ class GatherEvidence(NamedTool):
             [
                 f"{n + 1}. {sc.context}\n"
                 for n, sc in enumerate(
-                    sorted_contexts[: self.settings.agent.agent_evidence_n]
+                    sorted_nonempty_contexts[: self.settings.agent.agent_evidence_n]
                 )
             ]
         )

--- a/src/paperqa/core.py
+++ b/src/paperqa/core.py
@@ -276,14 +276,14 @@ async def _map_fxn_summary(  # noqa: PLR0912
 
         llm_results.append(llm_result)
         context = llm_result.text or ""
-        try:
-            result_data = parser(context) if parser else {}
-        except ValueError as exc:
-            raise LLMBadContextJSONError(
-                f"Failed to parse JSON from context {context!r} due to: {exc}",
-                llm_results=llm_results,
-            ) from exc
-        if result_data:
+        if parser:
+            try:
+                result_data = parser(context)
+            except ValueError as exc:
+                raise LLMBadContextJSONError(
+                    f"Failed to parse JSON from context {context!r} due to: {exc}",
+                    llm_results=llm_results,
+                ) from exc
             try:
                 context = result_data.pop("summary")
                 try:

--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -30,6 +30,7 @@ from pydantic import (
     Field,
     JsonValue,
     PlainSerializer,
+    StringConstraints,
     computed_field,
     field_validator,
     model_validator,
@@ -192,7 +193,9 @@ class Context(BaseModel):
         description="Unique identifier for the context. Auto-generated if not provided.",
     )
 
-    context: str = Field(description="Summary of the text with respect to a question.")
+    context: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
+        description="Summary of the text with respect to a question."
+    )
     question: str | None = Field(
         default=None,
         description=(

--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -194,7 +194,11 @@ class Context(BaseModel):
     )
 
     context: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
-        description="Summary of the text with respect to a question."
+        description=(
+            "Summary of the text with respect to a question."
+            " Can be an empty string if a summary is not useful"
+            " (which should accompany a score of 0)."
+        )
     )
     question: str | None = Field(
         default=None,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -524,8 +524,9 @@ async def test_propagate_options(agent_test_settings: Settings) -> None:
     result = response.session
     assert len(result.answer) > 200, "Answer did not return any results"
     assert "###" in result.answer, "Answer did not propagate system prompt"
+    # Subtract 2 to allow tolerance for chunks with leading/trailing whitespace
     assert (
-        len(result.contexts[0].context) == agent_test_settings.parsing.chunk_size
+        len(result.contexts[0].context) >= agent_test_settings.parsing.chunk_size - 2
     ), "Summary was not skipped"
 
 

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -576,7 +576,7 @@ async def test_json_evidence(docs_fixture: Docs) -> None:
 
 
 @pytest.mark.asyncio
-async def test_ablations(docs_fixture) -> None:
+async def test_ablations(docs_fixture: Docs) -> None:
     settings = Settings()
     settings.answer.evidence_skip_summary = True
     settings.answer.evidence_retrieval = False
@@ -588,7 +588,9 @@ async def test_ablations(docs_fixture) -> None:
             settings=settings,
         )
     ).contexts
-    assert contexts[0].text.text == contexts[0].context, "summarization not ablated"
+    assert (
+        contexts[0].text.text.strip() == contexts[0].context
+    ), "summarization not ablated"
 
     assert len(contexts) == len(docs_fixture.texts), "evidence retrieval not ablated"
 


### PR DESCRIPTION
We were seeing `gather_evidence` responses like this:

```none
Added 22 pieces of evidence, 0 of which were relevant. Best evidence(s):

1. 

2. 

3. 

4. 

5. 

...
```

There's more to the story here, but this PR at least:
- Documents when we'd have an empty `Context.context`
- Filters the `gather_evidence` tool response for empty `context`