### PR TITLE
Validating `ParsedMedia.data` is not empty

### DIFF
--- a/src/paperqa/types.py
+++ b/src/paperqa/types.py
@@ -574,7 +574,9 @@ class ParsedMedia(BaseModel):
         bytes,
         PlainSerializer(bytes_to_string),
         BeforeValidator(lambda x: x if isinstance(x, bytes) else string_to_bytes(x)),
-    ] = Field(description="Raw image, ideally directly savable to a PNG image.")
+    ] = Field(
+        min_length=1, description="Raw image, ideally directly savable to a PNG image."
+    )
     text: str | None = Field(
         default=None,
         description=(

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -1663,6 +1663,11 @@ def test_media_to_image_url(subtests: SubTests) -> None:
         assert "image/png" in url
 
 
+def test_parsed_media_empty_data_raises() -> None:
+    with pytest.raises(ValidationError, match="at least 1 byte"):
+        ParsedMedia(index=0, data=b"")
+
+
 @pytest.mark.asyncio
 async def test_image_aggregation(stub_data_dir: Path) -> None:
     png_path = stub_data_dir / "sf_districts.png"


### PR DESCRIPTION
Enabling client code to avoid `if media.data` checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens media validation to prevent empty image payloads.
> 
> - Update `ParsedMedia.data` in `types.py` to require `min_length=1` (non-empty bytes)
> - Add `test_parsed_media_empty_data_raises` asserting `ValidationError` for empty `data`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574adea73e91d1437e373911e37733df0b0c2ced. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->