### PR TITLE
Ability to disable rate limiting for Nvidia API

### DIFF
--- a/packages/paper-qa-nemotron/pyproject.toml
+++ b/packages/paper-qa-nemotron/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
 ]
 sagemaker = ["aiobotocore"]
 typing = [
+    "limits",
     "numpy",
     "types-aiobotocore",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2896,6 +2896,7 @@ dev = [
     { name = "docling" },
     { name = "fhlmi" },
     { name = "httpx-aiohttp" },
+    { name = "limits" },
     { name = "numpy" },
     { name = "paper-qa" },
     { name = "pytest" },
@@ -2909,6 +2910,7 @@ sagemaker = [
     { name = "aiobotocore" },
 ]
 typing = [
+    { name = "limits" },
     { name = "numpy" },
     { name = "types-aiobotocore" },
 ]
@@ -2921,6 +2923,7 @@ requires-dist = [
     { name = "fhlmi", specifier = ">=0.27.0" },
     { name = "fhlmi", marker = "extra == 'dev'", specifier = ">=0.39" },
     { name = "httpx-aiohttp", marker = "extra == 'dev'" },
+    { name = "limits", marker = "extra == 'typing'" },
     { name = "litellm", specifier = ">=1.71.0" },
     { name = "numpy", marker = "extra == 'typing'" },
     { name = "paper-qa", editable = "." },


### PR DESCRIPTION
When using Nvidia DGX Cloud Lepton (added in https://github.com/Future-House/paper-qa/pull/1218), we don't need 40 RPM limit