### PR TITLE
Fixed `parse_media` vs `parse_images` kwarg mix up

### DIFF
--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -279,7 +279,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 path,
                 Doc(docname="", citation="", dockey=dockey),  # Fake doc
                 page_size_limit=parse_config.page_size_limit,
-                parse_images=False,  # Peeking is text only
+                parse_media=False,  # Peeking is text only
                 # We only use the first chunk, so let's peek just enough pages for that.
                 # Usually pages 1 - 2 give that,
                 # but in the event page 2 is blank (true for some PDFs),
@@ -386,8 +386,8 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                 doc, **(query_kwargs | kwargs)
             )
 
-        parse_images, enrich_media = parse_config.should_parse_and_enrich_media
-        multimodal_kwargs: dict[str, Any] = {"parse_images": parse_images}
+        parse_media, enrich_media = parse_config.should_parse_and_enrich_media
+        multimodal_kwargs: dict[str, Any] = {"parse_media": parse_media}
         if enrich_media:
             multimodal_kwargs["multimodal_enricher"] = (
                 all_settings.make_media_enricher()

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -529,10 +529,25 @@ async def test_docs_lifecycle(subtests: SubTests, stub_data_dir: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_evidence(docs_fixture: Docs) -> None:
+async def test_evidence(stub_data_dir: Path) -> None:
     debug_settings = Settings.from_name("debug")
+    debug_settings.parsing.multimodal = False
+
+    docs = Docs()
+    assert await docs.aadd(
+        stub_data_dir / "paper.pdf",
+        citation="Wellawatte et al, XAI Review, 2023",  # Skip citation inference
+        doi="10.1021/acs.jctc.2c01235",  # Skip DOI inference
+        title="A Perspective on Explanations of Molecular Prediction Models",  # Skip title inference
+        settings=debug_settings,
+    )
+    assert docs.texts, "Test expects texts to be added"
+    assert all(
+        not t.media for t in docs.texts
+    ), "Expected no media to be parsed with multimodal disabled"
+
     evidence = (
-        await docs_fixture.aget_evidence(
+        await docs.aget_evidence(
             PQASession(question="What does XAI stand for?"),
             settings=debug_settings,
         )
@@ -560,7 +575,7 @@ async def test_evidence(docs_fixture: Docs) -> None:
     with patch.object(litellm, "acompletion", acompletion_that_breaks_first_context):
         # Let's also check we can get other evidence using the same underlying sources
         other_evidence = (
-            await docs_fixture.aget_evidence(
+            await docs.aget_evidence(
                 PQASession(question="What is an acronym for explainable AI?"),
                 settings=debug_settings,
             )
@@ -3083,10 +3098,12 @@ def test_reader_params_deprecation_warnings(recwarn: pytest.WarningsRecorder) ->
 
 
 @pytest.mark.asyncio
-async def test_reader_config_propagation(stub_data_dir: Path) -> None:
+@pytest.mark.parametrize("multimodal", [False, True])
+async def test_reader_config_propagation(stub_data_dir: Path, multimodal: bool) -> None:
     settings = Settings(
         parsing=ParsingSettings(
-            reader_config={"chunk_chars": 2000, "overlap": 50, "dpi": 144}
+            reader_config={"chunk_chars": 2000, "overlap": 50, "dpi": 144},
+            multimodal=multimodal,
         )
     )
 
@@ -3107,4 +3124,5 @@ async def test_reader_config_propagation(stub_data_dir: Path) -> None:
     mock_read_doc.assert_awaited_once()
     assert mock_read_doc.call_args.kwargs["chunk_chars"] == 2000
     assert mock_read_doc.call_args.kwargs["overlap"] == 50
+    assert mock_read_doc.call_args.kwargs["parse_media"] == multimodal
     assert mock_read_doc.call_args.kwargs["dpi"] == 144


### PR DESCRIPTION
Since our readers have different parameters, we swallow extra keyword arguments to them.

https://github.com/Future-House/paper-qa/pull/1047 had a bug where, at some point I renamed `parsed_images` to `parse_media`, but didn't rename all usages. So the result was all reads were actually parsing images, even if `multimodal=False` in settings.

This PR fixes that mistake, with added test coverage.