### PR TITLE
Cleaning up `tiktoken` usage in readers

### DIFF
--- a/src/paperqa/readers.py
+++ b/src/paperqa/readers.py
@@ -190,6 +190,7 @@ def chunk_text(
     content: str | list[int] = (
         parsed_text.content
         if not use_tiktoken
+        # we tokenize using tiktoken so cuts are in reasonable places
         else cast(list[int], parsed_text.encode_content(enc))
     )
     if not content:  # Avoid div0 in token calculations

--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -568,7 +568,6 @@ class ParsedText(BaseModel):
     def encode_content(
         self, enc: tiktoken.Encoding | str = "cl100k_base"
     ) -> list[int] | list[list[int]]:
-        # we tokenize using tiktoken so cuts are in reasonable places
         if isinstance(enc, str):
             enc = tiktoken.get_encoding(enc)
         if isinstance(self.content, str):


### PR DESCRIPTION
I observed `parse_text` didn't use `tiktoken` and wasn't sharing the `Encoding` with `ParsedText.reduce_content`