### PR TITLE
Fixed PyPDF reader's failure to handle non-PNG data without `pdfplumber`

### DIFF
--- a/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
+++ b/packages/paper-qa-pypdf/src/paperqa_pypdf/reader.py
@@ -321,7 +321,7 @@ def parse_pdf_to_pages(  # noqa: PLR0912
                     for img_idx, img_obj in enumerate(page.images):
                         pil_image = cast("Image.Image", img_obj.image)
                         width, height = pil_image.size
-                        if img_obj.name.lower().endswith(".png"):
+                        if pil_image.format == "PNG":
                             # LLM providers accept PNG, so leave the image data as-is
                             data: bytes = img_obj.data
                         else:

--- a/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
+++ b/packages/paper-qa-pypdf/tests/test_paperqa_pypdf.py
@@ -340,17 +340,20 @@ def test_clustering() -> None:
 
 
 @pytest.mark.parametrize(
-    ("name", "fmt"),
+    "img_format",
     [
-        pytest.param("Im0.bmp", "BMP", id="non_png_re_encodes"),
-        pytest.param("Im0.png", "PNG", id="png_passthrough"),
+        pytest.param("BMP", id="non_png_re_encodes"),
+        pytest.param("PNG", id="png_passthrough"),
     ],
 )
-def test_individual_mode_outputs_png(name: str, fmt: str) -> None:
-    pil_image = Image.new("RGB", (4, 4), "red")
+def test_individual_mode_outputs_png(img_format: str) -> None:
+    # Form an image in the input format
     raw_buf = io.BytesIO()
-    pil_image.save(raw_buf, format=fmt)
-    mock_img_obj = SimpleNamespace(name=name, image=pil_image, data=raw_buf.getvalue())
+    Image.new("RGB", (4, 4), "red").save(raw_buf, format=img_format)
+    raw_bytes = raw_buf.getvalue()
+    mock_img_obj = SimpleNamespace(
+        image=Image.open(io.BytesIO(raw_bytes)), data=raw_bytes
+    )
 
     with (
         patch("paperqa_pypdf.reader.pdfplumber", None),


### PR DESCRIPTION
Closes https://github.com/Future-House/paper-qa/issues/1273