### PR TITLE
Fixed bug in PyPDF reader where one can't avoid `pdfplumber`

### DIFF
--- a/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
+++ b/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
@@ -2,7 +2,7 @@ import io
 import json
 import os
 from contextlib import AbstractContextManager, closing, nullcontext
-from enum import StrEnum
+from enum import StrEnum, unique
 from typing import TYPE_CHECKING, Any, cast
 
 import pypdf
@@ -26,17 +26,23 @@ if TYPE_CHECKING:
     from PIL import Image
 
 
+@unique
 class MediaMode(StrEnum):
-    """
-    Mode for media extraction from PDFs.
-
-    Enum values are used in metadata.
-    """
+    """Mode for media extraction from PDFs."""
 
     NONE = ""  # No media extraction
     FULL_PAGE = "full-page"  # Screenshot entire page
-    INDIVIDUAL_CLUSTERING = "individual"  # Extract individual images then cluster
+    INDIVIDUAL_CLUSTERING = (  # Extract individual images then cluster
+        "individual-clustering"
+    )
     INDIVIDUAL = "individual"  # Extract individual images
+
+    def __str__(self) -> str:
+        return self.metadata_value
+
+    @property
+    def metadata_value(self) -> str:
+        return self.value.removesuffix("-clustering")
 
 
 # Attributes of pdfium.PdfBitmap that contain useful metadata
@@ -339,7 +345,7 @@ def parse_pdf_to_pages(  # noqa: PLR0912
                 f"pdfplumber ({pdfplumber.__version__})",
             ]
         )
-    multimodal_string = f"|multimodal|dpi={dpi}|mode={media_mode.value}"
+    multimodal_string = f"|multimodal|dpi={dpi}|mode={media_mode.metadata_value}"
     metadata = ParsedMetadata(
         parsing_libraries=[", ".join(lib_parts)],
         total_parsed_text_length=total_length,

--- a/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
+++ b/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
@@ -12,6 +12,7 @@ from paperqa.readers import PDFParserFn, chunk_pdf
 from paperqa.utils import ImpossibleParsingError, get_citation_ids
 
 from paperqa_pypdf import parse_pdf_to_pages
+from paperqa_pypdf.reader import MediaMode
 
 REPO_ROOT = Path(__file__).parents[3]
 STUB_DATA_DIR = REPO_ROOT / "tests" / "stub_data"
@@ -313,3 +314,33 @@ def test_clustering() -> None:
     assert len(p2_small_cluster[1]) >= len(
         p2_default_cluster[1]
     ), "Small tolerance should cluster less aggressively"
+
+
+class TestMediaMode:
+
+    def test_same_member_is_equal(self) -> None:
+        assert MediaMode.INDIVIDUAL == MediaMode.INDIVIDUAL
+        assert MediaMode.INDIVIDUAL_CLUSTERING == MediaMode.INDIVIDUAL_CLUSTERING
+        assert MediaMode.FULL_PAGE == MediaMode.FULL_PAGE
+        assert MediaMode.NONE == MediaMode.NONE
+
+    def test_individual_with_and_without_clustering(self) -> None:
+        assert MediaMode.INDIVIDUAL is not MediaMode.INDIVIDUAL_CLUSTERING
+        assert MediaMode.INDIVIDUAL != MediaMode.INDIVIDUAL_CLUSTERING
+        assert MediaMode.INDIVIDUAL_CLUSTERING != MediaMode.INDIVIDUAL
+
+        assert (
+            MediaMode.INDIVIDUAL.metadata_value
+            == MediaMode.INDIVIDUAL_CLUSTERING.metadata_value
+            == "individual"
+        )
+        assert (
+            str(MediaMode.INDIVIDUAL)  # noqa: FURB123
+            == str(MediaMode.INDIVIDUAL_CLUSTERING)  # noqa: FURB123
+            == "individual"
+        )
+
+    def test_different_members_different_values_are_not_equal(self) -> None:
+        assert MediaMode.NONE != MediaMode.FULL_PAGE
+        assert MediaMode.FULL_PAGE != MediaMode.INDIVIDUAL
+        assert MediaMode.NONE != MediaMode.INDIVIDUAL_CLUSTERING


### PR DESCRIPTION
In https://github.com/Future-House/paper-qa/pull/1241 I didn't realize `StrEnum` comparisons use `value`, which breaks our ability to use `paper-qa-pypdf` with `pypdfium2` but without `pdfplumber` installed.