### PR TITLE
Removed unnecessary `fhlmi` pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [
-    "fhlmi>=0.28",  # For update_litellm_max_callbacks convenience
     "ipykernel>=6.29",  # For running Jupter notebooks, and pin to keep recent
     "ipython>=8",  # Pin to keep recent
     "litellm>=1.71",  # Lower pin for aiohttp transport adoption

--- a/uv.lock
+++ b/uv.lock
@@ -2382,7 +2382,6 @@ requires-dist = [
     { name = "anyio" },
     { name = "fhaviary", extras = ["llm"], specifier = ">=0.27" },
     { name = "fhlmi", specifier = ">=0.39" },
-    { name = "fhlmi", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "fhlmi", extras = ["image"], marker = "extra == 'image'" },
     { name = "html2text" },
     { name = "httpx" },


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/1137 missed removing this one after core deps surpassed `0.28`