### PR TITLE
Add `NemotronParseBBox.to_original_coordinates` for raw nemotron-parse output

### DIFF
--- a/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
+++ b/packages/paper-qa-nemotron/src/paperqa_nemotron/api.py
@@ -91,6 +91,12 @@ NemotronParseToolName: TypeAlias = Literal[
     "markdown_bbox", "markdown_no_bbox", "detection_only"
 ]
 
+# nemotron-parse resizes each input image (preserving aspect ratio) to fit within this
+# target height x width canvas. These are the model's native input dimensions:
+# https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/preprocessor_config.json#L22-L33
+NEMOTRON_PARSE_TARGET_HEIGHT = 2048  # px
+NEMOTRON_PARSE_TARGET_WIDTH = 1648  # px
+
 
 class NemotronParseBBox(BaseModel):
     """
@@ -159,6 +165,68 @@ class NemotronParseBBox(BaseModel):
             self.ymin * height,
             self.xmax * width,
             self.ymax * height,
+        )
+
+    def to_original_coordinates(
+        self,
+        height: float,
+        width: float,
+        target_height: int = NEMOTRON_PARSE_TARGET_HEIGHT,
+        target_width: int = NEMOTRON_PARSE_TARGET_WIDTH,
+    ) -> tuple[float, float, float, float]:
+        """Map this canvas-normalized bbox to original-image pixel coordinates.
+
+        Port of https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/postprocessing.py#L23-L53
+
+        nemotron-parse resizes each input image (preserving aspect ratio)
+        and center-pads it to a `target_height` x `target_width` canvas,
+        then emits bounding boxes normalized to that padded canvas.
+        SEE its image processor's LongestMaxSize resize:
+        https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/hf_nemotron_parse_processor.py#L151-L170
+        and its centered white PadIfNeeded:
+        https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/hf_nemotron_parse_processor.py#L74-L82
+
+        This method inverts that (the aspect-preserving resize, then centered padding)
+        to recover original-image pixels. It is needed for the model's raw output,
+        i.e. when you run the weights yourself via vLLM or HuggingFace `transformers`,
+        as NVIDIA's example.py does:
+        https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/example.py#L34
+
+        NOTE: NVIDIA's hosted NIM returns coordinates already in input-image space,
+        as opposed to the model's padded-canvas space, so NIM responses do not need it.
+        Contrast `to_page_coordinates`, which just scales coordinates already relative to the page.
+
+        Args:
+            height: Original ("pre-letterbox") image height (px).
+            width: Original ("pre-letterbox") image width (px).
+            target_height: Canvas height (px) the model normalized coordinates against.
+            target_width: Canvas width (px) the model normalized coordinates against.
+
+        Returns:
+            Four-tuple of (xmin, ymin, xmax, ymax), in original-image pixel coordinates.
+                Returned coordinates can fall outside the image (negative, or past
+                width/height) when the box overlaps the padded canvas region, matching
+                NVIDIA's reference `transform_bbox_to_original`. Clamp the returned
+                coordinates to the image bounds if you need in-bounds values.
+        """
+        aspect_ratio = width / height
+        # Replicate the model's "LongestMaxSize" resize (only shrinks oversized inputs)
+        resized_width, resized_height = width, height
+        if height > target_height:
+            resized_height = target_height
+            resized_width = int(resized_height * aspect_ratio)
+        if resized_width > target_width:
+            resized_width = target_width
+            resized_height = int(resized_width / aspect_ratio)
+        # Centered padding (matching the Albumentations PadIfNeeded)
+        # SEE: https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/hf_nemotron_parse_processor.py#L74-L82
+        pad_left = (target_width - resized_width) // 2
+        pad_top = (target_height - resized_height) // 2
+        return (
+            (self.xmin * target_width - pad_left) * width / resized_width,
+            (self.ymin * target_height - pad_top) * height / resized_height,
+            (self.xmax * target_width - pad_left) * width / resized_width,
+            (self.ymax * target_height - pad_top) * height / resized_height,
         )
 
     def iou(self, other: "NemotronParseBBox") -> float:

--- a/packages/paper-qa-nemotron/tests/test_api.py
+++ b/packages/paper-qa-nemotron/tests/test_api.py
@@ -9,6 +9,8 @@ from pydantic import ValidationError
 from tenacity import Future, RetryCallState
 
 from paperqa_nemotron.api import (
+    NEMOTRON_PARSE_TARGET_HEIGHT,
+    NEMOTRON_PARSE_TARGET_WIDTH,
     NemotronParseAnnotatedBBox,
     NemotronParseBBox,
     NemotronParseClassification,
@@ -82,6 +84,111 @@ class TestNemotronParseBBox:
         assert bbox.to_page_coordinates(height=100, width=200) == pytest.approx(
             (20.0, 20.0, 180.0, 80.0)
         )
+
+    def test_bbox_to_original_coordinates(self, subtests: pytest.Subtests) -> None:
+        def transform_bbox_to_original(
+            bbox: tuple[float, float, float, float],
+            original_width: int,
+            original_height: int,
+            target_w: int = 1648,
+            target_h: int = 2048,
+        ) -> tuple[float, float, float, float]:
+            """NVIDIA's reference, comments preserved, used here as a parity oracle.
+
+            https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/postprocessing.py#L23-L53
+            """
+            # Replicate exact resize logic
+            aspect_ratio = original_width / original_height
+            new_height = original_height
+            new_width = original_width
+            if original_height > target_h:
+                new_height = target_h
+                new_width = int(new_height * aspect_ratio)
+            if new_width > target_w:
+                new_width = target_w
+                new_height = int(new_width / aspect_ratio)
+            resized_width = new_width
+            resized_height = new_height
+            # Calculate padding
+            pad_left = (target_w - resized_width) // 2
+            pad_top = (target_h - resized_height) // 2
+            # Transform: use the ACTUAL resized dimensions, not the scale X coords
+            left = ((bbox[0] * target_w) - pad_left) * original_width / resized_width
+            right = ((bbox[2] * target_w) - pad_left) * original_width / resized_width
+            # Y coords - using original_height / resized_height directly
+            top = ((bbox[1] * target_h) - pad_top) * original_height / resized_height
+            bottom = ((bbox[3] * target_h) - pad_top) * original_height / resized_height
+            return left, top, right, bottom
+
+        # Parity with NVIDIA's reference across resize/pad regimes. coords are
+        # (xmin, xmax, ymin, ymax) per from_coordinates; dims are (width, height) px.
+        reference_cases = [
+            ("a4-no-resize", (0.1559, 0.8436, 0.0801, 0.1010), 1191, 1684),
+            ("letter-300dpi-downsized", (0.1, 0.9, 0.1, 0.9), 2550, 3300),
+            ("letter-150dpi-heavy-pad", (0.2, 0.8, 0.2, 0.8), 1395, 1770),
+            ("tall-full-canvas", (0.0, 1.0, 0.0, 1.0), 600, 1000),
+            ("exact-canvas-no-pad", (0.25, 0.75, 0.25, 0.75), 1648, 2048),
+            ("landscape-width-resize", (0.1, 0.7, 0.2, 0.6), 3000, 2000),
+        ]
+        for label, coords, width, height in reference_cases:
+            with subtests.test(msg=f"reference:{label}"):
+                bbox = NemotronParseBBox.from_coordinates(coords)
+                # NVIDIA's reference orders bbox as (xmin, ymin, xmax, ymax)
+                expected = transform_bbox_to_original(
+                    (bbox.xmin, bbox.ymin, bbox.xmax, bbox.ymax), width, height
+                )
+                assert bbox.to_original_coordinates(
+                    height=height, width=width
+                ) == pytest.approx(expected)
+
+        # Round-trip: a page rectangle, letterboxed as the model does, inverts to itself.
+        for label, width, height in (
+            ("a4-72dpi", 595, 842),
+            ("letter-300dpi", 2550, 3300),
+            ("letter-150dpi", 1395, 1770),
+            ("landscape", 3000, 2000),
+        ):
+            with subtests.test(msg=f"round-trip:{label}"):
+                target_w = NEMOTRON_PARSE_TARGET_WIDTH
+                target_h = NEMOTRON_PARSE_TARGET_HEIGHT
+                aspect_ratio = width / height
+                resized_w, resized_h = width, height
+                if height > target_h:
+                    resized_h = target_h
+                    resized_w = int(resized_h * aspect_ratio)
+                if resized_w > target_w:
+                    resized_w = target_w
+                    resized_h = int(resized_w / aspect_ratio)
+                pad_left = (target_w - resized_w) // 2
+                pad_top = (target_h - resized_h) // 2
+                xmin_px, ymin_px = 0.1 * width, 0.2 * height
+                xmax_px, ymax_px = 0.7 * width, 0.6 * height
+                canvas = NemotronParseBBox(
+                    xmin=(xmin_px * resized_w / width + pad_left) / target_w,
+                    xmax=(xmax_px * resized_w / width + pad_left) / target_w,
+                    ymin=(ymin_px * resized_h / height + pad_top) / target_h,
+                    ymax=(ymax_px * resized_h / height + pad_top) / target_h,
+                )
+                assert canvas.to_original_coordinates(
+                    height=height, width=width
+                ) == pytest.approx((xmin_px, ymin_px, xmax_px, ymax_px), abs=1.0)
+
+        with subtests.test(msg="corrects-letterbox-padding"):
+            # At low DPI the correction is large vs. a naive page scaling, guarding against
+            # regressing to a passthrough that treats canvas coords as page-relative (the
+            # bug behind every box drawn shifted/compressed against a raw endpoint).
+            # ~US-Letter @150 DPI + 60px border is smaller than the 1648x2048 canvas on
+            # both axes, so the model adds heavy centered white padding naive scaling skips.
+            width, height = 1395, 1770
+            bbox = NemotronParseBBox(xmin=0.0, xmax=1.0, ymin=0.0, ymax=1.0)
+            naive = bbox.to_page_coordinates(height=height, width=width)
+            corrected = bbox.to_original_coordinates(height=height, width=width)
+            assert (
+                corrected[0] < naive[0] - 100
+            ), "Expected a large left-edge correction"
+            assert (
+                corrected[2] > naive[2] + 100
+            ), "Expected a large right-edge correction"
 
     @pytest.mark.parametrize(
         ("bbox1_coords", "bbox2_coords", "expected_iou"),


### PR DESCRIPTION
## Why

`nemotron-parse` predicts bounding boxes in the space of its preprocessed input: each page is resized (aspect-preserving) and centered onto a target `2048x1648` (HxW) canvas with white padding, so the boxes are normalized to that padded canvas rather than to the page.

NVIDIA's hosted **NIM** undoes that and returns input-image coordinates, which is why PaperQA's current decode is correct against NIM. A consumer of the model's **raw** output, though, e.g. a self-hosted vLLM or HuggingFace `transformers` endpoint, receives canvas-space coordinates and draws every box shifted inward and compressed, worst at low DPI where the padding dominates. This adds a first-class way for such consumers to recover original-image coordinates, mirroring what NVIDIA's [`postprocessing.transform_bbox_to_original`](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.1/blob/fd1e3c6ba0b61a6dcab5a905f0ff92c5b19f14a4/postprocessing.py#L23-L53) and `example.py` do.

## Notes

- **Opt-in, and intentionally not used on the existing NIM path.** NIM already returns input-image coordinates, so applying this there would double-transform. `to_original_coordinates` sits alongside `to_page_coordinates` for the raw-output case only.
- Relation to #1271: that (closed) PR addressed the same mismatch from the *input* side, upsizing/pre-fitting pages to the training aspect ratio before sending. This is the complementary *output* side, and leaves the request path untouched.
- Tests assert parity against NVIDIA's reference across the no-resize, downsized, and width-resized regimes, plus round-trip recovery and a low-DPI heavy-padding case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
