### PR TITLE
Fixing Semantic Scholar crash on `max` over empty list

### DIFF
--- a/src/paperqa/clients/semantic_scholar.py
+++ b/src/paperqa/clients/semantic_scholar.py
@@ -265,9 +265,13 @@ async def s2_title_search(
             (strings_similarity(entry["title"], title), entry)
             for entry in data.get("data", data)
         )
+    except ValueError as exc:
+        # ValueError: S2 may return {"data": []} causing max() on an empty iterable to
+        # throw a ValueError
+        raise DOINotFoundError(f"No results found for title {title}.") from exc
     except (KeyError, IndexError) as exc:
         raise DOINotFoundError(
-            f"Unexpected Semantic Scholar search/match endpoint shape for {title}"
+            f"Unexpected Semantic Scholar search/match endpoint shape for title {title}"
             f" given data {data}."
         ) from exc
 

--- a/tests/cassettes/test_s2_title_search_empty_data.yaml
+++ b/tests/cassettes/test_s2_title_search_empty_data.yaml
@@ -1,0 +1,32 @@
+interactions:
+  - request:
+      body: ""
+      headers:
+        accept:
+          - "*/*"
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        host:
+          - api.semanticscholar.org
+        user-agent:
+          - python-httpx/0.28.1
+      method: GET
+      uri: https://api.semanticscholar.org/graph/v1/paper/search/match?query=empty+results+edge+case+query&fields=authors%2CcitationCount%2CcitationStyles%2CexternalIds%2CinfluentialCitationCount%2CisOpenAccess%2Cjournal%2CopenAccessPdf%2CpublicationDate%2CpublicationTypes%2Ctitle%2Curl%2Cvenue%2Cyear
+    response:
+      body:
+        string: '{"data": []}'
+      headers:
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "12"
+        Content-Type:
+          - application/json
+      status:
+        code: 200
+        message: OK
+version: 1


### PR DESCRIPTION
There's an edge case with Semantic Scholar seen in our production logs:

```none
request failed for query 'approximately 30% rheumatoid arthritis inadequate response to biologic DMARDs systematic review'

Traceback (most recent call last):
  ...
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/paperqa/clients/client_models.py", line 114, in query
    return await self._query(client_query)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/paperqa/clients/semantic_scholar.py", line 373, in _query
    return await get_s2_doc_details_from_title(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/paperqa/clients/semantic_scholar.py", line 358, in get_s2_doc_details_from_title
    return await s2_title_search(
           ^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/layers/google.python.pip/pip/lib/python3.13/site-packages/paperqa/clients/semantic_scholar.py", line 263, in s2_title_search
    title_similarity, result = max(
                               ~~~^
        # need to check if nested under a 'data' key or not (depends on filtering)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        (strings_similarity(entry["title"], title), entry)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        for entry in data.get("data", data)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
ValueError: max() iterable argument is empty
```

The issue is `max` over an empty `data` will throw a `ValueError`