### PR TITLE
Upstreamed `npm` deps caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
       - run: uv sync
       - run: uv run pylint src packages
       - run: uv run refurb .
-      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.0.0
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.1.0
   test-src:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
https://github.com/suzuki-shunsuke/github-action-renovate-config-validator/releases/tag/v2.1.0 has built-in `npm` caching, let's use it.