### PR TITLE
Disabling parallel CI jobs' fast fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,7 @@ jobs:
   test-src:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.11, 3.13] # Our min and max supported Python versions
     steps:
@@ -116,6 +117,7 @@ jobs:
   test-packages:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.12, 3.13] # Our min and max supported Python versions, skipping 3.11 to avoid https://github.com/BerriAI/litellm/issues/16518
     steps:


### PR DESCRIPTION
This was holding me back from diagnosing test flakes from real failures