### PR TITLE
Add NemotronParseBBox.to_original_coordinates for raw nemotron-parse output

### DIFF
--- a/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
+++ b/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
@@ -91,6 +91,69 @@ NemotronParseToolName: TypeAlias = Literal[
     "markdown_bbox", "markdown_no_bbox", "detection_only"
 ]
 
+# nemotron-parse resizes each input image (preserving aspect ratio) to fit within this
+# fixed height x width canvas, then center-pads the remainder with white, and emits
+# bounding boxes normalized to that padded canvas. These are the model's native input
+# dimensions; see "size" / "final_size" in:
+# https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/main/preprocessor_config.json
+NEMOTRON_PARSE_TARGET_HEIGHT = 2048  # px
+NEMOTRON_PARSE_TARGET_WIDTH = 1648  # px
+
+
+def transform_canvas_bbox_to_original(
+    xmin: float,
+    ymin: float,
+    xmax: float,
+    ymax: float,
+    height: float,
+    width: float,
+    target_height: int = NEMOTRON_PARSE_TARGET_HEIGHT,
+    target_width: int = NEMOTRON_PARSE_TARGET_WIDTH,
+) -> tuple[float, float, float, float]:
+    """Map nemotron-parse canvas-normalized coords to original-image pixel coordinates.
+
+    nemotron-parse emits bounding boxes normalized to its letterboxed
+    ``target_height`` x ``target_width`` canvas (aspect-preserving resize, then centered
+    white padding). This inverts that preprocessing to recover pixel coordinates in the
+    original ``height`` x ``width`` image. It is a faithful port of NVIDIA's reference
+    ``transform_bbox_to_original``:
+    https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/main/postprocessing.py
+
+    NVIDIA's hosted NIM applies this server-side (so its coordinates are already
+    original-image-relative); raw vLLM/Hugging Face output does not.
+
+    Args:
+        xmin: Canvas-normalized left bound in [0, 1].
+        ymin: Canvas-normalized top bound in [0, 1].
+        xmax: Canvas-normalized right bound in [0, 1].
+        ymax: Canvas-normalized bottom bound in [0, 1].
+        height: Original (pre-letterbox) image height in pixels.
+        width: Original (pre-letterbox) image width in pixels.
+        target_height: Canvas height the model normalized against.
+        target_width: Canvas width the model normalized against.
+
+    Returns:
+        Four-tuple of (xmin, ymin, xmax, ymax) in original-image pixel coordinates.
+    """
+    aspect_ratio = width / height
+    # Replicate the model's "LongestMaxSize" resize, which only shrinks oversized inputs
+    resized_width, resized_height = width, height
+    if height > target_height:
+        resized_height = target_height
+        resized_width = int(resized_height * aspect_ratio)
+    if resized_width > target_width:
+        resized_width = target_width
+        resized_height = int(resized_width / aspect_ratio)
+    # Padding is centered (matches the Albumentations PadIfNeeded used in preprocessing)
+    pad_left = (target_width - resized_width) // 2
+    pad_top = (target_height - resized_height) // 2
+    return (
+        (xmin * target_width - pad_left) * width / resized_width,
+        (ymin * target_height - pad_top) * height / resized_height,
+        (xmax * target_width - pad_left) * width / resized_width,
+        (ymax * target_height - pad_top) * height / resized_height,
+    )
+
 
 class NemotronParseBBox(BaseModel):
     """
@@ -159,6 +222,33 @@ class NemotronParseBBox(BaseModel):
             self.ymin * height,
             self.xmax * width,
             self.ymax * height,
+        )
+
+    def to_original_coordinates(
+        self,
+        height: float,
+        width: float,
+        target_height: int = NEMOTRON_PARSE_TARGET_HEIGHT,
+        target_width: int = NEMOTRON_PARSE_TARGET_WIDTH,
+    ) -> tuple[float, float, float, float]:
+        """Map this canvas-normalized bbox to ``(xmin, ymin, xmax, ymax)`` image pixels.
+
+        Companion to ``to_page_coordinates`` for when coordinates are normalized to
+        nemotron-parse's letterboxed ``target_height`` x ``target_width`` canvas rather
+        than directly to the page (e.g. raw vLLM/Hugging Face output, as opposed to
+        NVIDIA's hosted NIM which already maps coordinates to the input image). Inverts
+        the aspect-preserving resize + centered white pad; see
+        ``transform_canvas_bbox_to_original``.
+        """
+        return transform_canvas_bbox_to_original(
+            self.xmin,
+            self.ymin,
+            self.xmax,
+            self.ymax,
+            height,
+            width,
+            target_height,
+            target_width,
         )
 
     def iou(self, other: "NemotronParseBBox") -> float:

--- a/packages/paper-qa-nemotron/tests/test_api.py
+++ b/packages/paper-qa-nemotron/tests/test_api.py
@@ -9,6 +9,8 @@ from pydantic import ValidationError
 from tenacity import Future, RetryCallState
 
 from paperqa_nemotron.api import (
+    NEMOTRON_PARSE_TARGET_HEIGHT,
+    NEMOTRON_PARSE_TARGET_WIDTH,
     NemotronParseAnnotatedBBox,
     NemotronParseBBox,
     NemotronParseClassification,
@@ -82,6 +84,121 @@ class TestNemotronParseBBox:
         assert bbox.to_page_coordinates(height=100, width=200) == pytest.approx(
             (20.0, 20.0, 180.0, 80.0)
         )
+
+    @pytest.mark.parametrize(
+        ("coords", "width", "height"),
+        [
+            # coords are (xmin, xmax, ymin, ymax) per from_coordinates; (width, height) px
+            pytest.param(
+                (0.1559, 0.8436, 0.0801, 0.1010), 1191, 1684, id="a4-no-resize"
+            ),
+            pytest.param(
+                (0.1, 0.9, 0.1, 0.9), 2550, 3300, id="letter-300dpi-downsized"
+            ),
+            pytest.param(
+                (0.2, 0.8, 0.2, 0.8), 1395, 1770, id="letter-150dpi-heavy-pad"
+            ),
+            pytest.param((0.0, 1.0, 0.0, 1.0), 600, 1000, id="tall-full-canvas"),
+            pytest.param(
+                (0.25, 0.75, 0.25, 0.75), 1648, 2048, id="exact-canvas-no-pad"
+            ),
+            pytest.param((0.1, 0.7, 0.2, 0.6), 3000, 2000, id="landscape-width-resize"),
+        ],
+    )
+    def test_bbox_to_original_coordinates_matches_nvidia_reference(
+        self, coords: tuple[float, float, float, float], width: int, height: int
+    ) -> None:
+        # Verbatim port target: NVIDIA's postprocessing.py::transform_bbox_to_original
+        # https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/main/postprocessing.py
+        def nvidia_reference(
+            bbox: tuple[float, float, float, float],
+            original_width: int,
+            original_height: int,
+            target_w: int = 1648,
+            target_h: int = 2048,
+        ) -> tuple[float, float, float, float]:
+            aspect_ratio = original_width / original_height
+            new_height = original_height
+            new_width = original_width
+            if original_height > target_h:
+                new_height = target_h
+                new_width = int(new_height * aspect_ratio)
+            if new_width > target_w:
+                new_width = target_w
+                new_height = int(new_width / aspect_ratio)
+            resized_width = new_width
+            resized_height = new_height
+            pad_left = (target_w - resized_width) // 2
+            pad_top = (target_h - resized_height) // 2
+            left = ((bbox[0] * target_w) - pad_left) * original_width / resized_width
+            right = ((bbox[2] * target_w) - pad_left) * original_width / resized_width
+            top = ((bbox[1] * target_h) - pad_top) * original_height / resized_height
+            bottom = ((bbox[3] * target_h) - pad_top) * original_height / resized_height
+            return left, top, right, bottom
+
+        bbox = NemotronParseBBox.from_coordinates(coords)
+        # NVIDIA's reference orders bbox as (xmin, ymin, xmax, ymax)
+        expected = nvidia_reference(
+            (bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax), width, height
+        )
+        assert bbox.to_original_coordinates(
+            height=height, width=width
+        ) == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        ("width", "height"),
+        [
+            pytest.param(595, 842, id="a4-72dpi"),
+            pytest.param(2550, 3300, id="letter-300dpi"),
+            pytest.param(1395, 1770, id="letter-150dpi"),
+            pytest.param(3000, 2000, id="landscape"),
+        ],
+    )
+    def test_bbox_to_original_coordinates_round_trip(
+        self, width: int, height: int
+    ) -> None:
+        """A page rectangle, letterboxed as the model does, must invert back to itself."""
+        target_w, target_h = NEMOTRON_PARSE_TARGET_WIDTH, NEMOTRON_PARSE_TARGET_HEIGHT
+        # Forward: replicate the model's aspect-preserving resize + centered white pad
+        aspect_ratio = width / height
+        resized_w, resized_h = width, height
+        if height > target_h:
+            resized_h = target_h
+            resized_w = int(resized_h * aspect_ratio)
+        if resized_w > target_w:
+            resized_w = target_w
+            resized_h = int(resized_w / aspect_ratio)
+        pad_left = (target_w - resized_w) // 2
+        pad_top = (target_h - resized_h) // 2
+
+        # An inset rectangle in original-image pixels
+        xmin_px, ymin_px = 0.1 * width, 0.2 * height
+        xmax_px, ymax_px = 0.7 * width, 0.6 * height
+        canvas = NemotronParseBBox(
+            xmin=(xmin_px * resized_w / width + pad_left) / target_w,
+            xmax=(xmax_px * resized_w / width + pad_left) / target_w,
+            ymin=(ymin_px * resized_h / height + pad_top) / target_h,
+            ymax=(ymax_px * resized_h / height + pad_top) / target_h,
+        )
+        assert canvas.to_original_coordinates(
+            height=height, width=width
+        ) == pytest.approx((xmin_px, ymin_px, xmax_px, ymax_px), abs=1.0)
+
+    def test_bbox_to_original_coordinates_corrects_letterbox_padding(self) -> None:
+        """At low DPI the letterbox correction is large vs. a naive page scaling.
+
+        Guards against regressing to a passthrough that treats canvas-normalized
+        coordinates as if normalized directly to the page (the bug behind every box
+        being drawn shifted/compressed against a raw vLLM endpoint).
+        """
+        # ~US-Letter @150 DPI + 60px border: smaller than the 1648x2048 canvas on both
+        # axes, so the model adds heavy centered white padding the naive scaling ignores.
+        width, height = 1395, 1770
+        bbox = NemotronParseBBox(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+        naive = bbox.to_page_coordinates(height=height, width=width)
+        corrected = bbox.to_original_coordinates(height=height, width=width)
+        assert corrected[0] < naive[0] - 100, "Expected a large left-edge correction"
+        assert corrected[2] > naive[2] + 100, "Expected a large right-edge correction"
 
     @pytest.mark.parametrize(
         ("bbox1_coords", "bbox2_coords", "expected_iou"),


### PR DESCRIPTION
## What

`nemotron-parse` emits bounding boxes normalized to its letterboxed **2048×1648** canvas (aspect-preserving resize + centered white padding). NVIDIA's hosted NIM maps these back to the input image **server-side** — via [`postprocessing.py::transform_bbox_to_original`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/main/postprocessing.py) — before returning, so PaperQA's existing decode (`coord × input_dims`) is correct against NIM. Raw vLLM / Hugging Face output is **not** transformed, so a consumer of raw model output draws every box shifted and compressed — worst at low DPI, where the canvas padding is largest.

This ports that inverse transform so raw-output consumers can recover original-image coordinates:

- `NEMOTRON_PARSE_TARGET_HEIGHT = 2048`, `NEMOTRON_PARSE_TARGET_WIDTH = 1648` — sourced (with a link) from the model's [`preprocessor_config.json`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/main/preprocessor_config.json)
- `transform_canvas_bbox_to_original(...)` module function
- `NemotronParseBBox.to_original_coordinates(height, width)` method, mirroring the existing `to_page_coordinates`

## Why it lives here

Our self-hosted vLLM Modal proxy returns raw canvas coordinates rather than replicating NIM's server-side mapping; this is the canonical, tested transform it will call. PaperQA's NIM decode path is intentionally unchanged — applying this on NIM coordinates would double-transform.

## Tests

`test_api.py` adds:
- **Parity** against NVIDIA's reference `transform_bbox_to_original` across the no-resize, downsized, and width-resized regimes
- **Round-trip** recovery (forward-letterbox a page rectangle → invert → recover, 0 px error)
- **Low-DPI** heavy-padding case, where the correction is large vs. naive page scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
