### PR TITLE
Extending Docling `test_parse_pdf_to_pages` timeout from 5-min to 7-min

### DIFF
--- a/packages/paper-qa-docling/tests/test_paperqa_docling.py
+++ b/packages/paper-qa-docling/tests/test_paperqa_docling.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).parents[3]
 STUB_DATA_DIR = REPO_ROOT / "tests" / "stub_data"
 
 
+@pytest.mark.timeout(60 * 7)  # Extended from global 5-min timeout
 @pytest.mark.asyncio
 async def test_parse_pdf_to_pages() -> None:
     assert isinstance(parse_pdf_to_pages, PDFParserFn)


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/1192 added a global 5-min timeout for tests. As seen in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/19275829036/job/55115282511) for Docling's `test_parse_pdf_to_pages`:

```none
+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
```

Docling is a bit slower than other readers, so let's just let this test run for longer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the timeout for `test_parse_pdf_to_pages` to 7 minutes to avoid flakiness with slower Docling parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56eca214e274cf04ab5c1073700565b57a0cb6b0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->