### PR TITLE
Caching `npm` deps in lint CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.npm
-          key: renovate-npm-${{ runner.os }}
+          key: renovate-npm-${{ runner.os }}-${{ hashFiles('.github/workflows/tests.yaml') }}
       - uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.0.0
   test-src:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`lint` workflow got killed in [this CI run](https://github.com/Future-House/paper-qa/actions/runs/22410611522/job/64882754551) by 403s:

```none
Run suzuki-shunsuke/github-action-renovate-config-validator@v2.0.0
Run actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f
Found in cache @ /opt/hostedtoolcache/node/24.13.0/x64
(node:4098) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Environment details
Run set -eu
npm error code E403
npm error 403 403 Forbidden - GET https://registry.npmjs.org/to-regex-range
npm error 403 In most cases, you or one of your dependencies are requesting
npm error 403 a package version that is forbidden by your security policy, or
npm error 403 on a server you do not have access to.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-02-25T18_45_05_471Z-debug-0.log
```

Let's add `npm` caching to speed this up and increase reliability