### PR TITLE
fix: improve prompt robustness for local models during indexing (closes #1321)

### DIFF
--- a/src/paperqa/prompts.py
+++ b/src/paperqa/prompts.py
@@ -11,7 +11,7 @@ summary_prompt = (
     " Stay detailed; report specific numbers, equations, or direct quotes"
     ' (marked with quotation marks). Reply "Not applicable" if the excerpt is'
     " irrelevant. At the end of your response,"
-    " provide an integer score from 1-10 on a newline indicating relevance to question."  
+    " provide an integer score from 1-10 on a newline indicating relevance to question."
     " Do not explain your score.\n"
     "IMPORTANT: Your response must end with the score alone on its own line (e.g., '7'). "
     "No other text after the score."

--- a/src/paperqa/prompts.py
+++ b/src/paperqa/prompts.py
@@ -11,8 +11,10 @@ summary_prompt = (
     " Stay detailed; report specific numbers, equations, or direct quotes"
     ' (marked with quotation marks). Reply "Not applicable" if the excerpt is'
     " irrelevant. At the end of your response,"
-    " provide an integer score from 1-10 on a newline indicating relevance to question."  # Don't use 0-10 since we mention "not applicable" instead  # noqa: E501
-    " Do not explain your score."
+    " provide an integer score from 1-10 on a newline indicating relevance to question."  
+    " Do not explain your score.\n"
+    "IMPORTANT: Your response must end with the score alone on its own line (e.g., '7'). "
+    "No other text after the score."
     "\n\nRelevant Information Summary ({summary_length}):"
 )
 # This prompt template integrates with `text` variable of the above `summary_prompt`


### PR DESCRIPTION
## What
The PDF indexing process was failing when using local models (e.g., Ollama) because the summary prompt didn't clearly specify that the score must be on its own line at the end of the response. Local models often include extra text or formatting after the score, causing parsing failures during indexing.

## Fix
Added explicit formatting instructions to the summary prompt telling the model that its response must end with the score alone on its own line, with no other text after it. This makes the output format more explicit and robust across different model providers.

Closes #1321