### PR TITLE
Upsizing PDF pages to match `nemotron-parse` training data

### DIFF
--- a/packages/paper-qa-nemotron/tests/test_paperqa_nemotron.py
+++ b/packages/paper-qa-nemotron/tests/test_paperqa_nemotron.py
@@ -56,7 +56,7 @@ async def test_parse_pdf_to_pages(api_params_base: dict[str, Any]) -> None:
     # between Abstract and Introduction
     matches = re.findall(
         r"(?:###? 1 Introduction[\n]+)?We introduce Pa ?S[as],"
-        r" an advanced Paper Search agent powered by large language models\.",
+        r" an advanced (?:\*\*)?Paper Search(?:\*\*)? agent powered by large language models\.",
         p1_text,
     )
     assert len(matches) == 1, f"Parsing failed to handle abstract in {p1_text}."


### PR DESCRIPTION
On [DOI 10.1016/j.neuron.2011.12.023](https://pubmed.ncbi.nlm.nih.gov/22365549/) "Encoding of luminance and contrast by linear and nonlinear synapses in the retina"

Without this PR at temperature of 0, we fail to resolve a valid bounding box (e.g. we hit a negative xmin below on page 11) and get blown up with:

```none
paperqa_nemotron.api.NemotronBBoxError: nemotron-parse response [[{"bbox": {"xmin": -0.0008105461393596986, "ymin": 0.0484, "xmax": 0.8993305712492153, "ymax": 0.0953}, "text": "**Neuron** # Encoding Luminance and Contrast in Retina Synapses", "type": "Page-header"}, {"bbox": {"xmin": 0.1164012554927809, "ymin": 0.8758, "xmax": 0.49627922159447585, "ymax": 0.9187}, "text": "was measured at contrasts varying between 10% and 100% (5 Hz square wave; Figure S6A). Each stimulus was applied from a steady background, which was varied over 4 log units,", "type": "Text"}, ... ]] has invalid bounding box.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):

...

tenacity.RetryError: RetryError[<Future at 0x1469df950 state=finished raised NemotronBBoxError>]
```

This PR moves the `nemotron-parse` driver to resize the image to 2048-px height x 1648-px width, matching `nemotron-parse`'s training regime. After this PR, we can successfully read in the PDF.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns input preprocessing with Nemotron-Parse training and corrects bbox -> original image coordinate mapping.
> 
> - Add `NEMOTRON_PARSE_TARGET_WIDTH/HEIGHT` and `fit_image_to_target_aspect_ratio()` to scale/center pages onto a minimal canvas with the model’s aspect ratio
> - `parse_pdf_to_pages`: new `optimize_aspect_ratio` flag (default True); apply aspect-ratio fit before border padding for both bbox and no-bbox flows
> - Fix bbox back-projection by subtracting aspect/border offsets and dividing by scale in both detection fallback and media extraction
> - Extend tests: import new constants/util, and add thorough tests for `fit_image_to_target_aspect_ratio()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebfbd69a1d7454c96f3f243b32a080dcb04922d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->