### PR TITLE
Fixing crash from bad PDF read with PyMuPDF

### DIFF
--- a/packages/paper-qa-pymupdf/src/paperqa_pymupdf/reader.py
+++ b/packages/paper-qa-pymupdf/src/paperqa_pymupdf/reader.py
@@ -41,8 +41,14 @@ PYMUPDF_PIXMAP_ATTRS = {
 # This garbage led to `asyncpg==0.30.0` with a PostgreSQL 15 DB throwing:
 # > asyncpg.exceptions.CharacterNotInRepertoireError:
 # > invalid byte sequence for encoding "UTF8": 0x00
+# On 12/30/2025 with pymupdf==1.26.7, a `pymupdf.table.Table.to_markdown` call on
+# https://arxiv.org/pdf/1711.07566's page 3's Figure 2a's mesh and pixels example
+# outputs an orphaned low surrogate (U+DC3C), which is interpreted as an
+# incomplete UTF-16 surrogate pair downstream and causes:
+# > UnicodeEncodeError: 'utf-8' codec can't encode character '\udc3c'
+# > in position 46888: surrogates not allowed
 # Thus, this regex exists to deny table markdown exports containing invalid chars
-_INVALID_MD_CHARS = re.compile(r"\x00")
+_INVALID_MD_CHARS = re.compile(r"[\x00\uD800-\uDFFF]")
 
 
 def parse_pdf_to_pages(  # noqa: PLR0912


### PR DESCRIPTION
`pymupdf==1.26.7` is misinterpreting this Figure 2a from https://arxiv.org/pdf/1711.07566 as a table, and then `pymupdf.table.Table.to_markdown` is exporting malformed text (orphaned surrogate):

<img width="126" height="153" alt="media with bad table export" src="https://github.com/user-attachments/assets/9f5b195d-ed14-4afa-b8c3-9882d182706a" />

This later crashes `gather_evidence` (with `httpx==0.28.1`, `litellm==1.76.1`, and `openai==2.13.0`) when the table's Markdown is put into the LLM prompt:

```none
Traceback (most recent call last):
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 812, in acompletion
    headers, response = await self.make_openai_chat_completion_request(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/logging_utils.py", line 190, in async_wrapper
    result = await func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 447, in make_openai_chat_completion_request
    raise e
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 429, in make_openai_chat_completion_request
    await openai_aclient.chat.completions.with_raw_response.create(
        **data, timeout=timeout
    )
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/openai/_legacy_response.py", line 381, in wrapped
    return cast(LegacyAPIResponse[R], await func(*args, **kwargs))
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 2678, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
    ...<49 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1797, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1518, in request
    request = self._build_request(options, retries_taken=retries_taken)
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 547, in _build_request
    return self._client.build_request(  # pyright: ignore[reportUnknownMemberType]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        headers=headers,
        ^^^^^^^^^^^^^^^^
    ...<8 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/httpx/_client.py", line 378, in build_request
    return Request(
        method,
    ...<8 lines>...
        extensions=extensions,
    )
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/httpx/_models.py", line 408, in __init__
    headers, stream = encode_request(
                      ~~~~~~~~~~~~~~^
        content=content,
        ^^^^^^^^^^^^^^^^
    ...<7 lines>...
        ),
        ^^
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/httpx/_content.py", line 216, in encode_request
    return encode_json(json)
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/httpx/_content.py", line 179, in encode_json
    ).encode("utf-8")
      ~~~~~~^^^^^^^^^
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc3c' in position 46888: surrogates not allowed
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/main.py", line 546, in acompletion
    response = await init_response
               ^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/llms/openai/openai.py", line 859, in acompletion
    raise OpenAIError(
    ...<4 lines>...
    )
litellm.llms.openai.common_utils.OpenAIError: 'utf-8' codec can't encode character '\udc3c' in position 46888: surrogates not allowed
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/IPython/core/interactiveshell.py", line 3701, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ipython-input-4-86127841ee37>", line 1, in <module>
    raise __exception__[1]
  File "/Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pydev/pydevd.py", line 1647, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Applications/PyCharm.app/Contents/plugins/python-ce/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/a.py", line 97, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "/path/to/.pyenv/versions/3.13.5/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/path/to/.pyenv/versions/3.13.5/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/path/to/.pyenv/versions/3.13.5/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/path/to/paper-qa/a.py", line 84, in main
    session = await docs.aget_evidence("What kind of lighting was applied to the mesh?")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/src/paperqa/docs.py", line 552, in aget_evidence
    results = await gather_with_concurrency(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<18 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/utils.py", line 99, in gather_with_concurrency
    return await asyncio.gather(*(sem_coro(c) for c in coros))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/utils.py", line 86, in sem_coro
    return await coro
           ^^^^^^^^^^
  File "/path/to/paper-qa/src/paperqa/core.py", line 389, in map_fxn_summary
    return await _map_fxn_summary(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/src/paperqa/core.py", line 254, in _map_fxn_summary
    llm_result = await summary_llm_model.call_single(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<14 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/llms.py", line 488, in call_single
    results = await self.call(
              ^^^^^^^^^^^^^^^^
    ...<8 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/llms.py", line 435, in call
    results = await self.acompletion(messages, **chat_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/llms.py", line 600, in wrapper
    return await func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/llms.py", line 555, in wrapper
    result = await func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/llms.py", line 948, in acompletion
    completions = await track_costs(router.acompletion)(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.name, prompts, **kwargs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/lmi/cost_tracker.py", line 105, in wrapped_func
    response = await func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 1076, in acompletion
    raise e
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 1052, in acompletion
    response = await self.async_function_with_fallbacks(**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 3895, in async_function_with_fallbacks
    return await self.async_function_with_fallbacks_common_utils(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<8 lines>...
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 3853, in async_function_with_fallbacks_common_utils
    raise original_exception
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 3887, in async_function_with_fallbacks
    response = await self.async_function_with_retries(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 4092, in async_function_with_retries
    raise original_exception
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 3983, in async_function_with_retries
    response = await self.make_call(original_function, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 4101, in make_call
    response = await response
               ^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 1357, in _acompletion
    raise e
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/router.py", line 1309, in _acompletion
    response = await _response
               ^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/utils.py", line 1598, in wrapper_async
    raise e
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/utils.py", line 1449, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/main.py", line 565, in acompletion
    raise exception_type(
          ~~~~~~~~~~~~~~^
        model=model,
        ^^^^^^^^^^^^
    ...<3 lines>...
        extra_kwargs=kwargs,
        ^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 2301, in exception_type
    raise e
  File "/path/to/paper-qa/.venv/lib/python3.13/site-packages/litellm/litellm_core_utils/exception_mapping_utils.py", line 501, in exception_type
    raise InternalServerError(
    ...<5 lines>...
    )
litellm.exceptions.InternalServerError: litellm.InternalServerError: InternalServerError: OpenAIException - 'utf-8' codec can't encode character '\udc3c' in position 46888: surrogates not allowed. Received Model Group=gpt-4o-2024-11-20
Available Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 3
```

This PR cleans the markdown exports in this case, with a unit test and good documentation.

Relates to https://github.com/Future-House/paper-qa/issues/1258