### PR TITLE
Pulled in `UV_VENV_CLEAR` for `uv==0.10.0` break

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      UV_VENV_CLEAR: 1 # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
     steps:
       - uses: actions/checkout@v6
       - id: build-paper-qa-pymupdf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
         if: always()
   lint:
     runs-on: ubuntu-latest
+    env:
+      UV_VENV_CLEAR: 1 # Work around https://github.com/hynek/build-and-inspect-python-package/issues/174
     strategy:
       matrix:
         python-version: [3.11] # Our min supported Python version


### PR DESCRIPTION
Sister PR to https://github.com/Future-House/aviary/pull/338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only environment-variable change; the main risk is unexpected build/lint behavior changes in GitHub Actions runs.
> 
> **Overview**
> Adds `UV_VENV_CLEAR=1` to the GitHub Actions environment for the `Publish` workflow’s `publish` job and the `Lint and Test` workflow’s `lint` job, as a workaround for a `hynek/build-and-inspect-python-package`/`uv` venv clearing issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a95c17c327c2735a9e32d5674637a76dc461c7d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->