### PR TITLE
Adding host def for openalex

### DIFF
--- a/src/paperqa/clients/openalex.py
+++ b/src/paperqa/clients/openalex.py
@@ -16,7 +16,8 @@ from paperqa.utils import BIBTEX_MAPPING, mutate_acute_accents, strings_similari
 from .client_models import DOIOrTitleBasedProvider, DOIQuery, TitleAuthorQuery
 from .exceptions import DOINotFoundError
 
-OPENALEX_BASE_URL = "https://api.openalex.org"
+OPENALEX_HOST = "api.openalex.org"
+OPENALEX_BASE_URL = f"https://{OPENALEX_HOST}"
 OPENALEX_API_REQUEST_TIMEOUT = float(
     os.environ.get("OPENALEX_API_REQUEST_TIMEOUT", "10.0")
 )  # seconds


### PR DESCRIPTION
see title

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts OPENALEX_HOST and constructs OPENALEX_BASE_URL from it in the OpenAlex client.
> 
> - **Clients/OpenAlex**:
>   - Define `OPENALEX_HOST` and derive `OPENALEX_BASE_URL` from it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068c79e3005b13b9ab9d8b7bec56d58302a171d0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->