### PR TITLE
Removed `image_enrichment_pages` extra in `read_doc` overloads

### DIFF
--- a/src/paperqa/readers.py
+++ b/src/paperqa/readers.py
@@ -408,7 +408,6 @@ async def read_doc(
     include_metadata: Literal[True],
     chunk_chars: int = ...,
     overlap: int = ...,
-    image_enrichment_pages: int | bool = ...,
     multimodal_enricher: Callable[[ParsedText], Awaitable] | None = ...,
     parse_pdf: PDFParserFn | None = ...,
     **parser_kwargs,


### PR DESCRIPTION
This was missed during a refactor I did halfway through https://github.com/Future-House/paper-qa/pull/1143