### PR TITLE
Fixing `test_parse_office_doc` by modernizing Gemini model

### DIFF
--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -3402,7 +3402,7 @@ async def test_parse_office_doc(stub_data_dir: Path, filename: str, query: str) 
 
     settings = Settings(
         llm="gemini/gemini-2.5-flash",
-        embedding="gemini/text-embedding-004",
+        embedding="gemini/gemini-embedding-001",
         summary_llm="gemini/gemini-2.5-flash",
         agent={"agent_llm": "gemini/gemini-2.5-flash"},
         parsing=ParsingSettings(use_doc_details=False),


### PR DESCRIPTION
From https://developers.googleblog.com/gemini-embedding-available-gemini-api/:

> Legacy models will also be deprecated in the coming months:
> - ...
> - _text-embedding-004_ on January 14, 2026

This PR just modernizes the model for `test_parse_office_doc` to the latest `gemini/gemini-embedding-001`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that updates a model identifier; main risk is CI flakiness if the new embedding model behaves differently or has different availability/quotas.
> 
> **Overview**
> Updates `test_parse_office_doc` to use `gemini/gemini-embedding-001` instead of the deprecated `gemini/text-embedding-004` embedding model, keeping the rest of the Gemini LLM configuration unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8c79691c7574e12ae52bcfc456753f0c1d7c56b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->