### PR TITLE
Safe default for `Context.score`

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -227,8 +227,8 @@ class Context(BaseModel):
     context: Annotated[str, StringConstraints(strip_whitespace=True)] = Field(
         description=(
             "Summary of the text with respect to a question."
-            " Can be an empty string if a summary is not useful"
-            " (which should accompany a score of 0)."
+            " Can be an empty string if a summary is not useful/irrelevant"
+            " (which should be paired with a score of 0)."
         )
     )
     question: str | None = Field(


### PR DESCRIPTION
`Context.score` is used for sorting the contextual summaries, so it's really a relative metric (not an absolute one). However, when constructing a standalone `Context` (outside of `Docs.aget_evidence`), it puts one in a regime of thinking in absolute terms.

Secondly, if one forgets to specify the `score` it's defaulted to `5`, which may or may not be appropriate.

This PR updates the default `score` to `-1` so at least the default behavior is somewhat safe and requires less thought.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `Context.score` default to -1 (via `UNSET_RELEVANCE`) and document the 0–10 relevance scale.
> 
> - **Types (`src/paperqa/types.py`)**:
>   - **`Context`**:
>     - Introduce `UNSET_RELEVANCE = -1` constant.
>     - Change `score` to a `Field` with default `UNSET_RELEVANCE` (previously `5`) and add description clarifying 0–10 relevance scale and purpose of `-1` as sorting-safe default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f68f52a62487e878ee25fc9abc58eeaa326a8ef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->