### PR TITLE
Fixing 60-sec wait for retrying `nemotron-parse` API calls' 408 timeouts

### DIFF
--- a/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
+++ b/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
@@ -364,12 +364,14 @@ async def _call_nvidia_api(
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 @retry(
-    retry=(
-        retry_if_exception_type(TimeoutError)  # Hitting rate limits
-        | retry_if_exception(_is_litellm_timeout_with_408)  # Inference timeout
-    ),
+    retry=retry_if_exception_type(TimeoutError),  # Hitting rate limits
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=2, min=GLOBAL_RATE_LIMITER_TIMEOUT),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+)
+@retry(
+    retry=retry_if_exception(_is_litellm_timeout_with_408),  # Inference timeout
+    stop=stop_after_attempt(3),
     before_sleep=before_sleep_log(logger, logging.WARNING),
 )
 async def _call_nvidia_api(


### PR DESCRIPTION
https://github.com/Future-House/paper-qa/pull/1276 incorrectly grouped the timeout errors, leading to an unnecessary 60-sec retry wait in the 408 timeout error case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `_call_nvidia_api` retry strategy to avoid unnecessary backoff on inference timeouts.
> 
> - Separates 408 (LiteLLM `Timeout` with status 408) into its own `@retry` without exponential wait
> - Keeps exponential backoff only for rate-limit `TimeoutError` and preserves retries for `NemotronBBoxError`
> 
> This prevents the previous ~60s wait when retrying 408 errors while maintaining proper backoff for rate limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8218ef918bc5d7ff1467867296ec0456a5ba3951. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->