### PR TITLE
Dropping irrelevant contexts

### DIFF
--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -252,13 +252,12 @@ class GatherEvidence(NamedTool):
         status = state.status
         logger.info(status)
         # only show top n contexts for this particular question to the agent
-        # only show context above score 0, because 0 is a sentinel for irrelevance
-        sorted_relevant_contexts = sorted(
-            [
+        sorted_contexts = sorted(
+            (
                 c
                 for c in state.session.contexts
-                if ((c.question is None or c.question == question) and c.score > 0)
-            ],
+                if c.question is None or c.question == question
+            ),
             key=lambda x: x.score,
             reverse=True,
         )
@@ -267,7 +266,7 @@ class GatherEvidence(NamedTool):
             [
                 f"{n + 1}. {sc.context}\n"
                 for n, sc in enumerate(
-                    sorted_relevant_contexts[: self.settings.agent.agent_evidence_n]
+                    sorted_contexts[: self.settings.agent.agent_evidence_n]
                 )
             ]
         )

--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -262,9 +262,9 @@ class GatherEvidence(NamedTool):
             reverse=True,
         )
 
-        top_contexts = "\n".join(
+        top_contexts = "\n\n".join(
             [
-                f"{n + 1}. {sc.context}\n"
+                f"- {sc.context}"
                 for n, sc in enumerate(
                     sorted_contexts[: self.settings.agent.agent_evidence_n]
                 )

--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -271,7 +271,11 @@ class GatherEvidence(NamedTool):
             ]
         )
 
-        best_evidence = f" Best evidence(s):\n\n{top_contexts}" if top_contexts else ""
+        best_evidence = (
+            f" Best evidence(s) for the current question:\n\n{top_contexts}"
+            if top_contexts
+            else ""
+        )
 
         if f"{self.TOOL_FN_NAME}_completed" in self.settings.agent.callbacks:
             await asyncio.gather(

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -682,7 +682,8 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             for r in llm_results:
                 session.add_tokens(r)
 
-        session.contexts += [c for c, _ in results if c is not None]
+        # Filter out failed context creations or irrelevant contexts
+        session.contexts += [c for c, _ in results if c is not None and c.score > 0]
         return session
 
     def query(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -711,11 +711,9 @@ async def test_agent_sharing_state(
         total_added_1 = int(split[1])
         assert total_added_1 > 0, "Expected non-negative added evidence count"
         assert len(env_state.get_relevant_contexts()) == total_added_1
-        # ensure 1 piece of top evidence is returned
-        assert "\n1." in response, "gather_evidence did not return any results"
         assert (
-            "\n2." not in response
-        ), "gather_evidence should return only 1 context, not 2"
+            response.count("\n- ") == 1
+        ), "Expected exactly one best evidence to be shown"
 
         # now adjust to give the agent 2x pieces of evidence
         gather_evidence_tool.settings.agent.agent_evidence_n = 2
@@ -745,9 +743,9 @@ async def test_agent_sharing_state(
         total_added_2 = int(split[1])
         assert total_added_2 > 0, "Expected non-negative added evidence count"
         assert len(env_state.get_relevant_contexts()) == total_added_1 + total_added_2
-        # ensure both evidences are returned
-        assert "\n1." in response, "gather_evidence did not return any results"
-        assert "\n2." in response, "gather_evidence should return 2 contexts"
+        assert (
+            response.count("\n- ") == 2
+        ), "Expected both evidences to be shown as best evidences"
 
         assert session.contexts, "Evidence did not return any results"
         assert not session.answer, "Expected no answer yet"


### PR DESCRIPTION
This PR clears up some fuzziness in our evidence accounting:

- Removes irrelevant evidence, instead of continually filtering them out
    - Comes with the benefit of much smaller `PQASession`
- Updates `Best evidence(s)` message for clarity
    - Including the 'for the current question', to make it clear the best evidence varies per question
    - Using a bulleted list over a numbered list, since order is defined by score (not element index)