### PR TITLE
More `nemotron-parse` links in `README.md`

### DIFF
--- a/packages/paper-qa-nemotron/README.md
+++ b/packages/paper-qa-nemotron/README.md
@@ -17,7 +17,9 @@ For more info on nemotron-parse, check out:
 - Technical blog:
   <https://developer.nvidia.com/blog/turn-complex-documents-into-usable-data-with-vlm-nvidia-nemotron-parse-1-1/>
 - Hugging Face weights: <https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1>
-- Model card: <https://build.nvidia.com/nvidia/nemotron-parse/modelcard>
+- NIM and model card: <https://build.nvidia.com/nvidia/nemotron-parse>
+  - Support matrix:
+    <https://docs.nvidia.com/nim/vision-language-models/1.5.0/support-matrix.html#nemotron-parse>
 - API docs:
   <https://docs.nvidia.com/nim/vision-language-models/1.5.0/examples/nemotron-parse/overview.html#nemotron-parse-overview>
 - Cookbook:


### PR DESCRIPTION
This lookup is handy for vibe coding 😈 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `packages/paper-qa-nemotron/README.md` with more nemotron-parse resources and minor formatting tweaks.
> 
> - Adds links for `NIM and model card`, `Support matrix`, and `NGC catalog`; retains technical blog, HF weights, API docs, cookbook, and AWS Marketplace
> - Updates inline `pyml disable-num-lines` directive from 9 to 11 for line-length handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4c4dddb6b6109cc026932046c59a9c21bad957c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->