### PR TITLE
Re-adding `refurb`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,7 @@ jobs:
         run: echo "UV_PYTHON=${{ matrix.python-version }}" >> "$GITHUB_ENV"
       - run: uv sync
       - run: uv run pylint src packages
+      - run: uv run refurb .
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@v1.1.1
   test:
     runs-on: ubuntu-latest

--- a/packages/paper-qa-pymupdf/src/paperqa_pymupdf/reader.py
+++ b/packages/paper-qa-pymupdf/src/paperqa_pymupdf/reader.py
@@ -4,7 +4,6 @@ import re
 import pymupdf
 from paperqa.types import ParsedMedia, ParsedMetadata, ParsedText
 from paperqa.utils import ImpossibleParsingError
-from paperqa.version import __version__ as pqa_version
 
 
 def setup_pymupdf_python_logging() -> None:
@@ -171,7 +170,6 @@ def parse_pdf_to_pages(
 
     metadata = ParsedMetadata(
         parsing_libraries=[f"{pymupdf.__name__} ({pymupdf.__version__})"],
-        paperqa_version=pqa_version,
         total_parsed_text_length=total_length,
         count_parsed_media=count_media,
         parse_type="pdf",

--- a/packages/paper-qa-pymupdf/tests/test_paperqa_pymupdf.py
+++ b/packages/paper-qa-pymupdf/tests/test_paperqa_pymupdf.py
@@ -73,14 +73,14 @@ async def test_parse_pdf_to_pages() -> None:
     fig_1_text.text = "stub"  # Replace text to confirm multimodality works
     docs = Docs()
     assert await docs.aadd_texts(texts=[fig_1_text], doc=doc)
-    for query, substrings_min_counts in [
+    for query, substrings_min_counts in (
         ("What actions can the Crawler take?", [(("search", "expand", "stop"), 2)]),
         ("What actions can the Selector take?", [(("select", "drop"), 2)]),
         (
             "How many User Query are there, and what do they do?",
             [(("two", "2"), 2), (("crawler", "selector"), 2)],
         ),
-    ]:
+    ):
         session = await docs.aquery(query=query)
         assert session.contexts, "Expected contexts to be generated"
         assert all(
@@ -107,7 +107,7 @@ async def test_parse_pdf_to_pages() -> None:
         assert page_text
         assert full_page_image.index == 0, "Full page image should have index 0"
         assert isinstance(full_page_image.data, bytes)
-        assert len(full_page_image.data) > 0, "Full page image should have data"
+        assert full_page_image.data, "Full page image should have data"
         # Check useful attributes are present and are JSON serializable
         json.dumps(p2_image.info)
         for attr in ("width", "height"):

--- a/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
+++ b/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
@@ -5,7 +5,6 @@ from typing import Any
 import pypdf
 from paperqa.types import ParsedMedia, ParsedMetadata, ParsedText
 from paperqa.utils import ImpossibleParsingError
-from paperqa.version import __version__ as pqa_version
 
 try:
     import pypdfium2 as pdfium
@@ -96,7 +95,6 @@ def parse_pdf_to_pages(
                 else pypdf_version_str
             )
         ],
-        paperqa_version=pqa_version,
         total_parsed_text_length=total_length,
         count_parsed_media=count_media,
         parse_type="pdf",

--- a/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
+++ b/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
@@ -76,14 +76,14 @@ async def test_parse_pdf_to_pages() -> None:
     fig_1_text.text = "stub"  # Replace text to confirm multimodality works
     docs = Docs()
     assert await docs.aadd_texts(texts=[fig_1_text], doc=doc)
-    for query, substrings_min_counts in [
+    for query, substrings_min_counts in (
         ("What actions can the Crawler take?", [(("search", "expand", "stop"), 2)]),
         ("What actions can the Selector take?", [(("select", "drop"), 2)]),
         (
             "How many User Query are there, and what do they do?",
             [(("two", "2"), 2), (("crawler", "selector"), 2)],
         ),
-    ]:
+    ):
         session = await docs.aquery(query=query)
         assert session.contexts, "Expected contexts to be generated"
         assert all(

--- a/src/paperqa/agents/tools.py
+++ b/src/paperqa/agents/tools.py
@@ -263,12 +263,8 @@ class GatherEvidence(NamedTool):
         )
 
         top_contexts = "\n\n".join(
-            [
-                f"- {sc.context}"
-                for n, sc in enumerate(
-                    sorted_contexts[: self.settings.agent.agent_evidence_n]
-                )
-            ]
+            f"- {sc.context}"
+            for sc in sorted_contexts[: self.settings.agent.agent_evidence_n]
         )
 
         best_evidence = (

--- a/src/paperqa/clients/journal_quality.py
+++ b/src/paperqa/clients/journal_quality.py
@@ -204,9 +204,7 @@ async def main() -> None:
         )
         records = await process_csv(downloaded_path)
 
-        with open(  # noqa: ASYNC230
-            DEFAULT_JOURNAL_QUALITY_CSV_PATH, "w", encoding="utf-8"
-        ) as csvfile:
+        with DEFAULT_JOURNAL_QUALITY_CSV_PATH.open("w", encoding="utf-8") as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow(["clean_name", "quality"])
             for name, quality in records:

--- a/src/paperqa/utils.py
+++ b/src/paperqa/utils.py
@@ -659,7 +659,7 @@ def string_to_bytes(value: str) -> bytes:
     """Convert a base64-encoded string to bytes."""
     # 1. Convert base64 string to base64 bytes
     # 2. Convert base64 bytes to original bytes
-    return base64.b64decode(value.encode("utf-8"))
+    return base64.b64decode(value.encode("utf-8"))  # noqa: FURB120
 
 
 def validate_image(path: StrOrBytesPath | IO[bytes]) -> None:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1470,7 +1470,7 @@ async def test_read_doc_images_metadata(stub_data_dir: Path) -> None:
     assert isinstance(parsed_image, ParsedMedia)
     assert parsed_image.index == 0
     assert isinstance(parsed_image.data, bytes)
-    assert len(parsed_image.data) > 0
+    assert parsed_image.data
     assert not parsed_image.text, "Expected no text content for a standalone image"
     assert parsed_image.info["suffix"] == ".png"
     image_id = parsed_image.to_id()


### PR DESCRIPTION
I realized https://github.com/Future-House/paper-qa/pull/1113 had left behind an extra `enumerate` we could have detected with `refurb`