### PR TITLE
Ensuring citation peeks aren't multimodal

### DIFF
--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -300,6 +300,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 or "insufficient" in citation
             ):
                 citation = f"Unknown, {os.path.basename(path)}, {datetime.now().year}"
+            del result, texts  # Ensure we don't reuse
 
         doc = Doc(
             docname=self._get_unique_name(


### PR DESCRIPTION
I realized our citation peeks could be multimodal, when we only use the texts in the ensuring LLM prompt.

Having the peek be multimodal was a mistake from https://github.com/Future-House/paper-qa/pull/1047