### PR TITLE
Remove duplicated "words" in evidence-summary JSON system prompts

### DIFF
--- a/src/paperqa/prompts.py
+++ b/src/paperqa/prompts.py
@@ -112,7 +112,7 @@ summary_json_system_prompt = (
     " will be given to the model to generate an answer."
     " Respond with the following JSON format:"
     '\n\n{{\n  "summary": "...",\n  "relevance_score": 0-10\n}}'
-    "\n\nwhere `summary` is relevant information from the text - {summary_length} words."
+    "\n\nwhere `summary` is relevant information from the text - {summary_length}."
     " `relevance_score` is an integer 0-10 for the relevance of `summary` to the question."
     "\n\nThe excerpt may or may not contain relevant information."
     " If not, leave `summary` empty, and make `relevance_score` be 0."
@@ -124,7 +124,7 @@ summary_json_multimodal_system_prompt = (
     " will be given to the model to generate an answer."
     " Respond with the following JSON format:"
     '\n\n{{\n  "summary": "...",\n  "relevance_score": 0-10,\n  "used_images": "..."\n}}'
-    "\n\nwhere `summary` is relevant information from the text - {summary_length} words."
+    "\n\nwhere `summary` is relevant information from the text - {summary_length}."
     " `relevance_score` is an integer 0-10 for the relevance of `summary` to the question."
     " `used_images` is a boolean flag indicating"
     " if any images present in a multimodal message were used,"


### PR DESCRIPTION
The JSON evidence-summary system prompts append a literal "words" after the {summary_length} placeholder, but {summary_length} is filled from AnswerSettings.evidence_summary_length, whose default is "about 100 words". With default settings the rendered system prompt therefore reads "...relevant information from the text - about 100 words words.".

The non-JSON summary_prompt already avoids this (it writes "Relevant Information Summary ({summary_length}):" without appending "words").

Drop the trailing literal " words" in both summary_json_system_prompt and summary_json_multimodal_system_prompt so the placeholder supplies its own units. Cosmetic prompt cleanup; no schema/API change.