### PR TITLE
Logging tool name in `NemotronBBoxError`/`NemotronLengthError`

### DIFF
--- a/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
+++ b/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
@@ -438,7 +438,7 @@ async def _call_nvidia_api(
         )
     if response.choices[0].finish_reason == "length":
         raise NemotronLengthError(
-            f"Model response {response} indicates the input"
+            f"Model response {response} from tool {tool_name!r} indicates the input"
             f" image of shape {image.shape} is too large or the model started babbling.",
             response.choices[0],  # Include if callers want
         )
@@ -463,7 +463,8 @@ async def _call_nvidia_api(
             assert_never(tool_name)
     except ValidationError as exc:
         raise NemotronBBoxError(
-            f"nemotron-parse response {args_json} has invalid bounding box."
+            f"nemotron-parse response {args_json} from tool {tool_name!r}"
+            " has invalid bounding box."
         ) from exc
     return response
 
@@ -576,7 +577,7 @@ async def _call_sagemaker_api(
         )
     if response.choices[0].finish_reason == "length":
         raise NemotronLengthError(
-            f"Model response {response} indicates the input"
+            f"Model response {response} from tool {tool_name!r} indicates the input"
             f" image of shape {image.shape} is too large or the model started babbling.",
             response.choices[0],  # Include if callers want
         )
@@ -601,6 +602,7 @@ async def _call_sagemaker_api(
             assert_never(tool_name)
     except ValidationError as exc:
         raise NemotronBBoxError(
-            f"nemotron-parse response {args_json} has invalid bounding box."
+            f"nemotron-parse response {args_json} from tool {tool_name!r}"
+            " has invalid bounding box."
         ) from exc
     return response


### PR DESCRIPTION
Just for traceability/debugging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts exception message strings to add context; no functional changes to request/response handling or retry logic.
> 
> **Overview**
> Improves error traceability in `paperqa_nemotron/api.py` by including the originating `tool_name` in exception messages for `NemotronLengthError` (when the model returns `finish_reason == "length"`) and `NemotronBBoxError` (when tool-call arguments fail Pydantic validation).
> 
> This is applied consistently across both the Nvidia API and SageMaker execution paths, without changing control flow or parsing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc41046d5a9764775745f8543bde9f8dc5b718a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->