### PR TITLE
Allowing Pydantic extras in `Text`

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -172,9 +172,14 @@ class Text(Embeddable):
             and self.text == other.text
             and self.media == other.media
             and self.doc == other.doc
+            and self.__pydantic_extra__ == other.__pydantic_extra__
         )
 
     def __hash__(self) -> int:
+        if self.__pydantic_extra__:
+            raise NotImplementedError(
+                f"Hashing a {type(self).__name__} with extras is not yet supported."
+            )
         return hash((self.name, self.text, tuple(self.media)))
 
     async def get_embeddable_text(self, with_enrichment: bool = False) -> str:

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -3440,6 +3440,29 @@ def test_text_comparison() -> None:
     assert hash(text_with_media1) != hash(text_no_media1)
     assert len({text_with_media1, text_with_media2, text_diff_media}) == 2
 
+    # Test with Pydantic extras
+    text_with_extra1 = Text(text="Hello", name="chunk1", doc=doc, custom_field="value1")
+    assert (
+        text_with_extra1 != text_no_media1
+    ), "Presence of an extra should not be equal"
+    text_with_extra2 = Text(text="Hello", name="chunk1", doc=doc, custom_field="value1")
+    assert text_with_extra1 == text_with_extra2
+    text_with_extra_diff = Text(
+        text="Hello", name="chunk1", doc=doc, custom_field="value2"
+    )
+    assert (
+        text_with_extra1 != text_with_extra_diff
+    ), "Different extra values should not be equal"
+    text_with_extra_other = Text(
+        text="Hello", name="chunk1", doc=doc, other_custom_field="value1"
+    )
+    assert (
+        text_with_extra1 != text_with_extra_other
+    ), "Different extra keys should not be equal"
+
+    with pytest.raises(NotImplementedError, match="extras"):
+        hash(text_with_extra1)
+
 
 def test_context_comparison() -> None:
     text1 = Text(


### PR DESCRIPTION
This enables client code to add chunk-specific metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable extra fields on `Text` so clients can attach chunk-specific metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07f3d3f65f9942b447152e29d91163ab96ab370a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->