### PR TITLE
docs: use ollama_chat/ for tool-calling models in the Locally Hosted example

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ answer_response = ask(
 
 Models hosted with `ollama` are also supported.
 To run the example below make sure you have downloaded llama3.2 and mxbai-embed-large via ollama.
+Use the `ollama_chat/` prefix, not `ollama/`, for `llm`, `summary_llm`, and `agent_llm`: PaperQA2's agents end a turn with a forced tool call, and litellm's `ollama/` provider (the `/api/generate` endpoint) does not carry tool calls, while `ollama_chat/` (`/api/chat`) does. Embeddings stay on `ollama/`.
 
 ```python
 from paperqa import Settings, ask
@@ -630,9 +631,9 @@ from paperqa import Settings, ask
 local_llm_config = {
     "model_list": [
         {
-            "model_name": "ollama/llama3.2",
+            "model_name": "ollama_chat/llama3.2",
             "litellm_params": {
-                "model": "ollama/llama3.2",
+                "model": "ollama_chat/llama3.2",
                 "api_base": "http://localhost:11434",
             },
         }
@@ -642,9 +643,9 @@ local_llm_config = {
 answer_response = ask(
     "What is PaperQA2?",
     settings=Settings(
-        llm="ollama/llama3.2",
+        llm="ollama_chat/llama3.2",
         llm_config=local_llm_config,
-        summary_llm="ollama/llama3.2",
+        summary_llm="ollama_chat/llama3.2",
         summary_llm_config=local_llm_config,
         embedding="ollama/mxbai-embed-large",
     ),

--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ Use the `ollama_chat/` prefix, not `ollama/`, for `llm`, `summary_llm`, and `age
 
 ```python
 from paperqa import Settings, ask
+from paperqa.settings import AgentSettings
 
 local_llm_config = {
     "model_list": [
@@ -647,6 +648,10 @@ answer_response = ask(
         llm_config=local_llm_config,
         summary_llm="ollama_chat/llama3.2",
         summary_llm_config=local_llm_config,
+        agent=AgentSettings(
+            agent_llm="ollama_chat/llama3.2",
+            agent_llm_config=local_llm_config,
+        ),
         embedding="ollama/mxbai-embed-large",
     ),
 )


### PR DESCRIPTION
## What

The "Locally Hosted" Ollama example sets `llm` and `summary_llm` to the `ollama/` litellm provider, which routes to Ollama's `/api/generate` endpoint - not documented by litellm as supporting tool/function calling (https://docs.litellm.ai/docs/providers/ollama). Every PaperQA2 agent ends a turn with a forced tool call, so a model reached through `ollama/` returns an empty message and the agent answers "I cannot answer this question due to having no papers." - the exact symptom in #1128, diagnosed there as an LLM limitation ("This is an LLM failure beyond the control of PaperQA").

`ollama_chat/` routes to `/api/chat`, litellm's documented tool-calling endpoint. Switching the example's chat-model entries to that prefix is enough for the same question to get a real, cited answer.

## Fix

Change `ollama/llama3.2` to `ollama_chat/llama3.2` in the three chat-model spots (`model_name`, `litellm_params.model`, and the top-level `llm`/`summary_llm`), and add one sentence explaining why. The embedding line stays on `ollama/`, since litellm's embedding call uses that provider regardless of chat support.

Verified locally against a running Ollama server with `qwen3.5:9b`: `ollama/` -> empty message, agent finishes with no answer; `ollama_chat/` -> tool calls succeed, agent produces a cited answer.

Not addressing the separate "`agent_llm` and `embedding_config` must also be set for local models" gap tracked in #1321 - out of scope here.