### PR TITLE
Unsilenced flaky `test_duplicate_media_context_creation`

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -2117,7 +2117,7 @@ async def test_images(stub_data_dir: Path) -> None:
             for district in ("The Avenues", "Golden Gate", "Civic Center", "Haight")
         )
         >= 2
-    ), "Expected at least two neighbors to be matched"
+    ), f"Expected at least two neighbors to be matched in answer {session.answer!r}"
     assert session.cost > 0
     contexts_used = [
         c


### PR DESCRIPTION
Seen in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/20435193491/job/58714699613):

```none
>       assert (
            sum(
                district in session.answer
                for district in ("The Avenues", "Golden Gate", "Civic Center", "Haight")
            )
            >= 2
        ), "Expected at least two neighbors to be matched"
E       AssertionError: Expected at least two neighbors to be matched
E       assert 1 >= 2
E        +  where 1 = sum(<generator object test_duplicate_media_context_creation.<locals>.<genexpr> at 0x7f3da08f9560>)
```

This PR expands the assertion message so this can be debugged