### PR TITLE
Compatibility with Nvidia DGX Cloud Lepton

### DIFF
--- a/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
+++ b/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
@@ -280,7 +280,9 @@ async def _call_nvidia_api(
         tool_choice=tool_spec,
         api_key=api_key,
         api_base=api_base,
-        base_url=api_base,  # Duplicate so LiteLLM can infer LLM provider
+        # Explicitly specify OpenAI-compatible provider over Nvidia NIM provider,
+        # so this works with both Nvidia API and DGX Cloud Lepton
+        custom_llm_provider=litellm.types.utils.LlmProviders.CUSTOM_OPENAI,
         **completion_kwargs,
     )
     if (


### PR DESCRIPTION
Now we can work with both Nvidia API and DGX Cloud Lepton

```python
from paperqa_nemotron import parse_pdf_to_pages

...

parsed_text = await parse_pdf_to_pages(
    path=REPO_ROOT_DIR / "tests/stub_data/pasa.pdf",
    api_params={"api_base": "https://abc123-nemotron-parse.xenon.lepton.run/v1"},
)
```