### PR TITLE
Add `response_schema` parameter to `Docs`'s aquery response generation

### DIFF
--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -780,6 +780,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
         summary_llm_model: LLMModel | None = None,
         embedding_model: EmbeddingModel | None = None,
         partitioning_fn: Callable[[Embeddable], int] | None = None,
+        response_schema: BaseModel | None = None,
     ) -> PQASession:
         query_settings = get_settings(settings)
         answer_config = query_settings.answer
@@ -862,6 +863,7 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
                     messages=messages,
                     callbacks=callbacks,
                     name="answer",
+                    response_format=response_schema,
                 )
             answer_text = cast("str", answer_result.text)
             answer_reasoning = answer_result.reasoning_content


### PR DESCRIPTION
Corresponds to #700, #446



<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional `response_schema` to `Docs.aquery` and pass it to `llm_model.call_single` as `response_format` for answer generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de6751fff1e336bc7b22e2d5d137cb47d8376b56. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->