### PR TITLE
Define Session.extra_info

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -357,6 +357,12 @@ class PQASession(BaseModel):
         ),
     )
 
+    extra_info: dict[str, JsonValue] = Field(
+        default_factory=dict,
+        description="A field for any extra user-defined information. "
+        "Can be used for things like metadata.",
+    )
+
     def __str__(self) -> str:
         """Return the answer as a string."""
         return self.formatted_answer
@@ -1050,7 +1056,6 @@ class DocDetails(Doc):
     @model_validator(mode="before")
     @classmethod
     def validate_all_fields(cls, data: Mapping[str, Any]) -> dict[str, Any]:
-
         data = deepcopy(data)  # Avoid mutating input
         data = dict(data)
         if "fields_to_overwrite_from_metadata" in data:
@@ -1113,7 +1118,6 @@ class DocDetails(Doc):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def formatted_citation(self) -> str:
-
         if self.is_retracted:
             base_message = "**RETRACTED ARTICLE**"
             retract_info = "Retrieved from http://retractiondatabase.org/."

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -3209,6 +3209,17 @@ def test_pqa_context_id_parsing(raw_text: str, cleaned_text: str) -> None:
     ), "Expecting no leading/trailing whitespace"
 
 
+def test_pqa_session_serialization() -> None:
+    """Test that PQASession can be deserialized with and without extra_info."""
+    extra_data = {"foo": "bar", "baz": [1, 2, 3]}
+    session = PQASession(question="test", extra_info=extra_data)
+
+    dump = session.model_dump()
+    assert PQASession.model_validate(dump).extra_info == extra_data
+    dump.pop("extra_info")
+    assert PQASession.model_validate(dump).extra_info == {}
+
+
 @pytest.mark.asyncio
 async def test_timeout_resilience() -> None:
     model_name = CommonLLMNames.ANTHROPIC_TEST.value
@@ -3584,7 +3595,7 @@ def test_context_comparison() -> None:
     ), "Different context text should make contexts unequal"
     assert hash(context_base) == hash(context_with_list_extras), (
         "Since we discard extras that aren't hashable,"
-        "these should receive the same hash"
+        " these should receive the same hash"
     )
     assert (
         context_with_extras != context_with_list_extras


### PR DESCRIPTION
I wanted the ability to add extra fields to PQASession

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a user-defined `extra_info` field to `PQASession` with serialization support and tests.
> 
> - **Core/Types**:
>   - Add `PQASession.extra_info: dict[str, JsonValue]` for arbitrary user metadata.
> - **Tests**:
>   - Add `test_pqa_session_serialization` to validate (de)serialization with and without `extra_info`.
> - **Misc**:
>   - Minor string fix in a test assertion message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a6ddcf1660a33028921629d31fa3875baedac57. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->