### PR TITLE
Fixing `KeyError` crash when PDF reader misses a page

### DIFF
--- a/src/paperqa/readers.py
+++ b/src/paperqa/readers.py
@@ -61,7 +61,7 @@ def _make_chunk(
 ) -> Text:
     media: list[ParsedMedia] = []
     for pg_num in range(int(lower_page), int(upper_page) + 1):
-        pg_contents = cast(dict, parsed_text.content)[str(pg_num)]
+        pg_contents = cast(dict, parsed_text.content).get(str(pg_num))
         if isinstance(pg_contents, tuple):
             media.extend(pg_contents[1])
     # pretty formatting of pages (e.g. 1-3, 4, 5-7)


### PR DESCRIPTION
Testing out some different Docling models, sometimes they mess up and read a page without text. However, since https://github.com/Future-House/paper-qa/pull/1046 added media parsing, a skipped page will crash our chunking logic, which is just unnecessary. This PR fixes that, with a simple unit test.