### PR TITLE
Serialization support for `ParsingSettings.parse_pdf`

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -3289,28 +3289,35 @@ def test_reader_params_deprecation_warnings(recwarn: pytest.WarningsRecorder) ->
 
 def test_parse_pdf_string_resolution() -> None:
     # Test with a valid string FQN
-    assert (
-        Settings(
-            parsing=ParsingSettings(parse_pdf="paperqa_pymupdf.parse_pdf_to_pages")
-        ).parsing.parse_pdf
-        == pymupdf_parse_pdf_to_pages
+    pymupdf_str = Settings(
+        parsing=ParsingSettings(parse_pdf="paperqa_pymupdf.parse_pdf_to_pages")
     )
+    assert pymupdf_str.parsing.parse_pdf == pymupdf_parse_pdf_to_pages
+    assert (
+        pymupdf_str.model_dump(mode="json")["parsing"]["parse_pdf"]
+        == "paperqa_pymupdf.reader.parse_pdf_to_pages"
+    )
+    assert "parse_pdf" not in pymupdf_str.model_dump()["parsing"]
 
     # Test another valid string FQN
-    assert (
-        Settings(
-            parsing=ParsingSettings(parse_pdf="paperqa_pypdf.parse_pdf_to_pages")
-        ).parsing.parse_pdf
-        == pypdf_parse_pdf_to_pages
+    pypdf_str = Settings(
+        parsing=ParsingSettings(parse_pdf="paperqa_pypdf.parse_pdf_to_pages")
     )
+    assert pypdf_str.parsing.parse_pdf == pypdf_parse_pdf_to_pages
+    assert (
+        pypdf_str.model_dump(mode="json")["parsing"]["parse_pdf"]
+        == "paperqa_pypdf.reader.parse_pdf_to_pages"
+    )
+    assert "parse_pdf" not in pypdf_str.model_dump()["parsing"]
 
     # Test directly passing a parser
+    pymupdf_fn = Settings(parsing=ParsingSettings(parse_pdf=pymupdf_parse_pdf_to_pages))
+    assert pymupdf_fn.parsing.parse_pdf == pymupdf_parse_pdf_to_pages
     assert (
-        Settings(
-            parsing=ParsingSettings(parse_pdf=pymupdf_parse_pdf_to_pages)
-        ).parsing.parse_pdf
-        == pymupdf_parse_pdf_to_pages
+        pymupdf_fn.model_dump(mode="json")["parsing"]["parse_pdf"]
+        == "paperqa_pymupdf.reader.parse_pdf_to_pages"
     )
+    assert "parse_pdf" not in pymupdf_fn.model_dump()["parsing"]
 
     # Test a nonexistent FQN
     with pytest.raises(ValueError, match="Failed to locate"):


### PR DESCRIPTION
This PR adds serialization support for the `parse_pdf` function using fully-qualified name