### PR TITLE
fix(index): honor disabled document validation

### DIFF
--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -310,23 +310,22 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             **parse_config.reader_config,
         )
         # loose check to see if document was loaded
-        if metadata.name != "image" and (
-            not texts
-            or len(texts[0].text) < 10  # noqa: PLR2004
-            or (
-                not parse_config.disable_doc_valid_check
-                and (
-                    (
-                        # Quick sanity check the text is not just some terse one-page
-                        # 404 message interspersed with newlines. Check here
-                        # instead of maybe_is_text because a 404 HTML page is text
-                        sum(len(t.text.replace("\n", "")) for t in texts[:2])
-                        < 20  # noqa: PLR2004
-                    )
-                    # Use the first few text chunks to avoid potential issues with
-                    # title page parsing in the first chunk
-                    or not maybe_is_text("".join(t.text for t in texts[:5]))
+        if (
+            metadata.name != "image"
+            and not parse_config.disable_doc_valid_check
+            and (
+                not texts
+                or len(texts[0].text) < 10  # noqa: PLR2004
+                or (
+                    # Quick sanity check the text is not just some terse one-page
+                    # 404 message interspersed with newlines. Check here
+                    # instead of maybe_is_text because a 404 HTML page is text
+                    sum(len(t.text.replace("\n", "")) for t in texts[:2])
+                    < 20  # noqa: PLR2004
                 )
+                # Use the first few text chunks to avoid potential issues with
+                # title page parsing in the first chunk
+                or not maybe_is_text("".join(t.text for t in texts[:5]))
             )
         ):
             raise ValueError(

--- a/src/paperqa/docs.py
+++ b/src/paperqa/docs.py
@@ -329,8 +329,8 @@ class Docs(BaseModel):  # noqa: PLW1641  # TODO: add __hash__
             )
         ):
             raise ValueError(
-                f"This does not look like a text document: {path}. Pass disable_check"
-                " to ignore this error."
+                f"This does not look like a text document: {path}. Set"
+                " ParsingSettings.disable_doc_valid_check=True to ignore this error."
             )
         if await self.aadd_texts(texts, doc, all_settings, embedding_model):
             return doc.docname

--- a/tests/test_paperqa.py
+++ b/tests/test_paperqa.py
@@ -2334,6 +2334,33 @@ async def test_code() -> None:
     assert "test_paperqa.py" in session.answer
 
 
+@pytest.mark.parametrize(
+    ("filename", "contents"),
+    [("py.typed", ""), (".python-version", "3.13\n")],
+)
+@pytest.mark.asyncio
+async def test_disable_doc_valid_check_allows_short_code_files(
+    tmp_path: Path, filename: str, contents: str
+) -> None:
+    settings = Settings.from_name("fast")
+    settings.parsing.disable_doc_valid_check = True
+    settings.parsing.defer_embedding = True
+    settings.parsing.use_doc_details = False
+    path = tmp_path / filename
+    path.write_text(contents)
+
+    docs = Docs()
+    docname = await docs.aadd(
+        path,
+        citation=filename,
+        docname=filename,
+        settings=settings,
+    )
+
+    assert docname == filename
+    assert docs.texts[0].text == contents
+
+
 @pytest.mark.asyncio
 async def test_querying_tables(stub_data_dir: Path) -> None:
     settings = Settings.from_name("fast")


### PR DESCRIPTION
Fixes #966

Honor disable_doc_valid_check for empty and short code files.

Verification:
- `uv run pytest tests/test_paperqa.py -k disable_doc_valid_check_allows_short_code_files`
- `uv run prek run --all-files`
- `uv run pylint src packages`
- `uv run refurb .`
