### PR TITLE
Fixing flaky Docling tests due to filesystem race conditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,6 +110,9 @@ jobs:
             ~/.cache/docling
           key: ${{ runner.os }}-docling-${{ hashFiles('uv.lock') }}
           restore-keys: ${{ runner.os }}-docling-
+      - name: Pre-download Docling's RapidOCR models # Avoid CI race conditions in filesystem on model download
+        if: steps.cache-models.outputs.cache-hit != 'true'
+        run: uv run docling-tools models download rapidocr
       - run: uv run pytest -n auto packages
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Seen in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/18576357500/job/52962361015?pr=1143):

```none
___________________________ test_parse_pdf_to_pages ____________________________
[gw0] linux -- Python 3.13.9 /home/runner/work/paper-qa/paper-qa/.venv/bin/python

    @pytest.mark.asyncio
    async def test_parse_pdf_to_pages() -> None:
        assert isinstance(parse_pdf_to_pages, PDFParserFn)
    
        filepath = STUB_DATA_DIR / "pasa.pdf"
>       parsed_text = parse_pdf_to_pages(filepath)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

packages/paper-qa-docling/tests/test_paperqa_docling.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
packages/paper-qa-docling/src/paperqa_docling/reader.py:77: in parse_pdf_to_pages
    result = converter.convert(path)
             ^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py:39: in wrapper_function
    return wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/pydantic/_internal/_validate_call.py:136: in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/document_converter.py:245: in convert
    return next(all_res)
           ^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/document_converter.py:268: in convert_all
    for conv_res in conv_res_iter:
                    ^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/document_converter.py:340: in _convert
    for item in map(
.venv/lib/python3.13/site-packages/docling/document_converter.py:387: in _process_document
    conv_res = self._execute_pipeline(in_doc, raises_on_error=raises_on_error)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/document_converter.py:408: in _execute_pipeline
    pipeline = self._get_pipeline(in_doc.format)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/document_converter.py:370: in _get_pipeline
    self.initialized_pipelines[cache_key] = pipeline_class(
.venv/lib/python3.13/site-packages/docling/pipeline/standard_pdf_pipeline.py:49: in __init__
    ocr_model = self.get_ocr_model(artifacts_path=self.artifacts_path)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/pipeline/standard_pdf_pipeline.py:119: in get_ocr_model
    return factory.create_instance(
.venv/lib/python3.13/site-packages/docling/models/factories/base_factory.py:57: in create_instance
    return _cls(options=options, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/docling/models/auto_ocr_model.py:103: in __init__
    self._engine = RapidOcrModel(
.venv/lib/python3.13/site-packages/docling/models/rapid_ocr_model.py:198: in __init__
    self.reader = RapidOCR(
.venv/lib/python3.13/site-packages/rapidocr/main.py:43: in __init__
    self._initialize(cfg)
.venv/lib/python3.13/site-packages/rapidocr/main.py:73: in _initialize
    self.text_rec = TextRecognizer(cfg.Rec)
                    ^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/rapidocr/ch_ppocr_rec/main.py:37: in __init__
    self.session = get_engine(cfg.engine_type)(cfg)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/rapidocr/inference_engine/torch.py:25: in __init__
    self.predictor = self._build_and_load_model(arch_config, model_path)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/rapidocr/inference_engine/torch.py:69: in _build_and_load_model
    state_dict = torch.load(model_path, map_location="cpu", weights_only=False)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.13/site-packages/torch/serialization.py:1554: in load
    return _legacy_load(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
...
            for key in deserialized_storage_keys:
                assert key in deserialized_objects
                typed_storage = deserialized_objects[key]
>               typed_storage._untyped_storage._set_from_file(
                    f,
                    offset,
                    f_should_read_directly,
                    torch._utils._element_size(typed_storage.dtype),
                )
E               RuntimeError: storage has wrong byte size: expected %ld got %ld08
```

This PR pre-downloads the RapidOCR model, so `pytest -n auto` doesn't hit race conditions in the filesystem upon download.